### PR TITLE
DAPI-1234: fix back link for product models when clicking on an attribute with spelling mistake in DQI tab

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/Criterion.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/Criterion.tsx
@@ -9,7 +9,7 @@ import Evaluation, {
   CriterionEvaluationResult
 } from "../../../../../domain/Evaluation.interface";
 import {useFetchProductFamilyInformation, useProduct} from "../../../../../infrastructure/hooks";
-import {isSimpleProduct} from "../../../../helper/ProductEditForm/Product";
+import {isProductModel, isSimpleProduct} from "../../../../helper/ProductEditForm/Product";
 import {ATTRIBUTE_OPTION_SPELLING_CRITERION_CODE, ATTRIBUTE_SPELLING_CRITERION_CODE, BACK_LINK_SESSION_STORAGE_KEY} from "../../../../constant";
 import {
   redirectToAttributeGridFilteredByFamilyAndQuality,
@@ -72,7 +72,7 @@ const Criterion: FunctionComponent<CriterionProps> = ({criterionEvaluation, axis
       if (family) {
           window.sessionStorage.setItem(BACK_LINK_SESSION_STORAGE_KEY, JSON.stringify({
             label: __('akeneo_data_quality_insights.product_edit_form.back_to_products'),
-            route: 'pim_enrich_product_edit',
+            route: isProductModel(product) ? 'pim_enrich_product_model_edit' : 'pim_enrich_product_edit',
             routeParams: {id: product.meta.id},
             displayLinkRoutes: [
               'pim_enrich_attribute_index',


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
