### PR TITLE
PIM-9478: Allow the modification of the identifier on a variant product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - PIM-9466: Fix selection counter in datagrid
 - GITHUB-12578: Fix trailing zeros when formatting numbers
 - PIM-9476: Fix locale selector behavior on the product edit form when the user doesn't have permissions to edit attributes
+- PIM-9478: Allow the modification of the identifier on a variant product
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
@@ -50,7 +50,7 @@ SQL;
 SELECT identifier, raw_values
 FROM pim_catalog_product
 WHERE product_model_id = :parentId
-AND identifier != :identifier;
+AND id != :id
 SQL;
         } else {
             return [];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
@@ -45,24 +45,23 @@ WHERE parent_id = :parentId
 AND code != :identifier;
 SQL;
         } elseif ($entity instanceof ProductInterface) {
-            $identifier = $entity->getIdentifier();
+            $identifier = $entity->getId() ?? 0;
             $sql = <<<SQL
 SELECT identifier, raw_values
 FROM pim_catalog_product
 WHERE product_model_id = :parentId
-AND id != :id
+AND id != :identifier
 SQL;
         } else {
             return [];
         }
-
+        
         $valuesOfSiblings = [];
         $rows = $this->connection->executeQuery(
             $sql,
             [
                 'parentId' => $entity->getParent()->getId(),
                 'identifier' => $identifier,
-                'id' => $entity->getId(),
             ]
         );
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/SqlGetValuesOfSiblings.php
@@ -62,6 +62,7 @@ SQL;
             [
                 'parentId' => $entity->getParent()->getId(),
                 'identifier' => $identifier,
+                'id' => $entity->getId(),
             ]
         );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Previously :
The identifier could be properly updated on a simple product but not in a variant product.

Solution:
Now, I compare the id instead of the identifier (which can be updated).

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
