### PR TITLE
PIM-9497: Improve performances of SQL query about product model children completeness

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9497: Improve performances of SQL query about product model children completeness
+
 # 4.0.62 (2020-10-07)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
@@ -175,7 +175,11 @@ SQL;
             FROM 
                 pim_catalog_product_model pm
                 LEFT JOIN pim_catalog_product_model pm_child ON pm_child.parent_id = pm.id
-                LEFT JOIN pim_catalog_product p_child ON p_child.product_model_id = COALESCE(pm_child.id, pm.id)
+                LEFT JOIN pim_catalog_product p_child ON (
+                    p_child.product_model_id = pm_child.id
+                    OR
+                    p_child.product_model_id = pm.id
+                )
                 LEFT JOIN pim_catalog_completeness completeness ON completeness.product_id = p_child.id
                 LEFT JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
                 LEFT JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This query was really slow on the **first** execution due to mysql not being able to optimize it properly, because of the COALESCE.
(We have up to 4min30s for a customer with 800.000 products)

With a simple `OR`, we are down to ~ `0.01 sec`, even on first execution.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
