### PR TITLE
PIM-9450: Fix error during family import, compute products/product models doesn't work when products/product models are skipped

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9450: Fix error during family import, compute products/product models doesn't work when products/product models are skipped
+
 # 3.2.70 (2020-09-10)
 
 # 3.2.69 (2020-09-07)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTasklet.php
@@ -130,6 +130,7 @@ class ComputeDataRelatedToFamilySubProductModelsTasklet implements TaskletInterf
                 continue;
             }
 
+            $skippedProductModels = [];
             $productModelsToSave = [];
             $productModels = $this->getSubProductModelsForFamily($family);
 
@@ -137,22 +138,21 @@ class ComputeDataRelatedToFamilySubProductModelsTasklet implements TaskletInterf
                 $this->keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$productModel]);
 
                 if (!$this->isValid($productModel)) {
+                    $skippedProductModels[] = $productModel;
                     $this->stepExecution->incrementSummaryInfo('skip');
-                    continue;
+                } else {
+                    $productModelsToSave[] = $productModel;
                 }
 
-                $productModelsToSave[] = $productModel;
-
-                if (0 === count($productModelsToSave) % $this->batchSize) {
+                if (0 === (count($productModelsToSave) + count($skippedProductModels)) % $this->batchSize) {
                     $this->saveProductsModel($productModelsToSave);
-                    $productModelsToSave= [];
+                    $productModelsToSave = [];
+                    $skippedProductModels = [];
                     $this->cacheClearer->clear();
                 }
             }
 
-            if (!empty($productModelsToSave)) {
-                $this->saveProductsModel($productModelsToSave);
-            }
+            $this->saveProductsModel($productModelsToSave);
         }
     }
 
@@ -181,6 +181,10 @@ class ComputeDataRelatedToFamilySubProductModelsTasklet implements TaskletInterf
      */
     private function saveProductsModel(array $productModels): void
     {
+        if (empty($productModels)) {
+            return;
+        }
+
         $this->productModelSaver->saveAll($productModels);
         $this->stepExecution->incrementSummaryInfo('process', count($productModels));
         $this->jobRepository->updateStepExecution($this->stepExecution);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
@@ -223,7 +223,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalledTimes(2);
+        $cacheClearer->clear()->shouldBeCalledTimes(3);
 
         $this->setStepExecution($stepExecution);
         $this->execute();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyRootProductModelsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyRootProductModelsTaskletSpec.php
@@ -212,7 +212,7 @@ class ComputeDataRelatedToFamilyRootProductModelsTaskletSpec extends ObjectBehav
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(1);
-        $cacheClearer->clear()->shouldBeCalledTimes(1);
+        $cacheClearer->clear()->shouldBeCalledTimes(2);
 
         $this->execute();
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
@@ -212,7 +212,7 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(1);
-        $cacheClearer->clear()->shouldBeCalledTimes(1);
+        $cacheClearer->clear()->shouldBeCalledTimes(2);
 
         $this->execute();
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually on ComputeDataRelatedToFamilyProductsTasklet, ComputeDataRelatedToFamilyRootProductModelsTasklet and ComputeDataRelatedToFamilySubProductModelsTasklet we call clear function on UnitOfWork when product to save is equal to the batch size. 

Problem is when product or product model is invalid. UnitOfWork clear and Cursor fetch data are desynchronized. When it the case, we have in cursor versionA of FamilyVariant and a versionB when we fetch Product/ProductModel on save (due to permission fullProduct). Those two versions are totally same but for Doctrine they are different due to clear function call.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
