### PR TITLE
Add an "auditable" option to the create connection command

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
@@ -60,6 +60,13 @@ class CreateConnectionCommand extends Command
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Label of the connection. Default will be the provided code.'
+            )
+            ->addOption(
+                'auditable',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'If you want the connection to be auditable.',
+                false
             );
     }
 
@@ -71,9 +78,10 @@ class CreateConnectionCommand extends Command
         $code = $input->getArgument('code');
         $label = $input->getOption('label') ?? $code;
         $flowType = $input->getOption('flow-type');
+        $auditable = $input->getOption('auditable') !== false;
 
         try {
-            $command = new CreationCommand($code, $label, $flowType, false);
+            $command = new CreationCommand($code, $label, $flowType, $auditable);
             $connectionWithCredentials = $this->createConnection->handle($command);
             $output->writeln([
                 '<info>A new connection has been created with the following settings:</info>',

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Cli;
@@ -78,7 +79,8 @@ class CreateConnectionCommand extends Command
         $code = $input->getArgument('code');
         $label = $input->getOption('label') ?? $code;
         $flowType = $input->getOption('flow-type');
-        $auditable = $input->getOption('auditable') !== false;
+        $auditable = /* --auditable */ null === $input->getOption('auditable')
+            || /* --auditable=true|false */ false !== filter_var($input->getOption('auditable'), FILTER_VALIDATE_BOOLEAN);
 
         try {
             $command = new CreationCommand($code, $label, $flowType, $auditable);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Cli/CreateConnectionCommand.php
@@ -90,6 +90,7 @@ class CreateConnectionCommand extends Command
                 sprintf('Secret: %s', $connectionWithCredentials->secret()),
                 sprintf('Username: %s', $connectionWithCredentials->username()),
                 sprintf('Password: %s', $connectionWithCredentials->password()),
+                sprintf('Auditable: %s', $connectionWithCredentials->auditable() ? 'yes' : 'no'),
             ]);
         } catch (ConstraintViolationListException $exceptionList) {
             foreach ($exceptionList->getConstraintViolationList() as $e) {

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Connection/CreateConnectionCommandEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Connection/CreateConnectionCommandEndToEnd.php
@@ -41,6 +41,7 @@ class CreateConnectionCommandEndToEnd extends CommandTestCase
         $this->assertRegExp('/Client ID: [A-Za-z0-9_]*\n/', $output);
         $this->assertRegExp('/Username: magento_[0-9]{4}\n/', $output);
         $this->assertRegExp('/Password: [A-Za-z0-9]*\n/', $output);
+        $this->assertRegExp('/Auditable: (yes|no)\n/', $output);
         $this->assertStringContainsString('Code: magento', $output);
     }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

From https://github.com/akeneo/pim-community-dev/pull/12956

**Description (for Contributor and Core Developer)**

The auditable Connection parameter is currently set in hard, with this contribution it will be possible to pass a new option named --auditable in argument to specify that we want the connection to be auditable.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
