### PR TITLE
PIM-9425: Fix inaccurate attribute max characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PIM-9370: Fixes page freezing with a big number of attribute options
 - PIM-9391: Filter empty prices and measurement values
 - PIM-9407: Fix glitch in family variant selector if the family variant has no label
+- PIM-9425: Fix inaccurate attribute max characters
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Attribute.orm.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Attribute.orm.yml
@@ -27,7 +27,7 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
                 default: false
             column: useable_as_grid_filter
         maxCharacters:
-            type: smallint
+            type: integer
             nullable: true
             column: max_characters
         validationRule:

--- a/upgrades/schema/Version_5_0_20200827093636_increase_attribute_max_characters.php
+++ b/upgrades/schema/Version_5_0_20200827093636_increase_attribute_max_characters.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version_5_0_20200827093636_increase_attribute_max_characters extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE pim_catalog_attribute CHANGE max_characters max_characters INT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The database field type was not good. We should support at least 65535 characters.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
