### PR TITLE
RAC-178: Prevent opening job execution in new tab

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
@@ -21,7 +21,7 @@ define(
 
             action: null,
 
-            jobExportLinkTemplate: '<a href="<%= url %>" target="_blank"><%= label %></a>',
+            jobExportLinkTemplate: '<a href="<%= url %>"><%= label %></a>',
 
             initialize: function (action) {
                 this.action = action;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

After design review, we want the job execution to open in the same page the notification message is thrown in.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
