### PR TITLE
PIM-9379: fix attribute search by label in attribute group section

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,10 +1,12 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9379: attribute search by label was not working in attribute group add attributes
+
 # 4.0.45 (2020-07-31)
 
 # 4.0.44 (2020-07-28)
-
-- PIM-9379: attribute search by label was not working in attribute group add attributes
 
 # 4.0.43 (2020-07-27)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,8 @@
 
 # 4.0.44 (2020-07-28)
 
+- PIM-9379: attribute search by label was not working in attribute group add attributes
+
 # 4.0.43 (2020-07-27)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute-group/form/tab/select.js
@@ -14,7 +14,8 @@ define(
         'pim/product/add-select/attribute',
         'pim/fetcher-registry',
         'pim/formatter/choices/base',
-        'pim/common/add-select/line'
+        'pim/common/add-select/line',
+        'pim/user-context',
     ],
     function (
         $,
@@ -22,7 +23,8 @@ define(
         AddAttributeSelect,
         FetcherRegistry,
         ChoicesFormatter,
-        LineView
+        LineView,
+        UserContext
     ) {
         return AddAttributeSelect.extend({
             lineView: LineView,
@@ -49,7 +51,10 @@ define(
                 return FetcherRegistry.getFetcher('attribute').search({
                         identifiers: this.getParent().getOtherAttributes().join(','),
                         rights: 0,
-                        search: options.term
+                        search: options.term,
+                        options: {
+                          locale: UserContext.get('catalogLocale'),
+                        },
                     }).then(this.prepareChoices)
                     .then(function (choices) {
                         options.callback({


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9379

The catralog locale was missing in the attribute search request. So the search by label could not working.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
