### PR TITLE
Index from foreign key are automatically removed by foreign key dropped

### DIFF
--- a/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
+++ b/upgrades/schema/Version_5_0_20200826153300_add_primary_key_connection.php
@@ -26,9 +26,6 @@ final class Version_5_0_20200826153300_add_primary_key_connection extends Abstra
         if ($this->indexExists('IDX_CONNECTIVITY_CONNECTION_code')) {
             $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP INDEX IDX_CONNECTIVITY_CONNECTION_code');
         }
-        if ($this->indexExists('FK_APP_oro_user_app_user_id')) {
-            $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP INDEX FK_APP_oro_user_app_user_id');
-        }
         if ($this->indexExists('code')) {
             $this->addSql('ALTER TABLE akeneo_connectivity_connection DROP INDEX code');
         }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Index from foreign key are automatically removed by foreign key dropped.

The current code generated problems as it registered the DROP of the foreign key and the drop of the index.
Then all the "added" SQL is executed sequentially and when it's time to remove fhe index from foreign key, the code goes into error as the index has already been removed by the drop of the FOREIGN KEY.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
