### PR TITLE
TIP-1513: Fixing env variables not available from outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- TIP-1513: Environment variables declared in the env were not loaded when using a compiled .env file
 - PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files
 - TIP-1406: Add a tag to configure a DIC service based on a feature flag
 - PIM-9133: Fix product save when the user has no permission on some attribute groups

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -2,7 +2,7 @@
 
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
@@ -13,7 +13,7 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
 } elseif (!class_exists(Dotenv::class)) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
 } else {
-    $path = dirname(__DIR__).'/.env';
+    $path = dirname(__DIR__) . '/.env';
     $dotenv = new Dotenv();
 
     // load all the .env files
@@ -46,3 +46,5 @@ if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
         }
     }
 }
+
+$_SERVER += $_ENV;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Environment variables declared outside of the PIM were not integrated in production mode when the .env file is compiled.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
