### PR TITLE
PIM-9461: Fix display of multiselect fields with a lot of selected options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 - PIM-9407: Fix glitch in family variant selector if the family variant has no label
 - PIM-9425: Fix inaccurate attribute max characters
 - PIM-9443: Do not cache extensions.json
-- PIM-9454: Fix scalar value type check in PQB filters 
+- PIM-9454: Fix scalar value type check in PQB filters
+- PIM-9461: Fix display of multiselect fields with a lot of selected options
 
 
 ## New features

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/product-edit-form/FieldContainer.less
@@ -108,7 +108,7 @@
     position: relative;
     flex-grow: 10000;
     &-multiSelect {
-      height: 45px;
+      min-height: 45px;
     }
 
     &-simpleSelect {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

before: 
![before](https://user-images.githubusercontent.com/5301298/93881315-08935000-fcdf-11ea-9b5f-ada7bc879e28.png)

after:
![after](https://user-images.githubusercontent.com/5301298/93881338-0e893100-fcdf-11ea-9e11-b643208512a5.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
