### PR TITLE
PIM-9493: Attributes with no values are well rendered in PDF

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9490: [Backport] PIM-9461: Fix display of multiselect fields with a lot of selected options
+- PIM-9493: Attributes with no values are well rendered in PDF
 
 ## Technical Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -133,7 +133,8 @@ class ProductPdfRenderer implements RendererInterface
     protected function getGroupedAttributes(ProductInterface $product): array
     {
         $groups = [];
-        $attributesFromFamily = $product->getFamily()->getAttributes();
+        $productFamily = $product->getFamily();
+        $attributesFromFamily = $productFamily ? $productFamily->getAttributes() : [];
         foreach ($attributesFromFamily as $attribute) {
             if (null !== $attribute) {
                 $groupLabel = $attribute->getGroup()->getLabel();

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -130,13 +130,11 @@ class ProductPdfRenderer implements RendererInterface
      *
      * @return AttributeInterface[]
      */
-    protected function getGroupedAttributes(ProductInterface $product)
+    protected function getGroupedAttributes(ProductInterface $product): array
     {
         $groups = [];
-
-        foreach ($this->getAttributeCodes($product) as $attributeCode) {
-            $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
-
+        $attributesFromFamily = $product->getFamily()->getAttributes();
+        foreach ($attributesFromFamily as $attribute) {
             if (null !== $attribute) {
                 $groupLabel = $attribute->getGroup()->getLabel();
                 if (!isset($groups[$groupLabel])) {
@@ -159,7 +157,7 @@ class ProductPdfRenderer implements RendererInterface
      *
      * @return string[]
      */
-    protected function getImagePaths(ProductInterface $product, $locale, $scope)
+    protected function getImagePaths(ProductInterface $product, $locale, $scope): array
     {
         $imagePaths = [];
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -133,9 +133,14 @@ class ProductPdfRenderer implements RendererInterface
     protected function getGroupedAttributes(ProductInterface $product): array
     {
         $groups = [];
-        $productFamily = $product->getFamily();
-        $attributesFromFamily = $productFamily ? $productFamily->getAttributes() : [];
-        foreach ($attributesFromFamily as $attribute) {
+
+        $attributeCodes = $product->getUsedAttributeCodes();
+        if ($product->getFamily()) {
+            $attributeCodes = array_unique(array_merge($attributeCodes, $product->getFamily()->getAttributeCodes()));
+        }
+
+        foreach ($attributeCodes as $attributeCode) {
+            $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
             if (null !== $attribute) {
                 $groupLabel = $attribute->getGroup()->getLabel();
                 if (!isset($groups[$groupLabel])) {

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -68,7 +68,7 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
 
     private function createProduct($identifier, array $data = []): ProductInterface
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, 'familyA');
         $this->get('pim_catalog.updater.product')->update($product, $data);
 
         $errors = $this->get('pim_catalog.validator.product')->validate($product);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -28,22 +28,41 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
 
     public function test_it_downloads_a_pdf_for_a_product_with_an_image(): void
     {
-        $product = $this->createProduct('simple', [
-            'values' => [
-                'an_image' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))
-                    ]
-                ]
+        $product = $this->createProduct(
+            'simple',
+            'familyA',
+            [
+                'values' => [
+                    'an_image' => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')),
+                        ],
+                    ],
+                ],
             ]
-        ]);
+        );
 
         $url = $this->getRouter()->generate('pim_pdf_generator_download_product_pdf', [
             'id' => $product->getId(),
             'dataLocale' => 'en_US',
-            'dataScope' => 'ecommerce'
+            'dataScope' => 'ecommerce',
+        ]);
+
+        $this->client->request('GET', $url);
+
+        Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
+    public function test_it_downloads_a_pdf_for_a_product_without_family(): void
+    {
+        $product = $this->createProduct('simple', null, []);
+
+        $url = $this->getRouter()->generate('pim_pdf_generator_download_product_pdf', [
+            'id' => $product->getId(),
+            'dataLocale' => 'en_US',
+            'dataScope' => 'ecommerce',
         ]);
 
         $this->client->request('GET', $url);
@@ -66,9 +85,9 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
         return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 
-    private function createProduct($identifier, array $data = []): ProductInterface
+    private function createProduct(string $identifier, ?string $familyCode, array $data = []): ProductInterface
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, 'familyA');
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $familyCode);
         $this->get('pim_catalog.updater.product')->update($product, $data);
 
         $errors = $this->get('pim_catalog.validator.product')->validate($product);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
@@ -15,8 +15,9 @@ use Akeneo\Pim\Structure\Component\Model\AttributeGroup;
 use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOption;
-use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
+use Akeneo\Pim\Structure\Component\Model\Family;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Liip\ImagineBundle\Imagine\Cache\CacheManager;
@@ -66,9 +67,12 @@ class ProductPdfRendererSpec extends ObjectBehavior
         ProductInterface $blender,
         AttributeGroupInterface $design,
         AttributeInterface $color,
+        FamilyInterface $family,
         $attributeRepository
     ) {
         $blender->getUsedAttributeCodes()->willReturn(['color']);
+        $blender->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn([$color]);
 
         $color->getGroup()->willReturn($design);
         $design->getLabel()->willReturn('Design');
@@ -108,8 +112,12 @@ class ProductPdfRendererSpec extends ObjectBehavior
         ValueInterface $value,
         FileInfoInterface $fileInfo,
         CacheManager $cacheManager,
+        FamilyInterface $family,
         $attributeRepository
     ) {
+        $blender->getFamily()->willReturn($family);
+        $family->getAttributes()->willReturn([$mainImage]);
+
         $mainImage->isLocalizable()->willReturn(true);
         $mainImage->isScopable()->willReturn(true);
 
@@ -187,7 +195,10 @@ class ProductPdfRendererSpec extends ObjectBehavior
         $red->addOptionValue($redValue);
         $attributeOptionRepository->findOneByIdentifier('colors.red')->willReturn($red);
 
+        $family = new Family();
+        $family->addAttribute($colors);
         $product = new Product();
+        $product->setFamily($family);
         $product->setValues(
             new WriteValueCollection(
                 [
@@ -222,8 +233,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
 
     function it_renders_a_simple_select_without_any_option_for_a_given_locale(
         EngineInterface $templating,
-        IdentifiableObjectRepositoryInterface $attributeRepository,
-        IdentifiableObjectRepositoryInterface $attributeOptionRepository
+        IdentifiableObjectRepositoryInterface $attributeRepository
     ) {
         $colors = new Attribute();
         $colors->setCode('colors');
@@ -238,7 +248,10 @@ class ProductPdfRendererSpec extends ObjectBehavior
         $colors->setScopable(true);
         $attributeRepository->findOneByIdentifier('colors')->willReturn($colors);
 
+        $family = new Family();
+        $family->addAttribute($colors);
         $product = new Product();
+        $product->setFamily($family);
         $product->setValues(
             new WriteValueCollection(
                 [

--- a/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/PdfGeneration/Renderer/ProductPdfRendererSpec.php
@@ -72,7 +72,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
     ) {
         $blender->getUsedAttributeCodes()->willReturn(['color']);
         $blender->getFamily()->willReturn($family);
-        $family->getAttributes()->willReturn([$color]);
+        $family->getAttributeCodes()->willReturn(['color']);
 
         $color->getGroup()->willReturn($design);
         $design->getLabel()->willReturn('Design');
@@ -116,7 +116,7 @@ class ProductPdfRendererSpec extends ObjectBehavior
         $attributeRepository
     ) {
         $blender->getFamily()->willReturn($family);
-        $family->getAttributes()->willReturn([$mainImage]);
+        $family->getAttributeCodes()->willReturn(['main_image']);
 
         $mainImage->isLocalizable()->willReturn(true);
         $mainImage->isScopable()->willReturn(true);


### PR DESCRIPTION
PR to render all product attributes in the PDF, even empty ones.
Before, empty attributes where part of the values, but since 4.0, empty values are not stored and we must retrieve all the attributes from the product family