### PR TITLE
AOB-1023: Fix duplicated assets menu in PEF

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- AOB-1023: Fix duplicated assets menu in PEF
+
 # 4.0.56 (2020-09-09)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/column-tabs-navigation.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/column-tabs-navigation.js
@@ -86,7 +86,15 @@ define(
                     label: event.label,
                     route: event.code
                 };
-                this.tabs.push(tab);
+                const existingTab = this.tabs.find((currentTab) => currentTab.code === tab.code);
+
+                if (undefined === existingTab) {
+                    this.tabs.push(tab);
+                } else {
+                    existingTab.label = event.label;
+                    existingTab.isVisible = event.isVisible;
+                }
+
                 this.trigger('pim_menu:column:register_navigation_item', tab);
 
                 this.render();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The asset menu was duplicated when saving the PEF:
![assets-tab](https://user-images.githubusercontent.com/2642302/92752191-fe8d5b00-f388-11ea-97fa-b98a1bd8d167.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

A fix has been done in the `master` branch in [this PR](https://github.com/akeneo/pim-community-dev/commit/89118a466118b2cdae6be911883e525405223f73#diff-23012730008abf6dd08375d900598d73).
On the Onboarder, we are still using the 4.0.x version of CE & EE so this PR backports the fix in `4.0`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
