### PR TITLE
RAC-219: fix unit value translation is filled with '[]' when product does not have value on unit

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MetricTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MetricTranslator.php
@@ -39,6 +39,10 @@ class MetricTranslator implements FlatAttributeValueTranslatorInterface
         );
 
         return array_map(function ($value) use ($unitTranslations) {
+            if (empty($value)) {
+                return $value;
+            }
+
             return $unitTranslations[$value] ?? sprintf(FlatTranslatorInterface::FALLBACK_PATTERN, $value);
         }, $values);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MetricTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MetricTranslatorSpec.php
@@ -39,8 +39,8 @@ class MetricTranslatorSpec extends ObjectBehavior
             'POUND' => 'Livre',
         ]);
 
-        $this->translate('weight-fr_FR-unit', ['measurement_family_code' => 'Weight'], ['MICROGRAM', 'ONCE', 'unknown', 'POUND'], 'fr_FR')
-            ->shouldReturn(['Microgramme', 'Once française', '[unknown]', 'Livre']);
+        $this->translate('weight-fr_FR-unit', ['measurement_family_code' => 'Weight'], ['MICROGRAM', 'ONCE', 'unknown', 'POUND', ''], 'fr_FR')
+            ->shouldReturn(['Microgramme', 'Once française', '[unknown]', 'Livre', '']);
     }
 
     function it_should_throw_when_reference_data_is_not_set(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When doing an export with label, values in metric column are translated. Problem is when the value is empty, the translation is not found => The value is transformed under bracket but value is empty

![Capture du 2020-09-02 14-36-33](https://user-images.githubusercontent.com/7239572/92093545-c3f95080-edd3-11ea-8152-99cfa0a6487c.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
