### PR TITLE
DAPI-1407: Fix get products to re-evaluate because attribute-group activation

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetProductIdsImpactedByAttributeGroupActivationQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetProductIdsImpactedByAttributeGroupActivationQuery.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Q
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\Clock;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductIdsImpactedByAttributeGroupActivationQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Doctrine\DBAL\Connection;
 
@@ -33,25 +32,13 @@ final class GetProductIdsImpactedByAttributeGroupActivationQuery implements GetP
         }
 
         $query = <<<SQL
-SELECT DISTINCT product.id
-FROM pim_catalog_product AS product
-INNER JOIN pim_data_quality_insights_product_criteria_evaluation AS evaluation 
-    ON evaluation.product_id = product.id
-    AND evaluation.evaluated_at < :updatedSince
-    AND evaluation.status != :pending
-WHERE product.family_id IN (:families)
+SELECT product.id FROM pim_catalog_product AS product WHERE product.family_id IN (:families)
 SQL;
 
         $stmt = $this->dbConnection->executeQuery(
             $query,
-            [
-                'updatedSince' => $updatedSince->format(Clock::TIME_FORMAT),
-                'pending' => CriterionEvaluationStatus::PENDING,
-                'families' => $impactedFamilies
-            ],
-            [
-                'families' => Connection::PARAM_INT_ARRAY,
-            ]
+            ['families' => $impactedFamilies],
+            ['families' => Connection::PARAM_INT_ARRAY,]
         );
 
         $productIds = [];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelIdsImpactedByAttributeGroupActivationQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelIdsImpactedByAttributeGroupActivationQuery.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Q
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\Clock;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductIdsImpactedByAttributeGroupActivationQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\ResultStatement;
@@ -61,24 +60,14 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQuery implements
         $query = <<<SQL
 SELECT DISTINCT product_model.id
 FROM pim_catalog_product_model AS product_model
-INNER JOIN pim_data_quality_insights_product_model_criteria_evaluation AS evaluation 
-    ON evaluation.product_id = product_model.id
-    AND evaluation.evaluated_at < :updatedSince
-    AND evaluation.status != :pending
 WHERE product_model.family_variant_id IN (:familyVariants)
     AND product_model.parent_id IS NULL
 SQL;
 
         return $this->dbConnection->executeQuery(
             $query,
-            [
-                'updatedSince' => $updatedSince->format(Clock::TIME_FORMAT),
-                'pending' => CriterionEvaluationStatus::PENDING,
-                'familyVariants' => $familyVariantIds
-            ],
-            [
-                'familyVariants' => Connection::PARAM_INT_ARRAY,
-            ]
+            ['familyVariants' => $familyVariantIds],
+            ['familyVariants' => Connection::PARAM_INT_ARRAY]
         );
     }
 
@@ -114,24 +103,14 @@ SQL;
         $query = <<<SQL
 SELECT DISTINCT product_model.id
 FROM pim_catalog_product_model AS product_model
-INNER JOIN pim_data_quality_insights_product_model_criteria_evaluation AS evaluation 
-    ON evaluation.product_id = product_model.id
-    AND evaluation.evaluated_at < :updatedSince
-    AND evaluation.status != :pending
 WHERE product_model.family_variant_id IN (:familyVariants)
     AND product_model.parent_id IS NOT NULL
 SQL;
 
         return $this->dbConnection->executeQuery(
             $query,
-            [
-                'updatedSince' => $updatedSince->format(Clock::TIME_FORMAT),
-                'pending' => CriterionEvaluationStatus::PENDING,
-                'familyVariants' => $familyVariantIds
-            ],
-            [
-                'familyVariants' => Connection::PARAM_INT_ARRAY,
-            ]
+            ['familyVariants' => $familyVariantIds],
+            ['familyVariants' => Connection::PARAM_INT_ARRAY,]
         );
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/ProductEvaluation/GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/ProductEvaluation/GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration.php
@@ -43,13 +43,9 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
 
         $this->givenARootProductModelNotImpactedBecauseOfItsVariantFamily();
         $this->givenARootProductModelNotImpactedBecauseOfItsLevelOneAttributes();
-        $this->givenAnImpactedRootProductModelButAlreadyEvaluated();
-        $this->givenAnImpactedRootProductModelButWithEvaluationInPending();
 
         $this->givenASubProductModelNotImpactedBecauseOfItsVariantFamily();
         $this->givenASubProductModelNotImpactedBecauseOfItsLevelTwoAttributes();
-        $this->givenAnImpactedSubProductModelButAlreadyEvaluated();
-        $this->givenAnImpactedSubProductModelButWithEvaluationInPending();
 
         $productModelIds = iterator_to_array($this->get(GetProductModelIdsImpactedByAttributeGroupActivationQuery::class)
             ->updatedSince($this->updatedSince, 2));
@@ -72,7 +68,6 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
         ]);
 
         $productModel = $this->createProductModel('ImpactedRootProductModelWithASingleVariationLevel', 'impacted_family_variant_A');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-1 day'));
 
         return new ProductId($productModel->getId());
     }
@@ -96,7 +91,6 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
         ]);
 
         $productModel = $this->createProductModel('ImpactedRootProductModelWithTwoVariationLevels', 'impacted_family_variant_A2');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-3 hour'));
 
         return new ProductId($productModel->getId());
     }
@@ -104,7 +98,6 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
     private function givenAnotherImpactedRootProductModelWithTwoVariationLevels(): ProductId
     {
         $productModel = $this->createProductModel('AnotherImpactedRootProductModelWithTwoVariationLevels', 'impacted_family_variant_A2');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-1 second'));
 
         return new ProductId($productModel->getId());
     }
@@ -122,8 +115,7 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
             ],
         ]);
 
-        $productModel = $this->createProductModel('RootProductModelNotImpactedBecauseOfItsVariantFamily', 'not_impacted_family_variant_A');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-1 day'));
+        $this->createProductModel('RootProductModelNotImpactedBecauseOfItsVariantFamily', 'not_impacted_family_variant_A');
     }
 
     private function givenARootProductModelNotImpactedBecauseOfItsLevelOneAttributes(): void
@@ -138,27 +130,12 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
             ],
         ]);
 
-        $productModel = $this->createProductModel('RootProductModelNotImpactedBecauseOfItsLevelOneAttributes', 'remove_impact_family_variant_A');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-1 day'));
-    }
-
-    private function givenAnImpactedRootProductModelButAlreadyEvaluated(): void
-    {
-        $productModel = $this->createProductModel('ImpactedRootProductModelButAlreadyEvaluated', 'impacted_family_variant_A');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('+1 second'));
-    }
-
-
-    private function givenAnImpactedRootProductModelButWithEvaluationInPending(): void
-    {
-        $productModel = $this->createProductModel('ImpactedRootProductModelButWithEvaluationInPending', 'impacted_family_variant_A');
-        $this->updateProductModelEvaluationsAt($productModel->getId(), CriterionEvaluationStatus::PENDING, $this->updatedSince->modify('-1 month'));
+        $this->createProductModel('RootProductModelNotImpactedBecauseOfItsLevelOneAttributes', 'remove_impact_family_variant_A');
     }
 
     private function givenASubProductModelImpactedByACommonAttribute(): ProductId
     {
         $subProductModel = $this->createSubProductModel('SubProductModelImpactedByACommonAttribute', 'impacted_family_variant_A2', 'ImpactedRootProductModelWithTwoVariationLevels');
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-3 minute'));
 
         return new ProductId($subProductModel->getId());
     }
@@ -183,7 +160,6 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
 
         $parent = $this->createProductModel('ParentSubProductModelImpactedByALevelOneVariantAttribute', 'impacted_family_variant_B2');
         $subProductModel = $this->createSubProductModel('SubProductModelImpactedByALevelOneVariantAttribute', 'impacted_family_variant_B2', $parent->getCode());
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-5 minute'));
 
         return new ProductId($subProductModel->getId());
     }
@@ -207,8 +183,7 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
         ]);
 
         $parent = $this->createProductModel('ParentSubProductModelNotImpactedBecauseOfItsVariantFamily', 'not_impacted_family_variant_B2');
-        $subProductModel = $this->createSubProductModel('SubProductModelNotImpactedBecauseOfItsVariantFamily', 'not_impacted_family_variant_B2', $parent->getCode());
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince);
+        $this->createSubProductModel('SubProductModelNotImpactedBecauseOfItsVariantFamily', 'not_impacted_family_variant_B2', $parent->getCode());
     }
 
     public function givenASubProductModelNotImpactedBecauseOfItsLevelTwoAttributes(): void
@@ -229,22 +204,7 @@ final class GetProductModelIdsImpactedByAttributeGroupActivationQueryIntegration
         ]);
 
         $parent = $this->createProductModel('ParentSubProductModelNotImpactedBecauseOfItsLevelTwoAttributes', 'remove_impact_family_variant_A2');
-        $this->updateProductModelEvaluationsAt($parent->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-3 hour'));
-
-        $subProductModel = $this->createSubProductModel('SubProductModelNotImpactedBecauseOfItsLevelTwoAttributes', 'remove_impact_family_variant_A2', $parent->getCode());
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('-3 hour'));
-    }
-
-    private function givenAnImpactedSubProductModelButAlreadyEvaluated(): void
-    {
-        $subProductModel = $this->createSubProductModel('ImpactedSubProductModelButAlreadyEvaluated', 'impacted_family_variant_A2', 'ImpactedRootProductModelWithTwoVariationLevels');
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::DONE, $this->updatedSince->modify('+3 minute'));
-    }
-
-    private function givenAnImpactedSubProductModelButWithEvaluationInPending(): void
-    {
-        $subProductModel = $this->createSubProductModel('ImpactedSubProductModelButWithEvaluationInPending', 'impacted_family_variant_A2', 'ImpactedRootProductModelWithTwoVariationLevels');
-        $this->updateProductModelEvaluationsAt($subProductModel->getId(), CriterionEvaluationStatus::PENDING, $this->updatedSince->modify('-6 minute'));
+        $this->createSubProductModel('SubProductModelNotImpactedBecauseOfItsLevelTwoAttributes', 'remove_impact_family_variant_A2', $parent->getCode());
     }
 
     private function createAttributeGroupWithAttributes(string $code, array $attributes, bool $activated, \DateTimeImmutable $activationUpdatedAt): int


### PR DESCRIPTION
There was an error in the queries that retrieve the products to re-evaluate when an attribute-group is (de)activated.

I tried to exclude the products that have been evaluated after the (de)activation of the attribute-group, but I used the wrong date. To use the right date (the update date of the attribute-group) the request would be too complex and not efficient.

The best solution is to remove this optimization. It was overkill because the (de)activation of an attribute-group is a very rare action.