### PR TITLE
DAPI-1236: allow watch options on @akeneo packages for the webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -227,7 +227,7 @@ const webpackConfig = {
   },
 
   watchOptions: {
-    ignored: /node_modules|var\/cache|vendor/,
+    ignored: /node_modules\/(?!@akeneo)|var\/cache|vendor/,
   },
 
   plugins: [
@@ -245,7 +245,7 @@ const webpackConfig = {
 
     // Ignore these directories when webpack watches for changes
     new webpack.WatchIgnorePlugin([
-      path.resolve(rootDir, './node_modules'),
+      /node_modules\/(?!@akeneo)/,
       path.resolve(rootDir, './app'),
       path.resolve(rootDir, './var'),
       path.resolve(rootDir, './vendor'),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
