### PR TITLE
PIM-9454: Fix scalar values type check in PQB filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - PIM-9407: Fix glitch in family variant selector if the family variant has no label
 - PIM-9425: Fix inaccurate attribute max characters
 - PIM-9443: Do not cache extensions.json
+- PIM-9454: Fix scalar value type check in PQB filters 
 
 
 ## New features

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/NumberFilter.php
@@ -160,7 +160,7 @@ class NumberFilter extends AbstractAttributeFilter implements AttributeFilterInt
      */
     protected function checkValue(AttributeInterface $attribute, $value)
     {
-        if (!is_numeric($value) && null !== $value) {
+        if (!is_numeric($value)) {
             throw InvalidPropertyTypeException::numericExpected($attribute->getCode(), static::class, $value);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilter.php
@@ -174,7 +174,7 @@ class TextAreaFilter extends AbstractAttributeFilter implements AttributeFilterI
      */
     protected function checkValue(AttributeInterface $attribute, $value)
     {
-        if (!is_string($value) && null !== $value) {
+        if (!is_string($value)) {
             throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $value);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Attribute/TextFilter.php
@@ -170,7 +170,7 @@ class TextFilter extends AbstractAttributeFilter implements AttributeFilterInter
      */
     protected function checkValue(AttributeInterface $attribute, $value)
     {
-        if (!is_string($value) && null !== $value) {
+        if (!is_string($value)) {
             throw InvalidPropertyTypeException::stringExpected($attribute->getCode(), static::class, $value);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
@@ -117,7 +117,7 @@ class FieldFilterHelper
      */
     public static function checkString($field, $value, $className)
     {
-        if (!is_string($value) && null !== $value) {
+        if (!is_string($value)) {
             throw InvalidPropertyTypeException::stringExpected($field, $className, $value);
         }
     }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
@@ -109,6 +109,14 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->executeFilter([['an_image', Operators::CONTAINS, []]]);
     }
 
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "an_image" expects a string as data, "NULL" given.');
+
+        $this->executeFilter([['an_image', Operators::EQUALS, null]]);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(UnsupportedFilterException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
@@ -148,6 +148,14 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->executeFilter([['a_number_float_negative', Operators::NOT_EQUAL, 'string']]);
     }
 
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_number_float_negative" expects a numeric as data, "NULL" given.');
+
+        $this->executeFilter([['a_number_float_negative', Operators::NOT_EQUAL, null]]);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(UnsupportedFilterException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
@@ -187,6 +187,14 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->executeFilter([['a_text', Operators::NOT_EQUAL, [[]]]]);
     }
 
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_text" expects a string as data, "NULL" given.');
+
+        $this->executeFilter([['a_text', Operators::EQUALS, null]]);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(UnsupportedFilterException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
@@ -254,6 +254,14 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->executeFilter([['a_text_area', Operators::NOT_EQUAL, [[]]]]);
     }
 
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "a_text_area" expects a string as data, "NULL" given.');
+
+        $this->executeFilter([['a_text_area', Operators::EQUALS, null]]);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(UnsupportedFilterException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdFilterIntegration.php
@@ -86,6 +86,14 @@ class IdFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->executeFilter([['id', Operators::EQUALS, ['string']]]);
     }
 
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "id" expects a string as data, "NULL" given.');
+
+        $this->executeFilter([['id', Operators::EQUALS, null]]);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(UnsupportedFilterException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/IdentifierFilterIntegration.php
@@ -181,4 +181,12 @@ class IdentifierFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->executeFilter([['identifier', Operators::STARTS_WITH, ['string']]]);
     }
+
+    public function testErrorDataIsNull()
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->expectExceptionMessage('Property "identifier" expects a string as data, "NULL" given.');
+
+        $this->executeFilter([['identifier', Operators::EQUALS, null]]);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/IdentifierFilterSpec.php
@@ -220,6 +220,22 @@ class IdentifierFilterSpec extends ObjectBehavior
         )->during('addAttributeFilter', [$sku, Operators::EQUALS, ['sku-001'], null, null, []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        SearchQueryBuilder $sqb,
+        AttributeInterface $sku
+    ) {
+        $sku->getCode()->willReturn('sku');
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'sku',
+                IdentifierFilter::class,
+                null
+            )
+        )->during('addAttributeFilter', [$sku, Operators::EQUALS, null, null, null, []]);
+    }
+
     function it_throws_an_exception_when_the_given_value_is_not_an_array_with_unsupported_operator_for_field_filter(
         SearchQueryBuilder $sqb,
         AttributeInterface $sku

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/MediaFilterSpec.php
@@ -267,6 +267,28 @@ class MediaFilterSpec extends ObjectBehavior
         )->during('addAttributeFilter', [$name, Operators::CONTAINS, 123, 'en_US', 'ecommerce', []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        $filterValidator,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('an_image');
+        $name->getBackendType()->willReturn('media');
+
+        $filterValidator->validateLocaleForAttribute('an_image', 'en_US')->shouldBeCalled();
+        $filterValidator->validateChannelForAttribute('an_image', 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'an_image',
+                MediaFilter::class,
+                null
+            )
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, null, 'en_US', 'ecommerce', []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $filterValidator,
         AttributeInterface $name,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/NumberFilterSpec.php
@@ -300,6 +300,28 @@ class NumberFilterSpec extends ObjectBehavior
         )->during('addAttributeFilter', [$size, Operators::LOWER_THAN, 'NOT_NUMERIC', 'en_US', 'ecommerce', []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        $filterValidator,
+        AttributeInterface $size,
+        SearchQueryBuilder $sqb
+    ) {
+        $size->getCode()->willReturn('size');
+        $size->getBackendType()->willReturn('decimal');
+
+        $filterValidator->validateLocaleForAttribute('size', 'en_US')->shouldBeCalled();
+        $filterValidator->validateChannelForAttribute('size', 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::numericExpected(
+                'size',
+                NumberFilter::class,
+                null
+            )
+        )->during('addAttributeFilter', [$size, Operators::LOWER_THAN, null, 'en_US', 'ecommerce', []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $filterValidator,
         AttributeInterface $size,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextAreaFilterSpec.php
@@ -270,6 +270,28 @@ class TextAreaFilterSpec extends ObjectBehavior
         )->during('addAttributeFilter', [$description, Operators::CONTAINS, 123, 'en_US', 'ecommerce', []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        $filterValidator,
+        AttributeInterface $description,
+        SearchQueryBuilder $sqb
+    ) {
+        $description->getCode()->willReturn('description');
+        $description->getBackendType()->willReturn('textarea');
+
+        $filterValidator->validateLocaleForAttribute('description', 'en_US')->shouldBeCalled();
+        $filterValidator->validateChannelForAttribute('description', 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'description',
+                TextAreaFilter::class,
+                null
+            )
+        )->during('addAttributeFilter', [$description, Operators::CONTAINS, null, 'en_US', 'ecommerce', []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $filterValidator,
         AttributeInterface $description,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Attribute/TextFilterSpec.php
@@ -264,6 +264,28 @@ class TextFilterSpec extends ObjectBehavior
         )->during('addAttributeFilter', [$name, Operators::CONTAINS, 123, 'en_US', 'ecommerce', []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        ElasticsearchFilterValidator $filterValidator,
+        AttributeInterface $name,
+        SearchQueryBuilder $sqb
+    ) {
+        $name->getCode()->willReturn('name');
+        $name->getBackendType()->willReturn('text');
+
+        $filterValidator->validateLocaleForAttribute('name', 'en_US')->shouldBeCalled();
+        $filterValidator->validateChannelForAttribute('name', 'ecommerce')->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'name',
+                TextFilter::class,
+                123
+            )
+        )->during('addAttributeFilter', [$name, Operators::CONTAINS, 123, 'en_US', 'ecommerce', []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(
         $filterValidator,
         AttributeInterface $name,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/EntityTypeFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/EntityTypeFilterSpec.php
@@ -100,6 +100,14 @@ class EntityTypeFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['entity_type', Operators::EQUALS, 123]);
     }
 
+    function it_throws_if_the_given_value_is_null(SearchQueryBuilder $sqb)
+    {
+        $this->setQueryBuilder($sqb);
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected('entity_type', EntityTypeFilter::class, 123)
+        )->during('addFieldFilter', ['entity_type', Operators::EQUALS, 123]);
+    }
+
     function it_throws_if_the_given_operator_is_not_supported(SearchQueryBuilder $sqb)
     {
         $this->setQueryBuilder($sqb);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
@@ -201,6 +201,20 @@ class IdentifierFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['identifier', Operators::EQUALS, ['sku-001'], null, null, []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_null(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::stringExpected(
+                'identifier',
+                IdentifierFilter::class,
+                null
+            )
+        )->during('addFieldFilter', ['identifier', Operators::EQUALS, null, null, null, []]);
+    }
+
     function it_throws_an_exception_when_the_given_value_is_not_an_array_with_unsupported_operator_for_field_filter(
         SearchQueryBuilder $sqb
     ) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We currently accept null as "value" for some field/operator combinations in the PQB, though Elasticsearch does not accept such values for these fields, and throws a BadRequestException, (for instance ["a_text_attribute_value", "=", null])
This PR checks value types more strictly when applying filters (text fields only accept non null strings, numeric fields only accept numeric values)

Note: the error is quite rare because:
- sometimes this passed value is transformed (e.g with `sprintf`), and cast as string
- sometimes filters with `null` are not applied (e.g when coming from the product grid)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
