### PR TITLE
fix: Cannot find module 'es-abstract/2020/RequireObjectCoercible' from 'implementation.js'

### DIFF
--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -16,7 +16,7 @@ const unitConfig = {
   },
   testRegex: '(tests/front/unit)(.*)(unit).(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
-  moduleDirectories: ['<rootDir>/node_modules', `<rootDir>/web/bundles/`],
+  moduleDirectories: ['node_modules', `<rootDir>/web/bundles/`],
   globals: {
     __moduleConfig: {},
     'ts-jest': {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Currenly, the 3.2 nightly does not pass. 
Reason ? yarn.lock is not versionned only in pim-enterprise 3.2. 
But this problem will arrived when we are going to update dependency on others versions

Reproduce in locale in pim-enterprise-dev 3.2: 
```
rm -rf yarn.lock
docker-compose run --rm node yarn install
docker-compose run --rm node yarn run unit src/Akeneo/ReferenceEntity/tests/front/unit/akeneoreferenceentity/domain/model/attribute/type/text/validation-rule.unit.ts
```

Why this error now ?
A new version of https://github.com/es-shims/String.prototype.trim have been released it require version es-abstract: 1.18.0. Due to conflict with other package that require es-abstract 1.17.*, yarn download es-abstract: 1.18.0 into node_modules of package String.prototype.trim. Problem is that jest is configured to load module directory from <rootDir>/node_modules instead of doing search recursively on node_modules

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
