### PR TITLE
PIM-9358: Break down values & properties query with CTE to use less memory

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - Fix pdf renderer for image attributes, it was displaying the path instead of the original filename
+- PIM-9358: Break down values & properties query with CTE to use less memory
 
 # 4.0.42 (2020-07-22)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiers.php
@@ -28,6 +28,14 @@ final class GetValuesAndPropertiesFromProductIdentifiers
     public function fetchByProductIdentifiers(array $productIdentifiers): array
     {
         $query = <<<SQL
+WITH groupCodes AS (
+    SELECT p.id AS pid, JSON_ARRAYAGG(g.code) AS group_codes
+    FROM pim_catalog_product p
+    LEFT JOIN pim_catalog_group_product pg ON p.id = pg.product_id
+    LEFT JOIN pim_catalog_group g ON pg.group_id = g.id
+    WHERE p.identifier IN (?)
+    GROUP BY p.id
+)
 SELECT
     p.id,
     p.identifier,
@@ -36,22 +44,21 @@ SELECT
     p.created,
     p.updated,
     f.code AS family_code,
-    JSON_ARRAYAGG(g.code) AS group_codes,
+    group_codes,
     JSON_MERGE(COALESCE(pm1.raw_values, '{}'), COALESCE(pm2.raw_values, '{}'), p.raw_values) as raw_values
 FROM pim_catalog_product p
 LEFT JOIN pim_catalog_family f ON p.family_id = f.id
-LEFT JOIN pim_catalog_group_product pg ON p.id = pg.product_id
-LEFT JOIN pim_catalog_group g ON pg.group_id = g.id
 LEFT JOIN pim_catalog_product_model pm1 ON p.product_model_id = pm1.id
 LEFT JOIN pim_catalog_product_model pm2 ON pm1.parent_id = pm2.id
+INNER JOIN groupCodes gc ON p.id = gc.pid
 WHERE p.identifier IN (?)
 GROUP BY p.id, p.identifier
 SQL;
 
         $rows = $this->connection->fetchAll(
             $query,
-            [$productIdentifiers],
-            [Connection::PARAM_STR_ARRAY]
+            [$productIdentifiers, $productIdentifiers],
+            [Connection::PARAM_STR_ARRAY, Connection::PARAM_STR_ARRAY]
         );
 
         $platform = $this->connection->getDatabasePlatform();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->



<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Trying to mitigate memory usage by breaking down the query with a CTE for the group codes, the combination of the JSON array aggregate & the JSON merge on the raw values was overflowing the `sort_buffer_size` which is set at 256Kb

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
