### PR TITLE
PIM-9407: Fix glitch in family variant selector if the family variant…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PIM-9360: Fix PHP Warning raised in PriceComparator
 - PIM-9370: Fixes page freezing with a big number of attribute options
 - PIM-9391: Filter empty prices and measurement values
+- PIM-9407: Fix glitch in family variant selector if the family variant has no label
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -60,6 +60,11 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
             $qb->setParameter('search', '%' . $search . '%');
         }
 
+        if (isset($options['identifiers'])) {
+            $qb->andWhere('f.code IN (:identifiers)')
+               ->setParameter('identifiers', $options['identifiers']);
+        }
+
         if ($limit) {
             $qb->setMaxResults((int) $limit);
         }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/creation/variant.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/creation/variant.js
@@ -89,7 +89,7 @@ define([
     getFamilyVariantLabelFromCode(code) {
       return FetcherRegistry.getFetcher('family-variant')
         .fetch(code)
-        .then(familyVariant => familyVariant.labels[UserContext.get('catalogLocale')]);
+        .then(familyVariant => familyVariant.labels[UserContext.get('catalogLocale')] || `[${familyVariant.code}]`);
     },
 
     /**


### PR DESCRIPTION
… has no label

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
