### PR TITLE
Automatically pull-up a merge in next branch version and notify the result in Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   setup:
     machine:
@@ -255,6 +255,9 @@ jobs:
             command: docker-compose run --rm node yarn run integration
             when: always
 
+orbs:
+    pull-up: akeneo-orbs/pull-up@1.0
+
 workflows:
   version: 2
   pull_request:
@@ -264,7 +267,7 @@ workflows:
                 filters:
                     branches:
                         ignore:
-                            - master
+                            - "3.2"
           - setup:
                 requires:
                     - wait_for_user_approval
@@ -311,3 +314,18 @@ workflows:
           - back_behat_legacy:
                 requires:
                     - back_phpunit_end_to_end
+
+  pull_up:
+      jobs:
+          - pull-up/pull-up:
+                from: "3.2"
+                into: "4.0"
+                branch_prefix: "32_to_40"
+                checkout_ours: 'src/Akeneo/Platform/CommunityVersion.php **/translations/*.yml'
+                github_token: MICHEL_TAG_TOKEN
+                github_username: "micheltag"
+                slack_webhook: "${SLACK_URL_PULL_UP}"
+                filters:
+                    branches:
+                        only:
+                            - "3.2"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Issue(s) of the pull-up**

Bug fixes are pull-up from supported branches manually. For example, if a fix is done in `3.2` version, it's pulled-up in `4.0` by the maintenance team, when they can.

I's long, and sometimes painful when not done regularly.
It impacts the workflow of the support team in many ways:

- support team does not exactly which fixes are in which version. It's possible thanks to Github, but this is not their main tool. They rely mainly on the changelog. 
- pull-up are done by the maintenance team, but it could be a long task sometimes. That's why people don't necessary know which fix is in which version (see point above).
- some fixes are **maybe** done in the branch having the bug even if the bug is in older supported versions, because it's long to pull-up a fix. So, sometimes, we have to backport a fix (not very long but still manual task).

If a pull-up is done automatically, the feedback loop would be much better. And *maybe* this workflow could change.

**Proposed solution**

I propose to pull-up **automatically** a fix as soon as we merge a PR. For example, if we merge a fix in 3.0, we try to pull-up this one in 3.2 and open a PR. If there are manual conflicts to resolve, the process is aborted, and we warn the maintenance team in Slack. If the merge is successful, we warn also the team in Slack, with a link to the PR.

**Technical issues**

I think that most of the time (but I could totally be wrong) , we could merge a fix into the next version without any conflict. The main issues are:
- there are a lot of conflicts with translation files, but the rule is to keep the file from the branch to merge into when there is a conflict (3.0 -> 3.2, it keeps the files from 3.2 instead of merging the changes done in 3.0)
- there are most of the time a conflict with CommunityVersion as we increment the version number when we tag. The rule is the same as for the translation file  (3.0 -> 3.2, it keeps the CommunityVersion from 3.2 instead of merging the changes done in 3.0)

This can be solved automatically. Otherwise we cannot merge automatically the fix and a manual merge should be done.

**Technical solution**

As this issue is a common issue among a lot of repositories, I used a Circle CI orb. This is like a Github action: a reusable component to pull up a branch into another one.

So, this solution could be used in:
- the PIM (CE & EE)
- the doc (maybe it would help to be up-to-date easily) 
- many repository using multiple branches

For now, it notifies in **#pim-pull-up** Slack channel.
The code of the orb is in a dedicated organization for security purpose:
https://github.com/akeneo-circle-ci-orbs/pull-up


**What's left?**

- [ ] Purge automatically previous opened PR if a more recent pull up PR exists
- [ ] Don't notify successful merge, but successful merge + green CI (imply to have a workflow without approval in 4.0 + modify branch 4.0 for the notification part)
- [ ] we could also imagine to automatize the tag as soon as we pull-up fixes

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
