### PR TITLE
Fix google/cloud-sdk Docker image tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - 'pim'
 
   pubsub-emulator:
-    image: 'google/cloud-sdk:latest'
+    image: 'google/cloud-sdk:312.0.0'
     command: 'gcloud --user-output-enabled --log-http beta emulators pubsub start --host-port=0.0.0.0:8085'
     networks:
       - 'pim'


### PR DESCRIPTION
Description

This Docker image is used to emulate GCloud Pub/Sub. However, the latest release 313.0.0 seems to have a different behavior or to not work at all. Quick fix proposed in this PR is to set the Docker image version to the last working tag 312.0.0.