### PR TITLE
AOB-1080: fix pim/onboarder logo submenu display under collapsed column

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,7 @@
 # 3.2.x
 
+- AOB-1080: Fix pim/onboarder logo submenu display under collapsed column
+
 # 3.2.70 (2020-09-10)
 
 # 3.2.69 (2020-09-07)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
@@ -258,6 +258,6 @@
   }
 
   &--firstColumn {
-    z-index: 803;
+    z-index: 802;
   }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Before
![before2](https://user-images.githubusercontent.com/17565301/93434356-53206100-f8c8-11ea-9647-0941d8c25224.gif)

After
![after2](https://user-images.githubusercontent.com/17565301/93434363-561b5180-f8c8-11ea-8e9b-d0540921f8b4.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | OK
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
