### PR TITLE
Type 'undefined' cannot be used as an index type

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base.ts
@@ -90,6 +90,10 @@ class BaseView extends Backbone.View<any> implements View {
 
       return expectedPosition >= 0 && expectedPosition === extension.code.indexOf(code, expectedPosition);
     });
+    
+    if (undefined === extensionKey || null === extensionKey) {
+      throw 'extensionKey is not defined.';
+    }
 
     return this.extensions[extensionKey];
   }


### PR DESCRIPTION
When installing/upgrading yarn (yarn install or yarn upgrade) and afterwards executing "yarn run webpack", the process fails:

```
ERROR in /projects/akeneo-pim/web/bundles/pimui/js/view/base.ts
./web/bundles/pimui/js/view/base.ts
[tsl] ERROR in /path/to/project/akeneo-pim/web/bundles/pimui/js/view/base.ts(94,28)
      TS2538: Type 'undefined' cannot be used as an index type.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

The problem affects Akeneo "tags/v3.2.65" (and most probably also other versions)

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
Fixes type 'undefined' index type usage.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
