### PR TITLE
PIM-9440: Fix locked MySQL tables during removing DQI evaluations without product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PIM-9461: Fix display of multiselect fields with a lot of selected options
 - PIM-9466: Fix selection counter in datagrid
 - GITHUB-12578: Fix trailing zeros when formatting numbers
+- PIM-9440: Fix locked MySQL tables during removing DQI evaluations without product
 - PIM-9476: Fix locale selector behavior on the product edit form when the user doesn't have permissions to edit attributes
 
 ## New features

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/PrepareProductModelsCriteriaEvaluationTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/PrepareProductModelsCriteriaEvaluationTasklet.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateMissingCriteriaEvaluationsInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\CriterionEvaluationRepositoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\JobParameters\PrepareEvaluationsParameters;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
@@ -33,22 +32,16 @@ class PrepareProductModelsCriteriaEvaluationTasklet implements TaskletInterface
     /** @var LoggerInterface */
     private $logger;
 
-    /** @var CriterionEvaluationRepositoryInterface */
-    private $productModelCriterionEvaluationRepository;
-
     public function __construct(
         CreateMissingCriteriaEvaluationsInterface $createMissingCriteriaEvaluations,
-        LoggerInterface $logger,
-        CriterionEvaluationRepositoryInterface $productModelCriterionEvaluationRepository
+        LoggerInterface $logger
     ) {
         $this->createMissingCriteriaEvaluations = $createMissingCriteriaEvaluations;
         $this->logger = $logger;
-        $this->productModelCriterionEvaluationRepository = $productModelCriterionEvaluationRepository;
     }
 
     public function execute(): void
     {
-        $this->cleanCriteriaOfDeletedProductModels();
         $this->createMissingCriteriaEvaluations();
     }
 
@@ -78,10 +71,5 @@ class PrepareProductModelsCriteriaEvaluationTasklet implements TaskletInterface
         $evaluateFrom = $this->stepExecution->getJobParameters()->get(PrepareEvaluationsParameters::UPDATED_SINCE_PARAMETER);
 
         return \DateTimeImmutable::createFromFormat(PrepareEvaluationsParameters::UPDATED_SINCE_DATE_FORMAT, $evaluateFrom);
-    }
-
-    private function cleanCriteriaOfDeletedProductModels()
-    {
-        $this->productModelCriterionEvaluationRepository->deleteUnknownProductsEvaluations();
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/PrepareProductsCriteriaEvaluationTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/PrepareProductsCriteriaEvaluationTasklet.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateMissingCriteriaEvaluationsInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\CriterionEvaluationRepositoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\JobParameters\PrepareEvaluationsParameters;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
@@ -33,22 +32,16 @@ final class PrepareProductsCriteriaEvaluationTasklet implements TaskletInterface
     /** @var LoggerInterface */
     private $logger;
 
-    /** @var CriterionEvaluationRepositoryInterface */
-    private $productCriterionEvaluationRepository;
-
     public function __construct(
         CreateMissingCriteriaEvaluationsInterface $createMissingProductsCriteriaEvaluations,
-        LoggerInterface $logger,
-        CriterionEvaluationRepositoryInterface $productCriterionEvaluationRepository
+        LoggerInterface $logger
     ) {
         $this->createMissingProductsCriteriaEvaluations = $createMissingProductsCriteriaEvaluations;
         $this->logger = $logger;
-        $this->productCriterionEvaluationRepository = $productCriterionEvaluationRepository;
     }
 
     public function execute(): void
     {
-        $this->cleanCriteriaOfDeletedProducts();
         $this->createMissingCriteriaEvaluations();
     }
 
@@ -78,10 +71,5 @@ final class PrepareProductsCriteriaEvaluationTasklet implements TaskletInterface
         $evaluateFrom = $this->stepExecution->getJobParameters()->get(PrepareEvaluationsParameters::UPDATED_SINCE_PARAMETER);
 
         return \DateTimeImmutable::createFromFormat(PrepareEvaluationsParameters::UPDATED_SINCE_DATE_FORMAT, $evaluateFrom);
-    }
-
-    private function cleanCriteriaOfDeletedProducts()
-    {
-        $this->productCriterionEvaluationRepository->deleteUnknownProductsEvaluations();
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/RemoveEvaluationsWithoutProductTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/RemoveEvaluationsWithoutProductTasklet.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\CriterionEvaluationRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RemoveEvaluationsWithoutProductTasklet implements TaskletInterface
+{
+    /** @var CriterionEvaluationRepositoryInterface */
+    private $productCriterionEvaluationRepository;
+
+    /** @var CriterionEvaluationRepositoryInterface */
+    private $productModelCriterionEvaluationRepository;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /** @var StepExecution */
+    private $stepExecution;
+
+    public function __construct(
+        CriterionEvaluationRepositoryInterface $productCriterionEvaluationRepository,
+        CriterionEvaluationRepositoryInterface $productModelCriterionEvaluationRepository,
+        LoggerInterface $logger
+    ) {
+        $this->productCriterionEvaluationRepository = $productCriterionEvaluationRepository;
+        $this->productModelCriterionEvaluationRepository = $productModelCriterionEvaluationRepository;
+        $this->logger = $logger;
+    }
+
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    public function execute()
+    {
+        try {
+            $this->productCriterionEvaluationRepository->deleteUnknownProductsEvaluations();
+            $this->productModelCriterionEvaluationRepository->deleteUnknownProductsEvaluations();
+        } catch (\Throwable $exception) {
+            $this->stepExecution->addFailureException($exception);
+            $this->logger->error('Remove evaluations without product failed.', [
+                'step_execution_id' => $this->stepExecution->getId(),
+                'message' => $exception->getMessage()
+            ]);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductCriterionEvaluationRepository.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductCriterionEvaluationRepository.php
@@ -19,7 +19,7 @@ use Doctrine\DBAL\Connection;
 
 final class ProductCriterionEvaluationRepository implements CriterionEvaluationRepositoryInterface
 {
-    private const DELETE_BATCH_SIZE = 1000;
+    private const DELETE_BATCH_SIZE = 10000;
 
     /** @var Connection */
     private $db;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductCriterionEvaluationRepository.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductCriterionEvaluationRepository.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Connection;
 
 final class ProductCriterionEvaluationRepository implements CriterionEvaluationRepositoryInterface
 {
+    private const DELETE_BATCH_SIZE = 1000;
+
     /** @var Connection */
     private $db;
 
@@ -45,11 +47,38 @@ final class ProductCriterionEvaluationRepository implements CriterionEvaluationR
     public function deleteUnknownProductsEvaluations(): void
     {
         $query = <<<SQL
-DELETE evaluation
+SELECT evaluation.product_id
 FROM pim_data_quality_insights_product_criteria_evaluation AS evaluation
 LEFT JOIN pim_catalog_product AS product ON(evaluation.product_id = product.id)
 WHERE product.id IS NULL
 SQL;
-        $this->db->executeQuery($query);
+
+        $stmt = $this->db->executeQuery($query);
+
+        while ($productId = $stmt->fetchColumn()) {
+            $productIds[] = $productId;
+
+            if (count($productIds) >= self::DELETE_BATCH_SIZE) {
+                $this->deleteByProductIds($productIds);
+                $productIds = [];
+            }
+        }
+
+        if (!empty($productIds)) {
+            $this->deleteByProductIds($productIds);
+        }
+    }
+
+    private function deleteByProductIds(array $productIds): void
+    {
+        $deleteQuery = <<<SQL
+DELETE evaluation FROM pim_data_quality_insights_product_criteria_evaluation AS evaluation
+WHERE evaluation.product_id IN (:productIds)
+SQL;
+        $this->db->executeQuery(
+            $deleteQuery,
+            ['productIds' => $productIds],
+            ['productIds' => Connection::PARAM_INT_ARRAY]
+        );
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductModelCriterionEvaluationRepository.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductModelCriterionEvaluationRepository.php
@@ -19,6 +19,8 @@ use Doctrine\DBAL\Connection;
 
 final class ProductModelCriterionEvaluationRepository implements CriterionEvaluationRepositoryInterface
 {
+    private const DELETE_BATCH_SIZE = 1000;
+
     /** @var Connection */
     private $db;
 
@@ -44,11 +46,38 @@ final class ProductModelCriterionEvaluationRepository implements CriterionEvalua
     public function deleteUnknownProductsEvaluations(): void
     {
         $query = <<<SQL
-DELETE evaluation
+SELECT evaluation.product_id
 FROM pim_data_quality_insights_product_model_criteria_evaluation AS evaluation
 LEFT JOIN pim_catalog_product_model AS product_model ON(evaluation.product_id = product_model.id)
 WHERE product_model.id IS NULL
 SQL;
-        $this->db->executeQuery($query);
+
+        $stmt = $this->db->executeQuery($query);
+
+        while ($productModelId = $stmt->fetchColumn()) {
+            $productModelIds[] = $productModelId;
+
+            if (count($productModelIds) >= self::DELETE_BATCH_SIZE) {
+                $this->deleteByProductModelIds($productModelIds);
+                $productModelIds = [];
+            }
+        }
+
+        if (!empty($productModelIds)) {
+            $this->deleteByProductModelIds($productModelIds);
+        }
+    }
+
+    private function deleteByProductModelIds(array $productModelIds): void
+    {
+        $deleteQuery = <<<SQL
+DELETE evaluation FROM pim_data_quality_insights_product_model_criteria_evaluation AS evaluation
+WHERE evaluation.product_id IN (:productModelIds)
+SQL;
+        $this->db->executeQuery(
+            $deleteQuery,
+            ['productModelIds' => $productModelIds],
+            ['productModelIds' => Connection::PARAM_INT_ARRAY]
+        );
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductModelCriterionEvaluationRepository.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductModelCriterionEvaluationRepository.php
@@ -19,7 +19,7 @@ use Doctrine\DBAL\Connection;
 
 final class ProductModelCriterionEvaluationRepository implements CriterionEvaluationRepositoryInterface
 {
-    private const DELETE_BATCH_SIZE = 1000;
+    private const DELETE_BATCH_SIZE = 10000;
 
     /** @var Connection */
     private $db;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
@@ -35,6 +35,7 @@ services:
             -
                 - '@akeneo.pim.automation.data_quality_insights.connector.step.consolidate_dashboard_rates'
                 - '@akeneo.pim.automation.data_quality_insights.connector.step.purge_outdated_data'
+                - '@akeneo.pim.automation.data_quality_insights.connector.step.remove_evaluations_without_product'
                 - '@akeneo.pim.automation.data_quality_insights.connector.step.log_metrics'
         tags:
             - { name: akeneo_batch.job, connector: 'Data Quality Insights Connector', type: 'data_quality_insights' }
@@ -96,6 +97,15 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\LogMetricsTasklet'
+
+    akeneo.pim.automation.data_quality_insights.connector.step.remove_evaluations_without_product:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - 'remove_evaluations_without_product'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\RemoveEvaluationsWithoutProductTasklet'
+
     #Tasklets
     akeneo.pim.automation.data_quality_insights.connector.tasklet.evaluate_product_criteria:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\EvaluateProductsCriteriaTasklet
@@ -117,14 +127,12 @@ services:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.create_missing_products_criteria_evaluations'
             - '@logger'
-            - '@akeneo.pim.automation.data_quality_insights.repository.product_criterion_evaluation'
 
     akeneo.pim.automation.data_quality_insights.infrastructure.connector.tasklet.prepare_product_models_criteria_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\PrepareProductModelsCriteriaEvaluationTasklet
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.create_missing_product_models_criteria_evaluations'
             - '@logger'
-            - '@akeneo.pim.automation.data_quality_insights.repository.product_model_criterion_evaluation'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\ConsolidateDashboardRatesTasklet:
         arguments:
@@ -141,6 +149,12 @@ services:
             - '@database_connection'
             - '@logger'
             - '@monolog.logger.quality'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\RemoveEvaluationsWithoutProductTasklet:
+        arguments:
+            - '@akeneo.pim.automation.data_quality_insights.repository.product_criterion_evaluation'
+            - '@akeneo.pim.automation.data_quality_insights.repository.product_model_criterion_evaluation'
+            - '@logger'
 
     #Job parameters
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\JobParameters\PrepareEvaluationsParameters:


### PR DESCRIPTION
When a product (or product model) is deleted, their evaluations are not deleted. (no foreign key with "cascade delete"). 
The cleaning of these evaluations is done with a single `DELETE`  query. As there is a `JOIN` on the products table, this one is locked during all the query execution.  As the deletion can take a long time for big catalog, it's problematic.

Adding a foreign key with "cascade delete" would take too much time. We would have to find a way to perform this kind of migration without locks, but it's not an easy task.

in the meantime, we decided to split the query to not lock the products table. As there's still a slow query to execute, this one will done only once per day instead of every 30 min. To do so, I added a step to the job "DQI daily tasks".