### PR TITLE
GITHUB-APD-224: don't display the Read more button in communication panel if there is no link in the announcement

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Announcement.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Announcement.tsx
@@ -50,14 +50,14 @@ const AnnouncementComponent = ({announcement, campaign}: AnnouncementProps): JSX
       <Title tags={announcement.tags} title={announcement.title} />
       <Description tags={announcement.tags} description={announcement.description} />
       {null !== announcement.img && <Image src={announcement.img} alt={altImg} />}
-      <LineContainer>
-        <LinkComponent
-          baseUrl={announcement.link}
-          title={announcement.title}
-          campaign={campaign}
-          content={announcement.id}
-        />
-      </LineContainer>
+      {null !== announcement.link &&
+        <LineContainer> <LinkComponent
+            baseUrl={announcement.link}
+            title={announcement.title}
+            campaign={campaign}
+            content={announcement.id}
+        /> </LineContainer>
+      }
     </Container>
   );
 };

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Tag.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Tag.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import {AkeneoThemedProps} from '@akeneo-pim-community/shared';
 
-type Tag = 'new' | 'updates';
+type Tag = 'new' | 'updates' | 'product_marketing';
 type TagProps = {
   tag: Tag;
 };
@@ -32,7 +32,12 @@ const StyledTag = styled.div`
           color: #763e9e;
           border: 1px solid #9452ba;
         `;
-
+      case 'product_marketing':
+        return `
+          background-color: #f0f7fc;
+          color: #3278b7;
+          border: 1px solid #4ca8e0;
+        `;
       default:
         return;
     }

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/definitions/announcement.schema.json
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/definitions/announcement.schema.json
@@ -7,7 +7,7 @@
     "description": {"type": "string"},
     "img": {"type": ["string", "null"]},
     "altImg": {"type": ["string", "null"]},
-    "link": {"type": "string"},
+    "link": {"type": ["string", "null"]},
     "tags": {
       "type": "array",
       "items": {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/__mocks__/dataProvider.ts
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/__mocks__/dataProvider.ts
@@ -14,10 +14,10 @@ export const getExpectedAnnouncements = () => {
       id: 'update-title_announcement_2-20-04-2020',
       title: 'Title announcement 2',
       description: 'Description announcement 2',
-      link: 'http://external-2.com',
+      link: null,
       img: null,
       altImg: null,
-      tags: ['tag'],
+      tags: ['product_marketing'],
       startDate: '20-04-2020',
     },
   ];

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
@@ -137,6 +137,24 @@ test('it can open the read more link in a new tab', async () => {
   );
 });
 
+test('it does not generate Read more button when there is no link.', async () => {
+  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
+  useInfiniteScroll.mockReturnValue([
+    {
+      items: expectedAnnouncements,
+      isFetching: false,
+      hasError: false,
+    },
+    jest.fn(),
+  ]);
+
+  await act(async () =>
+      renderWithProviders(<AnnouncementList campaign={campaign} panelIsClosed={false} />, container as HTMLElement)
+  );
+
+  expect(container.querySelectorAll('ul li a').length).toEqual(1);
+});
+
 test('it can display a message when it has an error during the fetch', async () => {
   const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
   useInfiniteScroll.mockReturnValue([


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**Before**
In the communication panel, there is a link in each announcement. This link target a page in the helpcenter website. The link is  a "Read more" button in the PIM.

**After**

There are marketing announcements that will be written by the product marketing. These announcements will not necessary have a link. In that case, it should not display a Read more button.

Note: the color of the "tag" for the marketing announcements are coming from UX designer

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
