### PR TITLE
RAC-175: Rework QuickExportConfigurator to hide with-labels select

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
@@ -150,7 +150,7 @@ define(
 
                         launcher.action.route_parameters = {
                             ...launcher.action.route_parameters,
-                            _withLabels: isProductGrid && 'with-labels' === formValue['with-labels'],
+                            _withLabels: isProductGrid && 'with-labels' === formValue['with-labels'] ? 1 : 0,
                             _fileLocale: UserContext.get('catalogLocale'),
                         };
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
@@ -131,10 +131,10 @@ define(
 
             _.each(groupedLaunchers, function (groupLaunchers, groupName) {
                 const button = this.el.querySelector(`.${this.getGroupClassname(groupName)}`);
-                const isPublishedGrid = 'published-product-grid' === groupLaunchers[0]?.action.datagrid.name || false;
+                const isProductGrid = 'product-grid' === groupLaunchers[0]?.action.datagrid.name || false;
 
                 const Component = React.createElement(QuickExportConfigurator, {
-                    hideWithLabelsSelect: isPublishedGrid,
+                    showWithLabelsSelect: isProductGrid,
                     onActionLaunch: formValue => {
                         const actionName = `quick_export${
                           'grid-context' === formValue['context'] ? `_grid_context` : ''
@@ -150,7 +150,7 @@ define(
 
                         launcher.action.route_parameters = {
                             ...launcher.action.route_parameters,
-                            _withLabels: 'with-labels' === formValue['with-labels'],
+                            _withLabels: isProductGrid && 'with-labels' === formValue['with-labels'],
                             _fileLocale: UserContext.get('catalogLocale'),
                         };
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
@@ -131,8 +131,10 @@ define(
 
             _.each(groupedLaunchers, function (groupLaunchers, groupName) {
                 const button = this.el.querySelector(`.${this.getGroupClassname(groupName)}`);
+                const isPublishedGrid = 'published-product-grid' === groupLaunchers[0]?.action.datagrid.name || false;
 
                 const Component = React.createElement(QuickExportConfigurator, {
+                    hideWithLabelsSelect: isPublishedGrid,
                     onActionLaunch: formValue => {
                         const actionName = `quick_export${
                           'grid-context' === formValue['context'] ? `_grid_context` : ''

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Form.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Form.tsx
@@ -8,20 +8,15 @@ type FormValue = {
 type FormProps = {
   children?: ReactNode;
   value: FormValue;
-  disabledChildren?: string[];
   onChange: (value: FormValue) => void;
 };
 
-const Form = ({value, disabledChildren, onChange, children}: FormProps) => {
+const Form = ({value, onChange, children}: FormProps) => {
   return (
     <>
       {Children.map(children, (child, index) => {
         if (!isValidElement<SelectProps>(child) || child.type !== Select) {
           return child;
-        }
-
-        if (disabledChildren?.includes(child.props.name)) {
-          return null;
         }
 
         const selects = Children.toArray(children).filter(

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Form.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Form.tsx
@@ -8,15 +8,20 @@ type FormValue = {
 type FormProps = {
   children?: ReactNode;
   value: FormValue;
+  disabledChildren?: string[];
   onChange: (value: FormValue) => void;
 };
 
-const Form = ({value, onChange, children}: FormProps) => {
+const Form = ({value, disabledChildren, onChange, children}: FormProps) => {
   return (
     <>
       {Children.map(children, (child, index) => {
         if (!isValidElement<SelectProps>(child) || child.type !== Select) {
           return child;
+        }
+
+        if (disabledChildren?.includes(child.props.name)) {
+          return null;
         }
 
         const selects = Children.toArray(children).filter(

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Option.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/Option.tsx
@@ -53,7 +53,6 @@ const Option = ({isSelected, children, onSelect, isDisabled, title}: OptionProps
           color: isSelected ? theme.color.blue100 : child.props.color,
         });
       })}
-      {title}
     </OptionContainer>
   );
 };

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import {DependenciesProvider, useTranslate} from '@akeneo-pim-community/legacy-bridge';
 import {
@@ -81,12 +81,10 @@ const QuickExportConfiguratorContainer = ({
   useShortcut(Key.Escape, closeModal);
 
   const productCount = getProductCount();
-
-  useEffect(() => {
-    if (hideWithLabelsSelect) {
-      setFormValue(formValue => ({...formValue, 'with-labels': 'with-codes'}));
-    }
-  }, []);
+  const readyToSubmit =
+    undefined !== formValue['type'] &&
+    undefined !== formValue['context'] &&
+    (undefined !== formValue['with-labels'] || hideWithLabelsSelect);
 
   return (
     <>
@@ -104,11 +102,7 @@ const QuickExportConfiguratorContainer = ({
                   onActionLaunch(formValue);
                   closeModal();
                 }}
-                disabled={
-                  undefined === formValue['type'] ||
-                  undefined === formValue['context'] ||
-                  undefined === formValue['with-labels']
-                }
+                disabled={!readyToSubmit}
               >
                 {translate('pim_common.export')}
               </ModalConfirmButton>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -118,31 +118,41 @@ const QuickExportConfiguratorContainer = ({
                 <Select name="type">
                   <Option value="csv" title={translate('pim_datagrid.mass_action.quick_export.configurator.csv')}>
                     <CSVFileIcon size={48} />
+                    {translate('pim_datagrid.mass_action.quick_export.configurator.csv')}
                   </Option>
                   <Option value="xlsx" title={translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}>
                     <XLSXFileIcon size={48} />
+                    {translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}
                   </Option>
                 </Select>
                 <Select name="context">
                   <Option
                     value="grid-context"
                     title={translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
-                  />
+                  >
+                    {translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
+                  </Option>
                   <Option
                     value="all-attributes"
                     title={translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
-                  />
+                  >
+                    {translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
+                  </Option>
                 </Select>
                 {showWithLabelsSelect && (
                   <Select name="with-labels">
                     <Option
                       value="with-codes"
                       title={translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
-                    />
+                    >
+                      {translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
+                    </Option>
                     <Option
                       value="with-labels"
                       title={translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
-                    />
+                    >
+                      {translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
+                    </Option>
                   </Select>
                 )}
               </Form>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import styled from 'styled-components';
 import {DependenciesProvider, useTranslate} from '@akeneo-pim-community/legacy-bridge';
 import {
@@ -56,6 +56,7 @@ const QuickExportButton = styled.button`
 `;
 
 type QuickExportConfiguratorProps = {
+  hideWithLabelsSelect: boolean;
   onActionLaunch: (formValue: FormValue) => void;
   getProductCount: () => number;
 };
@@ -68,7 +69,11 @@ const QuickExportConfigurator = (props: QuickExportConfiguratorProps) => (
   </DependenciesProvider>
 );
 
-const QuickExportConfiguratorContainer = ({onActionLaunch, getProductCount}: QuickExportConfiguratorProps) => {
+const QuickExportConfiguratorContainer = ({
+  hideWithLabelsSelect,
+  onActionLaunch,
+  getProductCount,
+}: QuickExportConfiguratorProps) => {
   const [isModalOpen, openModal, closeModal] = useToggleState(false);
   const translate = useTranslate();
   const [formValue, setFormValue] = useStorageState<FormValue>({}, 'quick_export_configuration');
@@ -76,6 +81,12 @@ const QuickExportConfiguratorContainer = ({onActionLaunch, getProductCount}: Qui
   useShortcut(Key.Escape, closeModal);
 
   const productCount = getProductCount();
+
+  useEffect(() => {
+    if (hideWithLabelsSelect) {
+      setFormValue(formValue => ({...formValue, 'with-labels': 'with-codes'}));
+    }
+  }, []);
 
   return (
     <>
@@ -111,6 +122,7 @@ const QuickExportConfiguratorContainer = ({onActionLaunch, getProductCount}: Qui
               <Title>{translate('pim_datagrid.mass_action.quick_export.configurator.title')}</Title>
               <Form
                 value={formValue}
+                disabledChildren={hideWithLabelsSelect ? ['with-labels'] : undefined}
                 onChange={(newValue: FormValue) => {
                   setFormValue(newValue);
                 }}

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -122,7 +122,6 @@ const QuickExportConfiguratorContainer = ({
               <Title>{translate('pim_datagrid.mass_action.quick_export.configurator.title')}</Title>
               <Form
                 value={formValue}
-                disabledChildren={hideWithLabelsSelect ? ['with-labels'] : undefined}
                 onChange={(newValue: FormValue) => {
                   setFormValue(newValue);
                 }}
@@ -145,16 +144,18 @@ const QuickExportConfiguratorContainer = ({
                     title={translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
                   />
                 </Select>
-                <Select name="with-labels">
-                  <Option
-                    value="with-codes"
-                    title={translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
-                  />
-                  <Option
-                    value="with-labels"
-                    title={translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
-                  />
-                </Select>
+                {!hideWithLabelsSelect && (
+                  <Select name="with-labels">
+                    <Option
+                      value="with-codes"
+                      title={translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
+                    />
+                    <Option
+                      value="with-labels"
+                      title={translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
+                    />
+                  </Select>
+                )}
               </Form>
             </Content>
           </Modal>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -56,7 +56,7 @@ const QuickExportButton = styled.button`
 `;
 
 type QuickExportConfiguratorProps = {
-  hideWithLabelsSelect: boolean;
+  showWithLabelsSelect: boolean;
   onActionLaunch: (formValue: FormValue) => void;
   getProductCount: () => number;
 };
@@ -70,7 +70,7 @@ const QuickExportConfigurator = (props: QuickExportConfiguratorProps) => (
 );
 
 const QuickExportConfiguratorContainer = ({
-  hideWithLabelsSelect,
+  showWithLabelsSelect,
   onActionLaunch,
   getProductCount,
 }: QuickExportConfiguratorProps) => {
@@ -84,7 +84,7 @@ const QuickExportConfiguratorContainer = ({
   const readyToSubmit =
     undefined !== formValue['type'] &&
     undefined !== formValue['context'] &&
-    (undefined !== formValue['with-labels'] || hideWithLabelsSelect);
+    (undefined !== formValue['with-labels'] || !showWithLabelsSelect);
 
   return (
     <>
@@ -114,12 +114,7 @@ const QuickExportConfiguratorContainer = ({
                 )}`}
               </Subtitle>
               <Title>{translate('pim_datagrid.mass_action.quick_export.configurator.title')}</Title>
-              <Form
-                value={formValue}
-                onChange={(newValue: FormValue) => {
-                  setFormValue(newValue);
-                }}
-              >
+              <Form value={formValue} onChange={setFormValue}>
                 <Select name="type">
                   <Option value="csv" title={translate('pim_datagrid.mass_action.quick_export.configurator.csv')}>
                     <CSVFileIcon size={48} />
@@ -138,7 +133,7 @@ const QuickExportConfiguratorContainer = ({
                     title={translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
                   />
                 </Select>
-                {!hideWithLabelsSelect && (
+                {showWithLabelsSelect && (
                   <Select name="with-labels">
                     <Option
                       value="with-codes"

--- a/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
@@ -8,7 +8,11 @@ test('it displays a button and no modal initially', () => {
   const getProductCount = jest.fn(() => 3);
 
   const {getByTitle, queryByTitle} = render(
-    <QuickExportConfigurator onActionLaunch={onActionLaunch} getProductCount={getProductCount} />
+    <QuickExportConfigurator
+      showWithLabelsSelect={true}
+      onActionLaunch={onActionLaunch}
+      getProductCount={getProductCount}
+    />
   );
 
   expect(getByTitle('pim_datagrid.mass_action_group.quick_export.label')).toBeInTheDocument();
@@ -20,7 +24,11 @@ test('it does not call the action launch if an option is not set', () => {
   const getProductCount = jest.fn(() => 3);
 
   const {getByTitle} = render(
-    <QuickExportConfigurator onActionLaunch={onActionLaunch} getProductCount={getProductCount} />
+    <QuickExportConfigurator
+      showWithLabelsSelect={true}
+      onActionLaunch={onActionLaunch}
+      getProductCount={getProductCount}
+    />
   );
 
   fireEvent.click(getByTitle('pim_datagrid.mass_action_group.quick_export.label'));
@@ -37,7 +45,11 @@ test('it does call the action launch if every option is set', () => {
   const getProductCount = jest.fn(() => 3);
 
   const {getByTitle, getByText} = render(
-    <QuickExportConfigurator onActionLaunch={onActionLaunch} getProductCount={getProductCount} />
+    <QuickExportConfigurator
+      showWithLabelsSelect={true}
+      onActionLaunch={onActionLaunch}
+      getProductCount={getProductCount}
+    />
   );
 
   fireEvent.click(getByTitle('pim_datagrid.mass_action_group.quick_export.label'));

--- a/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
@@ -68,3 +68,18 @@ test('it does call the action launch if every option is set', () => {
 
   expect(onActionLaunch).toHaveBeenCalledWith({context: 'all-attributes', type: 'xlsx', 'with-labels': 'with-codes'});
 });
+
+test('it does not display the with-labels select if specified', () => {
+  const onActionLaunch = jest.fn();
+  const getProductCount = jest.fn(() => 3);
+
+  const {queryByText} = render(
+    <QuickExportConfigurator
+      showWithLabelsSelect={false}
+      onActionLaunch={onActionLaunch}
+      getProductCount={getProductCount}
+    />
+  );
+
+  expect(queryByText('pim_datagrid.mass_action.quick_export.configurator.with_labels')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add a boolean prop to show the select for with-labels options

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
