### PR TITLE
PIM-9416: Add translation keys for mass delete action and corresponding message on the job page

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9416: Add translation keys for mass delete action and corresponding message on the job page
+
 # 4.0.50 (2020-08-20)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -1,6 +1,7 @@
 pim_notification:
     types:
         settings: Settings
+        mass_delete: Deletion
 flash:
     comment:
         create:
@@ -443,3 +444,5 @@ batch_jobs:
         quick_export.label: XLSX product quick export
         quick_export_product_model.label: XLSX product model quick export
         perform.label: XLSX product quick export
+    default_steps:
+        delete_products_and_product_models: Delete products and product models


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When making a **mass delete action**, on the notification panel, instead of "Deletion", "pim_notification.types.mass_delete" was displayed.
On the job page, instead of "Delete products and product models", "batch_jobs.default_steps.delete_products_and_product_models" was displayed.

So, I added missing corresponding keys in the jsmessages.en_US.yml file.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
