### PR TITLE
PIM-9427: Fix ES filters with EMPTY operator

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,10 +1,14 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9427: Add new ES filters for EMPTY operator
+
 # 3.2.67 (2020-08-07)
 
 ## Bug fixes:
 
--PIM-9380: Parts of the PIM are not translatable on Crowdin
+- PIM-9380: Parts of the PIM are not translatable on Crowdin
 
 # 3.2.66 (2020-08-04)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/AbstractAttributeFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
@@ -17,6 +19,9 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
  */
 abstract class AbstractAttributeFilter implements AttributeFilterInterface
 {
+    protected const ATTRIBUTES_FOR_THIS_LEVEL_ES_ID = 'attributes_for_this_level';
+    protected const ATTRIBUTES_OF_ANCESTORS_ES_ID = 'attributes_of_ancestors';
+
     /** @var SearchQueryBuilder */
     protected $searchQueryBuilder = null;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/DateFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/DateFilter.php
@@ -1,0 +1,84 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class DateFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    const DATETIME_FORMAT = 'Y-m-d';
+    const HUMAN_DATETIME_FORMAT = "yyyy-mm-dd";
+
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $existsClause = [
+                    'exists' => ['field' => $attributePath]
+                ];
+                $this->searchQueryBuilder->addMustNot($existsClause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/MediaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/MediaFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class MediaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/MetricFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/MetricFilter.php
@@ -1,0 +1,97 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter;
+use Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager;
+
+class MetricFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    const PATH_SUFFIX = 'base_data';
+
+    /** @var MeasureManager */
+    protected $measureManager;
+
+    /** @var MeasureConverter */
+    protected $measureConverter;
+
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        MeasureManager $measureManager,
+        MeasureConverter $measureConverter,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->measureManager = $measureManager;
+        $this->measureConverter = $measureConverter;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel) . '.' . self::PATH_SUFFIX;
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath
+                    ]
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/NumberFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/NumberFilter.php
@@ -1,0 +1,84 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+
+class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath
+                    ]
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/OptionFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/OptionFilter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeOptionRepositoryInterface;
+
+class OptionFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    /** @var AttributeOptionRepositoryInterface */
+    protected $attributeOptionRepository;
+
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        AttributeOptionRepositoryInterface $attributeOptionRepository,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->attributeOptionRepository = $attributeOptionRepository;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $values,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/PriceFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/PriceFilter.php
@@ -1,0 +1,90 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Channel\Component\Repository\CurrencyRepositoryInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class PriceFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    /** @var CurrencyRepositoryInterface */
+    protected $currencyRepository;
+
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        CurrencyRepositoryInterface $currencyRepository,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->currencyRepository = $currencyRepository;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+            case Operators::IS_EMPTY_ON_ALL_CURRENCIES:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/ReferenceDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/ReferenceDataFilter.php
@@ -1,0 +1,105 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\ReferenceData\ConfigurationRegistryInterface;
+
+class ReferenceDataFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    /** @var ConfigurationRegistryInterface */
+    protected $registry;
+
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        ConfigurationRegistryInterface $registry,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $values,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param AttributeInterface $attribute
+     *
+     * @return bool
+     */
+    public function supportsAttribute(AttributeInterface $attribute)
+    {
+        $referenceDataName = $attribute->getReferenceDataName();
+
+        $isRegistredReferenceData = null !== $referenceDataName &&
+            !empty($referenceDataName) &&
+            $this->registry->has($attribute->getReferenceDataName());
+
+        return $isRegistredReferenceData;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/TextAreaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/TextAreaFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/TextFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/IsEmpty/TextFilter.php
@@ -1,0 +1,83 @@
+<?php
+
+// @todo pull-up 4.0: remove this class and its service definition
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\AbstractAttributeFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\AttributeValidatorHelper;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class TextFilter extends AbstractAttributeFilter implements AttributeFilterInterface
+{
+    public function __construct(
+        AttributeValidatorHelper $attrValidatorHelper,
+        array $supportedAttributeTypes = [],
+        array $supportedOperators = []
+    ) {
+        $this->attrValidatorHelper = $attrValidatorHelper;
+        $this->supportedAttributeTypes = $supportedAttributeTypes;
+        $this->supportedOperators = $supportedOperators;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addAttributeFilter(
+        AttributeInterface $attribute,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+
+        $this->checkLocaleAndChannel($attribute, $locale, $channel);
+
+        $attributePath = $this->getAttributePath($attribute, $locale, $channel);
+
+        switch ($operator) {
+            case Operators::IS_EMPTY:
+                $clause = [
+                    'exists' => [
+                        'field' => $attributePath,
+                    ],
+                ];
+                $this->searchQueryBuilder->addMustNot($clause);
+
+                $attributeInEntityClauses = [
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_FOR_THIS_LEVEL_ES_ID => [$attribute->getCode()],
+                        ],
+                    ],
+                    [
+                        'terms' => [
+                            self::ATTRIBUTES_OF_ANCESTORS_ES_ID => [$attribute->getCode()],
+                        ],
+                    ]
+                ];
+                $this->searchQueryBuilder->addFilter(
+                    [
+                        'bool' => [
+                            'should' => $attributeInEntityClauses,
+                            'minimum_should_match' => 1,
+                        ],
+                    ]
+                );
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/ProductAndProductModelSearchAggregator.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/ProductAndProductModelSearchAggregator.php
@@ -60,22 +60,6 @@ class ProductAndProductModelSearchAggregator
             );
         }
 
-        $attributeCodesWithIsEmptyOperator = $this->getAttributeCodesWithIsEmptyOperator($rawFilters);
-        if (!empty($attributeCodesWithIsEmptyOperator)) {
-            $searchQueryBuilder->addShould([
-                [
-                    'terms' => [
-                        'attributes_for_this_level' => $attributeCodesWithIsEmptyOperator,
-                    ],
-                ],
-                [
-                    'terms' => [
-                        'attributes_of_ancestors' => $attributeCodesWithIsEmptyOperator,
-                    ],
-                ],
-            ]);
-        }
-
         return $searchQueryBuilder;
     }
 
@@ -147,32 +131,5 @@ class ProductAndProductModelSearchAggregator
         }
 
         return $allChildrenCodes;
-    }
-
-    /**
-     * Returns the attribute codes for which there is a filter on with operator IsEmpty
-     *
-     * @param string[] $rawFilters
-     *
-     * @return string[]
-     */
-    private function getAttributeCodesWithIsEmptyOperator(array $rawFilters): array
-    {
-        $attributeFilters = array_filter(
-            $rawFilters,
-            function ($filter) {
-                $operator = $filter['operator'];
-
-                return
-                    'attribute' === $filter['type'] &&
-                    (
-                        Operators::IS_EMPTY === $operator ||
-                        Operators::IS_EMPTY_FOR_CURRENCY === $operator ||
-                        Operators::IS_EMPTY_ON_ALL_CURRENCIES === $operator
-                    );
-            }
-        );
-
-        return array_column($attributeFilters, 'field');
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -481,6 +481,15 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.is_empty.number:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\NumberFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_number']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
+
     pim_catalog.doctrine.query.filter.date:
         class: '%pim_catalog.query.elasticsearch.filter.date.class%'
         arguments:
@@ -491,6 +500,15 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.is_empty.date:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\DateFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_date']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
 
     pim_catalog.query.elasticsearch.filter.text:
         class: '%pim_catalog.query.elasticsearch.filter.text.class%'
@@ -503,6 +521,15 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.is_empty.text:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\TextFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_text']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
+
     pim_catalog.query.elasticsearch.filter.text_area:
         class: '%pim_catalog.query.elasticsearch.filter.text_area.class%'
         arguments:
@@ -513,6 +540,15 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.is_empty.text_area:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\TextAreaFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_textarea']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
 
     pim_catalog.query.elasticsearch.filter.option:
         class: '%pim_catalog.query.elasticsearch.filter.option.class%'
@@ -526,6 +562,16 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.is_empty.option:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\OptionFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.repository.attribute_option'
+            - ['pim_catalog_simpleselect', 'pim_catalog_multiselect']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
+
     pim_catalog.query.elasticsearch.filter.price:
         class: '%pim_catalog.query.elasticsearch.filter.price.class%'
         arguments:
@@ -537,6 +583,16 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.is_empty.price:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\PriceFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - '@pim_catalog.repository.currency'
+            - ['pim_catalog_price_collection']
+            - ['EMPTY', 'EMPTY ON ALL CURRENCIES']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
 
     pim_catalog.query.elasticsearch.filter.metric:
         class: '%pim_catalog.query.elasticsearch.filter.metric.class%'
@@ -551,6 +607,17 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
 
+    pim_catalog.query.elasticsearch.filter.is_empty.metric:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\MetricFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - '@akeneo_measure.manager'
+            - '@akeneo_measure.measure_converter'
+            - ['pim_catalog_metric']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
+
     pim_catalog.query.elasticsearch.filter.media:
         class: '%pim_catalog.query.elasticsearch.filter.media.class%'
         arguments:
@@ -561,6 +628,15 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim_catalog.query.elasticsearch.filter.is_empty.media:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\MediaFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - ['pim_catalog_file', 'pim_catalog_image']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
 
     # Fields sorters
     pim_catalog.query.elasticsearch.sorter.datetime:
@@ -676,6 +752,16 @@ services:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 30 }
+
+    pim.reference_data.query.filter.is_empty.reference_data:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Attribute\IsEmpty\ReferenceDataFilter'
+        arguments:
+            - '@pim_catalog.validator.helper.attribute'
+            - '@pim_reference_data.registry'
+            - ['pim_reference_data_simpleselect', 'pim_reference_data_multiselect']
+            - ['EMPTY']
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_and_product_model_filter', priority: 40 }
 
     pim.reference_data.query.sorter.attribute.reference_data:
         class: '%pim_catalog.query.elasticsearch.sorter.attribute.base.class%'

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * Test attribute filters with the EMPTY operator for product and product models
+ *
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
+{
+    public function testEmptyOperatorForDateFilter()
+    {
+        $this->loadFixtures('a_date', ['data' => '2020-05-16', 'scope' => null, 'locale' => null]);
+        $this->assert('a_date');
+    }
+
+    public function testEmptyOperatorForMediaFilter()
+    {
+        $this->loadFixtures(
+            'a_file',
+            ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_file');
+    }
+
+    public function testEmptyOperatorForMetricFilter()
+    {
+        $this->loadFixtures(
+            'a_metric',
+            ['data' => ['amount' => 2, 'unit' => 'KILOWATT'], 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_metric');
+    }
+
+    public function testEmptyOperatorForNumberFilter()
+    {
+        $this->loadFixtures(
+            'a_number_float',
+            ['data' => 25, 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_number_float');
+    }
+
+    public function testEmptyOperatorForOptionFilter()
+    {
+        $this->loadFixtures(
+            'a_simple_select',
+            ['data' => 'optionA', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_simple_select');
+    }
+
+    public function testEmptyOperatorForPriceFilter()
+    {
+        $this->loadFixtures(
+            'a_price',
+            ['data' => [['amount' => 100, 'currency' => 'USD']], 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_price');
+    }
+
+    public function testEmptyOperatorForReferenceDataFilter()
+    {
+        $this->loadFixtures(
+            'a_ref_data_simple_select',
+            ['data' => 'red', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_ref_data_simple_select');
+    }
+
+    public function testEmptyOperatorForTextareaFilter()
+    {
+        $this->loadFixtures(
+            'a_text_area',
+            ['data' => 'Lorem ipsum dolor sit amet', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_text_area');
+    }
+
+    public function testEmptyOperatorForTextFilter()
+    {
+        $this->loadFixtures(
+            'a_text',
+            ['data' => 'Foobar', 'scope' => null, 'locale' => null]
+        );
+        $this->assert('a_text');
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function assert(string $attributeCode)
+    {
+        $pqb = $this->get('pim_catalog.query.product_and_product_model_query_builder_factory')->create();
+        $pqb->addFilter($attributeCode, Operators::IS_EMPTY, null);
+        $results = $pqb->execute();
+        $identifiers = [];
+        foreach ($results as $entity) {
+            $identifiers[] = $entity instanceof ProductModelInterface ? $entity->getCode() : $entity->getIdentifier();
+        }
+        Assert::assertEqualsCanonicalizing(
+            ['pm_1_empty', 'variant_1_empty', 'variant_3_empty', 'simple_product_empty'],
+            $identifiers
+        );
+    }
+
+    /**
+     * Creates
+     * - a family with the given attribute code
+     * - a family variant with the given attribute at root level, and another one with the attribute at variant level
+     * - foreach family variant, product models and variant products with empty or filled value for the given attribute
+     * - 2 simple products, one with empty value, one with non empty value
+     * - a simple product without family
+     */
+    private function loadFixtures(string $attributeCode, array $nonEmptyData)
+    {
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => [$attributeCode, 'sku', 'a_yes_no', 'a_number_float_negative']
+        ]);
+        $this->createFamilyVariant([
+            'code' => 'attribute_at_common_level',
+            'family' => 'a_family',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['sku', 'a_yes_no']
+                ]
+            ]
+        ]);
+        $this->createProductModel([
+            'code' => 'pm_1_empty',
+            'family_variant' => 'attribute_at_common_level',
+        ]);
+        $this->createProduct('variant_1_empty', [
+            'parent' => 'pm_1_empty',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+        $this->createProductModel([
+            'code' => 'pm_2_filled',
+            'family_variant' => 'attribute_at_common_level',
+            'values' => [
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+        $this->createProduct('variant_2_filled', [
+            'parent' => 'pm_2_filled',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+
+        $this->createFamilyVariant([
+            'code' => 'attribute_at_variant_level',
+            'family' => 'a_family',
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['a_yes_no'],
+                    'attributes' => ['sku', 'a_yes_no', $attributeCode]
+                ]
+            ]
+        ]);
+
+        $this->createProductModel([
+            'code' => 'pm_3',
+            'family_variant' => 'attribute_at_variant_level',
+        ]);
+
+        $this->createProduct('variant_3_empty', [
+            'parent' => 'pm_3',
+            'values' => [
+                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
+            ]
+        ]);
+        $this->createProduct('variant_3_filled', [
+            'parent' => 'pm_3',
+            'values' => [
+                'a_yes_no' => [['data' => false, 'scope' => null, 'locale' => null]],
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+
+        $this->createProduct('simple_product_empty', [
+            'family' => 'a_family',
+        ]);
+        $this->createProduct('simple_product_filled', [
+            'family' => 'a_family',
+            'values' => [
+                $attributeCode => [$nonEmptyData],
+            ]
+        ]);
+        $this->createProduct('simple_product_without_family', []);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+    }
+
+    private function createFamily(array $data): void
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+        Assert::assertEmpty($this->get('validator')->validate($family));
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    private function createFamilyVariant($data): void
+    {
+        $familyVariant = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $data);
+        Assert::assertEmpty($this->get('validator')->validate($familyVariant));
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+    }
+
+    private function createProduct(string $identifier, array $data): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $violations = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertEmpty($violations, sprintf('The %s product is not valid: %s', $product->getIdentifier(), $violations));
+        $this->get('pim_catalog.saver.product')->save($product);
+    }
+
+    private function createProductModel(array $data): void
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        Assert::assertEmpty($this->get('pim_catalog.validator.product_model')->validate($productModel));
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelSearchAggregatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelSearchAggregatorSpec.php
@@ -118,18 +118,6 @@ class ProductAndProductModelSearchAggregatorSpec extends ObjectBehavior
                 ],
             ]
         ])->shouldBeCalled();
-        $searchQueryBuilder->addShould([
-            [
-                'terms' => [
-                    'attributes_for_this_level' => ['foo', 'foo_currency1', 'foo_currency2'],
-                ],
-            ],
-            [
-                'terms' => [
-                    'attributes_of_ancestors' => ['foo', 'foo_currency1', 'foo_currency2'],
-                ],
-            ],
-        ])->shouldBeCalled();
 
         $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);
     }
@@ -177,18 +165,6 @@ class ProductAndProductModelSearchAggregatorSpec extends ObjectBehavior
                     ],
                 ],
             ]
-        ])->shouldBeCalled();
-        $searchQueryBuilder->addShould([
-            [
-                'terms' => [
-                    'attributes_for_this_level' => ['foo'],
-                ],
-            ],
-            [
-                'terms' => [
-                    'attributes_of_ancestors' => ['foo'],
-                ],
-            ],
         ])->shouldBeCalled();
 
         $this->aggregateResults($searchQueryBuilder, $rawFilters)->shouldReturn($searchQueryBuilder);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A fix (https://github.com/akeneo/pim-community-dev/pull/12567) about Elasticsearch filters with EMPTY operators was merged in `4.0` and used fields (attributes_for_this_level and attributes_of_ancestors) which are not present in all indexes that we had in `3.2`. This PR adds specific filters for the EMPTY operator to use only the index that has these fields.

Note: these specific filters are irrelevant in `4.0` and should be removed during the next pull-up

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
