### PR TITLE
PIM-9371: Disable save button when user creation form is not ready to submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - API-1226: Be able to get attributes searching by a list of attribute types
 - PIM-9368: Allow minimum translation progress of 70% instead of 80%
 - PIM-9398: Add a primary key on connection table
+- PIM-9371: Disable save button when user creation form is not ready to submit
 
 # Technical Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -893,6 +893,7 @@ config:
     pim/form/common/creation/field:                      pimui/js/form/common/creation/field
     pim/form/common/creation/modal:                      pimui/js/form/common/creation/modal
     pim/form/common/creation/modal/client:               pimui/js/form/common/creation/modal/client
+    pim/form/common/creation/modal/create-user:          pimui/js/form/common/creation/modal/create-user
     pim/form/common/creation/type:                       pimui/js/form/common/creation/type
     pim/form/common/creation/job:                        pimui/js/form/common/creation/job
     pim/form/common/product/create-button:               pimui/js/form/common/product/create-button

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal/create-user.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal/create-user.js
@@ -1,0 +1,49 @@
+'use strict';
+
+define(
+    [
+        'pim/form/common/creation/modal',
+    ],
+    function (
+        BaseModal,
+    ) {
+        return BaseModal.extend({
+            events: {
+                'keyup input': 'checkReadyToSubmit'
+            },
+
+            checkReadyToSubmit() {
+                this.$el.parent().find('.AknButton.ok').toggleClass('AknButton--disabled', !this.isReadyToSubmit());
+            },
+
+            isReadyToSubmit() {
+                const data = this.getFormData();
+
+                return !Object.keys(this.extensions).some(extensionKey => {
+                    const extension = this.getExtension(extensionKey);
+
+                    return extension.config.required &&
+                        (undefined === data[extension.fieldName] || '' === data[extension.fieldName]);
+                });
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            render() {
+                this.checkReadyToSubmit();
+
+                return BaseModal.prototype.render.apply(this, arguments);
+            },
+
+            /**
+             * {@inheritdoc}
+             */
+            confirmModal() {
+                if (!this.isReadyToSubmit()) return;
+
+                return BaseModal.prototype.confirmModal.apply(this, arguments);
+            }
+        });
+    }
+);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal/create-user.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/modal/create-user.js
@@ -9,10 +9,10 @@ define(
     ) {
         return BaseModal.extend({
             events: {
-                'keyup input': 'checkReadyToSubmit'
+                'keyup input': 'updateButtonState'
             },
 
-            checkReadyToSubmit() {
+            updateButtonState() {
                 this.$el.parent().find('.AknButton.ok').toggleClass('AknButton--disabled', !this.isReadyToSubmit());
             },
 
@@ -31,9 +31,10 @@ define(
              * {@inheritdoc}
              */
             render() {
-                this.checkReadyToSubmit();
+                BaseModal.prototype.render.apply(this, arguments);
+                this.updateButtonState();
 
-                return BaseModal.prototype.render.apply(this, arguments);
+                return this;
             },
 
             /**

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/create.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/create.yml
@@ -1,6 +1,6 @@
 extensions:
     pim-user-create-modal:
-        module: pim/form/common/creation/modal
+        module: pim/form/common/creation/modal/create-user
         config:
             labels:
                 title: pim_common.create

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/validation.yml
@@ -12,6 +12,8 @@ Akeneo\UserManagement\Component\Model\User:
                 min:        3
                 max:        255
             - Akeneo\UserManagement\Bundle\Validator\Constraints\ValueShouldNotContainsBlacklistedCharacters: ~
+        password:
+            - NotBlank:     ~
         email:
             - NotBlank:     ~
             - Length:

--- a/tests/back/UserManagement/Integration/Component/Updater/UserUpdaterIntegration.php
+++ b/tests/back/UserManagement/Integration/Component/Updater/UserUpdaterIntegration.php
@@ -35,7 +35,7 @@ class UserUpdaterIntegration extends TestCase
         $this->get('pim_user.updater.user')->update($user, [], []);
 
         $errors = $this->get('validator')->validate($user);
-        $this->assertEquals(4, $errors->count());
+        $this->assertEquals(5, $errors->count());
 
         $result = [];
         foreach ($errors as $error) {
@@ -44,6 +44,7 @@ class UserUpdaterIntegration extends TestCase
 
         $expected = [
             'username' => 'This value should not be blank.',
+            'password' => 'This value should not be blank.',
             'email' => 'This value should not be blank.',
             'firstName' => 'This value should not be blank.',
             'lastName' => 'This value should not be blank.',


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Disable save button when user creation form is not ready to submit by adding a custom modal form.
- Add `NotBlank` constraint on password field to have a proper validation error instead of a `500`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
