### PR TITLE
GITHUB-APD-126: helpcenter link button redirects to serenity for CE master and Serenity

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/help.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/help.ts
@@ -35,12 +35,14 @@ class Help extends BaseView {
   private getUrl(): Promise<string> {
     return DataCollector.collect(this.analyticsUrl).then((data: any) => {
       const {pim_version, pim_edition} = data;
+
       let version = `v${pim_version.split('.')[0]}`;
       let campaign = `${pim_edition}${pim_version}`;
 
-      if ('serenity' === pim_edition.toLowerCase()) {
-        version = pim_edition.toLowerCase();
-        campaign = pim_edition;
+      // CE master, serenity
+      if (pim_version.split('.').length === 1) {
+        version = 'serenity';
+        campaign = 'serenity';
       }
 
       const url = new URL(`https://help.akeneo.com/pim/${version}/index.html`);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

On CE master, it's currently a 404 when clicking on the helpcenter button. It redirects now to serenity as soons as the version is not a number version (master, v20201009180000).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
