### PR TITLE
Fetch labels of options

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
@@ -25,6 +25,7 @@ services:
             - '@pim_catalog.query.product_query_builder_search_after_size_factory_external_api'
             - '@pim_api.security.primary_key_encrypter'
             - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers_with_option_labels'
             - '@event_dispatcher'
 
     pim_enrich.connector.use_cases.handler.list_product_models:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -64,6 +64,7 @@ services:
             - '@pim_api.normalizer.connector_products'
             - '@security.token_storage'
             - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers_with_option_labels'
             - '@pim_catalog.event_subscriber.product.on_save.api_aggregator_event_subscriber'
             - '@pim_api.warmup_query_cache.dummy'
             - '@event_dispatcher'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -200,7 +200,7 @@ services:
             - '@akeneo.pim.enrichment.product.query.quantified_association.get_id_mapping_from_product_model_ids_query'
             - '@akeneo.pim.enrichment.product.query.find_quantified_association_codes'
 
-    akeneo.pim.enrichment.product.connector.get_product_from_identifiers:
+    akeneo.pim.enrichment.product.connector.get_product_from_identifiers_without_option_label:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\SqlGetConnectorProducts'
         arguments:
             $getValuesAndPropertiesFromProductIdentifiers: '@akeneo.pim.enrichment.product.query.get_values_and_properties_from_product_identifiers'
@@ -212,6 +212,12 @@ services:
             $getCategoryCodesByProductIdentifiers: '@akeneo.pim.enrichment.product.query.category_codes_by_product_identifiers'
             $readValueCollectionFactory: '@akeneo.pim.enrichment.factory.read_value_collection'
             $attributeRepository: '@pim_catalog.repository.attribute'
+
+    akeneo.pim.enrichment.product.connector.get_product_from_identifiers:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\SqlGetConnectorProductsWithOptionLabels'
+        arguments:
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers_without_option_label'
+            - '@database_connection'
 
     akeneo.pim.enrichment.product.connector.get_product_models_from_codes:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\SqlGetConnectorProductModels'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -200,7 +200,7 @@ services:
             - '@akeneo.pim.enrichment.product.query.quantified_association.get_id_mapping_from_product_model_ids_query'
             - '@akeneo.pim.enrichment.product.query.find_quantified_association_codes'
 
-    akeneo.pim.enrichment.product.connector.get_product_from_identifiers_without_option_label:
+    akeneo.pim.enrichment.product.connector.get_product_from_identifiers:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\SqlGetConnectorProducts'
         arguments:
             $getValuesAndPropertiesFromProductIdentifiers: '@akeneo.pim.enrichment.product.query.get_values_and_properties_from_product_identifiers'
@@ -213,10 +213,10 @@ services:
             $readValueCollectionFactory: '@akeneo.pim.enrichment.factory.read_value_collection'
             $attributeRepository: '@pim_catalog.repository.attribute'
 
-    akeneo.pim.enrichment.product.connector.get_product_from_identifiers:
+    akeneo.pim.enrichment.product.connector.get_product_from_identifiers_with_option_labels:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector\SqlGetConnectorProductsWithOptionLabels'
         arguments:
-            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers_without_option_label'
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
             - '@database_connection'
 
     akeneo.pim.enrichment.product.connector.get_product_models_from_codes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionLabels.php
@@ -65,7 +65,8 @@ class SqlGetConnectorProductsWithOptionLabels implements Query\GetConnectorProdu
         }, $connectorProducts);
     }
 
-    /***
+    /**
+     * @param array $connectorProducts
      * @return array [['attribute_code', 'option_code']]
      */
     private function getOptionCodes(array $connectorProducts): array
@@ -133,7 +134,6 @@ class SqlGetConnectorProductsWithOptionLabels implements Query\GetConnectorProdu
             SELECT * FROM aggregated_attributes
             ;
         SQL;
-
 
         $row = $this->connection->executeQuery(
             sprintf($query, implode(',', $queryStringParams)),

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionLabels.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Connector;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductList;
+use Akeneo\Pim\Enrichment\Component\Product\Query;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlGetConnectorProductsWithOptionLabels implements Query\GetConnectorProducts
+{
+    /** @var Query\GetConnectorProducts */
+    private $getConnectorProducts;
+
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(
+        Query\GetConnectorProducts $getConnectorProducts,
+        Connection $connection
+    ) {
+        $this->getConnectorProducts = $getConnectorProducts;
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fromProductQueryBuilder(
+        ProductQueryBuilderInterface $pqb,
+        int $userId,
+        ?array $attributesToFilterOn,
+        ?string $channelToFilterOn,
+        ?array $localesToFilterOn
+    ): ConnectorProductList {
+        $connectorProductList = $this->getConnectorProducts->fromProductQueryBuilder($pqb, $userId, $attributesToFilterOn, $channelToFilterOn, $localesToFilterOn);
+        $productsWithOptionLabels = $this->getConnectorProductsWithLabels($connectorProductList->connectorProducts());
+
+        return new ConnectorProductList($connectorProductList->totalNumberOfProducts(), $productsWithOptionLabels);
+    }
+
+    public function fromProductIdentifier(string $productIdentifier, int $userId): ConnectorProduct
+    {
+        $connectorProduct = $this->getConnectorProducts = $this->getConnectorProducts->fromProductIdentifier($productIdentifier, $userId);
+
+        return $this->getConnectorProductsWithLabels([$connectorProduct])[0];
+    }
+
+    private function getConnectorProductsWithLabels(array $connectorProducts): array
+    {
+        $optionCodes = $this->getOptionCodes($connectorProducts);
+        $optionWithLabels = $this->getOptionWithLabels($optionCodes);
+
+        return array_map(function(ConnectorProduct $product) use ($optionWithLabels) {
+            return $product->transformOptionWithLabels($optionWithLabels);
+        }, $connectorProducts);
+    }
+
+    /***
+     * @return array [['attribute_code', 'option_code']]
+     */
+    private function getOptionCodes(array $connectorProducts): array
+    {
+        $optionCodes = [];
+        foreach ($connectorProducts as $connectorProduct) {
+            foreach ($connectorProduct->values() as $value) {
+                if ($value instanceof OptionValue) {
+                    $optionCodes[] = [$value->getAttributeCode(), $value->getData()];
+                } elseif ($value instanceof OptionsValue) {
+                    foreach ($value->getData() as $optionCode) {
+                        $optionCodes[] = [$value->getAttributeCode(), $optionCode];
+                    }
+                }
+            }
+        }
+
+        return $optionCodes;
+    }
+
+    /**
+     * @param array $optionCodes [['attribute_code', 'option_code']]
+     *
+     * @return array ['attribute_code' => ['option_code' => ['en_US' => 'translation']]
+     */
+    private function getOptionWithLabels(array $optionCodes): array
+    {
+        if (empty($optionCodes)) {
+            return [];
+        }
+
+        $queryStringParams = array_fill(0, count($optionCodes), '(?, ?)');
+
+        $queryParams = [];
+        foreach ($optionCodes as [$attributeCode, $optionCode]) {
+            $queryParams[] = $attributeCode;
+            $queryParams[] = $optionCode;
+        }
+
+        $query = <<<SQL
+            WITH option_values AS (
+                SELECT
+                    a.code AS attribute_code,
+                    ao.code AS option_code,
+                    JSON_OBJECTAGG(aov.locale_code, aov.value) AS option_values
+                FROM pim_catalog_attribute a
+                JOIN pim_catalog_attribute_option ao ON  ao.attribute_id = a.id
+                JOIN pim_catalog_attribute_option_value aov ON aov.option_id = ao.id
+                WHERE (a.code, ao.code) IN (%s)
+                GROUP BY attribute_code, ao.code
+            ),
+            aggregated_option_per_attribute AS (
+                SELECT 
+                    attribute_code,
+                    JSON_OBJECTAGG(option_code, option_values) as option_values
+                FROM option_values
+                GROUP BY attribute_code
+            ),
+            aggregated_attributes AS (
+                SELECT 
+                    JSON_OBJECTAGG(attribute_code, option_values) as result
+                FROM
+                    aggregated_option_per_attribute
+            )
+            SELECT * FROM aggregated_attributes
+            ;
+        SQL;
+
+
+        $row = $this->connection->executeQuery(
+            sprintf($query, implode(',', $queryStringParams)),
+            $queryParams
+        )->fetch();
+
+
+        return isset($row['result']) ? json_decode($row['result'], true) : [];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
@@ -192,21 +192,32 @@ final class ConnectorProduct
             if ($value instanceof OptionValue) {
                 return new OptionValueWithLabels(
                     $value->getAttributeCode(),
-                    [$value->getData() => $optionLabels[$value->getAttributeCode()][$value->getData()] ?? []],
+                    $value->getData(),
                     $value->getScopeCode(),
-                    $value->getLocaleCode()
+                    $value->getLocaleCode(),
+                    [
+                        "attribute" => $value->getAttributeCode(),
+                        "code"=> $value->getData(),
+                        "labels" => $optionLabels[$value->getAttributeCode()][$value->getData()] ?? []
+                    ],
                 );
+
             } elseif ($value instanceof OptionsValue) {
-                $data = [];
+                $linked_data = [];
                 foreach ($value->getData() as $optionCode) {
-                    $data[$optionCode] = $optionLabels[$value->getAttributeCode()][$optionCode] ?? [];
+                    $linked_data[$optionCode] = [
+                        "attribute" => $value->getAttributeCode(),
+                        "code"=> $optionCode,
+                        "labels" => $optionLabels[$value->getAttributeCode()][$optionCode] ?? [],
+                    ];
                 }
 
                 return new OptionsValueWithLabels(
                     $value->getAttributeCode(),
-                    $data,
+                    $value->getData(),
                     $value->getScopeCode(),
-                    $value->getLocaleCode()
+                    $value->getLocaleCode(),
+                    $linked_data
                 );
             } else {
                 return $value;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductsQuery.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductsQuery.php
@@ -51,6 +51,9 @@ final class ListProductsQuery
     /** @var int */
     public $userId;
 
+    /** @var string */
+    public $withAttributeOptions = 'false';
+
     /**
      * Returns the parameter 'with_count' typed as a boolean
      *
@@ -59,5 +62,15 @@ final class ListProductsQuery
     public function withCountAsBoolean(): bool
     {
         return $this->withCount === 'true';
+    }
+
+    /**
+     * Returns the parameter 'with_attribute_options' typed as a boolean
+     *
+     * @return bool
+     */
+    public function withAttributeOptionsAsBoolean(): bool
+    {
+        return $this->withAttributeOptions === 'true';
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ReadValueCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ReadValueCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Component\Product\Model;
 
 /**
@@ -131,5 +133,15 @@ final class ReadValueCollection implements \Countable, \IteratorAggregate
         $filteredValues = array_filter($this->values, $filterBy);
 
         return new self(array_values($filteredValues));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function map(\Closure $mapFunction)
+    {
+        $transformedValues = array_map($mapFunction, $this->values);
+
+        return new self(array_values($transformedValues));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ValuesNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ValuesNormalizer.php
@@ -35,22 +35,19 @@ final class ValuesNormalizer
     {
         $normalizedValues = [];
         foreach ($values as $value) {
-            // TODO: probably a dedicated API normalizer registry for asset override in EE
-            // be careful: this is not standard format, do not add normalizer in it
             if ($value instanceof OptionValueWithLabels || $value instanceof OptionsValueWithLabels) {
                 $normalizedValue = [
                     'locale' => $value->getLocaleCode(),
                     'scope' => $value->getScopeCode(),
-                    'data' => $value->getData()
+                    'data' => $value->getData(),
+                    'linked_data' => $value->getLinkedData(),
                 ];
-                $toto =1;
             } else {
                 $normalizedValue = $this->valueNormalizer->normalize($value, 'standard');
                 if ($value instanceof MediaValue) {
                     $normalizedValue = $this->addHalLink($value, $normalizedValue);
                 }
             }
-
 
             $normalizedValues[$value->getAttributeCode()][] = $normalizedValue;
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ValuesNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ValuesNormalizer.php
@@ -7,6 +7,8 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValueWithLabels;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValueWithLabels;
 use Akeneo\Tool\Component\Api\Hal\Link;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -33,10 +35,22 @@ final class ValuesNormalizer
     {
         $normalizedValues = [];
         foreach ($values as $value) {
-            $normalizedValue = $this->valueNormalizer->normalize($value, 'standard');
-            if ($value instanceof MediaValue) {
-                $normalizedValue = $this->addHalLink($value, $normalizedValue);
+            // TODO: probably a dedicated API normalizer registry for asset override in EE
+            // be careful: this is not standard format, do not add normalizer in it
+            if ($value instanceof OptionValueWithLabels || $value instanceof OptionsValueWithLabels) {
+                $normalizedValue = [
+                    'locale' => $value->getLocaleCode(),
+                    'scope' => $value->getScopeCode(),
+                    'data' => $value->getData()
+                ];
+                $toto =1;
+            } else {
+                $normalizedValue = $this->valueNormalizer->normalize($value, 'standard');
+                if ($value instanceof MediaValue) {
+                    $normalizedValue = $this->addHalLink($value, $normalizedValue);
+                }
             }
+
 
             $normalizedValues[$value->getAttributeCode()][] = $normalizedValue;
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetConnectorProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetConnectorProducts.php
@@ -17,6 +17,12 @@ interface GetConnectorProducts
     /**
      * Ideally, we should not pass the PQB but a Product Query agnostic of the storage.
      * It would be much easier fake it.
+     * @param ProductQueryBuilderInterface $productQueryBuilder
+     * @param int $userId
+     * @param array|null $attributesToFilterOn
+     * @param string|null $channelToFilterOn
+     * @param array|null $localesToFilterOn
+     * @return ConnectorProductList
      */
     public function fromProductQueryBuilder(
         ProductQueryBuilderInterface $productQueryBuilder,
@@ -27,6 +33,9 @@ interface GetConnectorProducts
     ): ConnectorProductList;
 
     /**
+     * @param string $productIdentifier
+     * @param int $userId
+     * @return ConnectorProduct
      * @throws ObjectNotFoundException when the product does not exist
      */
     public function fromProductIdentifier(string $productIdentifier, int $userId): ConnectorProduct;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionValueWithLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionValueWithLabels.php
@@ -9,27 +9,39 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class OptionValueWithLabels extends AbstractValue
+class OptionValueWithLabels extends AbstractValue implements OptionValueInterface
 {
     /** @var string Option code */
     protected $data;
+
+    /** @var array */
+    protected $linked_data;
 
     /**
      * {@inheritdoc}
      */
     public function __construct(
         string $attributeCode,
-        array $data,
+        ?string $data,
         ?string $scopeCode,
-        ?string $localeCode
+        ?string $localeCode,
+        ?array $linked_data
     ) {
         parent::__construct($attributeCode, $data, $scopeCode, $localeCode);
+        $this->linked_data = $linked_data;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getLinkedData(): ?array {
+        return $this->linked_data;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getData(): array
+    public function getData(): ?string
     {
         return $this->data;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionValueWithLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionValueWithLabels.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Value;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\AbstractValue;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OptionValueWithLabels extends AbstractValue
+{
+    /** @var string Option code */
+    protected $data;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        string $attributeCode,
+        array $data,
+        ?string $scopeCode,
+        ?string $localeCode
+    ) {
+        parent::__construct($attributeCode, $data, $scopeCode, $localeCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return null !== $this->data ? '['.$this->data.']' : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEqual(ValueInterface $value): bool
+    {
+        if (!$value instanceof OptionValueWithLabels ||
+            $this->getScopeCode() !== $value->getScopeCode() ||
+            $this->getLocaleCode() !== $value->getLocaleCode()) {
+            return false;
+        }
+
+        // useless for POC but inaccurate
+        return $this->getData() === $value->getData();
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLabels.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Value;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\AbstractValue;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OptionsValueWithLabels extends AbstractValue
+{
+    /** @var string Option code */
+    protected $data;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(
+        string $attributeCode,
+        array $data,
+        ?string $scopeCode,
+        ?string $localeCode
+    ) {
+        parent::__construct($attributeCode, $data, $scopeCode, $localeCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString(): string
+    {
+        return null !== $this->data ? '['.$this->data.']' : '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isEqual(ValueInterface $value): bool
+    {
+        if (!$value instanceof OptionValueWithLabels ||
+            $this->getScopeCode() !== $value->getScopeCode() ||
+            $this->getLocaleCode() !== $value->getLocaleCode()) {
+            return false;
+        }
+
+        // useless for POC but inaccurate
+        return $this->getData() === $value->getData();
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLabels.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLabels.php
@@ -11,27 +11,39 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
  */
 class OptionsValueWithLabels extends AbstractValue
 {
-    /** @var string Option code */
+    /** @var array */
     protected $data;
+
+    /** @var array */
+    protected $linked_data;
 
     /**
      * {@inheritdoc}
      */
     public function __construct(
         string $attributeCode,
-        array $data,
+        ?array $data,
         ?string $scopeCode,
-        ?string $localeCode
+        ?string $localeCode,
+        ?array $linked_data
     ) {
         parent::__construct($attributeCode, $data, $scopeCode, $localeCode);
+        $this->linked_data = $linked_data;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getData(): array
+    public function getData(): ?array
     {
         return $this->data;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getLinkedData(): ?array {
+        return $this->linked_data;
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -14,6 +14,128 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class GetProductEndToEnd extends AbstractProductTestCase
 {
+
+    public function test_it_gets_a_product_with_attribute_options_simple_select()
+    {
+        $this->createProduct('product', [
+            'family'     => 'familyA',
+            'categories' => [],
+            'groups'     => [],
+            'values'     => [
+                'a_simple_select' => [
+                    ['data' => 'optionA', 'locale' => null, 'scope' => null]
+                ],
+            ],
+        ]);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
+
+        $expectedProduct = [
+            'identifier'    => 'product',
+            'family'        => 'familyA',
+            'parent'        => null,
+            'groups'        => [],
+            'categories'    => [],
+            'enabled'       => true,
+            'values'        => [
+                'a_simple_select' => [
+                    [
+                        'data' => 'optionA',
+                        'locale' => null,
+                        'scope' => null,
+                        'linked_data' => [
+                            'attribute' => 'a_simple_select',
+                            'code' => 'optionA',
+                            'labels' => [
+                                'en_US' => 'Option A',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'created'       => '2016-06-14T13:12:50+02:00',
+            'updated'       => '2016-06-14T13:12:50+02:00',
+            'associations'  => [
+                'PACK'   => ['groups' => [], 'products' => [], 'product_models' => []],
+                'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'UPSELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'X_SELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+            ],
+            'quantified_associations' => [],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $expectedProduct);
+    }
+
+    public function test_it_gets_a_product_with_attribute_options_multi_select()
+    {
+        $this->createProduct('product', [
+            'family'     => 'familyA',
+            'categories' => [],
+            'groups'     => [],
+            'values'     => [
+                'a_multi_select' => [
+                    ['data' => ['optionA','optionB'], 'locale' => null, 'scope' => null]
+                ],
+            ],
+        ]);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
+
+        $expectedProduct = [
+            'identifier'    => 'product',
+            'family'        => 'familyA',
+            'parent'        => null,
+            'groups'        => [],
+            'categories'    => [],
+            'enabled'       => true,
+            'values'        => [
+                'a_multi_select' => [
+                    [
+                        'data' => ['optionA', 'optionB'],
+                        'locale' => null,
+                        'scope' => null,
+                        'linked_data' => [
+                            'optionA' => [
+                                'attribute' => 'a_multi_select',
+                                'code' => 'optionA',
+                                'labels' => [
+                                    'en_US' => 'Option A',
+                                ],
+                            ],
+                            'optionB' => [
+                                'attribute' => 'a_multi_select',
+                                'code' => 'optionB',
+                                'labels' => [
+                                    'en_US' => 'Option B',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'created'       => '2016-06-14T13:12:50+02:00',
+            'updated'       => '2016-06-14T13:12:50+02:00',
+            'associations'  => [
+                'PACK'   => ['groups' => [], 'products' => [], 'product_models' => []],
+                'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'UPSELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'X_SELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+            ],
+            'quantified_associations' => [],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $expectedProduct);
+    }
+
     /**
      * @group critical
      */

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -17,7 +17,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
     /** @var Collection */
     private $products;
 
-     /**
+    /**
      * {@inheritdoc}
      */
     protected function setUp(): void
@@ -27,7 +27,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         // no locale, no scope, 1 category
         $this->createProduct('simple', [
             'categories' => ['master'],
-            'values'     => [
+            'values' => [
                 'a_metric' => [
                     ['data' => ['amount' => 10, 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
                 ],
@@ -40,7 +40,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         // localizable, categorized in 1 tree (master)
         $this->createProduct('localizable', [
             'categories' => ['categoryB'],
-            'values'     => [
+            'values' => [
                 'a_localizable_image' => [
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'fr_FR', 'scope' => null],
@@ -52,12 +52,12 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         // scopable, categorized in 1 tree (master)
         $this->createProduct('scopable', [
             'categories' => ['categoryA1', 'categoryA2'],
-            'values'     => [
+            'values' => [
                 'a_scopable_price' => [
                     [
                         'locale' => null,
-                        'scope'  => 'ecommerce',
-                        'data'   => [
+                        'scope' => 'ecommerce',
+                        'data' => [
                             ['amount' => '78.77', 'currency' => 'CNY'],
                             ['amount' => '10.50', 'currency' => 'EUR'],
                             ['amount' => '11.50', 'currency' => 'USD'],
@@ -65,8 +65,8 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
                     ],
                     [
                         'locale' => null,
-                        'scope'  => 'tablet',
-                        'data'   => [
+                        'scope' => 'tablet',
+                        'data' => [
                             ['amount' => '78.77', 'currency' => 'CNY'],
                             ['amount' => '10.50', 'currency' => 'EUR'],
                             ['amount' => '11.50', 'currency' => 'USD'],
@@ -79,7 +79,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         // localizable & scopable, categorized in 2 trees (master and master_china)
         $this->createProduct('localizable_and_scopable', [
             'categories' => ['categoryA', 'master_china'],
-            'values'     => [
+            'values' => [
                 'a_localized_and_scopable_text_area' => [
                     ['data' => 'Big description', 'locale' => 'en_US', 'scope' => 'ecommerce'],
                     ['data' => 'Medium description', 'locale' => 'en_US', 'scope' => 'tablet'],
@@ -106,12 +106,12 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
             [
                 'code' => 'parent_prod_mod',
                 'family_variant' => 'familyVariantA1',
-                'values'  => [
-                    'a_price'  => [
+                'values' => [
+                    'a_price' => [
                         'data' => ['data' => [['amount' => '50', 'currency' => 'EUR']], 'locale' => null, 'scope' => null],
                     ],
-                    'a_number_float'  => [['data' => '12.5', 'locale' => null, 'scope' => null]],
-                    'a_localized_and_scopable_text_area'  => [['data' => 'my pink tshirt', 'locale' => 'en_US', 'scope' => 'ecommerce']],
+                    'a_number_float' => [['data' => '12.5', 'locale' => null, 'scope' => null]],
+                    'a_localized_and_scopable_text_area' => [['data' => 'my pink tshirt', 'locale' => 'en_US', 'scope' => 'ecommerce']],
                 ]
             ]
         );
@@ -121,7 +121,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
                 'code' => 'prod_mod_optA',
                 'parent' => 'parent_prod_mod',
                 'family_variant' => 'familyVariantA1',
-                'values'  => [
+                'values' => [
                     'a_simple_select' => [
                         ['locale' => null, 'scope' => null, 'data' => 'optionA'],
                     ]
@@ -437,7 +437,7 @@ JSON;
         $currentDate = (new \DateTime('now'))->format('Y-m-d H:i:s');
         $currentDateMinusHalf = (new \DateTime('now'))->modify('- 30 minutes')->format('Y-m-d H:i:s');
 
-        $search = sprintf('{"updated":[{"operator":"BETWEEN","value":["%s","%s"]}]}', $currentDateMinusHalf, $currentDate );
+        $search = sprintf('{"updated":[{"operator":"BETWEEN","value":["%s","%s"]}]}', $currentDateMinusHalf, $currentDate);
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&limit=10&search=' . $search);
         $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
         $expected = <<<JSON
@@ -445,6 +445,36 @@ JSON;
     "_links"       : {
         "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
         "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [            
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']},
+            {$standardizedProducts['product_with_parent']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithAttributeOptions()
+    {
+        $standardizedProducts = $this->getStandardizedProducts(true);
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/rest/v1/products?with_attribute_options=true');
+
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -623,8 +653,8 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $id = [
-            'simple'                   => $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('simple')),
-            'localizable'              => $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('localizable')),
+            'simple' => $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('simple')),
+            'localizable' => $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('localizable')),
             'localizable_and_scopable' => $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('localizable_and_scopable')),
         ];
 
@@ -656,7 +686,7 @@ JSON;
 
         $scopableEncryptedId = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($this->getEncryptedId('scopable'));
 
-        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=5&search_after=%s' , $scopableEncryptedId));
+        $client->request('GET', sprintf('api/rest/v1/products?pagination_type=search_after&limit=5&search_after=%s', $scopableEncryptedId));
         $expected = <<<JSON
 {
     "_links": {
@@ -721,7 +751,7 @@ JSON;
     /**
      * @return array
      */
-    private function getStandardizedProducts(): array
+    private function getStandardizedProducts(bool $withAttributeOptions = false): array
     {
         $standardizedProducts['simple'] = <<<JSON
 {
@@ -972,7 +1002,54 @@ JSON;
 }
 JSON;
 
-        $standardizedProducts['product_with_parent'] = <<<JSON
+        if ($withAttributeOptions) {
+            $standardizedProducts['product_with_parent'] = <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_with_parent"
+        }
+	},
+    "identifier": "product_with_parent",
+    "enabled": true,
+    "family": "familyA",
+    "categories": ["master"],
+    "groups": [],
+    "parent": "prod_mod_optA",
+    "values": {
+        "a_simple_select": [
+                        {
+                            "locale": null,
+                            "scope": null,
+                            "data": "optionA",
+                            "linked_data": {
+                                "attribute": "a_simple_select",
+                                "code": "optionA",
+                                "labels": {
+                                    "en_US": "Option A"
+                                }
+                            }
+                        }
+                    ],
+        "a_price": [{ "locale": null, "scope": null, "data": [{ "amount": "50.00", "currency": "EUR" }] }],
+        "a_yes_no": [{ "locale": null, "scope": null, "data": true }],
+        "a_number_float": [{ "locale": null, "scope": null, "data": "12.5000" }],
+        "a_localized_and_scopable_text_area": [{ "locale": "en_US", "scope": "ecommerce", "data": "my pink tshirt" }]
+    },
+    "created": "2019-06-10T12:37:47+02:00",
+    "updated": "2019-06-10T12:37:47+02:00",
+    "associations": {
+        "PACK": { "products": [], "product_models": [], "groups": [] },
+        "UPSELL": { "products": [], "product_models": [], "groups": [] },
+        "X_SELL": { "products": [], "product_models": [], "groups": [] },
+        "SUBSTITUTION": { "products": [], "product_models": [], "groups": [] }
+    },
+    "quantified_associations": {}
+}
+JSON;
+
+        } else {
+            $standardizedProducts['product_with_parent'] = <<<JSON
 {
     "_links": {
         "self": {
@@ -1003,6 +1080,7 @@ JSON;
     "quantified_associations": {}
 }
 JSON;
+        }
 
         return $standardizedProducts;
     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -17,7 +17,7 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
     /** @var Collection */
     private $products;
 
-    /**
+     /**
      * {@inheritdoc}
      */
     protected function setUp(): void


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This is a POC to fetch efficiently labels of options in the API.
The format for simple select and multi select in the output is :
```
                    "collection": [
                        {
                            "locale": null,
                            "scope": null,
                            "data": {
                                "winter_2016": {
                                    "de_DE": "Winter 2016",
                                    "en_US": "Winter 2016",
                                    "fr_FR": "Hiver 2016"
                                }
                            }
                        }
                    ],
```
## Not done

Add a query parameters in the API to activate/deactivate this feature.


## Performance concern

This implementation fetches only the needed options. It adds only one request, so the IO complexity is reduce to the minimal.

This implementation iterates over all values of all the returned products to get the option values. Then, it executes the request and re-iterates over all values to replace with labels.

This is not ideal but simple. To improve that, the read value collection could be indexed by attribute type. It means we could get only the needed value of a given type, without iterating over the whole collection of values. However, it means that you have to index everything as soon as you create a read value collection, which is costly (index is good at reading, not at writing). Maybe it would not be so efficient.


Keep in mind that iterating over 100 products x 500 values (reference catalog) takes more than 30 ms. Iterating over it 2 times more than 60ms.
So, if you have this logic for asset or some other attributes, it can impact the performance. Benchmarking and documenting the impact is important in my opinion.

## Implementation choices

I decided to do a dedicated "Query\GetConnectorProducts" implementation. This is simple for now as it uses decoration pattern, but not future proof if you want to do it for asset (=EE). 

I have no time to do it, but this is a first draft in term of design.

When you have more than 2 layers (filter with permission, option codes as label, assets with labels, etc) in different repos, with activable/desactivable feature, registry pattern would be more adapted.
As it is easy to switch from decoration pattern to registry pattern, you can start with this implen and switch later on depending of the needs. 

## Known limit and bugs

The case sensitivity of the option code is important. You can have `Red` in the value but `red` in database. You should lowercase `value->getData()` when accessing the data in `$optionLabels` array built from the data in the database (if you test it you will understand).

I would test also the sql query to get option labels with 0 labels for an option.


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
