### PR TITLE
PIM-9496: Change date format in the locale it_IT from dd/MM/yy to dd/MM/yyyy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PIM-9481: Fix the list of product models when trying to get them by family variant
 - GITHUB-12899: Fix error shown when importing product models with the same code
 - PIM-9494: Fix the performances of attribute-select-filter on long lists of AttributeOptions
+- PIM-9496: Change date format in the locale it_IT from dd/MM/yy to dd/MM/yyyy
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/factories.yml
@@ -6,9 +6,11 @@ parameters:
     pim_catalog.localization.factory.date.formats:
         en_US: 'MM/dd/yyyy'
         fr_FR: 'dd/MM/yyyy'
+        it_IT: 'dd/MM/yyyy'
     pim_catalog.localization.factory.datetime.formats:
         en_US: 'MM/dd/yyyy hh:mm a'
         fr_FR: 'dd/MM/yyyy HH:mm'
+        it_IT: 'dd/MM/yyyy HH:mm'
     pim_catalog.localization.factory.currency.formats:
         en_US: '¤#,##0.00'
         fr_FR: '#,##0.00 ¤'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Only a few locales (fr_FR & en_US) had a specified format when normalizing date values.
By default, IntlDateFormatter fallback to a short format like `10/10/99` and the year lack precision. (1999 ? 2099 ?)
With this fix, the italian date format is `dd/MM/yyyy` instead of `dd/MM/yy`

**Before:**

![Screenshot_2020-10-08_18-33-46](https://user-images.githubusercontent.com/1421130/95487713-f8dd6200-0994-11eb-8914-b8513b0dc6f7.png)

**After:**

![Screenshot_2020-10-08_18-34-06](https://user-images.githubusercontent.com/1421130/95487729-fd097f80-0994-11eb-8a23-722de37992b9.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -