### PR TITLE
DAPI-1284: Do not evaluate attributes of deactivated attribute groups

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetNonRequiredAttributesMasksQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetNonRequiredAttributesMasksQuery.php
@@ -64,6 +64,8 @@ SELECT
 FROM pim_catalog_family family
 LEFT JOIN pim_catalog_family_attribute family_attribute ON family_attribute.family_id = family.id
 LEFT JOIN pim_catalog_attribute attribute ON attribute.id = family_attribute.attribute_id
+LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+LEFT JOIN pim_data_quality_insights_attribute_group_activation AS attribute_group_activation ON attribute_group_activation.attribute_group_code = attribute_group.code
 JOIN (
     SELECT
         channel.id AS channel_id,
@@ -80,6 +82,7 @@ LEFT JOIN pim_catalog_attribute_locale pcal ON attribute.id = pcal.attribute_id
 WHERE family.code IN (:familyCodes)
     AND (pcal.locale_id IS NULL OR pcal.locale_id = channel_locale.locale_id)
     AND (pcar.attribute_id IS NULL OR pcar.required IS FALSE)
+    AND (attribute_group_activation.activated IS NULL OR attribute_group_activation.activated = 1)
 GROUP BY family.code, channel_code, locale_code;
 SQL;
         $rows = $this->connection->executeQuery(

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetNonRequiredProductModelAttributesMaskQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetNonRequiredProductModelAttributesMaskQuery.php
@@ -65,6 +65,8 @@ INNER JOIN pim_catalog_family_variant AS family_variant ON family_variant.id = p
 INNER JOIN pim_catalog_family AS family ON family.id = family_variant.family_id
 INNER JOIN pim_catalog_family_attribute AS family_attribute ON family_attribute.family_id = family.id
 INNER JOIN pim_catalog_attribute AS attribute ON attribute.id = family_attribute.attribute_id
+LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+LEFT JOIN pim_data_quality_insights_attribute_group_activation AS attribute_group_activation ON attribute_group_activation.attribute_group_code = attribute_group.code
 JOIN (
     SELECT
         channel.id AS channel_id,
@@ -81,6 +83,7 @@ LEFT JOIN pim_catalog_attribute_requirement pcar
 WHERE product_model.id = :productModelId
     AND (pcar.attribute_id IS NULL OR pcar.required IS FALSE)
     AND (pcal.locale_id IS NULL OR pcal.locale_id = channel_locale.locale_id)
+    AND (attribute_group_activation.activated IS NULL OR attribute_group_activation.activated = 1)
     AND NOT EXISTS(
         SELECT 1
         FROM pim_catalog_variant_attribute_set_has_attributes AS attribute_set_attributes

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetRequiredAttributesMasksQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetRequiredAttributesMasksQuery.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetRequiredAttributesMasks;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\RequiredAttributesMask;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\RequiredAttributesMaskForChannelAndLocale;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetRequiredAttributesMasksQuery implements GetRequiredAttributesMasks
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+    /**
+     * {@inheritdoc}
+     */
+    public function fromFamilyCodes(array $familyCodes): array
+    {
+        $sql = <<<SQL
+SELECT
+    family.code AS family_code,
+    channel_code,
+    locale_code,
+    JSON_ARRAYAGG(
+        CONCAT(
+            IF(
+                attribute.attribute_type = 'pim_catalog_price_collection',
+                CONCAT(
+                    attribute.code,
+                    '-',
+                    (
+                        SELECT GROUP_CONCAT(currency.code ORDER BY currency.code SEPARATOR '-')
+                        FROM pim_catalog_channel channel
+                        JOIN pim_catalog_channel_currency pccc ON channel.id = pccc.channel_id
+                        JOIN pim_catalog_currency currency ON pccc.currency_id = currency.id
+                        WHERE channel.code  = channel_code
+                        GROUP BY channel.id
+                    )
+                ),
+                attribute.code
+            ),
+            '-',
+            IF(attribute.is_scopable, channel_locale.channel_code, '<all_channels>'),
+            '-',
+            IF(attribute.is_localizable, channel_locale.locale_code, '<all_locales>')
+        )
+    ) AS mask
+FROM pim_catalog_family family
+JOIN pim_catalog_attribute_requirement pcar ON family.id = pcar.family_id
+JOIN (
+    SELECT
+        channel.id AS channel_id,
+        channel.code AS channel_code,
+        locale.id AS locale_id,
+        locale.code AS locale_code
+    FROM pim_catalog_channel channel
+    JOIN pim_catalog_channel_locale pccl ON channel.id = pccl.channel_id
+    JOIN pim_catalog_locale locale ON pccl.locale_id = locale.id
+) AS channel_locale ON channel_locale.channel_id = pcar.channel_id
+JOIN pim_catalog_attribute attribute ON pcar.attribute_id = attribute.id
+LEFT JOIN pim_catalog_attribute_locale pcal ON attribute.id = pcal.attribute_id
+LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+LEFT JOIN pim_data_quality_insights_attribute_group_activation AS attribute_group_activation ON attribute_group_activation.attribute_group_code = attribute_group.code
+WHERE
+    pcar.required is true
+    AND (pcal.locale_id IS NULL OR pcal.locale_id = channel_locale.locale_id)
+    AND family.code IN (:familyCodes)
+    AND (attribute_group_activation.activated IS NULL OR attribute_group_activation.activated = 1)
+GROUP BY family.code, channel_code, locale_code
+SQL;
+        $rows = $this->connection->executeQuery(
+            $sql,
+            ['familyCodes' => $familyCodes],
+            ['familyCodes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAll();
+
+        $masksPerFamily = array_fill_keys($familyCodes, []);
+        foreach ($rows as $masksPerChannelAndLocale) {
+            $masksPerFamily[$masksPerChannelAndLocale['family_code']][] = new RequiredAttributesMaskForChannelAndLocale(
+                $masksPerChannelAndLocale['channel_code'],
+                $masksPerChannelAndLocale['locale_code'],
+                json_decode($masksPerChannelAndLocale['mask'], true)
+            );
+        }
+
+        $masks = [];
+        foreach ($masksPerFamily as $familyCode => $masksPerChannelAndLocale) {
+            $masks[$familyCode] = new RequiredAttributesMask($familyCode, $masksPerChannelAndLocale);
+        }
+
+        return $masks;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetRequiredProductModelAttributesMaskQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Completeness/GetRequiredProductModelAttributesMaskQuery.php
@@ -76,9 +76,12 @@ JOIN (
 ) AS channel_locale ON channel_locale.channel_id = pcar.channel_id
 INNER JOIN pim_catalog_attribute AS attribute ON pcar.attribute_id = attribute.id
 LEFT JOIN pim_catalog_attribute_locale AS pcal ON attribute.id = pcal.attribute_id
+LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+LEFT JOIN pim_data_quality_insights_attribute_group_activation AS attribute_group_activation ON attribute_group_activation.attribute_group_code = attribute_group.code
 WHERE product_model.id = :productModelId
     AND pcar.required is true
     AND (pcal.locale_id IS NULL OR pcal.locale_id = channel_locale.locale_id)
+    AND (attribute_group_activation.activated IS NULL OR attribute_group_activation.activated = 1)
     AND NOT EXISTS(
         SELECT 1
         FROM pim_catalog_variant_attribute_set_has_attributes AS attribute_set_attributes

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluableAttributesByProductModelQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluableAttributesByProductModelQuery.php
@@ -44,8 +44,11 @@ FROM pim_catalog_product_model AS product_model
     INNER JOIN pim_catalog_family AS family ON family.id = family_variant.family_id
     INNER JOIN pim_catalog_family_attribute AS pca ON pca.family_id = family.id
     INNER JOIN pim_catalog_attribute AS attribute ON attribute.id = pca.attribute_id
+    LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+    LEFT JOIN pim_data_quality_insights_attribute_group_activation AS activation ON activation.attribute_group_code = attribute_group.code
 WHERE product_model.id = :product_model_id
     AND attribute.attribute_type IN (:attribute_types)
+    AND (activation.activated IS NULL OR activation.activated = 1)
     AND NOT EXISTS(
         SELECT 1
         FROM pim_catalog_variant_attribute_set_has_attributes AS attribute_set_attributes

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluableAttributesByProductQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluableAttributesByProductQuery.php
@@ -43,8 +43,11 @@ FROM pim_catalog_attribute AS attribute
 INNER JOIN pim_catalog_family_attribute AS pca ON attribute.id = pca.attribute_id
 INNER JOIN pim_catalog_product AS product ON product.family_id = pca.family_id
 INNER JOIN pim_catalog_family AS family ON (product.family_id = family.id)
+LEFT JOIN pim_catalog_attribute_group AS attribute_group ON attribute_group.id = attribute.group_id
+LEFT JOIN pim_data_quality_insights_attribute_group_activation AS activation ON activation.attribute_group_code = attribute_group.code
 WHERE product.id = :product_id
-AND attribute.attribute_type IN (:attribute_types);
+AND attribute.attribute_type IN (:attribute_types)
+AND (activation.activated IS NULL OR activation.activated = 1);
 SQL;
 
         $statement = $this->dbConnection->executeQuery($query,

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -162,6 +162,10 @@ services:
         arguments:
             - '@database_connection'
 
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetRequiredAttributesMasksQuery:
+        arguments:
+            - '@database_connection'
+
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetRequiredProductModelAttributesMaskQuery:
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -107,13 +107,19 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment\CalculateProductCompleteness
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdentifierFromProductIdQuery'
-            - '@pim_catalog.completeness.calculator'
+            - '@akeneo.pim.automation.completeness_product_required_attributes_calculator'
 
     akeneo.pim.automation.calculate_product_completeness_of_non_required_attributes:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment\CalculateProductCompleteness
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdentifierFromProductIdQuery'
             - '@akeneo.pim.automation.completeness_product_non_required_attributes_calculator'
+
+    akeneo.pim.automation.completeness_product_required_attributes_calculator:
+        class: Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator
+        arguments:
+            - '@akeneo.pim.enrichment.completeness.query.get_product_masks'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetRequiredAttributesMasksQuery'
 
     akeneo.pim.automation.completeness_product_non_required_attributes_calculator:
         class: Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/CompletenessTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/CompletenessTestCase.php
@@ -13,7 +13,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Persistence\Query\Completeness;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\AttributeGroupActivation;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\AttributeGroupCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\AttributeGroupActivationRepository;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\TestCase;
 use Webmozart\Assert\Assert;
@@ -39,7 +42,7 @@ abstract class CompletenessTestCase extends TestCase
             );
 
             $errors = $this->get('validator')->validate($family);
-            Assert::count($errors, 0);
+            Assert::count($errors, 0, sprintf('Family "%s" is invalid', $familyData['code']));
 
             return $family;
         }, $familiesData);
@@ -69,7 +72,7 @@ abstract class CompletenessTestCase extends TestCase
                     'type' => $attributeData['type'],
                     'localizable' => $attributeData['localizable'] ?? false,
                     'scopable' => $attributeData['scopable'] ?? false,
-                    'group' => 'other',
+                    'group' => $attributeData['group'] ?? 'other',
                     'available_locales' => $attributeData['available_locales'] ?? [],
                     'decimals_allowed' => $attributeData['type'] === AttributeTypes::PRICE_COLLECTION ? false : null,
                 ]
@@ -150,5 +153,15 @@ abstract class CompletenessTestCase extends TestCase
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
         return new ProductId((int) $productModel->getId());
+    }
+
+    protected function givenADeactivatedAttributeGroup(string $code): void
+    {
+        $attributeGroup = $this->get('pim_catalog.factory.attribute_group')->create();
+        $this->get('pim_catalog.updater.attribute_group')->update($attributeGroup, ['code' => $code]);
+        $this->get('pim_catalog.saver.attribute_group')->save($attributeGroup);
+
+        $attributeGroupActivation = new AttributeGroupActivation(new AttributeGroupCode($code), false);
+        $this->get(AttributeGroupActivationRepository::class)->save($attributeGroupActivation);
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetNonRequiredAttributesMasksQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetNonRequiredAttributesMasksQueryIntegration.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Persistence\Query\Completeness;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetNonRequiredAttributesMasksQuery;
-use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Persistence\Query\Completeness\CompletenessTestCase;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Webmozart\Assert\Assert;
 
@@ -28,6 +27,7 @@ class GetNonRequiredAttributesMasksQueryIntegration extends CompletenessTestCase
 
         $this->givenChannels([['code' => 'tablet', 'locales' => ['en_US', 'fr_FR'], 'labels' => ['en_US' => 'tablet', 'fr_FR' => 'Tablette'], 'currencies' => ['USD', 'EUR']]]);
 
+        $this->givenADeactivatedAttributeGroup('erp');
         $this->givenAttributes([
             ['code' => 'a_required_text', 'type' => AttributeTypes::TEXT],
             ['code' => 'a_required_text_for_ecommerce_only', 'type' => AttributeTypes::TEXT, 'scopable' => true],
@@ -45,6 +45,8 @@ class GetNonRequiredAttributesMasksQueryIntegration extends CompletenessTestCase
             ['code' => 'a_non_localizable_scopable_locale_specific_fr_us', 'type' => AttributeTypes::TEXT, 'scopable' => true, 'available_locales' => ['fr_FR', 'en_US']],
             ['code' => 'a_localizable_scopable_locale_specific_fr', 'type' => AttributeTypes::TEXT, 'localizable' => true, 'scopable' => true, 'available_locales' => ['fr_FR']],
             ['code' => 'a_required_locale_specific_fr', 'type' => AttributeTypes::TEXT, 'available_locales' => ['fr_FR']],
+            // Attribute required but deactivated from its attribute group
+            ['code' => 'a_required_deactivated_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
         ]);
 
         $this->givenFamilies([
@@ -55,6 +57,7 @@ class GetNonRequiredAttributesMasksQueryIntegration extends CompletenessTestCase
                     'a_price',
                     'a_localizable_non_scopable_price',
                     'a_required_text',
+                    'a_required_deactivated_text',
                     'a_required_text_for_ecommerce_only',
                     'a_non_localizable_non_scopable_text',
                     'a_localizable_non_scopable_text',
@@ -70,26 +73,30 @@ class GetNonRequiredAttributesMasksQueryIntegration extends CompletenessTestCase
                     'ecommerce' => [
                         'sku',
                         'a_required_text',
+                        'a_required_deactivated_text',
                         'a_required_text_for_ecommerce_only',
                     ],
                     'tablet' => [
                         'sku',
                         'a_required_text',
+                        'a_required_deactivated_text',
                         'a_required_locale_specific_fr',
                     ],
                 ]
             ],
             [
                 'code' => 'familyB',
-                'attribute_codes' => ['sku', 'a_required_text'],
+                'attribute_codes' => ['sku', 'a_required_text', 'a_required_deactivated_text'],
                 'attribute_requirements' => [
                     'ecommerce' => [
                         'sku',
                         'a_required_text',
+                        'a_required_deactivated_text',
                     ],
                     'tablet' => [
                         'sku',
                         'a_required_text',
+                        'a_required_deactivated_text',
                     ],
                 ]
             ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetNonRequiredProductModelAttributesMaskQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetNonRequiredProductModelAttributesMaskQueryIntegration.php
@@ -24,6 +24,7 @@ class GetNonRequiredProductModelAttributesMaskQueryIntegration extends Completen
         $this->givenCurrencyForChannel([['code' => 'ecommerce', 'currencies' => ['USD']]]);
         $this->givenChannels([['code' => 'tablet', 'locales' => ['en_US', 'fr_FR'], 'labels' => ['en_US' => 'tablet', 'fr_FR' => 'Tablette'], 'currencies' => ['USD', 'EUR']]]);
 
+        $this->givenADeactivatedAttributeGroup('erp');
         $this->givenAttributes([
             ['code' => 'a_required_text', 'type' => AttributeTypes::TEXT],
             ['code' => 'a_required_text_for_ecommerce_only', 'type' => AttributeTypes::TEXT, 'scopable' => true],
@@ -44,6 +45,9 @@ class GetNonRequiredProductModelAttributesMaskQueryIntegration extends Completen
             // Attributes for the family variant
             ['code' => 'a_required_variant_text', 'type' => AttributeTypes::TEXT],
             ['code' => 'a_variation_axis', 'type' => AttributeTypes::OPTION_SIMPLE_SELECT],
+            // Attributes non required but deactivated from their attribute group
+            ['code' => 'a_deactivated_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
+            ['code' => 'a_deactivated_variant_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
         ]);
 
         $this->givenFamilies([
@@ -66,6 +70,8 @@ class GetNonRequiredProductModelAttributesMaskQueryIntegration extends Completen
                     'a_required_locale_specific_fr',
                     'a_variation_axis',
                     'a_required_variant_text',
+                    'a_deactivated_text',
+                    'a_deactivated_variant_text',
                 ],
                 'attribute_requirements' => [
                     'ecommerce' => [
@@ -93,7 +99,7 @@ class GetNonRequiredProductModelAttributesMaskQueryIntegration extends Completen
                 [
                     'level' => 1,
                     'axes' => ['a_variation_axis'],
-                    'attributes' => ['a_variation_axis', 'sku', 'a_required_variant_text'],
+                    'attributes' => ['a_variation_axis', 'sku', 'a_required_variant_text', 'a_deactivated_variant_text'],
                 ],
             ],
         ]);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetRequiredAttributesMasksQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetRequiredAttributesMasksQueryIntegration.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Persistence\Query\Completeness;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetRequiredAttributesMasksQuery;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetRequiredAttributesMasksQueryIntegration extends CompletenessTestCase
+{
+    public function test_it_gives_the_required_attributes_masks_for_a_list_of_families()
+    {
+        $this->givenCurrencyForChannel([['code' => 'ecommerce', 'currencies' => ['USD']]]);
+
+        $this->givenChannels([['code' => 'tablet', 'locales' => ['en_US', 'fr_FR'], 'labels' => ['en_US' => 'tablet', 'fr_FR' => 'Tablette'], 'currencies' => ['USD', 'EUR']]]);
+
+        $this->givenADeactivatedAttributeGroup('erp');
+        $this->givenAttributes([
+            ['code' => 'a_non_required_text', 'type' => AttributeTypes::TEXT],
+            // A price because the handling is different than other attribute
+            ['code' => 'a_price', 'type' => AttributeTypes::PRICE_COLLECTION],
+            ['code' => 'a_localizable_non_scopable_price', 'type' => AttributeTypes::PRICE_COLLECTION, 'localizable' => true],
+            // Localizable and Scopable things
+            ['code' => 'a_non_localizable_non_scopable_text', 'type' => AttributeTypes::TEXT],
+            ['code' => 'a_localizable_non_scopable_text', 'type' => AttributeTypes::TEXT, 'localizable' => true],
+            ['code' => 'a_non_localizable_scopable_text', 'type' => AttributeTypes::TEXT, 'scopable' => true],
+            ['code' => 'a_localizable_scopable_text', 'type' => AttributeTypes::TEXT, 'scopable' => true, 'localizable' => true],
+            // Locale specific things
+            ['code' => 'a_non_localizable_non_scopable_locale_specific', 'type' => AttributeTypes::TEXT, 'available_locales' => ['fr_FR']],
+            ['code' => 'a_localizable_non_scopable_locale_specific', 'type' => AttributeTypes::TEXT, 'localizable' => true, 'available_locales' => ['en_US']],
+            ['code' => 'a_non_localizable_scopable_locale_specific', 'type' => AttributeTypes::TEXT, 'scopable' => true, 'available_locales' => ['fr_FR', 'en_US']],
+            ['code' => 'a_localizable_scopable_locale_specific', 'type' => AttributeTypes::TEXT, 'localizable' => true, 'scopable' => true, 'available_locales' => ['fr_FR']],
+            // Attribute required but deactivated from its attribute group
+            ['code' => 'a_required_deactivated_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
+        ]);
+
+        $this->givenFamilies([
+            [
+                'code' => 'familyA',
+                'attribute_codes' => ['sku', 'a_price', 'a_localizable_non_scopable_price', 'a_non_required_text', 'a_non_localizable_non_scopable_text', 'a_localizable_non_scopable_text', 'a_non_localizable_scopable_text', 'a_localizable_scopable_text', 'a_non_localizable_non_scopable_locale_specific', 'a_localizable_non_scopable_locale_specific', 'a_non_localizable_scopable_locale_specific', 'a_localizable_scopable_locale_specific', 'a_required_deactivated_text'],
+                'attribute_requirements' => [
+                    'ecommerce' => [
+                        'sku',
+                        'a_price',
+                        'a_localizable_non_scopable_text',
+                        'a_non_localizable_scopable_text',
+                        'a_localizable_non_scopable_locale_specific',
+                        'a_required_deactivated_text',
+                    ],
+                    'tablet' => [
+                        'sku',
+                        'a_price',
+                        'a_localizable_non_scopable_price',
+                        'a_non_localizable_non_scopable_text',
+                        'a_non_localizable_scopable_text',
+                        'a_localizable_scopable_text',
+                        'a_non_localizable_non_scopable_locale_specific',
+                        'a_non_localizable_scopable_locale_specific',
+                        'a_localizable_scopable_locale_specific',
+                        'a_required_deactivated_text',
+                    ],
+                ]
+            ],
+            [
+                'code' => 'familyB',
+                'attribute_codes' => ['sku', 'a_non_required_text'],
+            ],
+            [
+                'code' => 'familyC',
+                'attribute_codes' => [],
+            ]
+        ]);
+
+        $result = $this->get(GetRequiredAttributesMasksQuery::class)->fromFamilyCodes(['familyA']);
+        $familyAMask = $result['familyA'];
+        $this->assertCount(3, $familyAMask->masks());
+
+        $ecommerceEnUsMask = $familyAMask->requiredAttributesMaskForChannelAndLocale('ecommerce', 'en_US');
+        $tabletEnUS = $familyAMask->requiredAttributesMaskForChannelAndLocale('tablet', 'en_US');
+        $tabletFrFr = $familyAMask->requiredAttributesMaskForChannelAndLocale('tablet', 'fr_FR');
+
+        $this->assertEqualsCanonicalizing([
+            'sku-<all_channels>-<all_locales>',
+            'a_price-USD-<all_channels>-<all_locales>',
+            'a_localizable_non_scopable_text-<all_channels>-en_US',
+            'a_non_localizable_scopable_text-ecommerce-<all_locales>',
+            'a_localizable_non_scopable_locale_specific-<all_channels>-en_US'
+        ], $ecommerceEnUsMask->mask());
+
+        $this->assertEqualsCanonicalizing([
+            'sku-<all_channels>-<all_locales>',
+            'a_price-EUR-USD-<all_channels>-<all_locales>',
+            'a_localizable_non_scopable_price-EUR-USD-<all_channels>-en_US',
+            'a_non_localizable_non_scopable_text-<all_channels>-<all_locales>',
+            'a_non_localizable_scopable_text-tablet-<all_locales>',
+            'a_localizable_scopable_text-tablet-en_US',
+            'a_non_localizable_scopable_locale_specific-tablet-<all_locales>',
+        ], $tabletEnUS->mask());
+
+        $this->assertEqualsCanonicalizing( [
+            'sku-<all_channels>-<all_locales>',
+            'a_price-EUR-USD-<all_channels>-<all_locales>',
+            'a_localizable_non_scopable_price-EUR-USD-<all_channels>-fr_FR',
+            'a_non_localizable_non_scopable_text-<all_channels>-<all_locales>',
+            'a_non_localizable_scopable_text-tablet-<all_locales>',
+            'a_localizable_scopable_text-tablet-fr_FR',
+            'a_non_localizable_non_scopable_locale_specific-<all_channels>-<all_locales>',
+            'a_non_localizable_scopable_locale_specific-tablet-<all_locales>',
+            'a_localizable_scopable_locale_specific-tablet-fr_FR'
+        ], $tabletFrFr->mask());
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetRequiredProductModelAttributesMaskQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/Completeness/GetRequiredProductModelAttributesMaskQueryIntegration.php
@@ -24,6 +24,7 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
         $this->givenCurrencyForChannel([['code' => 'ecommerce', 'currencies' => ['USD']]]);
         $this->givenChannels([['code' => 'tablet', 'locales' => ['en_US', 'fr_FR'], 'labels' => ['en_US' => 'tablet', 'fr_FR' => 'Tablette'], 'currencies' => ['USD', 'EUR']]]);
 
+        $this->givenADeactivatedAttributeGroup('erp');
         $this->givenAttributes([
             ['code' => 'a_non_required_text', 'type' => AttributeTypes::TEXT],
             // A price because the handling is different than other attribute
@@ -42,6 +43,9 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
             // Attributes for the family variant
             ['code' => 'a_required_variant_text', 'type' => AttributeTypes::TEXT],
             ['code' => 'a_variation_axis', 'type' => AttributeTypes::OPTION_SIMPLE_SELECT],
+            // Attributes required but deactivated from their attribute group
+            ['code' => 'a_required_deactivated_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
+            ['code' => 'a_required_deactivated_variant_text', 'type' => AttributeTypes::TEXT, 'group' => 'erp'],
         ]);
 
         $this->givenFamilies([
@@ -62,6 +66,8 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
                     'a_localizable_scopable_locale_specific',
                     'a_variation_axis',
                     'a_required_variant_text',
+                    'a_required_deactivated_text',
+                    'a_required_deactivated_variant_text',
                 ],
                 'attribute_requirements' => [
                     'ecommerce' => [
@@ -72,6 +78,8 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
                         'a_localizable_non_scopable_locale_specific',
                         'a_variation_axis',
                         'a_required_variant_text',
+                        'a_required_deactivated_text',
+                        'a_required_deactivated_variant_text',
                     ],
                     'tablet' => [
                         'sku',
@@ -85,6 +93,8 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
                         'a_localizable_scopable_locale_specific',
                         'a_variation_axis',
                         'a_required_variant_text',
+                        'a_required_deactivated_text',
+                        'a_required_deactivated_variant_text',
                     ],
                 ]
             ],
@@ -97,7 +107,7 @@ class GetRequiredProductModelAttributesMaskQueryIntegration extends Completeness
                 [
                     'level' => 1,
                     'axes' => ['a_variation_axis'],
-                    'attributes' => ['a_variation_axis', 'sku', 'a_required_variant_text'],
+                    'attributes' => ['a_variation_axis', 'sku', 'a_required_variant_text', 'a_required_deactivated_variant_text'],
                 ],
             ],
         ]);


### PR DESCRIPTION
The simplest solution is to exclude the deactivated attributes directly from the MySQL queries that fetch the "evaluable" attributes.

The same for the completeness calculations. And now we have to write our own query for the "required attributes mask" instead of using the one of the Enrichment bundle.