### PR TITLE
API-1310: Create & dispatch ProductModelRemoved business event

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductModelEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductModelEventEndToEnd.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
+
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\FamilyVariantLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductModelLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Infrastructure\MessageHandler\BusinessEventHandler;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ConsumeProductModelEventEndToEnd extends ApiTestCase
+{
+    /** @var ConnectionLoader */
+    private $connectionLoader;
+
+    /** @var WebhookLoader */
+    private $webhookLoader;
+
+    /** @var ProductModelLoader */
+    private $productModelLoader;
+
+    /** @var AttributeLoader */
+    private $attributeLoader;
+
+    /** @var FamilyLoader */
+    private $familyLoader;
+
+    /** @var FamilyVariantLoader */
+    private $familyVariantLoader;
+
+    /** @var NormalizerInterface */
+    private $normalizer;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+        $this->webhookLoader = $this->get('akeneo_connectivity.connection.fixtures.webhook_loader');
+        $this->productModelLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.product_model');
+        $this->attributeLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.attribute');
+        $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
+        $this->familyVariantLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.family_variant');
+        $this->normalizer = $this->get('pim_catalog.normalizer.standard.product_model');
+    }
+
+    public function test_it_sends_a_product_model_removed_webhook_event()
+    {
+        $connection = $this->connectionLoader->createConnection('ecommerce', 'Ecommerce', FlowType::DATA_DESTINATION, false);
+        $this->webhookLoader->initWebhook($connection->code());
+
+        $this->attributeLoader->create(
+            [
+                'code' => 'test_variant_attribute',
+                'type' => 'pim_catalog_boolean',
+            ]
+        );
+        $this->familyLoader->create(
+            [
+                'code' => 'test_family',
+                'attributes' => ['test_variant_attribute'],
+            ]
+        );
+        $this->familyVariantLoader->create(
+            [
+                'code' => 'test_family_variant',
+                'family' => 'test_family',
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['test_variant_attribute'],
+                        'attributes' => [],
+                        'level' => 1,
+                    ],
+                ],
+            ]
+        );
+
+        $productModel = $this->productModelLoader->create(
+            ['code' => 'test_product_model', 'family_variant' => 'test_family_variant',]
+        );
+
+        /** @var HandlerStack $handlerStack*/
+        $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
+        $handlerStack->setHandler(new MockHandler([
+            new Response(200),
+        ]));
+
+        $container = [];
+        $history = Middleware::history($container);
+        $handlerStack->push($history);
+
+        $message = new ProductModelRemoved(
+            'ecommerce',
+            $this->normalizer->normalize($productModel, 'standard')
+        );
+
+        /** @var $businessEventHandler BusinessEventHandler */
+        $businessEventHandler = $this->get(BusinessEventHandler::class);
+        $businessEventHandler->__invoke($message);
+
+        $this->assertCount(1, $container);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
+
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\FamilyVariantLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductModelLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProduceProductModelEventEndToEnd extends ApiTestCase
+{
+    /** @var ProductModelLoader */
+    private $productModelLoader;
+
+    /** @var AttributeLoader */
+    private $attributeLoader;
+
+    /** @var FamilyLoader */
+    private $familyLoader;
+
+    /** @var FamilyVariantLoader */
+    private $familyVariantLoader;
+
+    /** @var RemoverInterface */
+    private $productModelRemover;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->productModelLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.product_model');
+        $this->attributeLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.attribute');
+        $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
+        $this->familyVariantLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.family_variant');
+        $this->productModelRemover = $this->get('pim_catalog.remover.product_model');
+    }
+
+    public function test_remove_product_model_add_business_event_to_queue()
+    {
+        $this->attributeLoader->create(
+            [
+                'code' => 'test_variant_attribute',
+                'type' => 'pim_catalog_boolean',
+            ]
+        );
+        $this->familyLoader->create(
+            [
+                'code' => 'test_family',
+                'attributes' => ['test_variant_attribute'],
+            ]
+        );
+        $this->familyVariantLoader->create(
+            [
+                'code' => 'test_family_variant',
+                'family' => 'test_family',
+                'variant_attribute_sets' => [
+                    [
+                        'axes' => ['test_variant_attribute'],
+                        'attributes' => [],
+                        'level' => 1,
+                    ],
+                ],
+            ]
+        );
+
+        $productModel = $this->productModelLoader->create(
+            ['code' => 'test_product_model', 'family_variant' => 'test_family_variant',]
+        );
+
+        $this->productModelRemover->remove($productModel);
+
+        $transport = self::$container->get('messenger.transport.business_event');
+
+        $envelopes = $transport->get();
+        $this->assertCount(1, $envelopes);
+        $this->assertInstanceOf(ProductModelRemoved::class, $envelopes[0]->getMessage());
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/Enrichment/FamilyVariantLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/Enrichment/FamilyVariantLoader.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FamilyVariantLoader
+{
+    /** @var SimpleFactoryInterface */
+    private $factory;
+
+    /** @var ObjectUpdaterInterface */
+    private $updater;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var SaverInterface */
+    private $saver;
+
+    public function __construct(
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver
+    ) {
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->validator = $validator;
+        $this->saver = $saver;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function create(array $data = []): FamilyVariantInterface
+    {
+        /** @var  FamilyVariantInterface $familyVariant */
+        $familyVariant = $this->factory->create();
+
+        $this->updater->update($familyVariant, $data);
+        $errors = $this->validator->validate($familyVariant);
+
+        if (0 !== $errors->count()) {
+            throw new \Exception(
+                sprintf(
+                    'Impossible to setup test in %s: %s',
+                    static::class,
+                    $errors->get(0)->getMessage()
+                )
+            );
+        }
+
+        $this->saver->save($familyVariant);
+
+        return $familyVariant;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/Enrichment/ProductModelLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Fixtures/Enrichment/ProductModelLoader.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelLoader
+{
+    /** @var SimpleFactoryInterface */
+    private $factory;
+
+    /** @var ObjectUpdaterInterface */
+    private $updater;
+
+    /** @var ValidatorInterface */
+    private $validator;
+
+    /** @var SaverInterface */
+    private $saver;
+
+    /** @var Client */
+    private $client;
+
+    public function __construct(
+        SimpleFactoryInterface $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        SaverInterface $saver,
+        Client $client
+    ) {
+        $this->factory = $factory;
+        $this->updater = $updater;
+        $this->validator = $validator;
+        $this->saver = $saver;
+        $this->client = $client;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function create(array $data = []): ProductModelInterface
+    {
+        /** @var  ProductModelInterface $productModel */
+        $productModel = $this->factory->create();
+
+        $this->updater->update($productModel, $data);
+        $errors = $this->validator->validate($productModel);
+
+        if (0 !== $errors->count()) {
+            throw new \Exception(
+                sprintf(
+                    'Impossible to setup test in %s: %s',
+                    static::class,
+                    $errors->get(0)->getMessage()
+                )
+            );
+        }
+
+        $this->saver->save($productModel);
+        $this->client->refreshIndex();
+
+        return $productModel;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/loaders.yml
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/loaders.yml
@@ -40,6 +40,23 @@ services:
             - '@validator'
             - '@akeneo_elasticsearch.client.product_and_product_model'
 
+    akeneo_connectivity.connection.fixtures.enrichment.product_model:
+        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductModelLoader'
+        arguments:
+            - '@pim_catalog.factory.product_model'
+            - '@pim_catalog.updater.product_model'
+            - '@pim_catalog.validator.product'
+            - '@pim_catalog.saver.product_model'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+
+    akeneo_connectivity.connection.fixtures.enrichment.family_variant:
+        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\FamilyVariantLoader'
+        arguments:
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@validator'
+            - '@pim_catalog.saver.family_variant'
+
     akeneo_connectivity.connection.fixtures.webhook_loader:
         class: Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModelEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModelEventSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @copyright 202O Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductModelEventSubscriber implements EventSubscriberInterface
+{
+    private $security;
+    private $normalizer;
+    private $messageBus;
+
+    public function __construct(Security $security, NormalizerInterface $normalizer, MessageBusInterface $messageBus)
+    {
+        $this->security = $security;
+        $this->normalizer = $normalizer;
+        $this->messageBus = $messageBus;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::POST_REMOVE => ['produceBusinessRemoveEvent', 1000],
+        ];
+    }
+
+    public function produceBusinessRemoveEvent(GenericEvent $event): void
+    {
+        /** @var ProductInterface */
+        $product = $event->getSubject();
+        if (false === $product instanceof ProductModelInterface) {
+            return;
+        }
+
+        if (null === $user = $this->security->getUser()) {
+            throw new \LogicException('User should not be null.');
+        }
+
+        $author = $user->getUsername();
+        $data = $this->normalizer->normalize($product, 'standard');
+
+        $message = new ProductModelRemoved($author, $data);
+
+        $this->messageBus->dispatch($message);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -183,3 +183,11 @@ services:
             - '@Symfony\Component\Messenger\MessageBusInterface'
         tags:
             - { name: kernel.event_subscriber }
+
+    Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductModelEventSubscriber:
+        arguments:
+            - '@security.helper'
+            - '@pim_catalog.normalizer.standard.product_model'
+            - '@Symfony\Component\Messenger\MessageBusInterface'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
@@ -14,3 +14,11 @@ services:
             - '@pim_api.normalizer.product'
         tags:
             - { name: akeneo_connectivity.connection.webhook.event_data_builder }
+
+    pim_catalog.webhook.event_data_builder.product_model_removed:
+        class: Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductModelRemovedEventDataBuilder
+        arguments:
+            - '@pim_api.repository.product_model'
+            - '@pim_api.normalizer.product_model'
+        tags:
+            - { name: akeneo_connectivity.connection.webhook.event_data_builder }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductModelRemoved.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductModelRemoved.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Message;
+
+use Akeneo\Platform\Component\EventQueue\BusinessEvent;
+
+/**
+ * @copyright 202O Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelRemoved extends BusinessEvent
+{
+    public function name(): string
+    {
+        return 'product_model.removed';
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Webhook;
+
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Platform\Component\EventQueue\BusinessEventInterface;
+use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductModelRemovedEventDataBuilder implements EventDataBuilderInterface
+{
+    public function supports(BusinessEventInterface $businessEvent): bool
+    {
+        return $businessEvent instanceof ProductModelRemoved;
+    }
+
+    /**
+     * @param ProductModelRemoved $businessEvent
+     */
+    public function build(BusinessEventInterface $businessEvent): array
+    {
+        if (false === $this->supports($businessEvent)) {
+            throw new \InvalidArgumentException();
+        }
+
+        $data = $businessEvent->data();
+
+        return [
+            'resource' => ['identifier' => $data['code']]
+        ];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
@@ -31,7 +31,7 @@ class ProductModelRemovedEventDataBuilder implements EventDataBuilderInterface
         $data = $businessEvent->data();
 
         return [
-            'resource' => ['identifier' => $data['code']]
+            'resource' => ['code' => $data['code']]
         ];
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductEventSubscriberSpec.php
@@ -101,7 +101,7 @@ class ProductEventSubscriberSpec extends ObjectBehavior
 
         $result = $this->produceBusinessSaveEvent(new GenericEvent('NOT_A_PRODUCT', ['updated' => true]));
 
-        Assert::assertEquals(null, $result->getWrappedObject());
+        Assert::assertCount(0, $messageBus->messages);
     }
 
     function it_does_not_produce_business_save_event_because_there_is_no_logged_user(
@@ -159,7 +159,7 @@ class ProductEventSubscriberSpec extends ObjectBehavior
 
         $result = $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT'));
 
-        Assert::assertEquals(null, $result->getWrappedObject());
+        Assert::assertCount(0, $messageBus->messages);
     }
 
     function it_does_not_produce_business_remove_event_because_there_is_no_logged_user(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductEventSubscriberSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductEventSubscriber;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
@@ -14,8 +15,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-
-use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 
 class ProductEventSubscriberSpec extends ObjectBehavior
 {

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductModelEventSubscriber;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use PhpSpec\ObjectBehavior;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ProductModelEventSubscriberSpec extends ObjectBehavior
+{
+    function let(Security $security, NormalizerInterface $normalizer, MessageBusInterface $messageBus)
+    {
+        $this->beConstructedWith($security, $normalizer, $messageBus);
+    }
+
+    function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ProductModelEventSubscriber::class);
+    }
+
+    function it_returns_subscribed_events(): void
+    {
+        $this->getSubscribedEvents()->shouldReturn(
+            [
+                StorageEvents::POST_REMOVE => ['produceBusinessRemoveEvent', 1000],
+            ]
+        );
+    }
+
+    function it_does_produce_business_remove_event(
+        UserInterface $user,
+        $security,
+        $normalizer
+    ) {
+        $productModel = new ProductModel();
+        $productModel->setCode('my_product_model');
+
+        $messageBus = $this->getMessageBus();
+        $this->beConstructedWith($security, $normalizer, $messageBus);
+
+        $user->getUsername()->willReturn('julia');
+        $security->getUser()->willReturn($user);
+
+        $normalizer->normalize($productModel, 'standard')->willReturn(
+            [
+                'code' => 12,
+            ]
+        );
+
+        $this->produceBusinessRemoveEvent(new GenericEvent($productModel));
+
+        Assert::assertCount(1, $messageBus->messages);
+    }
+
+    function it_does_not_produce_business_remove_event_because_event_subject_is_not_a_product(
+        $security,
+        $normalizer
+    ) {
+        $messageBus = $this->getMessageBus();
+        $this->beConstructedWith($security, $normalizer, $messageBus);
+
+        $result = $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
+
+        Assert::assertEquals(null, $result->getWrappedObject());
+    }
+
+    function it_does_not_produce_business_remove_event_because_there_is_no_logged_user(
+        $security,
+        $normalizer
+    ) {
+        $messageBus = $this->getMessageBus();
+        $this->beConstructedWith($security, $normalizer, $messageBus);
+
+        $productModel = new ProductModel();
+        $productModel->setCode('pm');
+
+        $security->getUser()->willReturn(null);
+
+        $this->shouldThrow(
+            new \LogicException('User should not be null.')
+        )->during('produceBusinessRemoveEvent', [new GenericEvent($productModel)]);
+    }
+
+    private function getMessageBus()
+    {
+        return new class() implements MessageBusInterface {
+
+            public $messages = [];
+
+            public function dispatch($message, array $stamps = []): Envelope
+            {
+                $this->messages[] = $message;
+
+                return new Envelope($message);
+            }
+        };
+    }
+}
+

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
@@ -53,7 +53,7 @@ class ProductModelEventSubscriberSpec extends ObjectBehavior
 
         $normalizer->normalize($productModel, 'standard')->willReturn(
             [
-                'code' => 12,
+                'code' => 'my_product_model',
             ]
         );
 
@@ -106,4 +106,3 @@ class ProductModelEventSubscriberSpec extends ObjectBehavior
         };
     }
 }
-

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModelEventSubscriberSpec.php
@@ -71,7 +71,7 @@ class ProductModelEventSubscriberSpec extends ObjectBehavior
 
         $result = $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
 
-        Assert::assertEquals(null, $result->getWrappedObject());
+        Assert::assertCount(0, $messageBus->messages);
     }
 
     function it_does_not_produce_business_remove_event_because_there_is_no_logged_user(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductModelRemovedSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductModelRemovedSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Message;
+
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Platform\Component\EventQueue\BusinessEvent;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class ProductModelRemovedSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith(
+            'author',
+            ['data'],
+            1598953500,
+            'a23e4567-e89b-12d3-a456-426614175000'
+        );
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ProductModelRemoved::class);
+    }
+
+    public function it_is_a_business_event(): void
+    {
+        $this->shouldBeAnInstanceOf(BusinessEvent::class);
+    }
+
+    public function it_returns_the_name(): void
+    {
+        $this->name()->shouldReturn('product_model.removed');
+    }
+
+    public function it_returns_the_author(): void
+    {
+        $this->author()->shouldReturn('author');
+    }
+
+    public function it_returns_the_data(): void
+    {
+        $this->data()->shouldReturn(['data']);
+    }
+
+    public function it_returns_the_timestamp(): void
+    {
+        $this->timestamp()->shouldReturn(1598953500);
+    }
+
+    public function it_returns_the_uuid(): void
+    {
+        $this->uuid()->shouldReturn('a23e4567-e89b-12d3-a456-426614175000');
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
@@ -35,9 +35,9 @@ class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
 
     public function it_builds_product_model_removed_event(): void
     {
-        $this->build(new ProductModelRemoved('julia', ['identifier' => 'product_identifier']))->shouldReturn(
+        $this->build(new ProductModelRemoved('julia', ['code' => 'product_identifier']))->shouldReturn(
             [
-                'resource' => ['identifier' => 'product_identifier'],
+                'resource' => ['code' => 'product_identifier'],
             ]
         );
     }
@@ -46,7 +46,7 @@ class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
     {
         $this->shouldThrow(new \InvalidArgumentException())->during(
             'build',
-            [new ProductCreated('julia', ['identifier' => 'product_identifier'])]
+            [new ProductCreated('julia', ['code' => 'product_identifier'])]
         );
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Webhook;
+
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
+use Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductModelRemovedEventDataBuilder;
+use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
+use PhpSpec\ObjectBehavior;
+
+class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith();
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldBeAnInstanceOf(ProductModelRemovedEventDataBuilder::class);
+        $this->shouldImplement(EventDataBuilderInterface::class);
+    }
+
+    public function it_supports_product_model_removed_event(): void
+    {
+        $this->supports(new ProductModelRemoved('julia', ['data']))->shouldReturn(true);
+    }
+
+    public function it_does_not_supports_other_business_event(): void
+    {
+        $this->supports(new ProductCreated('julia', ['data']))->shouldReturn(false);
+    }
+
+    public function it_builds_product_model_removed_event(): void
+    {
+        $this->build(new ProductModelRemoved('julia', ['identifier' => 'product_identifier']))->shouldReturn(
+            [
+                'resource' => ['identifier' => 'product_identifier'],
+            ]
+        );
+    }
+
+    public function it_does_not_build_other_business_event(): void
+    {
+        $this->shouldThrow(new \InvalidArgumentException())->during(
+            'build',
+            [new ProductCreated('julia', ['identifier' => 'product_identifier'])]
+        );
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Notify webhook when a product model has been deleted

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
