### PR TITLE
[Backport master => 4.0] PIM-9455: Make total_fields limit of elasticsearch configurable

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@ APP_INDEX_HOSTS=elasticsearch:9200
 APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME=akeneo_pim_product_and_product_model
 MAILER_URL=null://localhost
 AKENEO_PIM_URL=http://localhost:8080
+APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT=10000

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9455: Make total_fields limit of elasticsearch configurable
+
 # 4.0.57 (2020-09-15)
 
 ## Bug fixes

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -37,6 +37,9 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
+    # Total fields limit of elasticsearch
+    elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
+
     # Files used as configuration for the Elasticsearch index
     elasticsearch_index_configuration_files:
         - '%pim_ce_dev_src_folder_location%/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml'

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -37,6 +37,8 @@ parameters:
     # Maximum number of resources when updating a list of resources
     api_input_max_resources_number: 100
 
+    # env var default value if not present on server
+    env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT): 10000
     # Total fields limit of elasticsearch
     elasticsearch_total_fields_limit: '%env(APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT)%'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Filter/ProductEditDataFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Filter/ProductEditDataFilter.php
@@ -51,7 +51,7 @@ class ProductEditDataFilter implements CollectionFilterInterface
         $product = $options['product'];
 
         foreach ($collection as $type => $data) {
-            if ($this->isAllowed($product, $type)) {
+            if (!empty($type) && $this->isAllowed($product, $type)) {
                 $newProductData[$type] = $this->filterData($type, $data);
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/settings.yml
@@ -33,4 +33,5 @@ settings:
         # ES default value is 1000. This value can be too low for big catalogs.
         # For more information see https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping.html#mapping-limit-settings
         total_fields:
-            limit: 10000
+            limit: '%elasticsearch_total_fields_limit%'
+

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/AkeneoElasticsearchExtension.php
@@ -7,6 +7,7 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
@@ -54,7 +55,7 @@ class AkeneoElasticsearchExtension extends Extension
                 $index['service_name']
             );
             $container->register($configurationLoaderServiceName, Loader::class)
-                ->setArguments([$index['configuration_files']]);
+                ->setArguments([$index['configuration_files'], new Reference(ParameterBagInterface::class)]);
 
             $container->register($index['service_name'], Client::class)
                 ->setArguments([

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/Loader.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
 
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Yaml\Parser;
 
 /**
@@ -20,12 +21,16 @@ class Loader
     /** @var array */
     private $configurationFiles;
 
+    /** @var ParameterBagInterface */
+    private $parameterBag;
+
     /**
      * @param array $configurationFiles
      */
-    public function __construct(array $configurationFiles)
+    public function __construct(array $configurationFiles, ParameterBagInterface $parameterBag)
     {
         $this->configurationFiles = $configurationFiles;
+        $this->parameterBag = $parameterBag;
     }
 
     /**
@@ -49,6 +54,10 @@ class Loader
             }
 
             $configuration = $yaml->parse(file_get_contents($configurationFile));
+
+            array_walk_recursive($configuration, function (&$value) {
+                $value = $this->parameterBag->resolveValue($value);
+            });
 
             if (isset($configuration['settings'])) {
                 $settings = array_replace_recursive($settings, $configuration['settings']);

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/LoaderSpec.php
@@ -3,6 +3,8 @@
 namespace spec\Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
 
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 class LoaderSpec extends ObjectBehavior
 {

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf4.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/conf4.yml
@@ -1,0 +1,10 @@
+settings:
+  analysis:
+    char_filter:
+      newline_pattern:
+        type: "pattern_replace"
+        pattern: "\\n"
+        replacement: ""
+  mapping:
+    total_fields:
+      limit: '%elasticsearch_total_fields_limit%'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Total_fields limit of elasticsearch should be configurable on 4.0 instances.

PR done for master => https://github.com/akeneo/pim-community-dev/pull/11838

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | 
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | 
| Micro Demo to the PO (Story only) | 
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
