### PR TITLE
Added support for an SSL connection to the Elasticsearch Client.

### DIFF
--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -65,6 +65,12 @@ class Client
         $this->idPrefix = $idPrefix;
 
         $builder->setHosts($hosts);
+        $sslCa = getenv('APP_INDEX_SSL_CA');
+        if (isset($sslCa))
+        {
+            $builder->setSSLVerification($sslCa);
+        }
+
         $this->client = $builder->build();
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

I modified Elasticsearch's Client->__construct() to support establishing SSL connections.
I added one new environment variable named after what is required to be 
specified to enable an SSL connection:
APP_INDEX_SSL_CA
If this environment variable is present, then the function now passes 
the CA Certificate location to ClientBuilder->setSSLVerification().

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | No
| Added legacy Behats               | No
| Added acceptance tests            | No
| Added integration tests           | No
| Changelog updated                 | No
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
