### PR TITLE
PIM-9494: Fix the performances of attribute-select-filter on long lists of AttributeOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PIM-9478: Allow the modification of the identifier on a variant product
 - PIM-9481: Fix the list of product models when trying to get them by family variant
 - GITHUB-12899: Fix error shown when importing product models with the same code
+- PIM-9494: Fix the performances of attribute-select-filter on long lists of AttributeOptions
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -37,12 +37,16 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
                 ->setParameter('search', "%$search%");
         }
 
-        if (isset($options['ids'])) {
+        // both "ids" and "identifiers" are used in those options, which is never validated.
+        // To avoid any BC, we will allow both.
+        $ids = $options['ids'] ?? $options['identifiers'] ?? [];
+
+        if (!empty($ids)) {
             $qb
                 ->andWhere(
                     $qb->expr()->in(sprintf('o.%s', $identifier), ':ids')
                 )
-                ->setParameter('ids', $options['ids']);
+                ->setParameter('ids', $ids);
         }
 
         if (isset($options['limit']) && isset($options['page'])) {

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/AttributeOptionRepository.php
@@ -54,12 +54,16 @@ class AttributeOptionRepository extends EntityRepository implements
                 ->setParameter('search', "%$search%");
         }
 
-        if (isset($options['ids'])) {
+        // both "ids" and "identifiers" are used in those options, which is never validated.
+        // To avoid any BC, we will allow both.
+        $ids = $options['ids'] ?? $options['identifiers'] ?? [];
+
+        if (!empty($ids)) {
             $qb
                 ->andWhere(
                     $qb->expr()->in(sprintf('o.%s', $identifier), ':ids')
                 )
-                ->setParameter('ids', $options['ids']);
+                ->setParameter('ids', $ids);
         }
 
         if (isset($options['limit'])) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When a filter of type "attribute select", that let you pick attribute options, is used in the datagrid, there was performances issues when there is a lot of attribute options (eg: 5000).

This is because the filter in front tries to be smart and only fetch the selected values:

https://github.com/akeneo/pim-community-dev/blob/162def2dabfa6f4b62ab5c9deee6a3a781c83bf1/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select2-choice-filter.js#L234-L245

For doing so, it launch a search limited to some `identifiers`.

It was working on most repositories, like `FamilySearchableRepository`:
https://github.com/akeneo/pim-community-dev/blob/162def2dabfa6f4b62ab5c9deee6a3a781c83bf1/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/FamilySearchableRepository.php#L64-L67

But in `AttributeOptionRepository`, the key `ids` is expected, not `identifiers`.
https://github.com/akeneo/pim-community-dev/blob/162def2dabfa6f4b62ab5c9deee6a3a781c83bf1/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/AttributeOptionRepository.php#L57-L63
By using the wrong key, the list was not limited and the controller was returning ALL the rows (5000 in our case) and select2 was not able to handle it.

To avoid any BC break on things I've not seen, I choose to have `AttributeOptionRepository` support both keys.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
