### PR TITLE
PIM-9391: Filter empty price and measurement values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PIM-9362: Adapt System Information twig file for a clear and a correct display of the number of API connections
 - PIM-9360: Fix PHP Warning raised in PriceComparator
 - PIM-9370: Fixes page freezing with a big number of attribute options
+- PIM-9391: Filter empty prices and measurement values
 
 ## New features
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As of v4.0, empty values are not persisted anymore, and empty values are filtered. However the format of price and measurement attributes is a bit more complex than for other attributes (complex array), and the check performed to check if the value is empty did not take these formats into account.

In this PR we consider that a price or a measurement with a `null` amount is empty, and we filter these values.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
