### PR TITLE
PIM-9517: Fix locale selector default value on localizable attributes in product exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - PIM-9494: Fix the performances of attribute-select-filter on long lists of AttributeOptions
 - PIM-9496: Change date format in the locale it_IT from dd/MM/yy to dd/MM/yyyy
 - PIM-9519: Fix translation key for datagrid search field
+- PIM-9517: Fix locale selector default value on localizable attributes in product exports
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
@@ -67,16 +67,17 @@ define(
                     .done(function (locales) {
                         this.$el.removeClass('open');
 
-                        const params = {
-                            localeCode: _.first(locales).code,
-                            context: this.config.context
-                        };
+                        const params = {};
                         this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
-                        let currentLocale = locales.find(locale => locale.code === (this.selectedLocale ?
+                        const defaultLocaleCode = this.selectedLocale ?
                             this.selectedLocale :
-                            UserContext.get('catalogLocale'))
-                        );
+                            (params.localeCode ? params.localeCode : UserContext.get('catalogLocale'));
+
+                        let currentLocale = defaultLocaleCode && locales.find(locale => {
+                            return locale.code === defaultLocaleCode;
+                        });
+
                         if (undefined === currentLocale) {
                             currentLocale = _.first(locales);
                         }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
It's a regression introduced by this PR of mine a few weeks ago : https://github.com/akeneo/pim-community-dev/pull/12835

As I explained in the previous PR, the way the locale was selected in the UI was strange : the value was retrieved from another module by using events to update an object by reference to get the locale, and I made a mistake by ignoring it (I didn't know there was a use case in the export builder where it was needed). So instead of ignoring the value selected by the event, I use it this time.

The problem is that the locale switcher module is used everywhere in the PIM and the selected value can be set by different event listeners. So the algorithme to select the right value is now a bit like a chain-of-responsibility pattern : we first try to get the value that was manually selected by the user which is the first priority (this was the real fix of the previous PR), then we try to get the locale using the events like it has always been the case in the PIM, then we try to get the default catalog locale from the UserContext (also part of the previous fix). And if the locale is still undefined, we simply select the first locale of the list to be sure there is a value selected.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
