### PR TITLE
PIM-9361: Chunk large ES query

### DIFF
--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -96,7 +96,7 @@ class Client
         }
 
         if (isset($response['errors']) && true === $response['errors']) {
-            $this->throwIndexationExceptionFromReponse($response);
+            $this->throwIndexationExceptionFromResponse($response);
         }
 
         return $response;
@@ -140,17 +140,17 @@ class Client
                 ],
             ];
 
+            $params['body'][] = $document;
+
             if (null !== $refresh) {
                 $params['refresh'] = $refresh->getType();
             }
-
-            $params['body'][] = $document;
         }
 
         $mergedResponse = $this->doBulkIndex($params, $mergedResponse);
 
         if (isset($mergedResponse['errors']) && true === $mergedResponse['errors']) {
-            $this->throwIndexationExceptionFromReponse($mergedResponse);
+            $this->throwIndexationExceptionFromResponse($mergedResponse);
         }
 
         return $mergedResponse;
@@ -345,7 +345,7 @@ class Client
      *
      * @throws IndexationException
      */
-    private function throwIndexationExceptionFromReponse(array $response)
+    private function throwIndexationExceptionFromResponse(array $response)
     {
         foreach ($response['items'] as $item) {
             if (isset($item['index']['error'])) {

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -115,6 +115,7 @@ class Client
     public function bulkIndexes($documents, $keyAsId, Refresh $refresh = null)
     {
         $params = [];
+        $paramsComputedSize = 0;
         $mergedResponse = [
             'took' => 0,
             'errors' => false,
@@ -126,9 +127,7 @@ class Client
                 throw new MissingIdentifierException(sprintf('Missing "%s" key in document', $keyAsId));
             }
 
-            $paramsComputedSize = strlen(json_encode($params)) + strlen(json_encode($document));
-
-            if ($paramsComputedSize >= self::PARAMS_MAX_SIZE) {
+            if (($paramsComputedSize + strlen(json_encode($document))) >= self::PARAMS_MAX_SIZE) {
                 $mergedResponse = $this->doBulkIndex($params, $mergedResponse);
                 $params = [];
             }
@@ -141,6 +140,7 @@ class Client
             ];
 
             $params['body'][] = $document;
+            $paramsComputedSize += strlen(json_encode($document));
 
             if (null !== $refresh) {
                 $params['refresh'] = $refresh->getType();

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/ClientSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/ClientSpec.php
@@ -251,6 +251,15 @@ class ClientSpec extends ObjectBehavior
 
     function it_indexes_with_bulk_several_documents($client)
     {
+        $expectedResponse = [
+            'took' => 1,
+            'errors' => false,
+            'items' => [
+                ['item_foo'],
+                ['item_bar'],
+            ],
+        ];
+
         $client->bulk(
             [
                 'body' => [
@@ -267,14 +276,14 @@ class ClientSpec extends ObjectBehavior
                 ],
                 'refresh' => 'wait_for',
             ]
-        )->willReturn(['errors' => false]);;
+        )->shouldBeCalled()->willReturn($expectedResponse);;
 
         $documents = [
             ['identifier' => 'foo', 'name' => 'a name'],
             ['identifier' => 'bar', 'name' => 'a name'],
         ];
 
-        $this->bulkIndexes($documents, 'identifier', Refresh::waitFor());
+        $this->bulkIndexes($documents, 'identifier', Refresh::waitFor())->shouldReturn($expectedResponse);
     }
 
     public function it_throws_an_exception_during_the_indexation_of_several_documents($client)


### PR DESCRIPTION
Elasticsearch has a parametrized maximum request body size when indexing. (http.max_content_length, 100MB by default). If the request body is exceeded it will throw a 413 error (Request Entity Too Large), leading to an uncaught exception in the PIM. When indexing a large amount of products with a lot of data (e.g when reindexing products via the pim:product:index command), this body size can be exceeded.

This PR set a size limite for the query (100 MB) and split the query into multiple calls if it is exceeded.
The responses are then merged before returning.