### PR TITLE
DAPI-1231: Fix possible ES conflicts when updating product rates

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/subscribers.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/subscribers.yml
@@ -12,7 +12,6 @@ services:
             $logger: '@logger'
             $evaluatePendingCriteria: '@akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria'
             $consolidateProductAxisRates: '@akeneo.pim.automation.data_quality_insights.consolidate_product_axes_rates'
-            $indexProductRates: '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\IndexProductRates'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriberSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriberSpec.php
@@ -17,7 +17,6 @@ use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\Consolid
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\IndexProductRates;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
@@ -34,16 +33,14 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
         CreateCriteriaEvaluations $createProductsCriteriaEvaluations,
         LoggerInterface $logger,
         EvaluatePendingCriteria $evaluatePendingCriteria,
-        ConsolidateAxesRates $consolidateProductAxisRates,
-        IndexProductRates $indexProductRates
+        ConsolidateAxesRates $consolidateProductAxisRates
     ) {
         $this->beConstructedWith(
             $dataQualityInsightsFeature,
             $createProductsCriteriaEvaluations,
             $logger,
             $evaluatePendingCriteria,
-            $consolidateProductAxisRates,
-            $indexProductRates
+            $consolidateProductAxisRates
         );
     }
 
@@ -92,7 +89,6 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
         $createProductsCriteriaEvaluations,
         $evaluatePendingCriteria,
         $consolidateProductAxisRates,
-        $indexProductRates,
         ProductInterface $product
     ) {
         $product->getId()->willReturn(12345);
@@ -101,7 +97,6 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
 
         $evaluatePendingCriteria->evaluateSynchronousCriteria([12345])->shouldBeCalled();
         $consolidateProductAxisRates->consolidate([12345])->shouldBeCalled();
-        $indexProductRates->execute([12345])->shouldBeCalled();
 
         $this->onPostSave(new GenericEvent($product->getWrappedObject(), ['unitary' => true]));
     }


### PR DESCRIPTION
The problem occurs only when saving a single product (unitary update). The ES query that updates the rates can be in conflict with the ES query that re-index the product.

The solution is to not update the rates in ES anymore, and prioritize the evaluation to do it before the full indexation.