### PR TITLE
CXP-423: fix webhook form style & behavior

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/SmallHelper.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/SmallHelper.tsx
@@ -27,7 +27,6 @@ const HintIcon = styled.div<Level>`
 const HintTitle = styled.div`
     border-left: 1px solid ${({theme}) => theme.color.grey80};
     flex-grow: 1;
-    font-weight: 600;
     padding-left: 16px;
     margin: 10px 0;
     margin-right: 10px;

--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/button/GhostButton.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/button/GhostButton.tsx
@@ -1,8 +1,38 @@
-import React, {forwardRef, Ref} from 'react';
-import {Button, Props} from './Button';
+import styled from '../../styled-with-theme';
 
-export const GhostButton = forwardRef(({classNames = [], ...props}: Props, ref: Ref<HTMLButtonElement>) => {
-    classNames.push('AknButton--ghost');
+export const GhostButton = styled.button`
+    background-color: white;
+    border-radius: 16px;
+    border: 1px solid ${({theme}) => theme.color.grey100};
+    color: ${({theme}) => theme.color.grey120};
+    cursor: pointer;
+    font-size: ${({theme}) => theme.fontSize.big};
+    height: 32px;
+    line-height: 30px;
+    min-width: 32px;
+    padding: 0 16px;
+    text-transform: uppercase;
+    transition: all 0.1s ease;
+    white-space: nowrap;
 
-    return <Button {...props} ref={ref} classNames={classNames} />;
-});
+    :hover {
+        background-color: ${({theme}) => theme.color.grey20};
+        color: ${({theme}) => theme.color.grey140};
+    }
+
+    :disabled {
+        border: 1px solid ${({theme}) => theme.color.grey60};
+        color: ${({theme}) => theme.color.grey80};
+        cursor: not-allowed;
+    }
+
+    :focus {
+        box-shadow: 0px 0px 2px 0px ${({theme}) => theme.color.blue100};
+        outline: none;
+    }
+
+    :active {
+        border: 1px solid ${({theme}) => theme.color.grey140};
+        color: ${({theme}) => theme.color.grey140};
+    }
+`;

--- a/src/Akeneo/Connectivity/Connection/front/src/common/styled-with-theme.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/styled-with-theme.ts
@@ -13,7 +13,7 @@ const theme = {
         grey140: '#11324d',
         grey20: '#f6f7fb',
         grey60: '#e8ebee',
-        grey80: '#d9dde2',
+        grey80: '#c7cbd4',
         purple100: '#9452ba',
         red100: '#d4604f',
         yellow10: '#fef7ec',

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -20,7 +20,7 @@ export const EditForm: FC<Props> = ({webhook}: Props) => {
     const translate = useContext(TranslateContext);
     const history = useHistory();
 
-    const {register, getValues, errors, setError} = useFormContext();
+    const {register, getValues, errors, setError, clearError} = useFormContext();
 
     const checkReachability = useCheckReachability(webhook.connectionCode);
     const [testUrl, setTestUrl] = useState<{checking: boolean; status?: WebhookReachability}>({
@@ -28,6 +28,7 @@ export const EditForm: FC<Props> = ({webhook}: Props) => {
     });
 
     const handleTestUrl = async () => {
+        clearError('url');
         setTestUrl({checking: true});
 
         const result = await checkReachability(getValues('url'));
@@ -64,6 +65,7 @@ export const EditForm: FC<Props> = ({webhook}: Props) => {
                                 message: 'akeneo_connectivity.connection.webhook.error.required',
                             },
                         })}
+                        onKeyDown={handleTestUrl}
                     />
                     <TestUrlButton
                         onClick={handleTestUrl}
@@ -72,24 +74,22 @@ export const EditForm: FC<Props> = ({webhook}: Props) => {
                     />
                 </>
             </FormGroup>
-            {webhook.secret && (
-                <CredentialList>
-                    <CopiableCredential
-                        label={translate('akeneo_connectivity.connection.connection.secret')}
-                        actions={
-                            <RegenerateButton
-                                onClick={() =>
-                                    history.push(
-                                        `/connections/${webhook.connectionCode}/event-subscription/regenerate-secret`
-                                    )
-                                }
-                            />
-                        }
-                    >
-                        {webhook.secret}
-                    </CopiableCredential>
-                </CredentialList>
-            )}
+            <CredentialList>
+                <CopiableCredential
+                    label={translate('akeneo_connectivity.connection.connection.secret')}
+                    actions={
+                        <RegenerateButton
+                            onClick={() =>
+                                history.push(
+                                    `/connections/${webhook.connectionCode}/event-subscription/regenerate-secret`
+                                )
+                            }
+                        />
+                    }
+                >
+                    {webhook.secret || ''}
+                </CopiableCredential>
+            </CredentialList>
         </>
     );
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionHelper.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionHelper.tsx
@@ -1,0 +1,24 @@
+import React, {FC} from 'react';
+import styled from 'styled-components';
+import {HelperLink, SmallHelper} from '../../common/components';
+import {Translate} from '../../shared/translate';
+
+export const EventSubscriptionHelper: FC = () => (
+    <Container>
+        <SmallHelper>
+            <Translate id='akeneo_connectivity.connection.webhook.helper.message' />
+            &nbsp;
+            <HelperLink
+                href='https://help.akeneo.com/pim/serenity/articles/manage-your-connections.html#subscribe-to-events'
+                target='_blank'
+                rel='noopener noreferrer'
+            >
+                <Translate id='akeneo_connectivity.connection.webhook.helper.link' />
+            </HelperLink>
+        </SmallHelper>
+    </Container>
+);
+
+const Container = styled.div`
+    padding-bottom: 20px;
+`;

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -3,16 +3,7 @@ import {FormContext, useForm, useFormContext} from 'react-hook-form';
 import {useHistory, useParams} from 'react-router';
 import styled from 'styled-components';
 import defaultImageUrl from '../../common/assets/illustrations/NewAPI.svg';
-import {
-    ApplyButton,
-    Breadcrumb,
-    BreadcrumbItem,
-    HelperLink,
-    PageContent,
-    PageHeader,
-    Section,
-    SmallHelper,
-} from '../../common/components';
+import {ApplyButton, Breadcrumb, BreadcrumbItem, PageContent, PageHeader, Section} from '../../common/components';
 import {Loading} from '../../common/components/Loading';
 import {PimView} from '../../infrastructure/pim-view/PimView';
 import {useMediaUrlGenerator} from '../../settings/use-media-url-generator';
@@ -20,6 +11,7 @@ import {isErr} from '../../shared/fetch-result/result';
 import {BreadcrumbRouterLink} from '../../shared/router';
 import {Translate} from '../../shared/translate';
 import {EditForm} from '../components/EditForm';
+import {EventSubscriptionHelper} from '../components/EventSubscriptionHelper';
 import {useUpdateWebhook} from '../hooks/api/use-update-webhook';
 import {useWebhook} from '../hooks/api/use-webhook';
 import {Webhook} from '../model/Webhook';
@@ -98,19 +90,7 @@ export const EditConnectionWebhook: FC = () => {
                 <PageContent>
                     <Layout>
                         <Section title={<Translate id='akeneo_connectivity.connection.webhook.event_subscription' />} />
-                        <div>
-                            <SmallHelper>
-                                <Translate id='akeneo_connectivity.connection.webhook.helper.message' />
-                                &nbsp;
-                                <HelperLink
-                                    href='https://help.akeneo.com/pim/serenity/articles/manage-your-connections.html#subscribe-to-events'
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                >
-                                    <Translate id='akeneo_connectivity.connection.webhook.helper.link' />
-                                </HelperLink>
-                            </SmallHelper>
-                        </div>
+                        <EventSubscriptionHelper />
                         <EditForm webhook={webhook} />
                     </Layout>
                 </PageContent>


### PR DESCRIPTION
Url field
- [x] Error on the URL field is not cleared
- [x] Remove errors from URL field when the TEST URL button is clicked

Style issue from the BEM ghost button ………..  
- [x] Disabled style doesn’t work: the TEST URL button should be disabled when the spinner is loading
- [x] Ghost button style is not up-to-date: the grey color when we hover the button is too dark. Please, replace the current grey.

Helper
- [x] please remove the bold option on the helper text.
- [x] it should have 20px between the helper and the first field Event subscription activation

Secret field
- [x] The secret field should be displayed at all time event if it’s empty.
- [x] On the event subscription form, the enter key trigger the regenerate secret action.Enter should test the URL (or at least, do nothing)

![232](https://user-images.githubusercontent.com/1671213/95114519-5cbd1c00-0744-11eb-9368-49c2c4068c4a.gif)
