### PR TITLE
CXP-428: remove unused data from business events

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductBusinessEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductBusinessEventSubscriber.php
@@ -53,7 +53,7 @@ final class DispatchProductBusinessEventSubscriber implements EventSubscriberInt
         }
 
         $author = $user->getUsername();
-        $data = $this->normalizer->normalize($product, 'standard');
+        $data = $this->normalizeProductData($product);
 
         $message = null;
         if ($event->hasArgument('is_new') && true === $event->getArgument('is_new')) {
@@ -78,10 +78,20 @@ final class DispatchProductBusinessEventSubscriber implements EventSubscriberInt
         }
 
         $author = $user->getUsername();
-        $data = $this->normalizer->normalize($product, 'standard');
+        $data = $this->normalizeProductData($product);
 
         $message = new ProductRemoved($author, $data);
 
         $this->messageBus->dispatch($message);
+    }
+
+    private function normalizeProductData(ProductInterface $product): array
+    {
+        $standard = $this->normalizer->normalize($product, 'standard');
+
+        return [
+            'identifier' => $standard['identifier'],
+            'categories' => $standard['categories'],
+        ];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelBusinessEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelBusinessEventSubscriber.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -70,9 +69,9 @@ final class DispatchProductModelBusinessEventSubscriber implements EventSubscrib
 
     public function produceBusinessRemoveEvent(GenericEvent $event): void
     {
-        /** @var ProductInterface */
-        $product = $event->getSubject();
-        if (false === $product instanceof ProductModelInterface) {
+        /** @var ProductModelInterface */
+        $productModel = $event->getSubject();
+        if (false === $productModel instanceof ProductModelInterface) {
             return;
         }
 
@@ -81,10 +80,20 @@ final class DispatchProductModelBusinessEventSubscriber implements EventSubscrib
         }
 
         $author = $user->getUsername();
-        $data = $this->normalizer->normalize($product, 'standard');
+        $data = $this->normalizeProductModelData($productModel);
 
         $message = new ProductModelRemoved($author, $data);
 
         $this->messageBus->dispatch($message);
+    }
+
+    private function normalizeProductModelData(ProductModelInterface $productModel): array
+    {
+        $standard = $this->normalizer->normalize($productModel, 'standard');
+
+        return [
+            'code' => $standard['code'],
+            'categories' => $standard['categories'],
+        ];
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductBusinessEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductBusinessEventSubscriberSpec.php
@@ -44,7 +44,6 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $normalizer
     ) {
         $product = new Product();
-        $product->setId(1);
         $product->setIdentifier('product_identifier');
 
         $messageBus = $this->getMessageBus();
@@ -55,8 +54,8 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
 
         $normalizer->normalize($product, 'standard')->willReturn(
             [
-                'id' => 1,
                 'identifier' => 'product_identifier',
+                'categories' => ['a_category'],
             ]
         );
 
@@ -71,7 +70,6 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $normalizer
     ) {
         $product = new Product();
-        $product->setId(1);
         $product->setIdentifier('product_identifier');
 
         $messageBus = $this->getMessageBus();
@@ -82,8 +80,8 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
 
         $normalizer->normalize($product, 'standard')->willReturn(
             [
-                'id' => 1,
                 'identifier' => 'product_identifier',
+                'categories' => ['a_category'],
             ]
         );
 
@@ -99,13 +97,12 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
-        $result = $this->produceBusinessSaveEvent(new GenericEvent('NOT_A_PRODUCT', ['updated' => true]));
+        $this->produceBusinessSaveEvent(new GenericEvent('NOT_A_PRODUCT', ['updated' => true]));
 
         Assert::assertCount(0, $messageBus->messages);
     }
 
     function it_does_not_produce_business_save_event_because_there_is_no_logged_user(
-        UserInterface $user,
         $security,
         $normalizer
     ) {
@@ -113,7 +110,6 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
         $product = new Product();
-        $product->setId(1);
         $product->setIdentifier('product_identifier');
 
         $security->getUser()->willReturn(null);
@@ -129,7 +125,6 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $normalizer
     ) {
         $product = new Product();
-        $product->setId(1);
         $product->setIdentifier('product_identifier');
 
         $messageBus = $this->getMessageBus();
@@ -140,8 +135,8 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
 
         $normalizer->normalize($product, 'standard')->willReturn(
             [
-                'id' => 1,
                 'identifier' => 'product_identifier',
+                'categories' => ['a_category'],
             ]
         );
 
@@ -157,7 +152,7 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
-        $result = $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT'));
+        $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT'));
 
         Assert::assertCount(0, $messageBus->messages);
     }
@@ -170,7 +165,6 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
         $product = new Product();
-        $product->setId(1);
         $product->setIdentifier('product_identifier');
 
         $security->getUser()->willReturn(null);
@@ -182,7 +176,8 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
 
     private function getMessageBus()
     {
-        return new class() implements MessageBusInterface {
+        return new class () implements MessageBusInterface
+        {
 
             public $messages = [];
 
@@ -195,4 +190,3 @@ class DispatchProductBusinessEventSubscriberSpec extends ObjectBehavior
         };
     }
 }
-

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelBusinessEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelBusinessEventSubscriberSpec.php
@@ -55,7 +55,10 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
         $user->getUsername()->willReturn('julia');
         $security->getUser()->willReturn($user);
 
-        $normalizer->normalize($productModel, 'standard')->willReturn(['code' => 'polo_col_mao',]);
+        $normalizer->normalize($productModel, 'standard')->willReturn([
+            'code' => 'polo_col_mao',
+            'categories' => ['a_category'],
+        ]);
 
         $this->produceBusinessSaveEvent(new GenericEvent($productModel, ['is_new' => true]));
 
@@ -77,7 +80,10 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
         $user->getUsername()->willReturn('julia');
         $security->getUser()->willReturn($user);
 
-        $normalizer->normalize($productModel, 'standard')->willReturn(['code' => 'polo_col_mao',]);
+        $normalizer->normalize($productModel, 'standard')->willReturn([
+            'code' => 'polo_col_mao',
+            'categories' => ['a_category'],
+        ]);
 
         $this->produceBusinessSaveEvent(new GenericEvent($productModel));
 
@@ -92,13 +98,12 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
-        $result = $this->produceBusinessSaveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
+        $this->produceBusinessSaveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
 
         Assert::assertCount(0, $messageBus->messages);
     }
 
     function it_does_not_produce_business_save_event_because_there_is_no_logged_user(
-        UserInterface $user,
         $security,
         $normalizer
     ) {
@@ -132,6 +137,7 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
         $normalizer->normalize($productModel, 'standard')->willReturn(
             [
                 'code' => 'my_product_model',
+                'categories' => ['a_category'],
             ]
         );
 
@@ -148,7 +154,7 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $normalizer, $messageBus);
 
-        $result = $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
+        $this->produceBusinessRemoveEvent(new GenericEvent('NOT_A_PRODUCT_MODEL'));
 
         Assert::assertCount(0, $messageBus->messages);
     }
@@ -172,7 +178,8 @@ class DispatchProductModelBusinessEventSubscriberSpec extends ObjectBehavior
 
     private function getMessageBus()
     {
-        return new class() implements MessageBusInterface {
+        return new class () implements MessageBusInterface
+        {
 
             public $messages = [];
 


### PR DESCRIPTION
Removed product & product model data from the message sent to PubSub
Keeping only `identifier` and `categories` for permission check.

The goal is to avoid to put too much pressure on the PubSub stack for now, especially as we dont need the data.