### PR TITLE
GITHUB-APD-195: add locale to translate the announcements if it's needed in the future

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/HasNewAnnouncementsHandler.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/HasNewAnnouncementsHandler.php
@@ -30,7 +30,7 @@ final class HasNewAnnouncementsHandler
 
     public function execute(HasNewAnnouncementsQuery $query): bool
     {
-        $newAnnouncementIds = $this->findNewAnnouncementIds->find($query->edition(), $query->version());
+        $newAnnouncementIds = $this->findNewAnnouncementIds->find($query->edition(), $query->version(), $query->locale());
         $viewAnnouncementIds = $this->findViewedAnnouncementIds->byUserId($query->userId());
 
         return count(array_diff($newAnnouncementIds, $viewAnnouncementIds)) !== 0;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/HasNewAnnouncementsQuery.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/HasNewAnnouncementsQuery.php
@@ -17,13 +17,17 @@ final class HasNewAnnouncementsQuery
     /** @var string */
     private $version;
 
+    /** @var string */
+    private $locale;
+
     /** @var int */
     private $userId;
 
-    public function __construct(string $edition, string $version, int $userId)
+    public function __construct(string $edition, string $version, string $locale, int $userId)
     {
         $this->edition = $edition;
         $this->version = $version;
+        $this->locale = $locale;
         $this->userId = $userId;
     }
 
@@ -35,6 +39,11 @@ final class HasNewAnnouncementsQuery
     public function version(): string
     {
         return $this->version;
+    }
+
+    public function locale(): string
+    {
+        return $this->locale;
     }
 
     public function userId(): int

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsHandler.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsHandler.php
@@ -34,7 +34,7 @@ final class ListAnnouncementsHandler
      */
     public function execute(ListAnnouncementsQuery $query): array
     {
-        $announcementItems = $this->findAnnouncementItems->byPimVersion($query->edition(), $query->version(), $query->searchAfter());
+        $announcementItems = $this->findAnnouncementItems->byPimVersion($query->edition(), $query->version(), $query->locale(), $query->searchAfter());
         $viewedAnnouncementIds = $this->findViewedAnnouncementIds->byUserId($query->userId());
 
         $announcementItemsWithNew = [];

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsQuery.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Application/Announcement/Query/ListAnnouncementsQuery.php
@@ -17,16 +17,20 @@ final class ListAnnouncementsQuery
     /** @var string */
     private $version;
 
+    /** @var string */
+    private $locale;
+
     /** @var int */
     private $userId;
 
     /** @var string|null */
     private $searchAfter;
 
-    public function __construct(string $edition, string $version, int $userId, ?string $searchAfter)
+    public function __construct(string $edition, string $version, string $locale, int $userId, ?string $searchAfter)
     {
         $this->edition = $edition;
         $this->version = $version;
+        $this->locale = $locale;
         $this->userId = $userId;
         $this->searchAfter = $searchAfter;
     }
@@ -39,6 +43,11 @@ final class ListAnnouncementsQuery
     public function version(): string
     {
         return $this->version;
+    }
+
+    public function locale(): string
+    {
+        return $this->locale;
     }
 
     public function userId(): int

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindAnnouncementItemsInterface.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindAnnouncementItemsInterface.php
@@ -19,6 +19,7 @@ interface FindAnnouncementItemsInterface
     public function byPimVersion(
         string $pimEdition,
         string $pimVersion,
+        string $locale,
         ?string $searchAfter
     ): array;
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindNewAnnouncementIdsInterface.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Query/FindNewAnnouncementIdsInterface.php
@@ -14,5 +14,5 @@ interface FindNewAnnouncementIdsInterface
     /**
      * @return string[]
      */
-    public function find(string $pimEdition, string $pimVersion): array;
+    public function find(string $pimEdition, string $pimVersion, string $locale): array;
 }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/Api/ApiFindAnnouncementItems.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/Api/ApiFindAnnouncementItems.php
@@ -25,11 +25,12 @@ final class ApiFindAnnouncementItems implements FindAnnouncementItemsInterface
         $this->client = new Client(['base_uri' => $apiUrl]);
     }
 
-    public function byPimVersion(string $pimEdition, string $pimVersion, ?string $searchAfter): array
+    public function byPimVersion(string $pimEdition, string $pimVersion, string $locale, ?string $searchAfter): array
     {
         $queryParameters = [
             'pim_edition' => $pimEdition,
             'pim_version' => $pimVersion,
+            'locale' => $locale,
         ];
         if (null !== $searchAfter) {
             $queryParameters['search_after'] = $searchAfter;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/Api/ApiFindNewAnnouncementIds.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/Api/ApiFindNewAnnouncementIds.php
@@ -24,11 +24,12 @@ final class ApiFindNewAnnouncementIds implements FindNewAnnouncementIdsInterface
         $this->client = new Client(['base_uri' => $apiUrl]);
     }
 
-    public function find(string $pimEdition, string $pimVersion): array
+    public function find(string $pimEdition, string $pimVersion, string $locale): array
     {
         $queryParameters = [
             'pim_edition' => $pimEdition,
             'pim_version' => $pimVersion,
+            'locale' => $locale,
         ];
         $response = $this->client->request('GET', self::BASE_URI, ['query' => $queryParameters]);
         if ($response->getStatusCode() !== 200) {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/LocalFilestorage/LocalFilestorageFindAnnouncementItems.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/LocalFilestorage/LocalFilestorageFindAnnouncementItems.php
@@ -26,7 +26,7 @@ final class LocalFilestorageFindAnnouncementItems implements FindAnnouncementIte
         $this->externalJson = file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . self::FILENAME);
     }
 
-    public function byPimVersion(string $pimEdition, string $pimVersion, ?string $searchAfter): array
+    public function byPimVersion(string $pimEdition, string $pimVersion, string $locale, ?string $searchAfter): array
     {
         $content = json_decode($this->externalJson, true);
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/LocalFilestorage/LocalFilestorageFindNewAnnouncementIds.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/CommunicationChannel/LocalFilestorage/LocalFilestorageFindNewAnnouncementIds.php
@@ -23,7 +23,7 @@ final class LocalFilestorageFindNewAnnouncementIds implements FindNewAnnouncemen
         $this->externalJson = file_get_contents(dirname(__FILE__) . DIRECTORY_SEPARATOR . self::FILENAME);
     }
 
-    public function find(string $pimEdition, string $pimVersion): array
+    public function find(string $pimEdition, string $pimVersion, string $locale): array
     {
         $content = json_decode($this->externalJson, true);
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/HasNewAnnouncementsAction.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/HasNewAnnouncementsAction.php
@@ -46,6 +46,7 @@ class HasNewAnnouncementsAction
         $query = new HasNewAnnouncementsQuery(
             $this->versionProvider->getEdition(),
             $this->versionProvider->getMinorVersion(),
+            $this->userContext->getUiLocaleCode(),
             $user->getId()
         );
         $hasNewAnnouncements = $this->hasNewAnnouncementsHandler->execute($query);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/ListAnnouncementsAction.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Delivery/InternalApi/Announcement/ListAnnouncementsAction.php
@@ -12,7 +12,6 @@ use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
 /**
  * @author Christophe Chausseray <chausseray.christophe@gmail.com>
@@ -46,6 +45,7 @@ class ListAnnouncementsAction
         $query = new ListAnnouncementsQuery(
             $this->versionProvider->getEdition(),
             $this->versionProvider->getMinorVersion(),
+            $this->userContext->getUiLocaleCode(),
             $user->getId(),
             $request->query->get('search_after')
         );

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindAnnouncementItemsIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindAnnouncementItemsIntegration.php
@@ -39,7 +39,7 @@ class ApiFindAnnouncementItemsIntegration extends KernelTestCase
     public function test_it_finds_first_page_of_announcements()
     {
         $query = self::$container->get('akeneo_communication_channel.query.api.find_announcement_items');
-        $result = $query->byPimVersion('Serenity', '2020105', null, 10);
+        $result = $query->byPimVersion('Serenity', '2020105', 'en_US', null, 10);
         Assert::assertCount(10, $result);
         Assert::assertEquals(
             new AnnouncementItem(
@@ -59,13 +59,8 @@ class ApiFindAnnouncementItemsIntegration extends KernelTestCase
 
     public function test_it_finds_second_page_of_announcements()
     {
-        $currentDir = __DIR__ . '/Expectations';
-        $process = new Process("./vendor/bin/phiremock -p 8088 -i 0.0.0.0 -e '$currentDir'");
-        $process->start();
-        $this->waitServerUp();
-
         $query = self::$container->get('akeneo_communication_channel.query.api.find_announcement_items');
-        $result = $query->byPimVersion('Serenity', '2020105', 'update_1-new-screen-for-measurements-families_2020-05', 10);
+        $result = $query->byPimVersion('Serenity', '2020105', 'en_US', 'update_1-new-screen-for-measurements-families_2020-05', 10);
         Assert::assertCount(1, $result);
         Assert::assertEquals(
             new AnnouncementItem(

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindNewAnnouncementIdsIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindNewAnnouncementIdsIntegration.php
@@ -39,7 +39,7 @@ class ApiFindNewAnnouncementIdsIntegration extends KernelTestCase
     public function test_it_finds_new_announcement_ids()
     {
         $query = self::$container->get('akeneo_communication_channel.query.api.find_new_announcement_ids');
-        $result = $query->find('Serenity', '2020105');
+        $result = $query->find('Serenity', '2020105', 'en_US');
         Assert::assertCount(4, $result);
         Assert::assertEquals(
             [

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/firstAnnoucements.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/firstAnnoucements.json
@@ -3,7 +3,7 @@
     "request": {
         "method": "GET",
         "url": {
-            "isEqualTo": "/announcements?pim_edition=Serenity&pim_version=2020105"
+            "isEqualTo": "/announcements?pim_edition=Serenity&pim_version=2020105&locale=en_US"
         }
     },
     "response": {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/newAnnouncements.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/newAnnouncements.json
@@ -3,7 +3,7 @@
     "request": {
         "method": "GET",
         "url": {
-            "isEqualTo": "/new_announcements?pim_edition=Serenity&pim_version=2020105"
+            "isEqualTo": "/new_announcements?pim_edition=Serenity&pim_version=2020105&locale=en_US"
         }
     },
     "response": {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/nextAnnoucements.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/Expectations/nextAnnoucements.json
@@ -3,7 +3,7 @@
     "request": {
         "method": "GET",
         "url": {
-            "isEqualTo": "/announcements?pim_edition=Serenity&pim_version=2020105&search_after=update_1-new-screen-for-measurements-families_2020-05"
+            "isEqualTo": "/announcements?pim_edition=Serenity&pim_version=2020105&locale=en_US&search_after=update_1-new-screen-for-measurements-families_2020-05"
         }
     },
     "response": {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/HasNewAnnouncementsHandlerSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/HasNewAnnouncementsHandlerSpec.php
@@ -33,10 +33,11 @@ class HasNewAnnouncementsHandlerSpec extends ObjectBehavior
     {
         $userId = 1;
         $edition = 'Serenity';
+        $locale = 'en_US';
         $version = '20201015';
-        $query = new HasNewAnnouncementsQuery($edition, $version, $userId);
+        $query = new HasNewAnnouncementsQuery($edition, $version, $locale, $userId);
         $this->viewedAnnouncementsRepository->dataRows[] = ['announcement_id' => 'new_announcement_viewed', 'user_id' => $userId];
-        $findNewAnnouncementIds->find($edition, $version)->willReturn(['new_announcement_viewed', 'other_new_announcement']);
+        $findNewAnnouncementIds->find($edition, $version, $locale)->willReturn(['new_announcement_viewed', 'other_new_announcement']);
 
         $this->execute($query)->shouldReturn(true);
     }
@@ -46,7 +47,8 @@ class HasNewAnnouncementsHandlerSpec extends ObjectBehavior
         $userId = 1;
         $edition = 'Serenity';
         $version = '20201015';
-        $query = new HasNewAnnouncementsQuery($edition, $version, $userId);
+        $locale = 'en_US';
+        $query = new HasNewAnnouncementsQuery($edition, $version, $locale, $userId);
         $this->viewedAnnouncementsRepository->dataRows =
         [
             [
@@ -58,7 +60,7 @@ class HasNewAnnouncementsHandlerSpec extends ObjectBehavior
                 'user_id' => $userId
             ],
         ];
-        $findNewAnnouncementIds->find($edition, $version)->willReturn(['new_announcement_viewed', 'other_new_announcement_viewed']);
+        $findNewAnnouncementIds->find($edition, $version, $locale)->willReturn(['new_announcement_viewed', 'other_new_announcement_viewed']);
 
         $this->execute($query)->shouldReturn(false);
     }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/ListAnnouncementsHandlerSpec.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/Application/Announcement/Query/ListAnnouncementsHandlerSpec.php
@@ -38,10 +38,11 @@ class ListAnnouncementsHandlerSpec extends ObjectBehavior
         $findAnnouncementItems->byPimVersion(
             Argument::type('string'),
             Argument::type('string'),
+            Argument::type('string'),
             Argument::type('string')
         )->willReturn([$announcementItems[1]]);
 
-        $query = new ListAnnouncementsQuery('EE', '4.0', 1, 'f68a21bb-ec9a-4009-9b0b-2639c6798e5f');
+        $query = new ListAnnouncementsQuery('EE', '4.0', 'en_US', 1, 'f68a21bb-ec9a-4009-9b0b-2639c6798e5f');
         $this->execute($query)->shouldReturn([$announcementItems[1]]);
     }
 
@@ -53,11 +54,12 @@ class ListAnnouncementsHandlerSpec extends ObjectBehavior
         $findAnnouncementItems->byPimVersion(
             Argument::type('string'),
             Argument::type('string'),
+            Argument::type('string'),
             null
         )->willReturn($announcementItems);
         $this->viewedAnnouncementsRepository->dataRows[] = ['announcement_id' => 'update-easily_monitor_errors_on_your_connections-2020-06-04', 'user_id' => 1];
 
-        $query = new ListAnnouncementsQuery('EE', '4.0', 1, null);
+        $query = new ListAnnouncementsQuery('EE', '4.0', 'en_US', 1, null);
 
         $this->execute($query)->shouldBeLike([
             new AnnouncementItem(


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add the locale in query parameters to translate the announcements in the user locale. 

For now, we don't translate announcements (only english is supported). This parameter is therefore useless *for now*.
But as this feature will be backported in previous version and people migrates the PIM to a next patch ~6 months, it's better to anticipate it (instead of adding it in another patch).


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
