### PR TITLE
 RAC-134: POC: add label on export

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
@@ -61,14 +61,13 @@ services:
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
             - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
-            - '@translator'
 
     pim_connector.array_converter.standard_to_flat.product_with_label:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductWithLabel'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
             - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
-            - '@translator'
+            - '@pim_catalog.localization.translator.label'
 
     pim_connector.array_converter.standard_to_flat.product_localized:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
@@ -93,7 +92,7 @@ services:
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
             - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
-            - '@translator'
+            - '@pim_catalog.localization.translator.label'
 
     pim_connector.array_converter.standard_to_flat.product_model_localized:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
@@ -182,7 +181,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\MetricConverter'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
-            - '@translator'
+            - '@pim_catalog.localization.translator.label'
             - ['pim_catalog_metric']
         tags:
             - { name: 'pim_connector.array_converter.standard_to_flat.product.value_converter' }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
@@ -63,10 +63,24 @@ services:
             - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
             - '@translator'
 
+    pim_connector.array_converter.standard_to_flat.product_with_label:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductWithLabel'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
+            - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
+            - '@translator'
+
     pim_connector.array_converter.standard_to_flat.product_localized:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product'
+            - '@pim_catalog.localization.localizer.converter'
+
+
+    pim_connector.array_converter.standard_to_flat.product_localized_with_label:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product_with_label'
             - '@pim_catalog.localization.localizer.converter'
 
     pim_connector.array_converter.standard_to_flat.product_model:
@@ -74,10 +88,23 @@ services:
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
 
+    pim_connector.array_converter.standard_to_flat.product_model_with_label:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductModelWithLabel'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
+            - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
+            - '@translator'
+
     pim_connector.array_converter.standard_to_flat.product_model_localized:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model'
+            - '@pim_catalog.localization.localizer.converter'
+
+    pim_connector.array_converter.standard_to_flat.product_model_localized_with_label:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
+        arguments:
+            - '@pim_connector.array_converter.standard_to_flat.product_model_with_label'
             - '@pim_catalog.localization.localizer.converter'
 
     pim_connector.array_converter.standard_to_flat.product.product_value_converter:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
@@ -60,6 +60,8 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product.product_value_converter'
+            - '@akeneo.pim.enrichment.channel.query.get_association_type_labels'
+            - '@translator'
 
     pim_connector.array_converter.standard_to_flat.product_localized:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\ProductLocalized'
@@ -153,6 +155,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter\MetricConverter'
         arguments:
             - '@pim_connector.array_converter.flat_to_standard.product.attribute_columns_resolver'
+            - '@translator'
             - ['pim_catalog_metric']
         tags:
             - { name: 'pim_connector.array_converter.standard_to_flat.product.value_converter' }
@@ -282,6 +285,7 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.repository.currency'
             - '@pim_catalog.resolver.attribute_values'
+            - '@akeneo.pim.enrichment.attribute.query.get_labels'
 
     pim_connector.array_converter.flat_to_standard.product.association_columns_resolver:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AssociationColumnsResolver'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/translators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/translators.yml
@@ -10,4 +10,4 @@ services:
     pim_catalog.localization.translator.label:
         class: 'Akeneo\Tool\Component\Localization\LabelTranslator'
         arguments:
-            - '@translator.data_collector.inner'
+            - '@translator.default'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/translators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/translators.yml
@@ -6,3 +6,8 @@ services:
         class: '%pim_catalog.localization.translator.proxy.class%'
         arguments:
             - '@translator'
+
+    pim_catalog.localization.translator.label:
+        class: 'Akeneo\Tool\Component\Localization\LabelTranslator'
+        arguments:
+            - '@translator.data_collector.inner'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -82,11 +82,13 @@ services:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat\GenerateHeadersFromFamilyCodes'
         arguments:
             - '@database_connection'
+            - '@pim_catalog.localization.translator.label'
 
     akeneo.pim.enrichment.connector.write.file.flat.generate_headers_from_attribute_codes:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat\GenerateHeadersFromAttributeCodes'
         arguments:
             - '@database_connection'
+            - '@pim_catalog.localization.translator.label'
 
     pim_catalog.query.get_descendent_category_codes:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Category\GetDescendentCategoryCodes'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -248,6 +248,11 @@ services:
         arguments:
             - '@database_connection'
 
+    akeneo.pim.enrichment.channel.query.get_association_type_labels:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType\SqlGetAssociationTypeLabels'
+        arguments:
+            - '@database_connection'
+
     akeneo.pim.enrichment.attribute.query.get_labels:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Attribute\SqlGetAttributeLabels'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_standard.yml
@@ -77,6 +77,7 @@ services:
         arguments:
             - '@pim_standard_format_serializer'
             - '@akeneo.pim.structure.query.get_attributes'
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 90 }
         lazy: true

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/serializers_storage.yml
@@ -44,6 +44,7 @@ services:
         arguments:
             - '@pim_storage_serializer'
             - '@akeneo.pim.structure.query.get_attributes'
+            - '@pim_catalog.repository.attribute_option'
         tags:
             - { name: pim_standard_format_serializer.normalizer, priority: 90 }
         lazy: true

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/writers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/writers.yml
@@ -48,6 +48,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv\ProductWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -60,6 +61,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv\ProductModelWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_model.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -70,6 +72,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv\ProductWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -83,6 +86,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Csv\ProductModelWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_model_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -94,6 +98,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Xlsx\ProductWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -106,6 +111,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Xlsx\ProductModelWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_model.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -116,6 +122,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Xlsx\ProductWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'
@@ -129,6 +136,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\Xlsx\ProductModelWriter'
         arguments:
             - '@pim_connector.array_converter.standard_to_flat.product_model_localized'
+            - '@pim_connector.array_converter.standard_to_flat.product_model_localized_with_label'
             - '@pim_connector.factory.flat_item_buffer'
             - '@pim_connector.writer.file.product_model_quick_export.flat_item_buffer_flusher'
             - '@pim_catalog.repository.attribute'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/AssociationType/SqlGetAssociationTypeLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/AssociationType/SqlGetAssociationTypeLabels.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType;
+
+use Doctrine\DBAL\Connection;
+
+class SqlGetAssociationTypeLabels
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function forAssociationTypeCodes(array $associationTypeCodes): array
+    {
+        $sql = <<<SQL
+SELECT
+   at.code AS code,
+   trans.label AS label,
+   trans.locale AS locale
+FROM pim_catalog_association_type at
+INNER JOIN pim_catalog_association_type_translation trans ON at.id = trans.foreign_key
+WHERE at.code IN (:associationTypeCodes)
+SQL;
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['associationTypeCodes' => $associationTypeCodes],
+            ['associationTypeCodes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row['code']][$row['locale']] = $row['label'];
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
@@ -92,8 +92,8 @@ SQL;
                 $localeCodes,
                 $channelCurrencyCodes,
                 $activatedCurrencyCodes,
-                json_decode($attributeData['labels'], true),
                 null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : [],
+                json_decode($attributeData['labels'], true),
                 $unitLabel
             );
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
@@ -6,8 +6,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
+use Akeneo\Tool\Component\Localization\LabelTranslator;
 use Doctrine\DBAL\Connection;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author    Benoit Jacquemont <benoit@akeneo.com>
@@ -19,11 +19,11 @@ final class GenerateHeadersFromAttributeCodes implements GenerateFlatHeadersFrom
     /** @var Connection */
     private $connection;
     /**
-     * @var TranslatorInterface
+     * @var LabelTranslator
      */
     private $translator;
 
-    public function __construct(Connection $connection, TranslatorInterface $translator)
+    public function __construct(Connection $connection, LabelTranslator $translator)
     {
         $this->connection = $connection;
         $this->translator = $translator;
@@ -37,7 +37,8 @@ final class GenerateHeadersFromAttributeCodes implements GenerateFlatHeadersFrom
     public function __invoke(
         array $attributeCodes,
         string $channelCode,
-        array $localeCodes
+        array $localeCodes,
+        string $labelLocale
     ): array {
         $activatedCurrencyCodes = $this->connection->executeQuery(
             "SELECT code FROM pim_catalog_currency WHERE is_activated = 1"
@@ -79,7 +80,7 @@ SQL;
             ['attributeCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         )->fetchAll();
 
-        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, $labelLocale, '[unit]');
 
         $headers = [];
         foreach ($attributesData as $attributeData) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromAttributeCodes.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromAttributeCodesInterface;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author    Benoit Jacquemont <benoit@akeneo.com>
@@ -17,10 +18,15 @@ final class GenerateHeadersFromAttributeCodes implements GenerateFlatHeadersFrom
 {
     /** @var Connection */
     private $connection;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, TranslatorInterface $translator)
     {
         $this->connection = $connection;
+        $this->translator = $translator;
     }
 
     /**
@@ -59,8 +65,10 @@ SQL;
                      FROM pim_catalog_locale l
                      JOIN pim_catalog_attribute_locale al ON al.locale_id = l.id
                      WHERE al.attribute_id = a.id
-                   ) AS specific_to_locales
+                   ) AS specific_to_locales,
+                   JSON_OBJECTAGG(pcat.locale, pcat.label) AS labels
             FROM pim_catalog_attribute a
+            JOIN pim_catalog_attribute_translation pcat on pcat.foreign_key = a.id
             WHERE a.code IN (:attributeCodes)
             GROUP BY a.id;
 SQL;
@@ -70,6 +78,8 @@ SQL;
             ['attributeCodes' => $attributeCodes],
             ['attributeCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         )->fetchAll();
+
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
 
         $headers = [];
         foreach ($attributesData as $attributeData) {
@@ -82,7 +92,9 @@ SQL;
                 $localeCodes,
                 $channelCurrencyCodes,
                 $activatedCurrencyCodes,
-                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : []
+                json_decode($attributeData['labels'], true),
+                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : [],
+                $unitLabel
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
@@ -94,8 +94,8 @@ SQL;
                 $localeCodes,
                 $channelCurrencyCodes,
                 $activatedCurrencyCodes,
-                json_decode($attributeData['labels'], true),
                 null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : [],
+                json_decode($attributeData['labels'], true),
                 $unitLabel
             );
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
@@ -6,8 +6,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
+use Akeneo\Tool\Component\Localization\LabelTranslator;
 use Doctrine\DBAL\Connection;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author    Benoit Jacquemont <benoit@akeneo.com>
@@ -19,11 +19,11 @@ final class GenerateHeadersFromFamilyCodes implements GenerateFlatHeadersFromFam
     /** @var Connection */
     private $connection;
     /**
-     * @var TranslatorInterface
+     * @var LabelTranslator
      */
     private $translator;
 
-    public function __construct(Connection $connection, TranslatorInterface $translator)
+    public function __construct(Connection $connection, LabelTranslator $translator)
     {
         $this->connection = $connection;
         $this->translator = $translator;
@@ -37,7 +37,8 @@ final class GenerateHeadersFromFamilyCodes implements GenerateFlatHeadersFromFam
     public function __invoke(
         array $familyCodes,
         string $channelCode,
-        array $localeCodes
+        array $localeCodes,
+        string $labelLocale
     ): array {
         $activatedCurrencyCodes = $this->connection->executeQuery(
             "SELECT code FROM pim_catalog_currency WHERE is_activated = 1"
@@ -81,7 +82,7 @@ SQL;
             ['familyCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         )->fetchAll();
 
-        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, $labelLocale, '[unit]');
 
         $headers = [];
         foreach ($attributesData as $attributeData) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/Writer/File/Flat/GenerateHeadersFromFamilyCodes.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\Writer\File\Flat;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\FlatFileHeader;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Writer\File\GenerateFlatHeadersFromFamilyCodesInterface;
 use Doctrine\DBAL\Connection;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author    Benoit Jacquemont <benoit@akeneo.com>
@@ -17,10 +18,15 @@ final class GenerateHeadersFromFamilyCodes implements GenerateFlatHeadersFromFam
 {
     /** @var Connection */
     private $connection;
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
 
-    public function __construct(Connection $connection)
+    public function __construct(Connection $connection, TranslatorInterface $translator)
     {
         $this->connection = $connection;
+        $this->translator = $translator;
     }
 
     /**
@@ -59,10 +65,12 @@ SQL;
                      FROM pim_catalog_locale l
                      JOIN pim_catalog_attribute_locale al ON al.locale_id = l.id
                      WHERE al.attribute_id = a.id
-                   ) AS specific_to_locales
+                   ) AS specific_to_locales,
+                   JSON_OBJECTAGG(pcat.locale, pcat.label) AS labels
             FROM pim_catalog_family f
               JOIN pim_catalog_family_attribute fa ON fa.family_id = f.id
               JOIN pim_catalog_attribute a ON a.id = fa.attribute_id
+              JOIN pim_catalog_attribute_translation pcat on pcat.foreign_key = a.id
             WHERE f.code IN (:familyCodes)
             GROUP BY a.id;
 SQL;
@@ -72,6 +80,8 @@ SQL;
             ['familyCodes' => $familyCodes],
             ['familyCodes' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         )->fetchAll();
+
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
 
         $headers = [];
         foreach ($attributesData as $attributeData) {
@@ -84,7 +94,9 @@ SQL;
                 $localeCodes,
                 $channelCurrencyCodes,
                 $activatedCurrencyCodes,
-                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : []
+                json_decode($attributeData['labels'], true),
+                null !== $attributeData['specific_to_locales'] ? json_decode($attributeData['specific_to_locales'], true) : [],
+                $unitLabel
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/AttributeColumnsResolver.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/AttributeColumnsResolver.php
@@ -155,7 +155,7 @@ class AttributeColumnsResolver
         }
 
         if (!empty($extraInformation)) {
-            $field = $field . "(".implode(', ', $extraInformation) . ")";
+            $field = $field . " (".implode(', ', $extraInformation) . ")";
         }
 
         return $field;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/AttributeColumnsResolver.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/AttributeColumnsResolver.php
@@ -129,8 +129,22 @@ class AttributeColumnsResolver
      */
     public function resolveFlatAttributeName($attributeCode, $localeCode, $scopeCode)
     {
-        $field = $this->getAttributeLabels->forAttributeCodes([$attributeCode])[$attributeCode]['fr_FR'] ?? "[$attributeCode]";
+        $field = $attributeCode;
 
+        if (null !== $localeCode) {
+            $field = sprintf('%s-%s', $field, $localeCode);
+        }
+
+        if (null !== $scopeCode) {
+            $field = sprintf('%s-%s', $field, $scopeCode);
+        }
+
+        return $field;
+    }
+
+    public function resolveFlatAttributeLabelName($attributeCode, $localeCode, $scopeCode, $labelLocale)
+    {
+        $field = $this->getAttributeLabels->forAttributeCodes([$attributeCode])[$attributeCode][$labelLocale] ?? "[$attributeCode]";
         $extraInformation = [];
         if (null !== $localeCode) {
             $extraInformation[] = $localeCode;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product.php
@@ -2,11 +2,9 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat;
 
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType\SqlGetAssociationTypeLabels;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
-use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * Convert standard format to flat format for product
@@ -20,18 +18,12 @@ class Product extends AbstractSimpleArrayConverter implements ArrayConverterInte
     /** @var ProductValueConverter */
     protected $valueConverter;
 
-    private $associationTypeLabels;
-
-    private $translator;
-
     /**
      * @param ProductValueConverter $valueConverter
      */
-    public function __construct(ProductValueConverter $valueConverter, SqlGetAssociationTypeLabels $associationTypeLabels, TranslatorInterface $translator)
+    public function __construct(ProductValueConverter $valueConverter)
     {
         $this->valueConverter = $valueConverter;
-        $this->associationTypeLabels = $associationTypeLabels;
-        $this->translator = $translator;
     }
 
     /**
@@ -130,10 +122,9 @@ class Product extends AbstractSimpleArrayConverter implements ArrayConverterInte
      */
     protected function convertAssociations(array $data, array $convertedItem): array
     {
-        $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
         foreach ($data as $assocName => $associations) {
             foreach ($associations as $assocType => $entities) {
-                $propertyName = sprintf('%s %s', $associationTypeLabels[$assocName]['fr_FR'] ?? "[$assocName]", $this->translator->trans("pim_common.$assocType", [], null, 'fr_FR'));
+                $propertyName = sprintf('%s-%s', $assocName, $assocType);
                 $convertedItem[$propertyName] = implode(',', $entities);
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ProductValueConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ProductValueConverter.php
@@ -38,7 +38,21 @@ class ProductValueConverter
      *
      * @return array
      */
-    public function convertAttribute($attributeCode, $data)
+    public function convertAttribute($attributeCode, $data, array $options = [])
+    {
+        $converter = $this->getConverterByAttributeCode($attributeCode);
+
+        return $converter->convert($attributeCode, $data);
+    }
+
+    public function convertAttributeWithLabel(string $attributeCode,  string $labelLocale, $data)
+    {
+        $converter = $this->getConverterByAttributeCode($attributeCode);
+
+        return $converter->convertWithLabel($attributeCode, $labelLocale, $data);
+    }
+
+    private function getConverterByAttributeCode(string $attributeCode)
     {
         $attribute = $this->attributeRepo->findOneByIdentifier($attributeCode);
         $converter = $this->converterRegistry->getConverter($attribute);
@@ -52,6 +66,6 @@ class ProductValueConverter
             );
         }
 
-        return $converter->convert($attributeCode, $data);
+        return $converter;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/BooleanConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/BooleanConverter.php
@@ -47,4 +47,22 @@ class BooleanConverter extends AbstractValueConverter implements ValueConverterI
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = false === $value['data'] || null === $value['data'] ? '0' : '1';
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/DateConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/DateConverter.php
@@ -46,4 +46,22 @@ class DateConverter extends AbstractValueConverter implements ValueConverterInte
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = $value['data'];
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MediaConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MediaConverter.php
@@ -47,4 +47,22 @@ class MediaConverter extends AbstractValueConverter implements ValueConverterInt
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = (string) $value['data'];
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
@@ -2,6 +2,9 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AttributeColumnsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
 /**
  * Metric array converter.
  * Convert a standard metric array format to a flat one.
@@ -12,6 +15,17 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\Stand
  */
 class MetricConverter extends AbstractValueConverter implements ValueConverterInterface
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(AttributeColumnsResolver $columnsResolver, TranslatorInterface $translator, array $supportedAttributeTypes)
+    {
+        parent::__construct($columnsResolver, $supportedAttributeTypes);
+        $this->translator = $translator;
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -38,6 +52,7 @@ class MetricConverter extends AbstractValueConverter implements ValueConverterIn
     public function convert($attributeCode, $data)
     {
         $convertedItem = [];
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
 
         foreach ($data as $value) {
             $flatName = $this->columnsResolver->resolveFlatAttributeName(
@@ -45,7 +60,7 @@ class MetricConverter extends AbstractValueConverter implements ValueConverterIn
                 $value['locale'],
                 $value['scope']
             );
-            $flatUnitName = sprintf('%s-unit', $flatName);
+            $flatUnitName = sprintf('%s (%s)', $flatName, $unitLabel);
 
             if (null === $value['data']['amount']) {
                 $convertedItem[$flatName] = null;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
@@ -52,7 +52,6 @@ class MetricConverter extends AbstractValueConverter implements ValueConverterIn
     public function convert($attributeCode, $data)
     {
         $convertedItem = [];
-        $unitLabel = $this->translator->trans('pim_common.unit', [], null, 'fr_FR');
 
         foreach ($data as $value) {
             $flatName = $this->columnsResolver->resolveFlatAttributeName(
@@ -60,8 +59,36 @@ class MetricConverter extends AbstractValueConverter implements ValueConverterIn
                 $value['locale'],
                 $value['scope']
             );
-            $flatUnitName = sprintf('%s (%s)', $flatName, $unitLabel);
+            $flatUnitName = sprintf('%s-unit', $flatName);
 
+            if (null === $value['data']['amount']) {
+                $convertedItem[$flatName] = null;
+                $convertedItem[$flatUnitName] = null;
+
+                continue;
+            }
+
+            $convertedItem[$flatName] = (string) $value['data']['amount'];
+            $convertedItem[$flatUnitName] = $value['data']['unit'];
+        }
+
+        return $convertedItem;
+    }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, $labelLocale);
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $flatUnitName = sprintf('%s (%s)', $flatName, $unitLabel);
             if (null === $value['data']['amount']) {
                 $convertedItem[$flatName] = null;
                 $convertedItem[$flatUnitName] = null;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MetricConverter.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AttributeColumnsResolver;
-use Symfony\Component\Translation\TranslatorInterface;
+use Akeneo\Tool\Component\Localization\LabelTranslator;
 
 /**
  * Metric array converter.
@@ -16,11 +16,11 @@ use Symfony\Component\Translation\TranslatorInterface;
 class MetricConverter extends AbstractValueConverter implements ValueConverterInterface
 {
     /**
-     * @var TranslatorInterface
+     * @var LabelTranslator
      */
     private $translator;
 
-    public function __construct(AttributeColumnsResolver $columnsResolver, TranslatorInterface $translator, array $supportedAttributeTypes)
+    public function __construct(AttributeColumnsResolver $columnsResolver, LabelTranslator $translator, array $supportedAttributeTypes)
     {
         parent::__construct($columnsResolver, $supportedAttributeTypes);
         $this->translator = $translator;
@@ -78,7 +78,7 @@ class MetricConverter extends AbstractValueConverter implements ValueConverterIn
     public function convertWithLabel($attributeCode, $labelLocale, $data)
     {
         $convertedItem = [];
-        $unitLabel = $this->translator->trans('pim_common.unit', [], null, $labelLocale);
+        $unitLabel = $this->translator->trans('pim_common.unit', [], null, $labelLocale, '[unit]');
 
         foreach ($data as $value) {
             $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MultiSelectConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/MultiSelectConverter.php
@@ -47,4 +47,22 @@ class MultiSelectConverter extends AbstractValueConverter implements ValueConver
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = implode(',', $value['data']);
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/PriceConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/PriceConverter.php
@@ -59,6 +59,7 @@ class PriceConverter extends AbstractValueConverter implements ValueConverterInt
      *     'super_price-fr_FR-ecommerce-USD' => '29',
      * ]
      */
+
     public function convert($attributeCode, $data)
     {
         $convertedItem = [];
@@ -71,7 +72,28 @@ class PriceConverter extends AbstractValueConverter implements ValueConverterInt
             );
 
             foreach ($value['data'] as $currency) {
-                $language = \Locale::getPrimaryLanguage('fr_FR');
+                $flatCurrencyName = sprintf('%s-%s', $flatName, $currency['currency']);
+                $convertedItem[$flatCurrencyName] = (string) $currency['amount'];
+            }
+        }
+
+        return $convertedItem;
+    }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            foreach ($value['data'] as $currency) {
+                $language = \Locale::getPrimaryLanguage($labelLocale);
 
                 $currencyLabel = Intl::getCurrencyBundle()->getCurrencyName($currency['currency'], $language);
 
@@ -82,4 +104,6 @@ class PriceConverter extends AbstractValueConverter implements ValueConverterInt
 
         return $convertedItem;
     }
+
+
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/PriceConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/PriceConverter.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ValueConverter;
 
+use Symfony\Component\Intl\Intl;
+
 /**
  * Price array converter.
  * Convert a standard price array format to a flat one.
@@ -69,7 +71,11 @@ class PriceConverter extends AbstractValueConverter implements ValueConverterInt
             );
 
             foreach ($value['data'] as $currency) {
-                $flatCurrencyName = sprintf('%s-%s', $flatName, $currency['currency']);
+                $language = \Locale::getPrimaryLanguage('fr_FR');
+
+                $currencyLabel = Intl::getCurrencyBundle()->getCurrencyName($currency['currency'], $language);
+
+                $flatCurrencyName = sprintf('%s (%s)', $flatName, $currencyLabel);
                 $convertedItem[$flatCurrencyName] = (string) $currency['amount'];
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/SimpleSelectConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/SimpleSelectConverter.php
@@ -47,4 +47,22 @@ class SimpleSelectConverter extends AbstractValueConverter implements ValueConve
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = (string) $value['data'];
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/TextConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/TextConverter.php
@@ -47,4 +47,22 @@ class TextConverter extends AbstractValueConverter implements ValueConverterInte
 
         return $convertedItem;
     }
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data)
+    {
+        $convertedItem = [];
+
+        foreach ($data as $value) {
+            $flatName = $this->columnsResolver->resolveFlatAttributeLabelName(
+                $attributeCode,
+                $value['locale'],
+                $value['scope'],
+                $labelLocale
+            );
+
+            $convertedItem[$flatName] = (string) $value['data'];
+        }
+
+        return $convertedItem;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/ValueConverterInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/Product/ValueConverter/ValueConverterInterface.php
@@ -29,4 +29,6 @@ interface ValueConverterInterface
      * @return array
      */
     public function convert($attributeCode, $data);
+
+    public function convertWithLabel($attributeCode, $labelLocale, $data);
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductModelWithLabel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductModelWithLabel.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType\SqlGetAssociationTy
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
-use Symfony\Component\Translation\TranslatorInterface;
+use Akeneo\Tool\Component\Localization\LabelTranslator;
 
 class ProductModelWithLabel extends AbstractSimpleArrayConverter implements ArrayConverterInterface
 {
@@ -17,7 +17,7 @@ class ProductModelWithLabel extends AbstractSimpleArrayConverter implements Arra
      */
     private $associationTypeLabels;
     /**
-     * @var TranslatorInterface
+     * @var LabelTranslator
      */
     private $translator;
 
@@ -27,7 +27,7 @@ class ProductModelWithLabel extends AbstractSimpleArrayConverter implements Arra
     public function __construct(
         ProductValueConverter $valueConverter,
         SqlGetAssociationTypeLabels $associationTypeLabels,
-        TranslatorInterface $translator
+        LabelTranslator $translator
     ) {
         $this->valueConverter = $valueConverter;
         $this->associationTypeLabels = $associationTypeLabels;
@@ -49,7 +49,7 @@ class ProductModelWithLabel extends AbstractSimpleArrayConverter implements Arra
                 $convertedItem = $this->convertQuantifiedAssociations($data, $convertedItem, $labelLocale);
                 break;
             case 'categories':
-                $categoryLabel = $this->translator->trans('pim_common.categories', [], null, $labelLocale);
+                $categoryLabel = $this->translator->trans('pim_common.categories', [], null, $labelLocale, '[categories]');
 
                 $convertedItem[$categoryLabel] = implode(',', $data);
                 break;
@@ -79,7 +79,7 @@ class ProductModelWithLabel extends AbstractSimpleArrayConverter implements Arra
         $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
         foreach ($data as $associationTypeCode => $associations) {
             foreach ($associations as $entityType => $entities) {
-                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale);
+                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale, "[$entityType]");
                 $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$associationTypeCode]";
 
                 $propertyName = sprintf('%s %s', $associationTypeLabel, $entityTypeLabel);
@@ -93,12 +93,12 @@ class ProductModelWithLabel extends AbstractSimpleArrayConverter implements Arra
     private function convertQuantifiedAssociations(array $data, array $convertedItem, string $labelLocale): array
     {
         $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
-        $quantityLabel = $this->translator->trans('pim_common.quantity', [], null, $labelLocale);
+        $quantityLabel = $this->translator->trans('pim_common.quantity', [], null, $labelLocale, '[quantity]');
 
         foreach ($data as $associationTypeCode => $quantifiedAssociations) {
             foreach ($quantifiedAssociations as $entityType => $quantifiedLinks) {
-                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale);
-                $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$entityType]";
+                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale, "[$entityType]");
+                $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$associationTypeCode]";
                 $propertyName = sprintf('%s %s', $associationTypeLabel, $entityTypeLabel);
 
                 $convertedItem[$propertyName] = implode(',', array_column($quantifiedLinks, 'identifier'));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
@@ -67,7 +67,9 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
                 }
                 break;
             case 'groups':
-                $convertedItem = $this->convertGroups($data, $convertedItem);
+                $groupLabel = $this->translator->trans('pim_common.groups', [], null, $labelLocale);
+
+                $convertedItem[$groupLabel] = is_array($data) ? implode(',', $data) : (string) $data;
                 break;
             case 'values':
                 foreach ($data as $code => $attribute) {
@@ -80,26 +82,6 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
                 break;
             default:
                 $convertedItem = $convertedItem + $this->valueConverter->convertAttributeWithLabel($property, $labelLocale, $data);
-        }
-
-        return $convertedItem;
-    }
-
-    private function convertGroups($data, array $convertedItem)
-    {
-        if (!array_key_exists('groups', $convertedItem)) {
-            $convertedItem['groups'] = '';
-        }
-
-        $groups = is_array($data) ? implode(',', $data) : (string) $data;
-        if ('' === $groups) {
-            return $convertedItem;
-        }
-
-        if ('' !== $convertedItem['groups']) {
-            $convertedItem['groups'] .= sprintf(',%s', $groups);
-        } else {
-            $convertedItem['groups'] = $groups;
         }
 
         return $convertedItem;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType\SqlGetAssociationTy
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
-use Symfony\Component\Translation\TranslatorInterface;
+use Akeneo\Tool\Component\Localization\LabelTranslator;
 
 /**
  * Convert standard format to flat format for product
@@ -27,7 +27,7 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
     /**
      * @param ProductValueConverter $valueConverter
      */
-    public function __construct(ProductValueConverter $valueConverter, SqlGetAssociationTypeLabels $associationTypeLabels, TranslatorInterface $translator)
+    public function __construct(ProductValueConverter $valueConverter, SqlGetAssociationTypeLabels $associationTypeLabels, LabelTranslator $translator)
     {
         $this->valueConverter = $valueConverter;
         $this->associationTypeLabels = $associationTypeLabels;
@@ -49,25 +49,25 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
                 $convertedItem = $this->convertQuantifiedAssociations($data, $convertedItem, $labelLocale);
                 break;
             case 'categories':
-                $categoryLabel = $this->translator->trans('pim_common.categories', [], null, $labelLocale);
+                $categoryLabel = $this->translator->trans('pim_common.categories', [], null, $labelLocale, '[categories]');
                 $convertedItem[$categoryLabel] = implode(',', $data);
                 break;
             case 'enabled':
-                $enabledLabel = $this->translator->trans('pim_common.enabled', [], null, $labelLocale);
-                $convertedItem[$enabledLabel] = false === $data || null === $data ? $this->translator->trans('pim_common.no', [], null, $labelLocale) : $this->translator->trans('pim_common.yes', [], null, $labelLocale);
+                $enabledLabel = $this->translator->trans('pim_common.enabled', [], null, $labelLocale, '[enabled]');
+                $convertedItem[$enabledLabel] = false === $data || null === $data ? $this->translator->trans('pim_common.no', [], null, $labelLocale, '[no]') : $this->translator->trans('pim_common.yes', [], null, $labelLocale, '[yes]');
                 break;
             case 'family':
-                $familyLabel = $this->translator->trans('pim_common.family', [], null, $labelLocale);
+                $familyLabel = $this->translator->trans('pim_common.family', [], null, $labelLocale, '[family]');
                 $convertedItem[$familyLabel] = (string) $data;
                 break;
             case 'parent':
                 if (null !== $data && '' !== $data) {
-                    $parentLabel = $this->translator->trans('pim_common.parent', [], null, $labelLocale);
+                    $parentLabel = $this->translator->trans('pim_common.parent', [], null, $labelLocale, '[parent]');
                     $convertedItem[$parentLabel] = (string) $data;
                 }
                 break;
             case 'groups':
-                $groupLabel = $this->translator->trans('pim_common.groups', [], null, $labelLocale);
+                $groupLabel = $this->translator->trans('pim_common.groups', [], null, $labelLocale, '[groups]');
 
                 $convertedItem[$groupLabel] = is_array($data) ? implode(',', $data) : (string) $data;
                 break;
@@ -79,6 +79,7 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
             case 'identifier':
             case 'created':
             case 'updated':
+            case 'family_code':
                 break;
             default:
                 $convertedItem = $convertedItem + $this->valueConverter->convertAttributeWithLabel($property, $labelLocale, $data);
@@ -92,7 +93,7 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
         $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
         foreach ($data as $associationTypeCode => $associations) {
             foreach ($associations as $entityType => $entities) {
-                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale);
+                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale, "[$entityType]");
                 $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$associationTypeCode]";
 
                 $propertyName = sprintf('%s %s', $associationTypeLabel, $entityTypeLabel);
@@ -106,12 +107,12 @@ class ProductWithLabel extends AbstractSimpleArrayConverter implements ArrayConv
     private function convertQuantifiedAssociations(array $data, array $convertedItem, string $labelLocale): array
     {
         $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
-        $quantityLabel = $this->translator->trans('pim_common.quantity', [], null, $labelLocale);
+        $quantityLabel = $this->translator->trans('pim_common.quantity', [], null, $labelLocale, '[quantity]');
 
         foreach ($data as $associationTypeCode => $quantifiedAssociations) {
             foreach ($quantifiedAssociations as $entityType => $quantifiedLinks) {
-                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale);
-                $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$entityType]";
+                $entityTypeLabel = $this->translator->trans("pim_common.$entityType", [], null, $labelLocale, "[$entityType]");
+                $associationTypeLabel = $associationTypeLabels[$associationTypeCode][$labelLocale] ?? "[$associationTypeCode]";
                 $propertyName = sprintf('%s %s', $associationTypeLabel, $entityTypeLabel);
 
                 $convertedItem[$propertyName] = implode(',', array_column($quantifiedLinks, 'identifier'));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/StandardToFlat/ProductWithLabel.php
@@ -2,36 +2,21 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat;
 
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\AssociationType\SqlGetAssociationTypeLabels;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\StandardToFlat\Product\ProductValueConverter;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\StandardToFlat\AbstractSimpleArrayConverter;
-use Symfony\Component\Translation\TranslatorInterface;
 
-/**
- * Convert standard format to flat format for product
- *
- * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
- * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
- */
-class Product extends AbstractSimpleArrayConverter implements ArrayConverterInterface
+class ProductLabel extends AbstractSimpleArrayConverter implements ArrayConverterInterface
 {
     /** @var ProductValueConverter */
     protected $valueConverter;
 
-    private $associationTypeLabels;
-
-    private $translator;
-
     /**
      * @param ProductValueConverter $valueConverter
      */
-    public function __construct(ProductValueConverter $valueConverter, SqlGetAssociationTypeLabels $associationTypeLabels, TranslatorInterface $translator)
+    public function __construct(ProductValueConverter $valueConverter)
     {
         $this->valueConverter = $valueConverter;
-        $this->associationTypeLabels = $associationTypeLabels;
-        $this->translator = $translator;
     }
 
     /**
@@ -39,6 +24,7 @@ class Product extends AbstractSimpleArrayConverter implements ArrayConverterInte
      */
     protected function convertProperty($property, $data, array $convertedItem, array $options)
     {
+
         switch ($property) {
             case 'associations':
                 $convertedItem = $this->convertAssociations($data, $convertedItem);
@@ -130,10 +116,9 @@ class Product extends AbstractSimpleArrayConverter implements ArrayConverterInte
      */
     protected function convertAssociations(array $data, array $convertedItem): array
     {
-        $associationTypeLabels = $this->associationTypeLabels->forAssociationTypeCodes(array_keys($data));
         foreach ($data as $assocName => $associations) {
             foreach ($associations as $assocType => $entities) {
-                $propertyName = sprintf('%s %s', $associationTypeLabels[$assocName]['fr_FR'] ?? "[$assocName]", $this->translator->trans("pim_common.$assocType", [], null, 'fr_FR'));
+                $propertyName = sprintf('%s-%s', $assocName, $assocType);
                 $convertedItem[$propertyName] = implode(',', $entities);
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -46,7 +46,12 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
         $constraintFields = $baseConstraint->fields;
         $constraintFields['decimalSeparator'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
         $constraintFields['dateFormat'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
-        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_label'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
         $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
         $constraintFields['with_media'] = new Type(
             [

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -52,7 +52,7 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
-        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new Type(['type' => 'string', 'groups' => ['Default', 'FileConfiguration']]);
         $constraintFields['with_media'] = new Type(
             [
                 'type'   => 'bool',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductCsvExport.php
@@ -46,6 +46,8 @@ class ProductCsvExport implements ConstraintCollectionProviderInterface
         $constraintFields = $baseConstraint->fields;
         $constraintFields['decimalSeparator'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
         $constraintFields['dateFormat'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
         $constraintFields['with_media'] = new Type(
             [
                 'type'   => 'bool',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductModelCsvExport.php
@@ -79,6 +79,13 @@ class ProductModelCsvExport implements ConstraintCollectionProviderInterface
                 ]
             ),
         ];
+        $constraintFields['with_label'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
+        $constraintFields['label_locale'] = new Type(['type' => 'string', 'groups' => ['Default', 'FileConfiguration']]);
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -48,7 +48,12 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
         $constraintFields['locale'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['scope'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['ui_locale'] = new NotBlank(['groups' => 'Execution']);
-        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_label'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
         $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
 
         return new Collection(['fields' => $constraintFields]);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -54,7 +54,7 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
-        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new Type(['type' => 'string', 'groups' => ['Default', 'FileConfiguration']]);
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductQuickExport.php
@@ -48,6 +48,8 @@ class ProductQuickExport implements ConstraintCollectionProviderInterface
         $constraintFields['locale'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['scope'] = new NotBlank(['groups' => 'Execution']);
         $constraintFields['ui_locale'] = new NotBlank(['groups' => 'Execution']);
+        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
 
         return new Collection(['fields' => $constraintFields]);
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -50,7 +50,12 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
-        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['with_label'] = new Type(
+            [
+                'type'   => 'bool',
+                'groups' => ['Default', 'FileConfiguration'],
+            ]
+        );
         $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
 
         $constraintFields['filters'] = [

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -56,7 +56,7 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
-        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new Type(['type' => 'string', 'groups' => ['Default', 'FileConfiguration']]);
 
         $constraintFields['filters'] = [
             new Collection(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/ConstraintCollectionProvider/ProductXlsxExport.php
@@ -50,6 +50,9 @@ class ProductXlsxExport implements ConstraintCollectionProviderInterface
                 'groups' => ['Default', 'FileConfiguration'],
             ]
         );
+        $constraintFields['with_label'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+        $constraintFields['label_locale'] = new NotBlank(['groups' => ['Default', 'FileConfiguration']]);
+
         $constraintFields['filters'] = [
             new Collection(
                 [

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductCsvExport.php
@@ -57,6 +57,8 @@ class ProductCsvExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
+        $parameters['with_label'] = false;
+        $parameters['label_locale'] = null;
 
         $channels = $this->channelRepository->getFullChannels();
         $defaultChannelCode = (0 !== count($channels)) ? $channels[0]->getCode() : null;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductModelCsvExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductModelCsvExport.php
@@ -59,6 +59,9 @@ class ProductModelCsvExport implements DefaultValuesProviderInterface
         $parameters['decimalSeparator'] = LocalizerInterface::DEFAULT_DECIMAL_SEPARATOR;
         $parameters['dateFormat'] = LocalizerInterface::DEFAULT_DATE_FORMAT;
         $parameters['with_media'] = true;
+        $parameters['with_label'] = false;
+        $parameters['label_locale'] = null;
+
 
         $channels = $this->channelRepository->getFullChannels();
         $defaultChannelCode = (0 !== count($channels)) ? $channels[0]->getCode() : null;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductQuickExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductQuickExport.php
@@ -42,6 +42,8 @@ class ProductQuickExport implements DefaultValuesProviderInterface
         $parameters['locale'] = null;
         $parameters['scope'] = null;
         $parameters['ui_locale'] = null;
+        $parameters['with_label'] = false;
+        $parameters['label_locale'] = null;
 
         return $parameters;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductXlsxExport.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/JobParameters/DefaultValueProvider/ProductXlsxExport.php
@@ -59,6 +59,9 @@ class ProductXlsxExport implements DefaultValuesProviderInterface
         $parameters['with_media'] = true;
         $parameters['linesPerFile'] = 10000;
 
+        $parameters['with_label'] = false;
+        $parameters['label_locale'] = null;
+
         $channels = $this->channelRepository->getFullChannels();
         $defaultChannelCode = (0 !== count($channels)) ? $channels[0]->getCode() : null;
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Normalization;
 
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\FilterValues;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
@@ -100,6 +101,17 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
                 ARRAY_FILTER_USE_KEY
             );
         }
+
+        $parentLabel = '';
+        if($product->getParent() instanceof ProductModelInterface) {
+            $parentLabel = $product->getParent()->getLabel('fr_FR', $structure['scope']);
+        }
+        $productStandard['categories'] = $product->getCategories()->map(function (Category $category) {
+            return $category->getTranslation('fr_FR')->getLabel();
+        })->toArray();
+
+        $productStandard['family'] = $product->getFamily()->getTranslation('fr_FR')->getLabel();
+        $productStandard['parent'] = $parentLabel;
 
         return $productStandard;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Normalization/ProductProcessor.php
@@ -124,8 +124,10 @@ class ProductProcessor implements ItemProcessorInterface, StepExecutionAwareInte
 
             $productStandard['family_code'] = $productStandard['family'];
             $family = $product->getFamily();
-            $familyTranslation = $family->getTranslation($labelLocale);
-            $familyLabel = null !== $familyTranslation->getLabel() ? $familyTranslation->getLabel() : sprintf('[%s]', $family->getCode());
+            $familyLabel = '';
+            if ($family) {
+                $familyLabel = null !== $family->getTranslation($labelLocale)->getLabel() ? $family->getTranslation($labelLocale)->getLabel() : sprintf('[%s]', $family->getCode());
+            }
 
             $productStandard['family'] = $familyLabel;
             $productStandard['parent'] = $parentLabel;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -44,6 +44,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
     public function __construct(
         ArrayConverterInterface $arrayConverter,
+        ArrayConverterInterface $arrayConverterWithLabel,
         BufferFactory $bufferFactory,
         FlatItemBufferFlusher $flusher,
         AttributeRepositoryInterface $attributeRepository,
@@ -55,6 +56,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     ) {
         parent::__construct(
             $arrayConverter,
+            $arrayConverterWithLabel,
             $bufferFactory,
             $flusher,
             $attributeRepository,
@@ -116,6 +118,12 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $filters = $parameters->get('filters');
 
+        $withLabel = $parameters->has('with_label');
+        $labelLocale = '';
+        if ($parameters->has('label_locale')) {
+            $labelLocale = $parameters->get('label_locale');
+        }
+
         $localeCodes = isset($filters['structure']['locales']) ? $filters['structure']['locales'] : [$parameters->get('locale')];
         $channelCode = isset($filters['structure']['scope']) ? $filters['structure']['scope'] : $parameters->get('scope');
 
@@ -143,7 +151,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
             if ($withMedia || !$header->isMedia()) {
                 $headerStrings = array_merge(
                     $headerStrings,
-                    $header->generateHeaderStrings()
+                    $withLabel ? $header->generateHeaderLabelStrings($labelLocale) : $header->generateHeaderStrings()
                 );
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -125,7 +125,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
         $withLabel = $parameters->has('with_label') && $parameters->get('with_label');
         $labelLocale = '';
-        if ($parameters->has('label_locale')) {
+        if ($parameters->has('label_locale') && $parameters->get('label_locale')) {
             $labelLocale = $parameters->get('label_locale');
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -87,7 +87,12 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $this->hasItems = true;
         foreach ($items as $item) {
-            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
+            if (isset($item['family_code'])) {
+                if (!in_array($item['family_code'], $this->familyCodes)) {
+                    $this->familyCodes[] = $item['family_code'];
+                }
+                unset($item['family_code']);
+            } elseif (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
                 $this->familyCodes[] = $item['family'];
             }
         }
@@ -118,7 +123,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $filters = $parameters->get('filters');
 
-        $withLabel = $parameters->has('with_label');
+        $withLabel = $parameters->has('with_label') && $parameters->get('with_label');
         $labelLocale = '';
         if ($parameters->has('label_locale')) {
             $labelLocale = $parameters->get('label_locale');
@@ -139,9 +144,9 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
         $headers = [];
         if (!empty($attributeCodes)) {
-            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes);
+            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes, $labelLocale);
         } elseif (!empty($this->familyCodes)) {
-            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes);
+            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes, $labelLocale);
         }
 
         $withMedia = (!$parameters->has('with_media') || $parameters->has('with_media') && $parameters->get('with_media'));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
@@ -68,8 +68,8 @@ final class FlatFileHeader
         ?array $channelCurrencyCodes = [],
         ?array $allCurrencyCodes = [],
         ?bool $isLocaleSpecific = false,
-        ?array $attributeLabels = [],
         ?array $specificToLocales = [],
+        ?array $attributeLabels = [],
         ?string $unitLabel = ''
     ) {
         if ($isLocaleSpecific && empty($specificToLocales)) {
@@ -118,8 +118,8 @@ final class FlatFileHeader
         array $localeCodes,
         array $channelCurrencyCodes,
         array $activatedCurrencyCodes,
-        array $attributeLabels,
         array $specificToLocales,
+        array $attributeLabels,
         string $unitLabel
     ): FlatFileHeader {
         $mediaAttributeTypes = [
@@ -139,8 +139,8 @@ final class FlatFileHeader
             $channelCurrencyCodes,
             $activatedCurrencyCodes,
             !empty($specificToLocales),
-            $attributeLabels,
             $specificToLocales,
+            $attributeLabels,
             $unitLabel
         );
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/FlatFileHeader.php
@@ -252,7 +252,7 @@ final class FlatFileHeader
                     $language = \Locale::getPrimaryLanguage($labelLocale);
                     $currency = Intl::getCurrencyBundle()->getCurrencyName($currencyCode, $language);
 
-                    $headers[] = sprintf('%s %s', $prefix, $currency);
+                    $headers[] = sprintf('%s (%s)', $prefix, $currency);
                 }
             }
         } elseif ($this->usesUnit) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromAttributeCodesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromAttributeCodesInterface.php
@@ -19,6 +19,7 @@ interface GenerateFlatHeadersFromAttributeCodesInterface
     public function __invoke(
         array $attributeCodes,
         string $channelCode,
-        array $localeCodes
+        array $localeCodes,
+        string $labelLocale
     ): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromFamilyCodesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/GenerateFlatHeadersFromFamilyCodesInterface.php
@@ -19,6 +19,7 @@ interface GenerateFlatHeadersFromFamilyCodesInterface
     public function __invoke(
         array $familyCodes,
         string $channelCode,
-        array $localeCodes
+        array $localeCodes,
+        string $labelLocale
     ): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -87,7 +87,12 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $this->hasItems = true;
         foreach ($items as $item) {
-            if (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
+            if (isset($item['family_code']) && !in_array($item['family_code'], $this->familyCodes)) {
+                if (!in_array($item['family_code'], $this->familyCodes)) {
+                    $this->familyCodes[] = $item['family_code'];
+                }
+                unset($item['family_code']);
+            } elseif (isset($item['family']) && !in_array($item['family'], $this->familyCodes)) {
                 $this->familyCodes[] = $item['family'];
             }
         }
@@ -119,7 +124,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $filters = $parameters->get('filters');
 
-        $withLabel = $parameters->has('with_label');
+        $withLabel = $parameters->has('with_label') && $parameters->get('with_label');
         $labelLocale = '';
         if ($parameters->has('label_locale')) {
             $labelLocale = $parameters->get('label_locale');
@@ -140,9 +145,9 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
         $headers = [];
         if (!empty($attributeCodes)) {
-            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes);
+            $headers = ($this->generateHeadersFromAttributeCodes)($attributeCodes, $channelCode, $localeCodes, $labelLocale);
         } elseif (!empty($this->familyCodes)) {
-            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes);
+            $headers = ($this->generateHeadersFromFamilyCodes)($this->familyCodes, $channelCode, $localeCodes, $labelLocale);
         }
 
         $withMedia = (!$parameters->has('with_media') || $parameters->has('with_media') && $parameters->get('with_media'));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductWriter.php
@@ -44,6 +44,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
 
     public function __construct(
         ArrayConverterInterface $arrayConverter,
+        ArrayConverterInterface $arrayConverterWithLabel,
         BufferFactory $bufferFactory,
         FlatItemBufferFlusher $flusher,
         AttributeRepositoryInterface $attributeRepository,
@@ -55,6 +56,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
     ) {
         parent::__construct(
             $arrayConverter,
+            $arrayConverterWithLabel,
             $bufferFactory,
             $flusher,
             $attributeRepository,
@@ -117,6 +119,12 @@ class ProductWriter extends AbstractItemMediaWriter implements
     {
         $filters = $parameters->get('filters');
 
+        $withLabel = $parameters->has('with_label');
+        $labelLocale = '';
+        if ($parameters->has('label_locale')) {
+            $labelLocale = $parameters->get('label_locale');
+        }
+
         $localeCodes = isset($filters['structure']['locales']) ? $filters['structure']['locales'] : [$parameters->get('locale')];
         $channelCode = isset($filters['structure']['scope']) ? $filters['structure']['scope'] : $parameters->get('scope');
 
@@ -144,7 +152,7 @@ class ProductWriter extends AbstractItemMediaWriter implements
             if ($withMedia || !$header->isMedia()) {
                 $headerStrings = array_merge(
                     $headerStrings,
-                    $header->generateHeaderStrings()
+                    $withLabel ? $header->generateHeaderLabelStrings($labelLocale) : $header->generateHeaderStrings()
                 );
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -86,7 +86,7 @@ class ProductValueNormalizer implements NormalizerInterface, CacheableSupportsMe
         $data = [];
         foreach ($value->getData() as $item) {
             if (AttributeTypes::OPTION_MULTI_SELECT === $attributeType) {
-                $data[] = $this->getOptionLabel($attribute->code(), $item);
+                $data[] = $this->getOptionData($attribute->code(), $item, $context);
             } else if(isset($attribute->properties()['reference_data_name'])) {
                 $data[] = $item;
             } else {
@@ -122,7 +122,7 @@ class ProductValueNormalizer implements NormalizerInterface, CacheableSupportsMe
         }
 
         if($attributeType === AttributeTypes::OPTION_SIMPLE_SELECT) {
-            return $this->getOptionLabel($value->getAttributeCode(), $value->getData());
+            return $this->getOptionData($value->getAttributeCode(), $value->getData(), $context);
         }
 
         if ($attributeType === AttributeTypes::REFERENCE_DATA_SIMPLE_SELECT) {
@@ -156,14 +156,19 @@ class ProductValueNormalizer implements NormalizerInterface, CacheableSupportsMe
         return strlen($formattedNumber) >= strlen($data) ? $formattedNumber : rtrim($data, '0');
     }
 
-    private function getOptionLabel(string $attributeCode, string $optionCode)
+    private function getOptionData(string $attributeCode, string $optionCode, array $context)
     {
+        if (!array_key_exists('with_label', $context) || !$context['with_label']) {
+            return $optionCode;
+        }
+
+        $labelLocale = $context['label_locale'];
         $option = $this->attributeOptionRepository->findOneByIdentifier($attributeCode . '.' . $optionCode);
         if (! $option instanceof AttributeOptionInterface) {
             return sprintf('[%s]', $optionCode);
         }
 
-        $option->setLocale('fr_FR');
+        $option->setLocale($labelLocale);
         $translation = $option->getTranslation();
 
         return null !== $translation->getLabel() ? $translation->getValue() : sprintf('[%s]', $option->getCode());

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -173,6 +173,27 @@ extensions:
             label: pim_import_export.form.job_instance.tab.properties.with_media.title
             tooltip: pim_import_export.form.job_instance.tab.properties.with_media.help
 
+
+    pim-job-instance-csv-product-export-edit-properties-with-labels:
+        module: pim/job/common/edit/field/switch
+        parent: pim-job-instance-csv-product-export-edit-global
+        position: 190
+        targetZone: properties
+        config:
+            fieldCode: configuration.with_label
+            readOnly: false
+            label: With label
+
+    pim-job-instance-csv-product-export-edit-properties-label_locale:
+        module: pim/job/common/edit/field/text
+        parent: pim-job-instance-csv-product-export-edit-global
+        position: 200
+        targetZone: properties
+        config:
+            fieldCode: configuration.label_locale
+            readOnly: false
+            label: Label locale
+
     pim-job-instance-csv-product-export-edit-content-structure:
         module: pim/job/product/edit/content/structure
         parent: pim-job-instance-csv-product-export-edit-content

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -75,6 +75,7 @@ pim_common:
     categories: Categories
     family: Family
     parent: Parent
+    quantity: Quantity
 
 pim_enrich:
     # ACLs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -69,6 +69,13 @@ pim_common:
     product_models: Product models
     groups: Groups
     unit: Unit
+    yes: Yes
+    no: No
+    enabled: Enabled
+    categories: Categories
+    family: Family
+    parent: Parent
+
 pim_enrich:
     # ACLs
     acl:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -65,7 +65,10 @@ pim_common:
     name: Name
     remove: Remove
     code: Code
-
+    products: Products
+    product_models: Product models
+    groups: Groups
+    unit: Unit
 pim_enrich:
     # ACLs
     acl:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
@@ -62,6 +62,11 @@ pim_common:
   name: Nom
   remove: Supprimer
   code: Code
+  products: Produits
+  product_models: Modeles de produit
+  groups: Groupes
+  unit: Unité
+
 pim_enrich:
   #ACLs
   acl:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
@@ -72,6 +72,7 @@ pim_common:
   categories: Catégories
   family: Famille
   parent: Parent
+  quantity: Quantité
 
 pim_enrich:
   #ACLs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
@@ -66,6 +66,12 @@ pim_common:
   product_models: Modeles de produit
   groups: Groupes
   unit: Unité
+  yes: Oui
+  no: Non
+  enabled: Activé
+  categories: Catégories
+  family: Famille
+  parent: Parent
 
 pim_enrich:
   #ACLs

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -211,7 +211,7 @@ abstract class AbstractItemMediaWriter implements
     private function getArrayConverter(): ArrayConverterInterface
     {
         $jobParameters = $this->stepExecution->getJobParameters();
-        if ($jobParameters->has('with_label')) {
+        if ($jobParameters->has('with_label') && $jobParameters->get('with_label')) {
             return $this->arrayConverterWithLabel;
         }
 

--- a/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
+++ b/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
@@ -16,34 +16,17 @@ class LabelTranslator implements TranslatorInterface
 
     public function trans($id, array $parameters = [], $domain = null, $locale = null, $fallback = '')
     {
-        $fallbackLocales = $this->translator->getFallbackLocales();
-
-        try {
-            $this->translator->setFallbackLocales([]);
-            $translation = $this->translator->trans($id, $parameters, $domain, $locale);
-        } finally {
-            $this->translator->setFallbackLocales($fallbackLocales);
+        $catalog = $this->translator->getCatalogue($locale);
+        if ($catalog->defines($id)) {
+            return $fallback;
         }
 
-        if ($id === $translation) {
-            $translation = $fallback;
-        }
-
-        return $translation;
+        return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
     public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
     {
-        $fallbackLocales = $this->translator->getFallbackLocales();
-
-        try {
-            $this->translator->setFallbackLocales([]);
-            $translation = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
-        } finally {
-            $this->translator->setFallbackLocales($fallbackLocales);
-        }
-
-        return $translation;
+        return $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
     }
 
     public function setLocale($locale)

--- a/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
+++ b/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Akeneo\Tool\Component\Localization;
+
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class LabelTranslator implements TranslatorInterface
+{
+    private $translator;
+
+    public function __construct(Translator $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function trans($id, array $parameters = [], $domain = null, $locale = null, $fallback = '')
+    {
+        $fallbackLocales = $this->translator->getFallbackLocales();
+
+        try {
+            $this->translator->setFallbackLocales([]);
+            $translation = $this->translator->trans($id, $parameters, $domain, $locale);
+        } finally {
+            $this->translator->setFallbackLocales($fallbackLocales);
+        }
+
+        if ($id === $translation) {
+            $translation = $fallback;
+        }
+
+        return $translation;
+    }
+
+    public function transChoice($id, $number, array $parameters = [], $domain = null, $locale = null)
+    {
+        $fallbackLocales = $this->translator->getFallbackLocales();
+
+        try {
+            $this->translator->setFallbackLocales([]);
+            $translation = $this->translator->transChoice($id, $number, $parameters, $domain, $locale);
+        } finally {
+            $this->translator->setFallbackLocales($fallbackLocales);
+        }
+
+        return $translation;
+    }
+
+    public function setLocale($locale)
+    {
+        $this->translator->setLocale($locale);
+    }
+
+    public function getLocale()
+    {
+        return $this->translator->getLocale();
+    }
+}


### PR DESCRIPTION
**Description**
Done in this PR :
- Possibility to define the locale label
- Return the label of the "Parent", "Family", "" column value
- Generate the column name for quantified association property for products and product models
- Generate the column name for Price attributes
- Generate the column name for a localizable & scopable Measurement attribute
- Return the label of assets 
- Return the label of options (simple and multi)

Comparison between export without label and export with label (export the icecat catalog => 1239 products): 
![Capture du 2020-07-17 17-05-33](https://user-images.githubusercontent.com/7239572/87801292-cd445300-c84f-11ea-91e4-8edaaef8f1a0.png)

Comparison in database requests :
![Capture du 2020-07-17 17-08-32](https://user-images.githubusercontent.com/7239572/87801543-2a400900-c850-11ea-925a-160782b895e9.png)

Currently there is no LRU cache on query called

Informations : 
By call StructureBundle in EnrichementBundle we couple the two Bounded Context => we should create PublicApi 
=> More context information on : https://akeneo.atlassian.net/browse/RAC-134

**Definition Of Done**
| Q                                 | A
| --------------------------------- | ---
| CE Pull Request                   | -
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed