### PR TITLE
Fix pdf renderer for image attributes

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- Fix pdf renderer for image attributes, it was displaying the path instead of the original filename
+
 # 4.0.42 (2020-07-22)
 
 # 4.0.41 (2020-07-20)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/Product/renderPdf.html.twig
@@ -107,8 +107,8 @@
                                 {% set content = product.getValue(attribute.code, locale_attribute, channel_attribute) %}
                                 {% set manualHeight = true %}
 
-                                {% if 'pim_catalog_image' == attribute.type and content.media is not null %}
-                                    {% set content = content.media.originalFilename %}
+                                {% if 'pim_catalog_image' == attribute.type and content.data is defined and content.data is not null %}
+                                    {% set content = content.data.originalFilename %}
                                     {% set manualHeight = false %}
                                 {% elseif ('pim_catalog_simpleselect' == attribute.type or 'pim_catalog_multiselect' == attribute.type) and attribute.code in optionLabels|keys %}
                                     {% set content = optionLabels[attribute.code] %}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the pdf renderer of products, for attribute of type `pim_catalog_image`, the twig was trying to access `content.media`.

`content` is the attribute value and it's an object with the class `Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue`:
https://github.com/akeneo/pim-community-dev/blob/3a6cd4edb7e3182cd79cbfe9c4ae2aa3d01e6a45/src/Akeneo/Pim/Enrichment/Component/Product/Value/MediaValue.php#L9-L18

The problem is, this class do not have a property `media`, it's called `data`.
see https://github.com/akeneo/pim-community-dev/blob/3a6cd4edb7e3182cd79cbfe9c4ae2aa3d01e6a45/src/Akeneo/Pim/Enrichment/Component/Product/Value/MediaValue.php#L34-L37

Since it was not accessible, the fallback to `__toString` was used, returning the key of the media.
see https://github.com/akeneo/pim-community-dev/blob/3a6cd4edb7e3182cd79cbfe9c4ae2aa3d01e6a45/src/Akeneo/Pim/Enrichment/Component/Product/Value/MediaValue.php#L42-L45

The code was clearly trying to display the original filename, not the storage path.

**Currently, it's rendering like this:**

![Screenshot_2020-07-22_14-19-32](https://user-images.githubusercontent.com/1421130/88177201-c12e0c00-cc28-11ea-8f32-ae27abae62d1.png)

**With the fix, it's rendering like this:**

![Screenshot_2020-07-22_14-20-17](https://user-images.githubusercontent.com/1421130/88177224-cab77400-cc28-11ea-8cd7-efe768599fd2.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) -
| Migration script                  | -
| Tech Doc                          | -
