### PR TITLE
PIM-9408: Fix attribute group's updated_at field udpate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-9408: Fix attribute group's updated_at field udpate
 - TIP-1513: Environment variables declared in the env were not loaded when using a compiled .env file
 - PIM-9274: Fix Yaml reader to display the number of lines read for incorrectly formatted files
 - TIP-1406: Add a tag to configure a DIC service based on a feature flag

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeGroupInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeGroupInterface.php
@@ -4,6 +4,7 @@ namespace Akeneo\Pim\Structure\Component\Model;
 
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
 use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
+use Akeneo\Tool\Component\Versioning\Model\TimestampableInterface;
 use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 
@@ -14,7 +15,11 @@ use Doctrine\Common\Collections\ArrayCollection;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface AttributeGroupInterface extends TranslatableInterface, ReferableInterface, VersionableInterface
+interface AttributeGroupInterface extends
+    TimestampableInterface,
+    TranslatableInterface,
+    ReferableInterface,
+    VersionableInterface
 {
     /**
      * Get id


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

For entities persisted via doctrine ORM, if one need to have the "updated_at" field of this entity updated on save. This entity needs to implement the `TimestampableInterface` so that the subscriber https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/TimestampableSubscriber.php will catch this entity on preSave and automatically updates the updated_at field.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
