### PR TITLE
PIM-9485: Change ACL name “Remove a product model” to “Remove a product model (including children)”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - PIM-9398: Add a primary key on connection table
 - PIM-9371: Disable save button when user creation form is not ready to submit
 - RAC-178: When launching a job, the notification contains a link to the job status
+- PIM-9485: Change ACL name “Remove a product model” to “Remove a product model (including children)”
 
 # Technical Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.en_US.yml
@@ -108,7 +108,7 @@ pim_enrich:
             edit_attributes: Edit attributes of a product model
             categories_view: Consult the categories of a product model
             history: View product model history
-            remove: Remove a product model
+            remove: Remove a product model (including children)
         category:
             list: List categories
             create: Create a category

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/messages.fr_FR.yml
@@ -104,7 +104,7 @@ pim_enrich:
       edit_attributes: Modifier les attributs du modèle de produit
       categories_view: Afficher les catégories d'un modèle de produit
       history: Afficher l'historique d'un modèle de produit
-      remove: Supprimer un modèle de produit
+      remove: Supprimer un modèle de produit (enfants inclus)
     category:
       list: Liste des catégories
       create: Créer une catégorie


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The ACL "Remove a product model" allows the customer to see the various delete buttons available to delete a product model. And when we click on those buttons, the expected behavior is to remove the whole product model (with its children).
The ACL naming can be confusing because the customer doesn't clearly know that even the children of the product model are going to be deleted.

**Improvement:**  
Change "Remove a product model" to: “Remove a product model (including children)”

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
