### PR TITLE
RAC-319: Move the translations to the Enrichment bundle

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -386,6 +386,9 @@ pim_datagrid:
                 all_attributes: All attributes
                 with_codes: With codes
                 with_labels: With labels
+            success_message: "You can follow {{ job_link }}."
+            job_link_label: the progress of the execution here
+
         mass_edit: Bulk actions
         sequential_edit: Sequential edit
         mass_delete: Mass delete

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
@@ -62,8 +62,6 @@ pim_datagrid:
     quick_export:
       title: Quick Export
       success: Quick export has been launched
-      success_message: "You can follow {{ job_link }}."
-      job_link_label: the progress of the execution here
 
   action:
     default:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Since files in ` src/Oro/Bundle/PimDataGridBundle` are not translated in crowding, we need to move those new translations to Enrichment.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
