### PR TITLE
pass bubble exception for attribute remove action.

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
@@ -381,7 +381,12 @@ class AttributeController
             );
         }
 
-        $this->remover->remove($attribute);
+        try{
+            $this->remover->remove($attribute);
+        }
+        catch (\Exception $e) {
+            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
+        }
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
@@ -381,10 +381,9 @@ class AttributeController
             );
         }
 
-        try{
+        try {
             $this->remover->remove($attribute);
-        }
-        catch (\Exception $e) {
+        } catch (\Exception $e) {
             return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_BAD_REQUEST);
         }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Currently Attribute Remove Event Subscriber can't pass bubble exception message as exceptions are not handled in Controller for removeAction.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
