### PR TITLE
add default configuration for messenger module for prod_onprem_paas e…

### DIFF
--- a/config/packages/prod_onprem_paas/messenger.yml
+++ b/config/packages/prod_onprem_paas/messenger.yml
@@ -1,0 +1,4 @@
+framework:
+    messenger:
+        transports:
+            business_event: 'in-memory://'


### PR DESCRIPTION
…environment

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The bundle Messenger has been added to the PIM a few days ago, but because no default configuration was provided for the prod_onprem_paas environment.
this PR adds a default configuration for this bundle for the prod_onprem_paas environment.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
