### PR TITLE
PIM-9445: fix switch is broken on compare/translate when attribute is localisable or scopable

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - AOB-1023: Fix duplicated assets menu in PEF
+- PIM-9445: Fix boolean attribute is broken on compare/translate when the attribute is localisable or scopable
 
 # 4.0.56 (2020-09-09)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-switch/bootstrap.switch.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap-switch/bootstrap.switch.js
@@ -31,6 +31,10 @@
                 myClasses = el;
             });
 
+            if ($element.hasClass('has-switch')) {
+                return;
+            }
+
             $element.addClass('has-switch');
 
             if ($element.data('on') !== undefined)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

On compare/translate page, bootstrapSwitch is called twice on switcher => this function add div on parent div of checkbox input. 

Here we do not add div when div already have "has-switch" class

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
