### PR TITLE
BH-7 Logs Behat tests retried

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,28 +583,29 @@ workflows:
                 is_ee_built: false
                 requires:
                     - checkout_ce
-#          - test_back_static_and_acceptance:
-#                name: test_back_static_and_acceptance_ce
-#                requires:
-#                    - build_dev_ce
-#          - test_front_static_acceptance_and_integration:
-#                name: test_front_static_acceptance_and_integration_ce
-#                requires:
-#                    - build_dev_ce
-#          - test_back_phpunit:
-#                name: test_back_phpunit_ce
-#                requires:
-#                    - test_back_static_and_acceptance_ce
-#                    - test_front_static_acceptance_and_integration_ce
-#          - test_back_data_migrations:
-#                name: test_back_data_migrations_ce
-#                requires:
-#                    - test_back_static_and_acceptance_ce
-#                    - test_front_static_acceptance_and_integration_ce
+          - test_back_static_and_acceptance:
+                name: test_back_static_and_acceptance_ce
+                requires:
+                    - build_dev_ce
+          - test_front_static_acceptance_and_integration:
+                name: test_front_static_acceptance_and_integration_ce
+                requires:
+                    - build_dev_ce
+          - test_back_phpunit:
+                name: test_back_phpunit_ce
+                requires:
+                    - test_back_static_and_acceptance_ce
+                    - test_front_static_acceptance_and_integration_ce
+          - test_back_data_migrations:
+                name: test_back_data_migrations_ce
+                requires:
+                    - test_back_static_and_acceptance_ce
+                    - test_front_static_acceptance_and_integration_ce
           - test_back_behat_legacy:
                 name: test_back_behat_legacy_ce
                 requires:
-                    - build_dev_ce
+                    - test_back_phpunit_ce
+                    - test_back_data_migrations_ce
 
   nightly:
       triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -583,29 +583,28 @@ workflows:
                 is_ee_built: false
                 requires:
                     - checkout_ce
-          - test_back_static_and_acceptance:
-                name: test_back_static_and_acceptance_ce
-                requires:
-                    - build_dev_ce
-          - test_front_static_acceptance_and_integration:
-                name: test_front_static_acceptance_and_integration_ce
-                requires:
-                    - build_dev_ce
-          - test_back_phpunit:
-                name: test_back_phpunit_ce
-                requires:
-                    - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration_ce
-          - test_back_data_migrations:
-                name: test_back_data_migrations_ce
-                requires:
-                    - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration_ce
+#          - test_back_static_and_acceptance:
+#                name: test_back_static_and_acceptance_ce
+#                requires:
+#                    - build_dev_ce
+#          - test_front_static_acceptance_and_integration:
+#                name: test_front_static_acceptance_and_integration_ce
+#                requires:
+#                    - build_dev_ce
+#          - test_back_phpunit:
+#                name: test_back_phpunit_ce
+#                requires:
+#                    - test_back_static_and_acceptance_ce
+#                    - test_front_static_acceptance_and_integration_ce
+#          - test_back_data_migrations:
+#                name: test_back_data_migrations_ce
+#                requires:
+#                    - test_back_static_and_acceptance_ce
+#                    - test_front_static_acceptance_and_integration_ce
           - test_back_behat_legacy:
                 name: test_back_behat_legacy_ce
                 requires:
-                    - test_back_phpunit_ce
-                    - test_back_data_migrations_ce
+                    - build_dev_ce
 
   nightly:
       triggers:

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -17,7 +17,10 @@ for TEST_FILE in $TEST_FILES; do
 
     set +e
     docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
-    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
+    (
+      echo $TEST_FILE > var/tests/behat/behat_retried.txt &&
+      docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
+    )
 
     fail=$(($fail + $?))
     counter=$(($counter + 1))

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -18,7 +18,8 @@ for TEST_FILE in $TEST_FILES; do
     set +e
     docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
     (
-      echo $TEST_FILE > var/tests/behat/behat_retried.txt &&
+      echo Retrying $TEST_FILE &&
+      docker-compose exec -u www-data -T fpm /bin/bash -c "echo $TEST_FILE >> var/tests/behat/behats_retried.txt" &&
       docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
     )
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Adds a log when retrying a Behat test. The log will be stored as an artifact on Circle CI side.

The main goal is to have Behat stable enough that the retry system is not needed anymore. First step is to get the current state of the retries by logging them and analyzing after one week of run.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
