### PR TITLE
PIM-9112: Fix publish product if metric with null values

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9112: Fix empty values cleaner for metric with null values
+
 # 4.0.47 (2020-08-07)
 
 # 4.0.46 (2020-07-31)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/EmptyValuesCleaner.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/EmptyValuesCleaner.php
@@ -56,6 +56,13 @@ final class EmptyValuesCleaner
         }
 
         if (is_array($data)) {
+            // @see PIM-9112: Fix publish product if metric with null values
+            // @todo to rework in 5.0:
+            // to clean with a migration as the data should not be null in database
+            // add the missing NonExistenMetricValueFilter to filter non existing metric
+            if (array_key_exists('amount', $data) && null === $data['amount']) {
+                return false;
+            }
             foreach ($data as $subValue) {
                 if ($this->isFilled($subValue)) {
                     return true;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/EmptyValuesCleanerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/EmptyValuesCleanerSpec.php
@@ -37,7 +37,25 @@ final class EmptyValuesCleanerSpec extends ObjectBehavior
                     'tablet' => [
                         '<all_locales>' => ['blue']
                     ]
-                ]
+                ],
+                'a_metric' => [
+                    '<all_channels>' => [
+                        'en_US' => [
+                            'amount' => 22,
+                            'unit' => 'KILOGRAM',
+                            'base_data' => 22000,
+                            'base_unit' => 'GRAM',
+                            'family' => 'Weight',
+                        ],
+                        'fr_FR' => [
+                            'amount' => null,
+                            'unit' => 'KILOGRAM',
+                            'base_data' => null,
+                            'base_unit' => 'GRAM',
+                            'family' => 'Weight',
+                        ],
+                    ]
+                ],
             ],
             'productB' => [
                 'an_attribute' => [
@@ -46,7 +64,7 @@ final class EmptyValuesCleanerSpec extends ObjectBehavior
                         'fr_FR' => 'a_value',
                         'be_BE' => ''
                     ]
-                ]
+                ],
             ]
         ];
 
@@ -61,14 +79,25 @@ final class EmptyValuesCleanerSpec extends ObjectBehavior
                     'tablet' => [
                         '<all_locales>' => ['blue']
                     ]
-                ]
+                ],
+                'a_metric' => [
+                    '<all_channels>' => [
+                        'en_US' => [
+                            'amount' => 22,
+                            'unit' => 'KILOGRAM',
+                            'base_data' => 22000,
+                            'base_unit' => 'GRAM',
+                            'family' => 'Weight',
+                        ],
+                    ]
+                ],
             ],
             'productB' => [
                 'an_attribute' => [
                     '<all_channels>' => [
                         'fr_FR' => 'a_value',
                     ]
-                ]
+                ],
             ]
         ];
 


### PR DESCRIPTION
I was fooled by the API return example and was trying with prices, but the problem is only with metric attributes.

I greped the provided dump and found that we have raw values like that: 

```
"weight": {"<all_channels>": {"<all_locales>": {"unit": null, "amount": null, "family": "Weight", "base_data": null, "base_unit": "KILOGRAM"}}}
```

The EmptyCleaner consider them as filled because of not null values in `family` and `base_unit` values.

This is a quick fix for invalid data coming from previous migrations and we must set a migration for 4.0 -> 5.0 to really clean the data and not have to handle it at product load.
There is a PR for that: https://github.com/akeneo/pim-community-dev/pull/11628