### PR TITLE
PIM-9427: Update datagrid selection count when clearing filter

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,10 +1,14 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9427: Update datagrid selection count when clearing filter
+
 # 3.2.67 (2020-08-07)
 
 ## Bug fixes:
 
--PIM-9380: Parts of the PIM are not translatable on Crowdin
+- PIM-9380: Parts of the PIM are not translatable on Crowdin
 
 # 3.2.66 (2020-08-04)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
@@ -49,12 +49,13 @@ define(
              * {@inheritdoc}
              */
             configure() {
-                const setCollection = (collection) => {
+                const setCollection = (collection, datagrid) => {
                     if (null === this.collection) {
                         this.listenTo(collection, 'backgrid:selected', this.select.bind(this));
                     }
 
                     this.collection = collection;
+                    this.datagrid = datagrid;
                     this.updateView();
                 };
                 this.listenTo(this.getRoot(), 'grid_load:start', setCollection);
@@ -147,10 +148,17 @@ define(
              * - The events of the sub extensions are lost after re-render.
              */
             updateView() {
-                if (this.count > 0) {
+                const selectionState = this.datagrid?.getSelectionState();
+
+                let count = this.count;
+                if (undefined !== selectionState && !selectionState.inset) {
+                    count = this.collection.state.totalRecords - Object.keys(selectionState.selectedModels).length;
+                }
+
+                if (count > 0) {
                     this.$el.removeClass('AknDefault-bottomPanel--hidden');
 
-                    if (this.count >= this.collection.state.totalRecords) {
+                    if (count >= this.collection.state.totalRecords) {
                         this.$el.find('.AknSelectButton')
                             .removeClass('AknSelectButton--partial')
                             .addClass('AknSelectButton--selected');
@@ -167,7 +175,7 @@ define(
                         .removeClass('AknSelectButton--partial');
                 }
 
-                this.$el.find('.count').text(this.count);
+                this.$el.find('.count').text(count);
             }
         });
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When selecting ALL entities with a label filter and then clearing the label filter, the results counter was displaying an erroneous value, this PR updates the counter to show the effective affected products when selecting ALL items.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
