### PR TITLE
Make vertical list and column configurator take up all available vert…

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -38,6 +38,7 @@
   }
 
   &-listContainer {
+    height: 100%;
     max-height: ~"calc(100vh - 210px)";
     overflow-x: hidden;
     overflow-y: auto;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
-  height: auto !important; // Bootstrap adds an height in JS for nav-list, we have to remove it.
+  height: 100% !important; // Bootstrap adds an height in JS for nav-list, we have to remove it.
 
   &-item {
     border-bottom: 1px solid @AknBorderColor;


### PR DESCRIPTION
…ical space

 - This is in order to provide a larger area for drag and drop functionality

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

By default, the column selector for the product grid has some frustrating functionality with regards to drag and drop.
Since the "Selected Columns" list only takes up as much space as required by the current list, new column entries have to be first dragged inside the list before being dragged down if you want it to appear at the bottom.
The purpose of this PR is to make the list take up all available space, so that new entries can be dragged straight below the current entries.

Before change:
![image](https://user-images.githubusercontent.com/40189797/88509949-3b8fcf00-d021-11ea-85b3-5e4c1396cb0f.png)

After change:
![image](https://user-images.githubusercontent.com/40189797/88509960-40ed1980-d021-11ea-9e7c-09c6c0f25076.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
