### PR TITLE
Fixes wrong order: constraints need to be remove before indexes

### DIFF
--- a/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
+++ b/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
@@ -38,10 +38,10 @@ final class Version_5_0_20200826153300_add_primary_key_connection extends Abstra
     private function fixConstraints()
     {
         if ($this->constraintExists('FK_APP_oro_user_app_user_id')) {
-            $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP CONSTRAINT FK_APP_oro_user_app_user_id');
+            $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP FOREIGN KEY FK_APP_oro_user_app_user_id');
         }
         if ($this->constraintExists('FK_APP_pim_api_client_app_client_id')) {
-            $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP CONSTRAINT FK_APP_pim_api_client_app_client_id');
+            $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP FOREIGN KEY FK_APP_pim_api_client_app_client_id');
         }
 
         if (!$this->constraintExists('FK_CONNECTIVITY_CONNECTION_client_id')) {

--- a/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
+++ b/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
@@ -9,8 +9,8 @@ final class Version_5_0_20200826153300_add_primary_key_connection extends Abstra
 {
     public function up(Schema $schema): void
     {
-        $this->fixIndexes();
         $this->fixConstraints();
+        $this->fixIndexes();
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fixes wrong order: constraints need to be remove before indexes. Also DROP CONSTRAINT doesn't exist for MySQL.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
