### PR TITLE
replicate fix from v4 to have product asscociation display when their…

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
@@ -88,19 +88,6 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $scope
         );
 
-        $productModelLimit = $limit - $associatedProducts->count();
-        $associatedProductModels = [];
-        if ($productModelLimit > 0) {
-            $productModelFrom = $from - count($associatedProductsIdentifiers) + $associatedProducts->count();
-            $associatedProductModels = $this->getAssociatedProductModels(
-                $associatedProductModelsIdentifiers,
-                $productModelLimit,
-                max($productModelFrom, 0),
-                $locale,
-                $scope
-            );
-        }
-
         $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
             $associatedProducts,
             $associatedProductsIdentifiersFromParent,
@@ -108,12 +95,25 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $scope
         );
 
-        $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
-            $associatedProductModels,
-            $associatedProductModelsIdentifiersFromParent,
-            $locale,
-            $scope
-        );
+        $productModelLimit = $limit - $associatedProducts->count() + $from;
+        $normalizedAssociatedProductModels = [];
+        if ($productModelLimit > 0) {
+            $productModelFrom = $from - count($associatedProductsIdentifiers) + count($normalizedAssociatedProducts);
+            $associatedProductModels = $this->getAssociatedProductModels(
+                $associatedProductModelsIdentifiers,
+                $productModelLimit,
+                max($productModelFrom, 0),
+                $locale,
+                $scope
+            );
+
+            $normalizedAssociatedProductModels = $this->normalizeProductsAndProductModels(
+                $associatedProductModels,
+                $associatedProductModelsIdentifiersFromParent,
+                $locale,
+                $scope
+            );
+        }
 
         $rows = ['totalRecords' => count($associatedProductsIdentifiers) + count($associatedProductModelsIdentifiers)];
         $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);


### PR DESCRIPTION
… number is too high

I used the correction for akeneo 4 0b2e38d and put it in place for 3.2.X since we encountered a bug preventing us from seeing the list of product associations on the product associations page when the number of associated products was more than the limit.

https://github.com/akeneo/pim-community-dev/pull/12805#issuecomment-696721063