### PR TITLE
BH-46 Avoid polluting test migration output

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -73,7 +73,11 @@ endif
 ### Migration tests
 .PHONY: migration-back
 migration-back: var/tests/phpunit
+ifeq ($(CI),true)
 	.circleci/run_phpunit.sh . .circleci/find_phpunit.php PIM_Migration_Test
+else
+	APP_ENV=test $(PHP_RUN) ./vendor/bin/phpunit -c . --testsuite PIM_Migration_Test
+endif
 
 ### End to end tests
 .PHONY: end-to-end-back

--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -24,13 +24,13 @@ trait ExecuteMigrationTrait
         $pathFinder = new PhpExecutableFinder();
         $phpCommand = $pathFinder->find();
 
-        $rootDir = $this->getParameter('kernel.root_dir');
+        $rootDir = $this->getParameter('kernel.project_dir');
 
         $output = [];
         $status = null;
 
         exec(
-            sprintf('%s %s/../bin/console doctrine:migrations:execute %s --down -n 2>&1', $phpCommand, $rootDir, $migrationLabel),
+            sprintf('%s %s/bin/console doctrine:migrations:execute %s --down -n 2>&1', $phpCommand, $rootDir, $migrationLabel),
             $output,
             $status
         );
@@ -38,7 +38,7 @@ trait ExecuteMigrationTrait
         Assert::assertEquals(1, $status, 'Migration should be irreversible.');
 
         exec(
-            sprintf('%s %s/../bin/console doctrine:migrations:execute %s --up -n', $phpCommand, $rootDir, $migrationLabel),
+            sprintf('%s %s/bin/console doctrine:migrations:execute %s --up -n', $phpCommand, $rootDir, $migrationLabel),
             $output,
             $status
         );

--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema\Tests;
 
-use Akeneo\Tool\Component\Console\CommandLauncher;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Process\PhpExecutableFinder;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -15,26 +15,33 @@ use PHPUnit\Framework\Assert;
 trait ExecuteMigrationTrait
 {
     /**
-     * @param string $service
-     * @return mixed
+     * @return string
      */
-    abstract protected function get(string $service);
-
-    private function getCommandLauncher(): CommandLauncher
-    {
-        return $this->get('akeneo_integration_tests.migration_command_launcher');
-    }
+    abstract protected function getParameter(string $parameter);
 
     private function reExecuteMigration(string $migrationLabel): void
     {
-        $resultDown = $this->getCommandLauncher()->executeForeground(
-            sprintf('doctrine:migrations:execute %s --down -n', $migrationLabel)
-        );
-        Assert::assertEquals(1, $resultDown->getCommandStatus(), 'Migration should be irreversible.');
+        $pathFinder = new PhpExecutableFinder();
+        $phpCommand = $pathFinder->find();
 
-        $resultUp = $this->getCommandLauncher()->executeForeground(
-            sprintf('doctrine:migrations:execute %s --up -n', $migrationLabel)
+        $rootDir = $this->getParameter('kernel.root_dir');
+
+        $output = [];
+        $status = null;
+
+        exec(
+            sprintf('%s %s/../bin/console doctrine:migrations:execute %s --down -n 2>&1', $phpCommand, $rootDir, $migrationLabel),
+            $output,
+            $status
         );
-        Assert::assertEquals(0, $resultUp->getCommandStatus(), \json_encode($resultUp->getCommandOutput()));
+
+        Assert::assertEquals(1, $status, 'Migration should be irreversible.');
+
+        exec(
+            sprintf('%s %s/../bin/console doctrine:migrations:execute %s --up -n', $phpCommand, $rootDir, $migrationLabel),
+            $output,
+            $status
+        );
+        Assert::assertEquals(0, $status, \json_encode($output));
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The rollback migrations are not implemented in the application. So we test that they fail with an error. But the error is displayed in the output of the test, which can be very confusing.
And the CommandLauncher service is not able to redirect the error output. So the trait doesn't use it anymore. 
The PR allows as well the possibility to run the migration tests locally through the makefile 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
