### PR TITLE
GITHUB-APD-206: modify the treshold to fetch next announcements in the panel

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
@@ -55,6 +55,10 @@ const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
     return <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.error')} />;
   }
 
+  if (announcementResponse.items.length === 0) {
+    return <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.empty')} />;
+  }
+
   return (
     <Container ref={containerRef}>
       {announcementResponse.items.map(

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
@@ -9,10 +9,8 @@ import {formatCampaign} from '../../tools/formatCampaign';
 const Panel = (): JSX.Element => {
   const __ = useTranslate();
   const mediator = useMediator();
-  const cloudEEVersion = 'serenity';
   const [isOpened, setIsOpened] = useState<boolean>(false);
   const [campaign, setCampaign] = useState<string>('');
-  const [isSerenity, setIsSerenity] = useState<boolean>(false);
   const pimVersion = usePimVersion();
 
   const onClosePanel = () => {
@@ -20,7 +18,6 @@ const Panel = (): JSX.Element => {
   };
 
   useEffect(() => {
-    if (isSerenity) {
       /* istanbul ignore next: can't test the callback function */
       mediator.on('communication-channel:panel:open', () => {
         setIsOpened(true);
@@ -29,13 +26,11 @@ const Panel = (): JSX.Element => {
       mediator.on('communication-channel:panel:close', () => {
         setIsOpened(false);
       });
-    }
-  }, [isSerenity]);
+  }, []);
 
   useEffect(() => {
     if (null !== pimVersion.data) {
       setCampaign(formatCampaign(pimVersion.data.edition, pimVersion.data.version));
-      setIsSerenity(cloudEEVersion === pimVersion.data.edition.toLowerCase());
     }
   }, [pimVersion.data]);
 
@@ -51,11 +46,7 @@ const Panel = (): JSX.Element => {
   return (
     <>
       <HeaderPanel title={__('akeneo_communication_channel.panel.title')} onClickCloseButton={onClosePanel} />
-      {isSerenity ? (
         <AnnouncementList campaign={campaign} panelIsClosed={!isOpened} />
-      ) : (
-        <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.empty')} />
-      )}
     </>
   );
 };

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
@@ -53,19 +53,19 @@ const useInfiniteScroll = (
     return scrollPosition + clientHeight >= scrollSize - threshold && !lastAppend && !isFetching;
   };
 
+  if (null !== scrollableElement) {
+    scrollableElement.onscroll = () => {
+      if (hasToAppendItems(scrollableElement, state.lastAppend, state.isFetching)) {
+        const lastElement = state.items[state.items.length - 1];
+        const searchAfter = lastElement.id;
+        handleFetchingResults(searchAfter);
+      }
+    };
+  }
+
   useEffect(() => {
-    if (null !== scrollableElement) {
-      scrollableElement.onscroll = () => {
-        if (hasToAppendItems(scrollableElement, state.lastAppend, state.isFetching)) {
-          const lastElement = state.items[state.items.length - 1];
-          const searchAfter = lastElement.id;
-          handleFetchingResults(searchAfter);
-        }
-      };
-    } else {
-      handleFetchingResults(null);
-    }
-  }, [scrollableElement, state]);
+    handleFetchingResults(null);
+  }, []);
 
   return [{items: state.items, isFetching: state.isFetching, hasError: state.hasError}, handleFetchingResults];
 };

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/hooks/useInfiniteScroll.ts
@@ -25,7 +25,7 @@ type ResultsResponse = {
 const useInfiniteScroll = (
   fetch: (searchAfter: string | null) => Promise<any[]>,
   scrollableElement: HTMLElement | null,
-  threshold: number = 300
+  threshold: number = 4000
 ): [ResultsResponse, (searchAfter: string | null) => void] => {
   const [state, dispatch] = useReducer(reducer, initialState);
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
@@ -20,6 +20,9 @@ let container: HTMLElement;
 beforeEach(() => {
   container = document.createElement('div');
   document.body.appendChild(container);
+
+  const handleHasNewAnnouncements = jest.fn();
+  useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
 });
 afterEach(() => {
   document.body.removeChild(container);
@@ -30,6 +33,7 @@ test('it check if it has new announcements when the component is mounted', async
   const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
   const handleHasNewAnnouncements = jest.fn();
   useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
+
   useInfiniteScroll.mockReturnValue([
     {
       items: [],
@@ -63,6 +67,26 @@ test('it shows the announcements when we open the panel', async () => {
   );
 
   expect(container.querySelectorAll('ul li').length).toEqual(2);
+});
+
+test('it shows an empty list when there are no announcements', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  const handleFetchingResults = jest.fn();
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: [],
+      isFetching: false,
+      hasError: false,
+    },
+    handleFetchingResults,
+  ]);
+
+  await act(async () =>
+      renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
+  );
+
+  expect(container.querySelectorAll('ul li').length).toEqual(0);
+  expect(getByText(container, 'akeneo_communication_channel.panel.list.empty')).toBeInTheDocument();
 });
 
 test('it can show for each announcement the information from the json', async () => {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
@@ -19,10 +19,9 @@ beforeEach(() => {
 });
 afterEach(() => {
   document.body.removeChild(container);
-  container = null;
 });
 
-test('it displays a panel of announcements when it is a serenity version', async () => {
+test('it displays a panel of announcements', async () => {
   useHasNewAnnouncements.mockReturnValue(jest.fn());
   usePimVersion.mockReturnValue({
     data: {edition: 'Serenity', version: '192939349'},
@@ -40,19 +39,6 @@ test('it displays a panel of announcements when it is a serenity version', async
   await act(async () => renderWithProviders(<Panel />, container as HTMLElement));
 
   expect(getByText(container, 'akeneo_communication_channel.panel.title')).toBeInTheDocument();
-  expect(container.querySelector('ul')).toBeInTheDocument();
-});
-
-test('it displays an empty panel when it is not a serenity version', async () => {
-  usePimVersion.mockReturnValue({
-    data: {edition: 'CE', version: '4.0'},
-    hasError: false,
-  });
-
-  await act(async () => renderWithProviders(<Panel />, container as HTMLElement));
-
-  expect(getByText(container, 'akeneo_communication_channel.panel.title')).toBeInTheDocument();
-  expect(container.querySelector('ul')).not.toBeInTheDocument();
   expect(getByText(container, 'akeneo_communication_channel.panel.list.empty')).toBeInTheDocument();
 });
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/hooks/useInfiniteScroll.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/hooks/useInfiniteScroll.unit.tsx
@@ -112,9 +112,7 @@ it('it fetches items until there is no items in most recent response', async () 
 });
 
 it('it can handle error during the fetch', async () => {
-  const fetch = jest.fn((search) => Promise.reject<string>());
-  fetch.mockRejectedValueOnce(new Error('Async error'));
-
+  const fetch = (search) => {throw new Error('Async error')};
   await act(async () => ReactDOM.render(<MockComponent fetch={fetch} />, container as HTMLElement));
 
   expect(container.innerHTML).toStrictEqual('error');


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Two things:

- modify the threshold to fetch the next announcements (as it's search after), it was done too late when scrolling down
https://github.com/akeneo/actionable-product-data/issues/206

- it was hardcoded to fetch the announcements only in Serenity. This is not the case anymore. It asks both for Serenity and CE.

https://github.com/akeneo/actionable-product-data/issues/204


Note: there was an infinite loop when an error occured, because the AnnouncementList component listen on "state" in a `useEffect`. I extracted this logic as it was not correct to put it in `useEffect`.
Unfortunately, I can't reproduce it in unit test :/

It was completely blocking the browser.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
