### PR TITLE
PIM-9519: Fix translation key for datagrid search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PIM-9491: Translate product grid filters in user additional settings
 - PIM-9494: Fix the performances of attribute-select-filter on long lists of AttributeOptions
 - PIM-9496: Change date format in the locale it_IT from dd/MM/yy to dd/MM/yyyy
+- PIM-9519: Fix translation key for datagrid search field
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/label_or_identifier-filter.js
@@ -42,7 +42,7 @@ define(
             render: function () {
                 this.$el.html(
                     this.template({
-                        label: __('pim_datagrid.search', {label: __('pim_common.' + this.label)})
+                        label: __('pim_datagrid.search', {label: __(this.label.toLowerCase())})
                     })
                 );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

With a UI in french, the search field displayed "Rechercher sur pim_common.Libellé ou identifiant"
In a previous PR, the label had been translated, so, we had to remove the "pim_common" key from the template.

Small modification: I added the _toLowerCase()_ function to the _label_ because the first letter was in upper case ( label is used in other places in the pim so I preferred to make this specific modification in this js file).
_Please feel free to tell me if there is a more suitable way to do this._

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
