### PR TITLE
PIM-9443: Do not cache extensions.json

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,9 +1,5 @@
 # 4.0.x
 
-## Bug fixes
-
-- PIM-9443: Do not cache extensions.json
-
 # 4.0.54 (2020-08-28)
 
 ## Improvement

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9443: Do not cache extensions.json
+
 # 4.0.54 (2020-08-28)
 
 ## Improvement

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - PIM-9391: Filter empty prices and measurement values
 - PIM-9407: Fix glitch in family variant selector if the family variant has no label
 - PIM-9425: Fix inaccurate attribute max characters
+- PIM-9443: Do not cache extensions.json
+
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/config-provider.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/config-provider.js
@@ -27,7 +27,7 @@ define(
         const loadConfig = function () {
             if (null === promise) {
                 promise = $.when(
-                    $.get('/js/extensions.json'),
+                    $.get('/js/extensions.json', {version: Math.random().toString(36).substring(7)}),
                     SecurityContext.initialize(),
                     FeatureFlags.initialize()
                 )


### PR DESCRIPTION
We are loading extensions dynamically at page load and the `extensions.json` caused cache issues because it's "versioned" like other javascript assets.
By adding a random query string parameter, we will force it to be refreshed.
Note on perfs: with this query string, it is not cached anymore. But it's not a real problem because it's loaded only on HTML page refresh when the rest of the PIM is mainly a SPA. It will mainly be on login, so not very often for the same user.