### PR TITLE
PIM-9476: Fix locale selector behavior on the product edit form when the user does not have permissions to edit attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PIM-9460: Fix performance issue on export
 - PIM-9461: Fix display of multiselect fields with a lot of selected options
 - PIM-9466: Fix selection counter in datagrid
+- PIM-9476: Fix locale selector behavior on the product edit form when the user doesn't have permissions to edit attributes
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
@@ -14,7 +14,8 @@ define(
         'pim/form',
         'pim/template/product/locale-switcher',
         'pim/fetcher-registry',
-        'pim/i18n'
+        'pim/i18n',
+        'pim/user-context',
     ],
     function (
         _,
@@ -22,7 +23,8 @@ define(
         BaseForm,
         template,
         FetcherRegistry,
-        i18n
+        i18n,
+        UserContext
     ) {
         return BaseForm.extend({
             template: _.template(template),
@@ -33,6 +35,7 @@ define(
             displayInline: false,
             displayLabel: true,
             config: {},
+            selectedLocale: null,
 
             /**
              * {@inheritdoc}
@@ -70,7 +73,10 @@ define(
                         };
                         this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
-                        let currentLocale = locales.find(locale => locale.code === params.localeCode);
+                        let currentLocale = locales.find(locale => locale.code === (this.selectedLocale ?
+                            this.selectedLocale :
+                            UserContext.get('catalogLocale'))
+                        );
                         if (undefined === currentLocale) {
                             currentLocale = _.first(locales);
                         }
@@ -110,6 +116,7 @@ define(
                     localeCode: event.currentTarget.dataset.locale,
                     context: this.config.context
                 });
+                this.selectedLocale = event.currentTarget.dataset.locale;
 
                 this.render();
             },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
This PR fixes a bug on the locale selector on the product edit form when the user does not have the permission to edit attributes (i.e. the attributes tab is not visible). The locale switcher module relied on the attributes module (https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js#L156) to actually update the displayed locale via an event, so if this module was not loaded, the locale was simply not updated. The event content was modified by reference in the event listener to update the selected locale code.

My PR changes this behavior. I still send the event to notify the PIM that the locales has changed (so my PR shouldn't break anything in the PIM), but I don't rely on how the event was handled by another module to update the displayed locale. This is the locale switcher responsibility now. There is an exception for the very first time the module is displayed : I rely on the UserContext to get the default locale to display, otherwise I always display the locale the user selected.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
