### PR TITLE
Added support for an SSL connection to PimRequirements.

### DIFF
--- a/src/Akeneo/Platform/PimRequirements.php
+++ b/src/Akeneo/Platform/PimRequirements.php
@@ -214,15 +214,24 @@ class PimRequirements
      */
     protected function getConnection() : PDO
     {
-        return new PDO(
-            sprintf(
-                'mysql:port=%s;host=%s',
-                getenv('APP_DATABASE_PORT'),
-                getenv('APP_DATABASE_HOST')
-            ),
-            getenv('APP_DATABASE_USER'),
-            getenv('APP_DATABASE_PASSWORD')
+        $dsn = sprintf(
+            'mysql:port=%s;host=%s',
+            getenv('APP_DATABASE_PORT'),
+            getenv('APP_DATABASE_HOST')
         );
+        $username = getenv('APP_DATABASE_USER');
+        $passwd = getenv('APP_DATABASE_PASSWORD');
+        $sslCa = getenv('APP_DATABASE_SSL_CA');
+        $sslVerifyServerCert = getenv('APP_DATABASE_SSL_VERIFY_SERVER_CERT');
+        if (isset($sslCa) && isset($sslVerifyServerCert)) {
+            $options = array(
+                PDO::MYSQL_ATTR_SSL_CA => $sslCa,
+                PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => $sslVerifyServerCert
+            );
+            return new PDO($dsn, $username, $passwd, $options);
+        } else {
+            return new PDO($dsn, $username, $passwd);
+        }
     }
 
     protected function getBytes(string $val): float


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

I modified PimRequirements->getConnection() to support establishing SSL connections.
I added to new environment variables named after their PDO counterparts:
APP_DATABASE_SSL_CA
APP_DATABASE_SSL_VERIFY_SERVER_CERT
If both if these variables are present, then the function now establishes a connection using these as options.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | No
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
