### PR TITLE
API-1201: Be able get attributes searching by codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,16 @@
 
 - CLOUD-1959: Use cloud-deployer 2.2 and terraform 0.12.25
 - PIM-9306: Enhance catalog volume monitoring count queries for large datasets
+- API-1140: Be able get attributes searching by a list of attribute codes
 
 # Technical Improvements
 
 ## Classes
 
 ## BC breaks
+
+- API-1140: Change $criteria format from `Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Repository\ExternalApi\AttributeRepository`
+    the new format is `[property: [['operator' => (string), 'value' => (mixed)]]]`.
 
 ### Codebase
 

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
@@ -176,7 +176,6 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
             if (0 !== $violations->count()) {
                 $exceptionMessage = '';
                 foreach ($violations as $violation) {
-                    dump($violation);
                     $exceptionMessage .= $violation->getMessage();
                 }
                 throw new \InvalidArgumentException($exceptionMessage);

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Repository\ExternalApi;
 
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface as CatalogAttributeRepositoryInterface;
 use Akeneo\Pim\Structure\Component\Repository\ExternalApi\AttributeRepositoryInterface;
 use Doctrine\ORM\EntityManager;
@@ -123,7 +122,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
 
         foreach ($searchFilters as $property => $searchFilter) {
             foreach ($searchFilter as $criterion) {
-                if (Operators::IN_LIST === $criterion['operator']) {
+                if ('IN' === $criterion['operator']) {
                     $parameter = sprintf(':%s', $property);
                     $qb->where($qb->expr()->in(sprintf('r.%s', $property), $parameter));
                     $qb->setParameter($parameter, $criterion['value']);
@@ -145,7 +144,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
             'code' => new Assert\All([
                 new Assert\Collection([
                     'operator' => new Assert\IdenticalTo([
-                        'value' => Operators::IN_LIST,
+                        'value' => 'IN',
                         'message' => 'In order to search on attribute codes you must use "IN" operator, {{ compared_value }} given.',
                     ]),
                     'value' => [

--- a/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/ListAttributeEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/Attribute/ExternalApi/ListAttributeEndToEnd.php
@@ -105,6 +105,45 @@ JSON;
         $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
     }
 
+    public function testAttributeSearchByCode()
+    {
+        $client = $this->createAuthenticatedClient();
+        $search = '{"code":[{"operator":"IN","value":["a_metric","a_multi_select", "a_metric_negative"]}]}';
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+
+        $client->request('GET', 'api/rest/v1/attributes?limit=2&page=1&with_count=true&search=' . $search);
+
+        $standardizedAttributes = $this->getStandardizedAttributes();
+
+        $expected = <<<JSON
+{
+	"_links": {
+		"self": {
+			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=2&with_count=true&search={$searchEncoded}"
+		},
+		"first": {
+			"href": "http://localhost/api/rest/v1/attributes?page=1&limit=2&with_count=true&search={$searchEncoded}"
+		},
+		"next": {
+			"href": "http://localhost/api/rest/v1/attributes?page=2&limit=2&with_count=true&search={$searchEncoded}"
+		}
+	},
+	"current_page": 1,
+	"items_count": 3,
+    "_embedded" : {
+        "items" : [
+            {$standardizedAttributes['a_metric']},
+            {$standardizedAttributes['a_metric_negative']}
+        ]
+    }
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expected, $response->getContent());
+    }
+
     public function testAttributesWithCount()
     {
         $client = $this->createAuthenticatedClient();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Update the API endpoint `/api/rest/v1/attributes` to able to get all attributes given a list of attribute codes `/api/rest/v1/attributes?search={"code":[{"operator":"IN","value":["code1","code2"]}]}`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Added EndToEnd               | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
