### PR TITLE
PIM-9481: fix query to get product models by family variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - PIM-9440: Fix locked MySQL tables during removing DQI evaluations without product
 - PIM-9476: Fix locale selector behavior on the product edit form when the user doesn't have permissions to edit attributes
 - PIM-9478: Allow the modification of the identifier on a variant product
+- PIM-9481: Fix the list of product models when trying to get them by family variant
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -186,8 +186,7 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
             ->createQueryBuilder('pm')
             ->where('pm.familyVariant = :familyVariant')
             ->setParameter('familyVariant', $familyVariant->getId())
-            ->addOrderBy('pm.root', 'ASC')
-            ->addOrderBy('pm.level', 'ASC')
+            ->addOrderBy('pm.parent', 'ASC')
         ;
 
         if (! empty($search)) {

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/Repository/ProductModelRepositoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/Repository/ProductModelRepositoryIntegration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\ORM\Repository;
+
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+use Akeneo\Pim\Structure\Component\Repository\FamilyVariantRepositoryInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductModelRepositoryIntegration extends TestCase
+{
+    /** @var FamilyVariantRepositoryInterface */
+    private $familyVariantRepository;
+
+    /** @var ProductModelRepositoryInterface */
+    private $productModelRepository;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->familyVariantRepository = $this->get('pim_catalog.repository.family_variant');
+        $this->productModelRepository = $this->get('pim_catalog.repository.product_model');
+    }
+
+    /** @test */
+    public function it_returns_product_models_for_a_given_family_variant(): void
+    {
+        $familyVariant = $this->familyVariantRepository->findOneByIdentifier('clothing_color_size');
+        self::assertNotNull($familyVariant);
+
+        $productModels = $this->productModelRepository->findProductModelsForFamilyVariant($familyVariant);
+        self::assertNotEmpty($productModels);
+
+        $productModel = $productModels[0];
+        self::assertSame($familyVariant->getCode(), $productModel->getFamilyVariant()->getCode());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

`root` and `level` are not used anymore in the product model table. I use parent instead.  
The order is not the same than before. To get the exactly same order, we need to make more a complex query that needs study in order to check performance is still good. So I propose this fix as a quick fix and if the order matters (I don't find any test on that so I presume it doesn't) we can re-work the query.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
