### PR TITLE
PIM-9523: Fix pressure measure multiplicator error

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes:
+
+- PIM-9523: Fix pressure measure multiplicator error
+
 # 3.2.75 (2020-10-14)
 
 ## Bug fixes:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -438,7 +438,7 @@ measures_config:
                 convert: [{'mul': '0.001'}]
                 symbol: hPa
             MILLIBAR:
-                convert: [{'mul': '0.001'}]
+                convert: [{'mul': '1000'}]
                 symbol: mBar
             ATM:
                 convert: [{'mul': '0.986923'}]


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
The multiplicator for the millibar measure was wrong. The bar is 1, so the millibar should be 1000 and not 0.001.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
