### PR TITLE
GITHUB-APD-213: fix display of new tag when current date equals start date

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Domain/Announcement/Model/Read/AnnouncementItem.php
@@ -54,14 +54,17 @@ final class AnnouncementItem
         \DateTimeImmutable $endDate,
         array $tags
     ) {
+        $startDateWithoutTime = $startDate->setTime(0, 0);
+        $endDateWithoutTime = $endDate->setTime(0, 0);
+
         $this->id = $id;
         $this->title = $title;
         $this->description = $description;
         $this->img = $img;
         $this->altImg = $altImg;
         $this->link = $link;
-        $this->startDate = $startDate;
-        $this->endDate = $endDate;
+        $this->startDate = $startDateWithoutTime;
+        $this->endDate = $endDateWithoutTime;
         $this->tags = $tags;
     }
 
@@ -89,7 +92,7 @@ final class AnnouncementItem
      */
     public function shouldBeNotified(array $viewedAnnouncementIds): bool
     {
-        $currentDate = new \DateTimeImmutable();
+        $currentDate = new \DateTimeImmutable('today');
 
         return $this->startDate <= $currentDate && $currentDate <= $this->endDate && !in_array($this->id, $viewedAnnouncementIds);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Not testable as we can't easily mock  "new \datetime" in PHP.

When end date of notifcation is 12/06 and we are the 12/06, the comparison of the date was "12-06-2020 16:01:10" <  "12-06-2020 00:00:00" because `new \Datetime` returns the date with the current hour/minute/second, which is not what we want.


Link to https://github.com/akeneo/actionable-product-data/issues/213

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
