### PR TITLE
GITHUB-12899: Fix error shown when importing product models with the same code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - PIM-9476: Fix locale selector behavior on the product edit form when the user doesn't have permissions to edit attributes
 - PIM-9478: Allow the modification of the identifier on a variant product
 - PIM-9481: Fix the list of product models when trying to get them by family variant
+- GITHUB-12899: Fix error shown when importing product models with the same code
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -342,6 +342,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductModelEntityValidator'
         arguments:
             - '@pim_catalog.repository.product_model'
+            - '@pim_catalog.validator.unique_value_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_product_model_validator_entity }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
@@ -55,7 +55,7 @@ class UniqueProductModelEntityValidator extends ConstraintValidator
 
         if (false === $this->uniqueValuesSet->addValue($identifierValue, $entity)) {
             $this->context->buildViolation($constraint->message)
-                ->atPath('identifier')
+                ->atPath('code')
                 ->addViolation();
 
             return;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
@@ -49,10 +49,6 @@ class UniqueProductModelEntityValidator extends ConstraintValidator
         }
 
         $identifierValue = $this->getIdentifierValue($entity);
-        if (null === $identifierValue) {
-            return;
-        }
-
         if (false === $this->uniqueValuesSet->addValue($identifierValue, $entity)) {
             $this->context->buildViolation($constraint->message)
                 ->atPath('code')

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueValuesSet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueValuesSet.php
@@ -2,7 +2,9 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Validator;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
 /**
@@ -36,17 +38,12 @@ class UniqueValuesSet
 
     /**
      * Return true if value has been added, else if value already exists inside the set
-     *
-     * @param ValueInterface   $productValue
-     * @param ProductInterface $product
-     *
-     * @return bool
      */
-    public function addValue(ValueInterface $productValue, ProductInterface $product)
+    public function addValue(ValueInterface $value, EntityWithValuesInterface $entity): bool
     {
-        $identifier = $this->getProductId($product);
-        $data = $productValue->__toString();
-        $attributeCode = $productValue->getAttributeCode();
+        $identifier = $this->getEntityId($entity);
+        $data = $value->__toString();
+        $attributeCode = $value->getAttributeCode();
 
         if (isset($this->uniqueValues[$attributeCode][$data])) {
             $storedIdentifier = $this->uniqueValues[$attributeCode][$data];
@@ -66,23 +63,20 @@ class UniqueValuesSet
         return true;
     }
 
-    /**
-     * @return array
-     */
-    public function getUniqueValues()
+    public function getUniqueValues(): array
     {
         return $this->uniqueValues;
     }
 
     /**
-     * spl_object_hash for new product and id when product exists
-     *
-     * @param ProductInterface $product
-     *
-     * @return string
+     * spl_object_hash for new entity and id when entity exists
      */
-    protected function getProductId(ProductInterface $product)
+    protected function getEntityId(EntityWithValuesInterface $entity): string
     {
-        return $product->getId() ? $product->getId() : spl_object_hash($product);
+        if ($entity instanceof ProductInterface || $entity instanceof ProductModelInterface) {
+            return $entity->getId() ? $entity->getId() : spl_object_hash($entity);
+        }
+
+        return spl_object_hash($entity);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
@@ -106,6 +106,7 @@ final class ComputeFamilyVariantStructureChangesTaskletIntegration extends TestC
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
         $errors = $this->get('pim_catalog.validator.product')->validate($productModel);
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
 
         foreach ($errors as $error) {
             print_r($error->__toString() . "\n");

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidatorSpec.php
@@ -4,10 +4,12 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\Constr
 
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueValuesSet;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductModelEntity;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductModelEntityValidator;
+use Prophecy\Argument;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -17,9 +19,10 @@ class UniqueProductModelEntityValidatorSpec extends ObjectBehavior
 {
     function let(
         ExecutionContextInterface $context,
-        IdentifiableObjectRepositoryInterface $objectRepository
+        IdentifiableObjectRepositoryInterface $objectRepository,
+        UniqueValuesSet $uniqueValuesSet
     ) {
-        $this->beConstructedWith($objectRepository);
+        $this->beConstructedWith($objectRepository, $uniqueValuesSet);
 
         $this->initialize($context);
     }
@@ -29,9 +32,10 @@ class UniqueProductModelEntityValidatorSpec extends ObjectBehavior
         $this->shouldHaveType(UniqueProductModelEntityValidator::class);
     }
 
-    function it_adds_violation_to_the_context_if_a_product_already_exist_in_the_database(
+    function it_adds_violation_to_the_context_if_a_product_model_already_exist_in_the_database(
         $context,
         $objectRepository,
+        UniqueValuesSet $uniqueValuesSet,
         ProductModelInterface $productModel,
         ProductModelInterface $productModelInDatabase,
         ConstraintViolationBuilderInterface $constraintViolationBuilder
@@ -40,6 +44,7 @@ class UniqueProductModelEntityValidatorSpec extends ObjectBehavior
 
         $productModel->getCode()->willReturn('code');
         $objectRepository->findOneByIdentifier('code')->willReturn($productModelInDatabase);
+        $uniqueValuesSet->addValue(Argument::any(), $productModel)->willReturn(true);
 
         $productModelInDatabase->getId()->willReturn(40);
         $productModel->getId()->willReturn(64);
@@ -52,22 +57,44 @@ class UniqueProductModelEntityValidatorSpec extends ObjectBehavior
         $this->validate($productModel, $constraint)->shouldReturn(null);
     }
 
-    function it_does_nothing_if_the_product_does_not_exist_in_database(
+    function it_adds_violation_to_the_context_if_a_product_model_already_exist_in_the_batch(
+        $context,
+        UniqueValuesSet $uniqueValuesSet,
+        ProductModelInterface $productModel,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder
+    ) {
+        $constraint = new UniqueProductModelEntity();
+
+        $productModel->getCode()->willReturn('code');
+
+        $uniqueValuesSet->addValue(Argument::any(), $productModel)->willReturn(false);
+
+        $context->buildViolation('The same identifier is already set on another product model')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->atPath('code')->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->ShouldBeCalled();
+
+        $this->validate($productModel, $constraint)->shouldReturn(null);
+    }
+
+    function it_does_nothing_if_the_product_model_does_not_exist_in_database(
         $context,
         $objectRepository,
+        UniqueValuesSet $uniqueValuesSet,
         ProductModelInterface $productModel
     ) {
         $constraint = new UniqueProductModelEntity();
 
         $productModel->getCode()->willReturn('code');
         $objectRepository->findOneByIdentifier('code')->willReturn(null);
+        $uniqueValuesSet->addValue(Argument::any(), $productModel)->willReturn(true);
 
         $context->buildViolation('The same identifier is already set on another product')->shouldNotBeCalled();
 
         $this->validate($productModel, $constraint)->shouldReturn(null);
     }
 
-    function it_throws_an_exception_if_the_excepted_entity_is_not_a_product(
+    function it_throws_an_exception_if_the_excepted_entity_is_not_a_product_model(
         CategoryInterface $category
     ) {
         $constraint = new UniqueProductModelEntity();
@@ -75,11 +102,10 @@ class UniqueProductModelEntityValidatorSpec extends ObjectBehavior
         $this->shouldThrow(UnexpectedTypeException::class)->during('validate', [$category, $constraint]);
     }
 
-    function it_throws_an_exception_if_the_excepted_constraint_is_not_a_unique_product_constraint(
+    function it_throws_an_exception_if_the_excepted_constraint_is_not_a_unique_product_model_constraint(
         ProductModelInterface $productModel,
         Constraint $constraint
     ) {
         $this->shouldThrow(UnexpectedTypeException::class)->during('validate', [$productModel, $constraint]);
     }
-
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueValueValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/UniqueValueValidatorSpec.php
@@ -52,6 +52,7 @@ class UniqueValueValidatorSpec extends ObjectBehavior
         AttributeInterface $releaseDate,
         ProductInterface $product,
         ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        UniqueValuesSet $uniqueValuesSet,
         $context,
         $uniqueDataRepository,
         $attributeRepository
@@ -64,6 +65,7 @@ class UniqueValueValidatorSpec extends ObjectBehavior
         $value->getAttributeCode()->willReturn('release_date');
         $value->__toString()->willReturn('2015-16-03');
 
+        $uniqueValuesSet->addValue($value, $product)->willReturn(true);
         $uniqueDataRepository->uniqueDataExistsInAnotherProduct($value, $product)->willReturn(true);
 
         $context->buildViolation(Argument::cetera())->willReturn($constraintViolationBuilder);

--- a/tests/legacy/features/Behat/Context/Domain/Enrich/ProductModelContext.php
+++ b/tests/legacy/features/Behat/Context/Domain/Enrich/ProductModelContext.php
@@ -128,7 +128,6 @@ class ProductModelContext extends PimContext
         $productModel = $this->getProductModel($productModelCode);
 
         $this->productModelUpdater->update($productModel, ['parent' => $rootProductModelCode]);
-        $this->validateProduct($productModel);
         $this->productSaver->save($productModel);
     }
 

--- a/tests/legacy/features/pim/enrichment/product-model/import/import_with_invalid_data.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/import/import_with_invalid_data.feature
@@ -84,3 +84,21 @@ Feature: Skip invalid product models through CSV
       code;parent;family_variant;categories;collection;description-en_US-ecommerce;erp_name-en_US;price;color;variation_name-en_US;composition;size;ean;sku;weight
       code-003;code-001;clothing_color_size;master_men_blazers;;;;;blue;Blazers;composition;;;;
       """
+
+  Scenario: Skip a product model with a code that has just been created
+    Given the following root product model:
+      | code     | parent   | family_variant      | categories         | collection | description-en_US-ecommerce | erp_name-en_US | price   |
+      | code-001 |          | clothing_color_size | master_men         | Spring2017 | description                 | Blazers_1654   | 100 EUR |
+    And the following CSV file to import:
+      """
+      code;parent;family_variant;color
+      code-002;code-001;clothing_color_size;red
+      code-002;code-001;clothing_color_size;red
+      """
+    And the following job "csv_catalog_modeling_product_model_import" configuration:
+      | filePath          | %file to import% |
+      | enabledComparison | no               |
+    When I am on the "csv_catalog_modeling_product_model_import" import job page
+    And I launch the import job
+    And I wait for the "csv_catalog_modeling_product_model_import" job to finish
+    Then I should see the text "The same code is already set on another product model"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Bug reported in https://github.com/akeneo/pim-community-dev/issues/12899

When importing product models, if there is 2 product models with the same code in one batch, the UniqueProductModelValidator was not catching the error.

**Before**

![Screenshot_2020-10-02_17-31-13](https://user-images.githubusercontent.com/1421130/94941596-62f99100-04d5-11eb-90c3-24a8d1c110cf.png)

**After**

![Screenshot_2020-10-02_17-29-57](https://user-images.githubusercontent.com/1421130/94941586-5d9c4680-04d5-11eb-89c9-d423049bbec1.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | yes
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -