### PR TITLE
RAC-204: Add publish to npm github action

### DIFF
--- a/akeneo-design-system/.github/workflows/npm-publish.yml
+++ b/akeneo-design-system/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+
+# To run manual tests call POST https://api.github.com/repos/SamirBoulil/dsm/dispatches
+# and uncomment below
+# on: repository_dispatch
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 13.13
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@samirboulil' # <= TODO: Change me
+      - run: yarn
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Github action executed on the read-only repository that published the package to npm.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
