### PR TITLE
PIM-9362: Adapt System Information twig file for API connections display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PIM-9324: Fix product grid not loading when asset used as main picture is deleted
 - PIM-9356: Fix external api endpoint for products with invalid quantified associations
 - PIM-9357: Make rules case-insensitive so it complies with family and attribute codes
+- PIM-9362: Adapt System Information twig file for a clear and a correct display of the number of API connections
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/views/SystemInfo/index.html.twig
@@ -16,14 +16,23 @@
         ) }}
 
         <table class="AknGrid AknGrid--unclickable AknGrid--condensed table">
-            {% for infoType,info in data %}
+            {% for infoTypeLevel1,infoLevel1 in data %}
                 <tr class="AknGrid-bodyRow">
-                    <th class="AknGrid-bodyCell">{{ ('pim_analytics.info_type.' ~ infoType)|trans }}</th>
+                    <th class="AknGrid-bodyCell">{{ ('pim_analytics.info_type.' ~ infoTypeLevel1)|trans }}</th>
                     <td class="AknGrid-bodyCell">
-                        {% if info is iterable %}
-                            {{ info|join('<br>')|raw }}
+                        {% if infoLevel1 is iterable %}
+                            {% for infoTypeLevel2,infoLevel2 in infoLevel1 %}
+                                {% if infoLevel2 is iterable %}
+                                    {% for infoTypeLevel3,infoLevel3 in infoLevel2 %}
+                                        {{ ('pim_analytics.info_type.' ~ infoTypeLevel2 ~ '.' ~ infoTypeLevel3)|trans }} : {{ infoLevel3|raw }}
+                                        <br>
+                                    {% endfor %}
+                                {% else %}
+                                    {{ infoLevel1|join('<br>')|raw }}
+                                {% endif %}
+                            {% endfor %}
                         {% else %}
-                            {{ info }}
+                            {{ infoLevel1 }}
                         {% endif %}
                     </td>
                 </tr>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In System Information page, pim_analytics.info_type.api_connection related information was not relevant 
(because of specific data format) :

_Array
Array
Array._

So, I adapt the twig file in order to display a list of number for each type of connection 
(tracked and untracked, to respect the format):

_Data Destination tracked : 12
Data Destination untracked : 3
Data Source tracked : 0
Data Source untracked : 2
Other tracked : 4
Other untracked : 1_

(I added the translations in the corresponding EE PR)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
