### PR TITLE
Hotfix: Fix standard distribution required files

### DIFF
--- a/docker/wait_docker_up.sh
+++ b/docker/wait_docker_up.sh
@@ -15,7 +15,7 @@ while ! docker-compose exec mysql mysql --protocol TCP -uroot -proot -e "show da
     sleep 1
 done
 
-echo "MySQL server is running!"
+echo "MySQL server is running! (after $COUNTER checks)"
 
 COUNTER=1
 echo "Waiting for Elasticsearch server…"
@@ -28,4 +28,4 @@ while ! docker-compose exec elasticsearch curl -s -k --fail "http://elasticsearc
     sleep 1
 done
 
-echo "Elasticsearch server is running!"
+echo "Elasticsearch server is running! (after $COUNTER checks)"

--- a/std-build/install-required-files.sh
+++ b/std-build/install-required-files.sh
@@ -25,6 +25,7 @@ mkdir -p $STANDARD_DISTRIB_DIR/src \
 cp $DEV_DISTRIB_DIR/docker/wait_docker_up.sh $STANDARD_DISTRIB_DIR/docker/
 cp $DEV_DISTRIB_DIR/docker/httpd.conf $STANDARD_DISTRIB_DIR/docker/
 cp $DEV_DISTRIB_DIR/docker/akeneo.conf $STANDARD_DISTRIB_DIR/docker/
+cp $DEV_DISTRIB_DIR/docker/create_db_test.sh $STANDARD_DISTRIB_DIR/docker/
 
 # We use the same bootstrap.php to load .env file on standard as on CE-dev
 cp $DEV_DISTRIB_DIR/config/bootstrap.php $STANDARD_DISTRIB_DIR/config/


### PR DESCRIPTION
Fix for standard CI
- display the number of loops it takes to wait (improvement)
- copy missing required file