### PR TITLE
DAPI-1285: populate attribute groups activation during migration

### DIFF
--- a/upgrades/schema/Version_5_0_20200921153252_dqi_create_table_attribute_group_activation.php
+++ b/upgrades/schema/Version_5_0_20200921153252_dqi_create_table_attribute_group_activation.php
@@ -15,6 +15,10 @@ CREATE TABLE IF NOT EXISTS pim_data_quality_insights_attribute_group_activation 
     activated TINYINT NOT NULL,
     updated_at DATETIME NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+INSERT IGNORE INTO pim_data_quality_insights_attribute_group_activation (attribute_group_code, activated, updated_at)
+SELECT code, 1, created
+FROM pim_catalog_attribute_group;
 SQL
         );
     }

--- a/upgrades/test_schema/Version_5_0_20200921153252_dqi_create_table_attribute_group_activation_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20200921153252_dqi_create_table_attribute_group_activation_Integration.php
@@ -15,7 +15,11 @@ final class Version_5_0_20200921153252_dqi_create_table_attribute_group_activati
     public function test_it_creates_the_attribute_group_activation_table(): void
     {
         $this->get('database_connection')->executeQuery(<<<SQL
-DROP TABLE IF EXISTS pim_data_quality_insights_attribute_group_activation
+DROP TABLE IF EXISTS pim_data_quality_insights_attribute_group_activation;
+
+INSERT INTO pim_catalog_attribute_group (code, sort_order, created, updated) VALUES 
+    ('marketing', 1, '2020-09-23 15:12:34', '2020-09-23 16:54:12'), 
+    ('technical', 2, '2020-09-23 15:16:28', '2020-09-23 16:54:12')
 SQL
         );
 
@@ -23,10 +27,33 @@ SQL
 
         $schemaManager = $this->get('database_connection')->getSchemaManager();
         $this->assertTrue($schemaManager->tablesExist('pim_data_quality_insights_attribute_group_activation'));
+
+        $this->assertAttributeGroupActivationExists('marketing', '2020-09-23 15:12:34');
+        $this->assertAttributeGroupActivationExists('technical', '2020-09-23 15:16:28');
     }
 
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
+    }
+
+    private function assertAttributeGroupActivationExists(string $attributeGroupCode, string $updatedAt): void
+    {
+        $query = <<<SQL
+SELECT 1 FROM pim_data_quality_insights_attribute_group_activation
+WHERE attribute_group_code = :attributeGroupCode
+  AND updated_at = :updatedAt
+  AND activated = 1 ;
+SQL;
+
+        $attributeGroupExists = (bool) $this->get('database_connection')->executeQuery(
+            $query,
+            [
+                'attributeGroupCode' => $attributeGroupCode,
+                'updatedAt' => $updatedAt,
+            ]
+        )->fetchColumn();
+
+        $this->assertTrue($attributeGroupExists);
     }
 }


### PR DESCRIPTION
I used the attribute group creation date as activation update date.