### PR TITLE
PIM-9491: Translate product grid filters in user additional settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PIM-9478: Allow the modification of the identifier on a variant product
 - PIM-9481: Fix the list of product models when trying to get them by family variant
 - GITHUB-12899: Fix error shown when importing product models with the same code
+- PIM-9491: Translate product grid filters in user additional settings
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi;
 
-use Akeneo\Tool\Component\Localization\LabelTranslatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\SearchableRepositoryInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -12,6 +11,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Translation\Translator;
 
 /**
  * Controller to list the filters in the product grid.
@@ -37,8 +37,8 @@ class ProductGridFilterController
     /** @var UserContext */
     private $userContext;
 
-    /** @var LabelTranslatorInterface */
-    private $labelTranslator;
+    /** @var Translator */
+    private $translator;
 
     /**
      * @param Manager                       $datagridManager
@@ -46,7 +46,7 @@ class ProductGridFilterController
      * @param SearchableRepositoryInterface $attributeSearchRepository
      * @param NormalizerInterface           $lightAttributeNormalizer
      * @param UserContext                   $userContext
-     * @param LabelTranslatorInterface      $labelTranslator
+     * @param Translator                    $translator
      */
     public function __construct(
         Manager $datagridManager,
@@ -54,14 +54,14 @@ class ProductGridFilterController
         SearchableRepositoryInterface $attributeSearchRepository,
         NormalizerInterface $lightAttributeNormalizer,
         UserContext $userContext,
-        LabelTranslatorInterface $labelTranslator
+        Translator $translator
     ) {
         $this->datagridManager = $datagridManager;
         $this->tokenStorage = $tokenStorage;
         $this->attributeSearchRepository = $attributeSearchRepository;
         $this->lightAttributeNormalizer = $lightAttributeNormalizer;
         $this->userContext = $userContext;
-        $this->labelTranslator = $labelTranslator;
+        $this->translator = $translator;
     }
 
     /**
@@ -141,7 +141,7 @@ class ProductGridFilterController
 
         $formattedSystemFilters = [];
         foreach ($systemFilters as $code => $systemFilter) {
-            $label = $this->labelTranslator->translate($systemFilter['label'], $locale, $systemFilter['label']);
+            $label = $this->translator->trans($systemFilter['label'], [], null, $locale);
             if (!in_array($code, ['scope', 'locale']) && (
                     '' === $search || strpos($code, $search) !== false || strpos($label, $search) !== false
                 )) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductGridFilterController.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi;
 
+use Akeneo\Tool\Component\Localization\LabelTranslatorInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\SearchableRepositoryInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -36,25 +37,31 @@ class ProductGridFilterController
     /** @var UserContext */
     private $userContext;
 
+    /** @var LabelTranslatorInterface */
+    private $labelTranslator;
+
     /**
      * @param Manager                       $datagridManager
      * @param TokenStorageInterface         $tokenStorage
      * @param SearchableRepositoryInterface $attributeSearchRepository
      * @param NormalizerInterface           $lightAttributeNormalizer
      * @param UserContext                   $userContext
+     * @param LabelTranslatorInterface      $labelTranslator
      */
     public function __construct(
         Manager $datagridManager,
         TokenStorageInterface $tokenStorage,
         SearchableRepositoryInterface $attributeSearchRepository,
         NormalizerInterface $lightAttributeNormalizer,
-        UserContext $userContext
+        UserContext $userContext,
+        LabelTranslatorInterface $labelTranslator
     ) {
         $this->datagridManager = $datagridManager;
         $this->tokenStorage = $tokenStorage;
         $this->attributeSearchRepository = $attributeSearchRepository;
         $this->lightAttributeNormalizer = $lightAttributeNormalizer;
         $this->userContext = $userContext;
+        $this->labelTranslator = $labelTranslator;
     }
 
     /**
@@ -134,7 +141,7 @@ class ProductGridFilterController
 
         $formattedSystemFilters = [];
         foreach ($systemFilters as $code => $systemFilter) {
-            $label = $systemFilter['label'];
+            $label = $this->labelTranslator->translate($systemFilter['label'], $locale, $systemFilter['label']);
             if (!in_array($code, ['scope', 'locale']) && (
                     '' === $search || strpos($code, $search) !== false || strpos($label, $search) !== false
                 )) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -248,7 +248,7 @@ datagrid:
             columns:
                 family:
                     type:      product_family
-                    label:     Family
+                    label:     'pim_datagrid.filters.family.label'
                     data_name: family
                     options:
                         field_options:
@@ -267,7 +267,7 @@ datagrid:
                                 'pim_datagrid.filters.product_typology.variant': 'variant'
                 groups:
                     type:      product_groups
-                    label:     Groups
+                    label:     'pim_datagrid.filters.groups.label'
                     data_name: groups
                     options:
                         field_options:
@@ -275,7 +275,7 @@ datagrid:
                 enabled:
                     type:      product_enabled
                     ftype:     choice
-                    label:     Status
+                    label:     'pim_datagrid.filters.enabled.label'
                     data_name: enabled
                     options:
                         field_options:
@@ -284,31 +284,31 @@ datagrid:
                                 Disabled: 0
                 scope:
                     type:      product_scope
-                    label:     Scope
+                    label:     'pim_datagrid.filters.scope.label'
                     data_name: values.scope
                     options:
                         field_options:
                             choices: '@pim_catalog.repository.channel->getLabelsIndexedByCode(@pim_user.context.user->getCurrentLocaleCode())'
                 completeness:
                     type:      product_and_product_model_completeness
-                    label:     Complete
+                    label:     'pim_datagrid.filters.completeness.label'
                     data_name: ratio
                 created:
                     type:      product_date
                     ftype:     date
                     data_name: created
-                    label:     Created At
+                    label:     'pim_datagrid.filters.created.label'
                 updated:
                     type:      product_date
                     ftype:     date
                     data_name: updated
-                    label:     Updated At
+                    label:     'pim_datagrid.filters.updated.label'
                 label_or_identifier:
                     type: label_or_identifier
-                    label: Label or identifier
+                    label: 'pim_datagrid.filters.label_or_identifier.label'
                     data_name: label_or_identifier
                 parent:
-                    label:         Parent
+                    label:         'pim_datagrid.filters.parent.label'
                     data_name:     parent
                     type:          product_value_string
                     ftype:         parent
@@ -319,7 +319,7 @@ datagrid:
                 identifier:
                     type: product_value_string
                     ftype: identifier
-                    label: pim_catalog_identifier
+                    label: 'pim_datagrid.filters.identifier.label'
                     data_name: identifier
                     options:
                         field_options:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_grid_category_tree.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_grid_category_tree.yml
@@ -19,7 +19,7 @@ services:
             - '@pim_enrich.repository.attribute.search'
             - '@pim_enrich.normalizer.attribute'
             - '@pim_user.context.user'
-            - '@pim_catalog.localization.translator.label'
+            - '@translator.default'
 
     akeneo.pim.enrichment.category.category_tree.list_root_categories_with_count_handler:
         class: 'Akeneo\Pim\Enrichment\Component\Category\CategoryTree\UseCase\ListRootCategoriesWithCountHandler'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_grid_category_tree.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_grid_category_tree.yml
@@ -19,6 +19,7 @@ services:
             - '@pim_enrich.repository.attribute.search'
             - '@pim_enrich.normalizer.attribute'
             - '@pim_user.context.user'
+            - '@pim_catalog.localization.translator.label'
 
     akeneo.pim.enrichment.category.category_tree.list_root_categories_with_count_handler:
         class: 'Akeneo\Pim\Enrichment\Component\Category\CategoryTree\UseCase\ListRootCategoriesWithCountHandler'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -413,6 +413,26 @@ pim_datagrid:
             label: 'Variant'
             grouped: 'Grouped'
             ungrouped: 'Ungrouped'
+        family:
+            label: Family
+        groups:
+            label: Groups
+        enabled:
+            label: Status
+        scope:
+            label: Scope
+        completeness:
+            label: Complete
+        created:
+            label: Created At
+        updated:
+            label: Updated At
+        label_or_identifier:
+            label: Label or identifier
+        parent:
+            label: Parent
+        identifier:
+            label: Identifier
     search: Search on {{ label }}
 
 batch_jobs:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -465,6 +465,26 @@ pim_datagrid:
     filters:
         product_typology:
             label: Product typology
+        family:
+            label: Family
+        groups:
+            label: Groups
+        enabled:
+            label: Status
+        scope:
+            label: Scope
+        completeness:
+            label: Complete
+        created:
+            label: Created At
+        updated:
+            label: Updated At
+        label_or_identifier:
+            label: Label or identifier
+        parent:
+            label: Parent
+        identifier:
+            label: Identifier
 
 # Versioning / history
 Change History: Change history

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -465,6 +465,8 @@ pim_datagrid:
     filters:
         product_typology:
             label: Product typology
+        entity_type:
+            label: Variant
         family:
             label: Family
         groups:

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -52,7 +52,7 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   protected convertBackendItem(item: NormalizedAttribute): Object {
     return {
       id: item.code,
-      text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code),
+      text: __(i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code)),
       group: {
         text: (
           item.group ?

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -52,7 +52,7 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   protected convertBackendItem(item: NormalizedAttribute): Object {
     return {
       id: item.code,
-      text: __(i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code)),
+      text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code),
       group: {
         text: (
           item.group ?


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the user additional settings page, in the product grid filters dropdown, the labels were not translated. 
(some were hardcoded since 2014 ! :older_man: )

**Before**

![Screenshot_2020-10-05_17-36-40](https://user-images.githubusercontent.com/1421130/95100953-f0392180-0731-11eb-918b-cfc6ad0240cd.png)

**After**

![Screenshot_2020-10-05_17-40-50](https://user-images.githubusercontent.com/1421130/95100972-f4fdd580-0731-11eb-99a3-0d5224463c61.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
