### PR TITLE
PIM-9439: fix PEF shakes on product with lot of simple/multi select

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,7 @@
 
 - AOB-1023: Fix duplicated assets menu in PEF
 - PIM-9445: Fix boolean attribute is broken on compare/translate when the attribute is localisable or scopable
+- PIM-9439: Fix PEF shakes on product with lot of simple/multi select
 
 # 4.0.56 (2020-09-09)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -107,6 +107,13 @@
   &-subContainer {
     position: relative;
     flex-grow: 10000;
+    &-multiSelect {
+      height: 45px;
+    }
+
+    &-simpleSelect {
+      height: 40px;
+    }
   }
 
   &-iconsContainer {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/multi-select.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/multi-select.html
@@ -1,4 +1,4 @@
-<div class="AknFieldContainer-subContainer">
+<div class="AknFieldContainer-subContainer AknFieldContainer-subContainer-multiSelect">
     <% if (attribute.localizable) { %>
         <div class="AknTextField-layer AknTextField-layer--first"></div>
         <div class="AknTextField-layer AknTextField-layer--second"></div>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/simple-select.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/simple-select.html
@@ -1,4 +1,4 @@
-<div class="AknFieldContainer-subContainer">
+<div class="AknFieldContainer-subContainer AknFieldContainer-subContainer-simpleSelect">
     <% if (attribute.localizable) { %>
         <div class="AknTextField-layer AknTextField-layer--first"></div>
         <div class="AknTextField-layer AknTextField-layer--second"></div>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
On PEF, the attribute of type simple and multi select are handled by select2. On initilization, select2 create a div in specific height but before the div height :
- Is equal to 39px when the "+" is displayed
- Is equal to 0px when the user does not have access to edit attribute

On this PR :
Fix the size of simple/multi select container

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
