### PR TITLE
PM2020-4: update PQB to display all documents with quick search

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilder.php
@@ -132,6 +132,7 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         );
         $hasGroupsFilter = $this->hasRawFilter('field', 'groups');
         $hasCategoryFilter = $this->hasFilterOnCategoryWhichImplyAggregation();
+        $hasLabelOrIdentifierField = $this->hasRawFilter('field', 'label_or_identifier');
 
         return !$hasAttributeFilters &&
             !$hasParentFilter &&
@@ -142,7 +143,8 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
             !$hasSelfAndAncestorsIdsFilter &&
             !$hasSelfAndAncestorsLabelOrIdentifierFilter &&
             !$hasGroupsFilter &&
-            !$hasCategoryFilter;
+            !$hasCategoryFilter &&
+            !$hasLabelOrIdentifierField;
     }
 
     /**
@@ -200,10 +202,12 @@ class ProductAndProductModelQueryBuilder implements ProductQueryBuilderInterface
         $hasParentField = $this->hasRawFilter('field', 'parent');
         $hasIdField = $this->hasRawFilter('field', 'id');
         $hasEntityTypeField = $this->hasRawFilter('field', 'entity_type');
+        $hasLabelOrIdentifierField = $this->hasRawFilter('field', 'label_or_identifier');
 
         return
             !$hasParentField &&
             !$hasIdField &&
-            !$hasEntityTypeField;
+            !$hasEntityTypeField &&
+            !$hasLabelOrIdentifierField;
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/LabelOrIdentifierFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/LabelOrIdentifierFilterIntegration.php
@@ -27,10 +27,24 @@ class LabelOrIdentifierFilterIntegration extends AbstractProductAndProductModelQ
     public function testSearch()
     {
         $result = $this->executeFilter([['label_or_identifier', Operators::CONTAINS, 'hat', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
-        $this->assert($result, ['model-braided-hat', '1111111240']);
+        $this->assert($result, ['model-braided-hat', '1111111240', 'braided-hat-m', 'braided-hat-xxxl']);
 
         $result = $this->executeFilter([['label_or_identifier', Operators::CONTAINS, 'ha', ['locale' => 'en_US', 'scope' => 'ecommerce']]]);
-        $this->assert($result, ['model-braided-hat', 'hades', '1111111240']);
+        $this->assert($result, [
+            'model-braided-hat',
+            'hades',
+            'braided-hat-m',
+            'braided-hat-xxxl',
+            '1111111234',
+            '1111111235',
+            '1111111236',
+            '1111111237',
+            '1111111238',
+            '1111111239',
+            '1111111240',
+            'hades_blue',
+            'hades_red',
+        ]);
     }
 
     public function testSearchOnLabelAndCompleteness()
@@ -39,6 +53,6 @@ class LabelOrIdentifierFilterIntegration extends AbstractProductAndProductModelQ
             ['label_or_identifier', Operators::CONTAINS, 'hat', ['locale' => 'en_US', 'scope' => 'ecommerce']],
             ['completeness', Operators::AT_LEAST_COMPLETE, null, ['locale' => 'en_US', 'scope' => 'ecommerce']]
         ]);
-        $this->assert($result, ['model-braided-hat']);
+        $this->assert($result, ['model-braided-hat', 'braided-hat-m', 'braided-hat-xxxl']);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductAndProductModelQueryBuilderIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Oro\Bundle\PimDataGridBundle\Normalizer\IdEncoder;
@@ -804,4 +805,83 @@ class ProductAndProductModelQueryBuilderIntegration extends AbstractProductAndPr
         $this->assert($result, $expectedResult);
     }
 
+    public function testQuickSearchOnLabelOrIdentifierReturnsProductModelSubProductModelAndVariants(): void
+    {
+        $result = $this->executeFilter(
+            [
+                ['label_or_identifier', Operators::CONTAINS, 'apollon'],
+            ]
+        );
+
+        $expectedResult = [
+            '1111111119', // inherit label of its parent (apollon_blue)
+            '1111111120',
+            '1111111121',
+            '1111111122',
+            '1111111123',
+            '1111111124',
+            '1111111125',
+            '1111111126',
+            '1111111127',
+            '1111111128',
+            '1111111129',
+            '1111111130',
+            '1111111131',
+            'apollon',
+            'apollon_blue',
+            'apollon_pink',
+            'apollon_red',
+            'apollon_yellow',
+        ];
+        $this->assert($result, $expectedResult);
+    }
+
+    public function testQuickSearchOnLabelOrIdentifierReturnsSubProductModelAndVariants(): void
+    {
+        $result = $this->executeFilter(
+            [
+                ['label_or_identifier', Operators::CONTAINS, 'apollon blue'],
+            ]
+        );
+
+        $expectedResult = [
+            '1111111119',
+            '1111111120',
+            '1111111121',
+            'apollon_blue',
+        ];
+        $this->assert($result, $expectedResult);
+    }
+
+    public function testQuickSearchOnLabelOrIdentifierInUngroupedModeReturnsVariantsOnly(): void
+    {
+        $result = $this->executeFilter(
+            [
+                ['label_or_identifier', Operators::CONTAINS, 'apollon'],
+                $this->getUngroupedRawFilter(),
+            ]
+        );
+
+        $expectedResult = [
+            '1111111119',
+            '1111111120',
+            '1111111121',
+            '1111111122',
+            '1111111123',
+            '1111111124',
+            '1111111125',
+            '1111111126',
+            '1111111127',
+            '1111111128',
+            '1111111129',
+            '1111111130',
+            '1111111131',
+        ];
+        $this->assert($result, $expectedResult);
+    }
+
+    private function getUngroupedRawFilter(): array
+    {
+        return ['entity_type', Operators::EQUALS, ProductInterface::class];
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/ProductQueryBuilder/ProductAndProductModelQueryBuilderSpec.php
@@ -548,4 +548,30 @@ class ProductAndProductModelQueryBuilderSpec extends ObjectBehavior
 
         $this->execute()->shouldReturn($cursor);
     }
+
+    function it_does_not_add_a_default_filter_on_parents_and_does_not_aggregate_when_there_is_a_filter_on_label_or_identifier(
+        $pqb,
+        $searchAggregator,
+        CursorInterface $cursor,
+        SearchQueryBuilder $sqb
+    ) {
+        $rawFilters = [
+            [
+                'field'    => 'label_or_identifier',
+                'operator' => '=',
+                'value'    => 'id7',
+                'context'  => [],
+                'type'     => 'field'
+            ],
+        ];
+
+        $pqb->getRawFilters()->willReturn($rawFilters);
+
+        $pqb->addFilter('parent', Argument::cetera())->shouldNotBeCalled();
+        $pqb->execute()->willReturn($cursor);
+        $pqb->getQueryBuilder()->willReturn($sqb);
+        $searchAggregator->aggregateResults($sqb, $rawFilters)->shouldNotBeCalled();
+
+        $this->execute()->shouldReturn($cursor);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PM2020-4

Actually the quick search grid (on identifier and label) returns simple product and root product model, not sub product models and variants.  
With this PR we display all products and PM.

When there is another filter on an attribute value, we use to "aggregate" results to display only the level where the attribute is defined (= the PM). If there is also a "label or identifier" filter, now we don't aggregate otherwise the product cannot be displayed (same behavior as the filter on id).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
