### PR TITLE
RHF: React-hook-form update to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "@types/node": "11.9.5",
     "@types/react": "^16.8.0",
     "@types/react-dom": "^16.8.0",
+    "@types/react-redux": "^7.1.0",
     "@types/react-router-dom": "^5.1.0",
     "@types/react-test-renderer": "^16.8.0",
-    "@types/react-redux": "^7.1.0",
     "@types/styled-components": "^4.1.18",
     "@types/underscore": "^1.9.3",
     "@types/victory": "^33.0.1",
@@ -91,6 +91,7 @@
     "raw-loader": "1.0.0",
     "react-test-renderer": "^16.8.0",
     "read-pkg": "4.0.1",
+    "redux-devtools-extension": "^2.13.2",
     "text-loader": "0.0.1",
     "thread-loader": "^2.1.2",
     "ts-jest": "24.0.0",
@@ -102,10 +103,10 @@
     "webpack-livereload-plugin": "2.2.0",
     "webpack-shell-plugin": "^0.5.0",
     "write-file-webpack-plugin": "4.5.0",
-    "yamljs": "0.3.0",
-    "redux-devtools-extension": "^2.13.2"
+    "yamljs": "0.3.0"
   },
   "dependencies": {
+    "@hookform/error-message": "^0.0.3",
     "ajv": "^6.10.2",
     "babel-polyfill": "6.26.0",
     "backbone": "0.9.10",
@@ -120,17 +121,17 @@
     "lodash": "^4.17.0",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-hook-form": "^5.2.0",
+    "react-hook-form": "^6.3.0",
     "react-markdown": "^4.3.1",
+    "react-redux": "^7.1.0",
     "react-router-dom": "^5.1.0",
     "reakit": "^1.0.0-rc.0",
+    "redux": "^4.0.0",
     "style-loader": "^1.0.1",
     "styled-components": "^4.3.2",
     "summernote": "0.6.16",
     "underscore": "1.8.3",
-    "victory": "^33.1.6",
-    "react-redux": "^7.1.0",
-    "redux": "^4.0.0"
+    "victory": "^33.1.6"
   },
   "resolutions": {
     "jest/**/ip-regex": "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -783,6 +783,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@hookform/error-message@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-0.0.3.tgz#b6f11d5d9dfe17f0545aecec17fc3b1a9e891d70"
+  integrity sha512-4ZCiyvwcV5GHGira0PnNCgSgEU9Tqo5Kx2yKpku7m943JYqyJfeKIO+zQg2W4CkNSSS905c9BVIo8+ntB08QYA==
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -7289,10 +7294,10 @@ react-fast-compare@^2.0.0, react-fast-compare@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
-react-hook-form@^5.2.0:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.7.1.tgz#540d8d1747031dbd921c3e02ff689a9f5a00635b"
-  integrity sha512-j5Qw5UJ7jAzpYNnEiK0gDR3jRhcA42hmG5qQVRtXn0Ez5pjwiY5DhE7pzIABS1ZrjkjbM3UPV135319sSepoOA==
+react-hook-form@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.3.0.tgz#5c1926d51d4532f44818ef73f96d1a8c11015a76"
+  integrity sha512-Xz7xxnILftxttc6H+miTSi2eYPehiW3XdsPaqY5dW8HcURFZPrnpxnmaRqz6JtZcbfRM8qjjppP/pOBaUzhn4w==
 
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
RHF: React-hook-form update to v6
https://react-hook-form.com/migrate-v5-to-v6/
EE linked branch : https://github.com/akeneo/pim-enterprise-dev/pull/9379

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
