### PR TITLE
PIM-9357: Make rules case-insensitive so it complies with family and attribute codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PIM-9327: PDF generation header miss the product name when the attribute used as label is localizable 
 - PIM-9324: Fix product grid not loading when asset used as main picture is deleted
 - PIM-9356: Fix external api endpoint for products with invalid quantified associations
+- PIM-9357: Make rules case-insensitive so it complies with family and attribute codes
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/FamilyFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/FamilyFilter.php
@@ -52,7 +52,7 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
         }
 
         if (Operators::IS_EMPTY !== $operator && Operators::IS_NOT_EMPTY !== $operator) {
-            $this->checkValue($field, $value);
+            $value = $this->checkValue($field, $value);
         }
 
         switch ($operator) {
@@ -96,25 +96,31 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
     }
 
     /**
-     * Check if value is valid
+     * Check if value is valid (case insensitive)
      *
      * @param string $field
      * @param mixed  $values
      *
      * @throws ObjectNotFoundException
      */
+
     protected function checkValue($field, $values)
     {
         FieldFilterHelper::checkArray($field, $values, static::class);
+        $familyCodes = [];
 
-        foreach ($values as $value) {
+        foreach ($values as $index => $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
+            $family = $this->familyRepository->findOneByIdentifier($value);
 
-            if (null === $this->familyRepository->findOneByIdentifier($value)) {
+            if (null === $family) {
                 throw new ObjectNotFoundException(
                     sprintf('Object "family" with code "%s" does not exist', $value)
                 );
             }
+            $familyCodes[] = $family->getCode();
         }
+
+        return $familyCodes;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/FamilyFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/FamilyFilter.php
@@ -109,7 +109,7 @@ class FamilyFilter extends AbstractFieldFilter implements FieldFilterInterface
         FieldFilterHelper::checkArray($field, $values, static::class);
         $familyCodes = [];
 
-        foreach ($values as $index => $value) {
+        foreach ($values as $value) {
             FieldFilterHelper::checkIdentifier($field, $value, static::class);
             $family = $this->familyRepository->findOneByIdentifier($value);
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
@@ -52,6 +52,14 @@ class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assert($result, ['bar', 'baz', 'foo']);
     }
 
+    public function testCaseInsensitive()
+    {
+        $result = $this->executeFilter([['family', Operators::IN_LIST, ['FaMilya']]]);
+        $this->assert($result, ['foo']);
+        $result = $this->executeFilter([['family', Operators::NOT_IN_LIST, ['FAmilYa']]]);
+        $this->assert($result, ['bar', 'baz']);
+    }
+
     public function testOperatorEmpty()
     {
         $result = $this->executeFilter([['family', Operators::IS_EMPTY, '']]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/FamilyFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/FamilyFilterSpec.php
@@ -68,7 +68,7 @@ class FamilyFilterSpec extends ObjectBehavior
         FamilyInterface $family
     ) {
         $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
-
+        $family->getCode()->willReturn('familyA');
         $sqb->addFilter(
             [
                 'terms' => [
@@ -87,7 +87,7 @@ class FamilyFilterSpec extends ObjectBehavior
         FamilyInterface $family
     ) {
         $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
-
+        $family->getCode()->willReturn('familyA');
         $sqb->addMustNot(
             [
                 'terms' => [
@@ -105,7 +105,7 @@ class FamilyFilterSpec extends ObjectBehavior
         SearchQueryBuilder $sqb,
         FamilyInterface $family
     ) {
-        $familyRepository->findOneByIdentifier('familyA')->willReturn($family);
+        $familyRepository->findOneByIdentifier('familyA')->shouldNotBeCalled();
         $sqb->addMustNot(
             [
                 'exists' => ['field' => 'family.code'],
@@ -130,6 +130,25 @@ class FamilyFilterSpec extends ObjectBehavior
 
         $this->setQueryBuilder($sqb);
         $this->addFieldFilter('family', Operators::IS_NOT_EMPTY, ['familyA'], null, null, []);
+    }
+
+    function it_adds_a_filter_with_operator_in_list_regardless_of_the_case(
+        $familyRepository,
+        SearchQueryBuilder $sqb,
+        FamilyInterface $family
+    ) {
+        $familyRepository->findOneByIdentifier('FAMILYA')->willReturn($family);
+        $family->getCode()->willReturn('familyA');
+        $sqb->addFilter(
+            [
+                'terms' => [
+                    'family.code' => ['familyA'],
+                ],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('family', Operators::IN_LIST, ['FAMILYA'], null, null, []);
     }
 
     function it_throws_an_exception_when_the_search_query_builder_is_not_initialized()


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Before:** 

The rules were case sensitive. Meaning if you used a family code for your rule with no uppercase while your family code actually started with an uppercase then the rule didn't recognize it and so didn't find any product to apply the rule to.

**Solution:** 

In the FamilyFilter class, I added a way to replace the value by its familyCode.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
