### PR TITLE
PIM-9401: Fix ES filters with EMPTY operator

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9401: Fix Elasticsearch filters with EMPTY operator
+
 # 4.0.48 (2020-08-12)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
@@ -17,6 +17,9 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
  */
 abstract class AbstractAttributeFilter implements AttributeFilterInterface
 {
+    protected const ATTRIBUTES_FOR_THIS_LEVEL_ES_ID = 'attributes_for_this_level';
+    protected const ATTRIBUTES_OF_ANCESTORS_ES_ID = 'attributes_of_ancestors';
+
     /** @var SearchQueryBuilder */
     protected $searchQueryBuilder = null;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/DateFilter.php
@@ -134,12 +134,28 @@ class DateFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 ];
                 $this->searchQueryBuilder->addMustNot($existsClause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
-
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
+
             case Operators::IS_NOT_EMPTY:
                 $existsClause = [
                     'exists' => ['field' => $attributePath]

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MediaFilter.php
@@ -128,10 +128,26 @@ class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code'],
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/MetricFilter.php
@@ -143,10 +143,26 @@ class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
@@ -121,10 +121,26 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
             case Operators::IS_NOT_EMPTY:
                 $clause = [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/OptionFilter.php
@@ -83,10 +83,26 @@ class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInt
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/PriceFilter.php
@@ -170,10 +170,26 @@ class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInte
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-            $familyExistsClause = [
-                'exists' => ['field' => 'family.code']
-            ];
-            $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_EMPTY_FOR_CURRENCY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilter.php
@@ -89,10 +89,26 @@ class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFi
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -133,10 +133,26 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
@@ -129,10 +129,26 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
 
-                $familyExistsClause = [
-                    'exists' => ['field' => 'family.code']
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
                 ];
-                $this->searchQueryBuilder->addFilter($familyExistsClause);
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
                 break;
 
             case Operators::IS_NOT_EMPTY:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/ProductAndProductModelSearchAggregator.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/ProductAndProductModelSearchAggregator.php
@@ -60,22 +60,6 @@ class ProductAndProductModelSearchAggregator
             );
         }
 
-        $attributeCodesWithIsEmptyOperator = $this->getAttributeCodesWithIsEmptyOperator($rawFilters);
-        if (!empty($attributeCodesWithIsEmptyOperator)) {
-            $searchQueryBuilder->addShould([
-                [
-                    'terms' => [
-                        'attributes_for_this_level' => $attributeCodesWithIsEmptyOperator,
-                    ],
-                ],
-                [
-                    'terms' => [
-                        'attributes_of_ancestors' => $attributeCodesWithIsEmptyOperator,
-                    ],
-                ],
-            ]);
-        }
-
         return $searchQueryBuilder;
     }
 
@@ -147,32 +131,5 @@ class ProductAndProductModelSearchAggregator
         }
 
         return $allChildrenCodes;
-    }
-
-    /**
-     * Returns the attribute codes for which there is a filter on with operator IsEmpty
-     *
-     * @param string[] $rawFilters
-     *
-     * @return string[]
-     */
-    private function getAttributeCodesWithIsEmptyOperator(array $rawFilters): array
-    {
-        $attributeFilters = array_filter(
-            $rawFilters,
-            function ($filter) {
-                $operator = $filter['operator'];
-
-                return
-                    'attribute' === $filter['type'] &&
-                    (
-                        Operators::IS_EMPTY === $operator ||
-                        Operators::IS_EMPTY_FOR_CURRENCY === $operator ||
-                        Operators::IS_EMPTY_ON_ALL_CURRENCIES === $operator
-                    );
-            }
-        );
-
-        return array_column($attributeFilters, 'field');
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace back\Pim\Enrichment\Integration\PQB\Filter\Attribute;
+namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace back\Pim\Enrichment\Integration\PQB\Filter\Attribute;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Test attribute filters with the EMPTY operator for product and product models
+ *
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
+{
+    public function testEmptyOperatorForDateFilter()
+    {
+        $this->loadFixtures('a_date', ['data' => '2020-05-16', 'scope' => null, 'locale' => null]);
+        $this->assert('a_date');
+    }
+
+    public function testEmptyOperatorForMediaFilter()
+    {
+        $this->loadFixtures(
+            'a_file',
+            ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_file');
+    }
+
+    public function testEmptyOperatorForMetricFilter()
+    {
+        $this->loadFixtures(
+            'a_metric',
+            ['data' => ['amount' => 2, 'unit' => 'KILOWATT'], 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_metric');
+    }
+
+    public function testEmptyOperatorForNumberFilter()
+    {
+        $this->loadFixtures(
+            'a_number_float',
+            ['data' => 25, 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_number_float');
+    }
+
+    public function testEmptyOperatorForOptionFilter()
+    {
+        $this->loadFixtures(
+            'a_simple_select',
+            ['data' => 'optionA', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_simple_select');
+    }
+
+    public function testEmptyOperatorForPriceFilter()
+    {
+        $this->loadFixtures(
+            'a_price',
+            ['data' => [['amount' => 100, 'currency' => 'USD']], 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_price');
+    }
+
+    public function testEmptyOperatorForReferenceDataFilter()
+    {
+        $this->loadFixtures(
+            'a_ref_data_simple_select',
+            ['data' => 'red', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_ref_data_simple_select');
+    }
+
+    public function testEmptyOperatorForTextareaFilter()
+    {
+        $this->loadFixtures(
+            'a_text_area',
+            ['data' => 'Lorem ipsum dolor sit amet', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_text_area');
+    }
+
+    public function testEmptyOperatorForTextFilter()
+    {
+        $this->loadFixtures(
+            'a_text',
+            ['data' => 'Foobar', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_text');
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function assert(string $attributeCode)
+    {
+        $pqb = $this->get('pim_catalog.query.product_and_product_model_query_builder_factory')->create();
+        $pqb->addFilter($attributeCode, Operators::IS_EMPTY, null);
+        $results = $pqb->execute();
+        $identifiers = [];
+        foreach ($results as $entity) {
+            $identifiers[] = $entity instanceof ProductModelInterface ? $entity->getCode() : $entity->getIdentifier();
+        }
+        Assert::assertEqualsCanonicalizing(
+            ['pm_1_empty', 'variant_1_empty', 'variant_3_empty', 'simple_product_empty'],
+            $identifiers
+        );
+    }
+
+    /**
+     * Creates
+     * - a family with the given attribute code
+     * - a family variant with the given attribute at root level, and another one with the attribute at variant level
+     * - foreach family variant, product models and variant products with empty or filled value for the given attribute
+     * - 2 simple products, one with empty value, one with non empty value
+     * - a simple product without family
+     */
+    private function loadFixtures(string $attributeCode, array $nonEmptyData)
+    {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => [$attributeCode, 'sku', 'a_yes_no', 'a_number_float_negative']
+        ]);
+        $this->createFamilyVariant([
+            'code' => 'attribute_at_common_level',
+            'family' => 'a_family',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['sku', 'a_yes_no']
+                ]
+            ]
+        ]);
+        $this->createProductModel([
+            'code' => 'pm_1_empty',
+            'family_variant' => 'attribute_at_common_level',
+        ]);
+        $this->createProduct('variant_1_empty', [
+            'parent' => 'pm_1_empty',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+        $this->createProductModel([
+            'code' => 'pm_2_filled',
+            'family_variant' => 'attribute_at_common_level',
+            'values' => [
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+        $this->createProduct('variant_2_filled', [
+            'parent' => 'pm_2_filled',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+
+        $this->createFamilyVariant([
+            'code' => 'attribute_at_variant_level',
+            'family' => 'a_family',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['sku', 'a_yes_no', $attributeCode]
+                ]
+            ]
+        ]);
+
+        $this->createProductModel([
+            'code' => 'pm_3',
+            'family_variant' => 'attribute_at_variant_level',
+        ]);
+
+        $this->createProduct('variant_3_empty', [
+            'parent' => 'pm_3',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+        $this->createProduct('variant_3_filled', [
+            'parent' => 'pm_3',
+            'values' => [
+                'a_yes_no' => [['data' => false, 'scope' => null, 'locale' => null]],
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+
+        $this->createProduct('simple_product_empty', [
+            'family' => 'a_family',
+        ]);
+        $this->createProduct('simple_product_filled', [
+            'family' => 'a_family',
+            'values' => [
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+        $this->createProduct('simple_product_without_family', []);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+    }
+
+    private function createFamily(array $data): void
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+        Assert::assertEmpty($this->get('validator')->validate($family));
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    private function createFamilyVariant($data): void
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $data);
+        Assert::assertEmpty($this->get('validator')->validate($familyVariant));
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    private function createProduct(string $identifier, array $data): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $violations = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertEmpty($violations, sprintf('The %s product is not valid: %s', $product->getIdentifier(), $violations));
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+
+    private function createProductModel(array $data): void
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        Assert::assertEmpty($this->get('pim_catalog.validator.product_model')->validate($productModel));
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
@@ -21,16 +21,9 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createAttribute([
-            'code'                => 'a_localizable_media',
-            'type'                => AttributeTypes::IMAGE,
-            'localizable'         => true,
-            'scopable'            => false
-        ]);
-
         $this->createFamily([
             'code' => 'a_family',
-            'attributes' => ['sku', 'a_localizable_media']
+            'attributes' => ['sku', 'a_localizable_image']
         ]);
 
         $this->createProduct('product_one', [

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
@@ -21,16 +21,9 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createAttribute([
-            'code'                => 'a_localizable_media',
-            'type'                => AttributeTypes::IMAGE,
-            'localizable'         => false,
-            'scopable'            => true
-        ]);
-
         $this->createFamily([
             'code' => 'a_family',
-            'attributes' => ['sku', 'a_localizable_media']
+            'attributes' => ['sku', 'a_scopable_image']
         ]);
 
         $this->createProduct('product_one', [

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -24,7 +24,7 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
 
         $this->createFamily([
             'code' => 'a_family',
-            'attributes' => ['sku', 'a_ref_data_multi_select']
+            'attributes' => ['sku', 'a_ref_data_simple_select']
         ]);
 
         $this->createProduct(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/DateFilterSpec.php
@@ -289,7 +289,17 @@ class DateFilterSpec extends ObjectBehavior
         $attributeValidatorHelper->validateScope($publishedOn, 'ecommerce')->shouldBeCalled();
 
         $sqb->addMustNot(['exists' => ['field' => 'values.publishedOn-date.ecommerce.en_US']])->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['publishedOn']]],
+                        ['terms' => ['attributes_of_ancestors' => ['publishedOn']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
@@ -199,7 +199,17 @@ class MediaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['an_image']]],
+                        ['terms' => ['attributes_of_ancestors' => ['an_image']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MetricFilterSpec.php
@@ -327,7 +327,17 @@ class MetricFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['weight']]],
+                        ['terms' => ['attributes_of_ancestors' => ['weight']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($metric, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
@@ -231,7 +231,17 @@ class NumberFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['size']]],
+                        ['terms' => ['attributes_of_ancestors' => ['size']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($size, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/OptionFilterSpec.php
@@ -87,7 +87,17 @@ class OptionFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['color']]],
+                        ['terms' => ['attributes_of_ancestors' => ['color']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, ['black'], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/PriceFilterSpec.php
@@ -287,7 +287,17 @@ class PriceFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['a_price']]],
+                        ['terms' => ['attributes_of_ancestors' => ['a_price']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($price, Operators::IS_EMPTY, [], 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/ReferenceDataFilterSpec.php
@@ -96,7 +96,17 @@ class ReferenceDataFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['color_attribute']]],
+                        ['terms' => ['attributes_of_ancestors' => ['color_attribute']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($color, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
@@ -122,7 +122,17 @@ class TextAreaFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['description']]],
+                        ['terms' => ['attributes_of_ancestors' => ['description']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($description, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
@@ -118,7 +118,17 @@ class TextFilterSpec extends ObjectBehavior
                 ],
             ]
         )->shouldBeCalled();
-        $sqb->addFilter(['exists' => ['field' => 'family.code']])->shouldBeCalled();
+        $sqb->addFilter(
+            [
+                'bool' => [
+                    'should' => [
+                        ['terms' => ['attributes_for_this_level' => ['name']]],
+                        ['terms' => ['attributes_of_ancestors' => ['name']]],
+                    ],
+                    'minimum_should_match' => 1,
+                ],
+            ]
+        )->shouldBeCalled();
 
         $this->setQueryBuilder($sqb);
         $this->addAttributeFilter($name, Operators::IS_EMPTY, null, 'en_US', 'ecommerce', []);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelSearchAggregatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelSearchAggregatorSpec.php
@@ -118,18 +118,6 @@ class ProductAndProductModelSearchAggregatorSpec extends ObjectBehavior
                 ],
             ]
         ])->shouldBeCalled();
-        $searchQueryBuilder->addShould([
-            [
-                'terms' => [
-                    'attributes_for_this_level' => ['foo', 'foo_currency1', 'foo_currency2'],
-                ],
-            ],
-            [
-                'terms' => [
-                    'attributes_of_ancestors' => ['foo', 'foo_currency1', 'foo_currency2'],
-                ],
-            ],
-        ])->shouldBeCalled();
 
         $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);
     }
@@ -177,18 +165,6 @@ class ProductAndProductModelSearchAggregatorSpec extends ObjectBehavior
                     ],
                 ],
             ]
-        ])->shouldBeCalled();
-        $searchQueryBuilder->addShould([
-            [
-                'terms' => [
-                    'attributes_for_this_level' => ['foo'],
-                ],
-            ],
-            [
-                'terms' => [
-                    'attributes_of_ancestors' => ['foo'],
-                ],
-            ],
         ])->shouldBeCalled();
 
         $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

In #11518, the usage of attribute filters' EMPTY operator was fixed, adding a should clause testing that the target attribute had to be part of either the 'attributes_for_this_level' list or in the 'attributes_of_ancestors' one. Unfortunately the fix was only applied in ProductAndProductModelWithSearchAggregator (i.e the product grid's query builder). 
This leads ES queries with an EMPTY filter returning wrong results in other PQBs, especially when there are models and variants involved (see examples in #11518) => this can cause some mass actions (including mass delete) to affect more entities than desired.
In this PR I apply the should clause directly in the attribute filters, the final query being:

- the ES attribute path must must not exist
AND
    - the 'attributes_for_this_level' must contain the attribute code
    OR
    - the 'attributes_of_ancestors' list must contain the attribute code

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
