### PR TITLE
PIM-9426: Fix incorrect interface use

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9426: Fix incorrect use of `Akeneo\Tool\Component\Batch\Item\InvalidItemInterface`
+
 # 4.0.52 (2020-08-24)
 
 # 4.0.51 (2020-08-21)

--- a/src/Akeneo/Tool/Component/Connector/Archiver/AbstractInvalidItemWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Archiver/AbstractInvalidItemWriter.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Component\Connector\Archiver;
 
 use Akeneo\Tool\Bundle\ConnectorBundle\EventListener\InvalidItemsCollector;
-use Akeneo\Tool\Component\Batch\Item\InvalidItemInterface;
+use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\ItemWriterInterface;
 use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
@@ -82,7 +82,7 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
 
         $invalidItemPositions = new ArrayCollection();
         foreach ($this->collector->getInvalidItems() as $invalidItem) {
-            if ($invalidItem instanceof InvalidItemInterface) {
+            if ($invalidItem instanceof FileInvalidItem) {
                 $invalidItemPositions->add($invalidItem->getItemPosition());
             }
         }


### PR DESCRIPTION
Fix incorrect use of `Akeneo\Tool\Component\Batch\Item\InvalidItemInterface`