### PR TITLE
Bugfix/fix association display

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
@@ -88,19 +88,6 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $scope
         );
 
-        $productModelLimit = $limit - $associatedProducts->count();
-        $associatedProductModels = [];
-        if ($productModelLimit > 0) {
-            $productModelFrom = $from - count($associatedProductsIdentifiers) + $associatedProducts->count();
-            $associatedProductModels = $this->getAssociatedProductModels(
-                $associatedProductModelsIdentifiers,
-                $productModelLimit,
-                max($productModelFrom, 0),
-                $locale,
-                $scope
-            );
-        }
-
         $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
             $associatedProducts,
             $associatedProductsIdentifiersFromParent,
@@ -108,12 +95,25 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $scope
         );
 
-        $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
-            $associatedProductModels,
-            $associatedProductModelsIdentifiersFromParent,
-            $locale,
-            $scope
-        );
+        $productModelLimit = $limit - $associatedProducts->count() + $from;
+        $normalizedAssociatedProductModels = [];
+        if ($productModelLimit > 0) {
+            $productModelFrom = $from - count($associatedProductsIdentifiers) + count($normalizedAssociatedProducts);
+            $associatedProductModels = $this->getAssociatedProductModels(
+                $associatedProductModelsIdentifiers,
+                $productModelLimit,
+                max($productModelFrom, 0),
+                $locale,
+                $scope
+            );
+
+            $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
+                $associatedProductModels,
+                $associatedProductModelsIdentifiersFromParent,
+                $locale,
+                $scope
+            );
+        }
 
         $rows = ['totalRecords' => count($associatedProductsIdentifiers) + count($associatedProductModelsIdentifiers)];
         $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);


### PR DESCRIPTION

I used the correction for akeneo 4 https://github.com/akeneo/pim-community-dev/commit/0b2e38dbbfa652e82d3305fd5b281d8dda83d00c and put it in place for 3.1.X since we encountered a bug preventing us from seeing the list of product associations on the product associations page when the number of associated products was more than the limit.

This has been tested and does not prevent usage of the platform as of 3.1.X

