### PR TITLE
DAPI-1374: Key indicators - Renaming, specs, and fixes

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductsKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductsKeyIndicators.php
@@ -2,21 +2,17 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
-final class GetProductsKeyIndicators
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetProductsKeyIndicators
 {
     private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
 
@@ -29,13 +25,19 @@ final class GetProductsKeyIndicators
         $this->keyIndicatorQueries = $keyIndicatorQueries;
     }
 
-    public function get(array $productIds)
+    /**
+     * @param ProductId[] $productIds
+     *
+     * @return array
+     */
+    public function get(array $productIds): array
     {
         $localesByChannel = $this->getLocalesByChannelQuery->getArray();
         $keyIndicatorsResultsByName = $this->executeAllKeyIndicatorsQueries($productIds);
 
         $productsKeyIndicators = [];
         foreach ($productIds as $productId) {
+            $productId = $productId->toInt();
             foreach ($localesByChannel as $channel => $locales) {
                 foreach ($locales as $locale) {
                     foreach ($keyIndicatorsResultsByName as $keyIndicatorName => $keyIndicatorResultsByProduct) {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductsKeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductsKeyIndicator.php
@@ -2,20 +2,20 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 interface GetProductsKeyIndicator
 {
     public function getName(): string;
 
+    /**
+     * @param ProductId[] $productIds
+     */
     public function execute(array $productIds): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/EvaluateProductsAndProductModelsCriteriaTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/EvaluateProductsAndProductModelsCriteriaTasklet.php
@@ -21,6 +21,8 @@ final class EvaluateProductsAndProductModelsCriteriaTasklet implements TaskletIn
     private const BULK_SIZE = 100;
     private const TIMEBOX_IN_SECONDS_ALLOWED = 1700; // ~28 minutes
 
+    private ?StepExecution $stepExecution;
+
     private EvaluatePendingCriteria $evaluatePendingProductCriteria;
 
     private ConsolidateAxesRates $consolidateProductAxisRates;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/EvaluateProductsAndProductModelsCriteriaTasklet.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/EvaluateProductsAndProductModelsCriteriaTasklet.php
@@ -2,58 +2,43 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductIdsToEvaluateQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\IndexProductRates;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\UpdateProductsIndex;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class EvaluateProductsAndProductModelsCriteriaTasklet implements TaskletInterface
 {
     private const LIMIT_PER_LOOP = 1000;
     private const BULK_SIZE = 100;
     private const TIMEBOX_IN_SECONDS_ALLOWED = 1700; // ~28 minutes
 
-    /** @var EvaluatePendingCriteria */
-    private $evaluatePendingProductCriteria;
+    private EvaluatePendingCriteria $evaluatePendingProductCriteria;
 
-    /** @var StepExecution */
-    private $stepExecution;
+    private ConsolidateAxesRates $consolidateProductAxisRates;
 
-    /** @var ConsolidateAxesRates */
-    private $consolidateProductAxisRates;
+    private UpdateProductsIndex $updateProductsIndex;
 
-    /** @var IndexProductRates */
-    private $indexProductRates;
+    private GetProductIdsToEvaluateQueryInterface $getProductIdsToEvaluateQuery;
 
-    /** @var GetProductIdsToEvaluateQueryInterface */
-    private $getProductIdsToEvaluateQuery;
+    private EvaluatePendingCriteria $evaluatePendingProductModelCriteria;
 
-    /** @var EvaluatePendingCriteria */
-    private $evaluatePendingProductModelCriteria;
+    private ConsolidateAxesRates $consolidateProductModelAxisRates;
 
-    /** @var ConsolidateAxesRates */
-    private $consolidateProductModelAxisRates;
-
-    /** @var GetProductIdsToEvaluateQueryInterface */
-    private $getProductModelsIdsToEvaluateQuery;
+    private GetProductIdsToEvaluateQueryInterface $getProductModelsIdsToEvaluateQuery;
 
     public function __construct(
         EvaluatePendingCriteria $evaluatePendingProductCriteria,
         ConsolidateAxesRates $consolidateProductAxisRates,
-        IndexProductRates $indexProductRates,
+        UpdateProductsIndex $updateProductsIndex,
         GetProductIdsToEvaluateQueryInterface $getProductIdsToEvaluateQuery,
         EvaluatePendingCriteria $evaluatePendingProductModelCriteria,
         ConsolidateAxesRates $consolidateProductModelAxisRates,
@@ -61,7 +46,7 @@ final class EvaluateProductsAndProductModelsCriteriaTasklet implements TaskletIn
     ) {
         $this->evaluatePendingProductCriteria = $evaluatePendingProductCriteria;
         $this->consolidateProductAxisRates = $consolidateProductAxisRates;
-        $this->indexProductRates = $indexProductRates;
+        $this->updateProductsIndex = $updateProductsIndex;
         $this->getProductIdsToEvaluateQuery = $getProductIdsToEvaluateQuery;
         $this->evaluatePendingProductModelCriteria = $evaluatePendingProductModelCriteria;
         $this->consolidateProductModelAxisRates = $consolidateProductModelAxisRates;
@@ -106,7 +91,7 @@ final class EvaluateProductsAndProductModelsCriteriaTasklet implements TaskletIn
 
             $this->consolidateProductAxisRates->consolidate($productIds);
 
-            $this->indexProductRates->execute($productIds);
+            $this->updateProductsIndex->execute($productIds);
 
             $evaluationCount += count($productIds);
             $this->stepExecution->setWriteCount($this->stepExecution->getWriteCount() + count($productIds));

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
@@ -2,33 +2,24 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductAxesRanksQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetAdditionalPropertiesForProductProjectionInterface;
 
-final class GetRatesForProductProjection implements GetAdditionalPropertiesForProductProjectionInterface
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetDataQualityInsightsPropertiesForProductProjection implements GetAdditionalPropertiesForProductProjectionInterface
 {
-    /** @var GetProductIdsFromProductIdentifiersQueryInterface */
-    private $getProductIdsFromProductIdentifiersQuery;
+    private GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery;
 
-    /** @var GetLatestProductAxesRanksQueryInterface */
-    private $getLatestProductAxesRanksQuery;
+    private GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery;
 
-    /** @var GetProductsKeyIndicators */
-    private $getProductsKeyIndicators;
+    private GetProductsKeyIndicators $getProductsKeyIndicators;
 
     public function __construct(
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
@@ -47,11 +38,7 @@ final class GetRatesForProductProjection implements GetAdditionalPropertiesForPr
     {
         $productIds = $this->getProductIdsFromProductIdentifiersQuery->execute($productIdentifiers);
         $productAxesRanks = $this->getLatestProductAxesRanksQuery->byProductIds($productIds);
-        $productKeyIndicators = $this->getProductsKeyIndicators->get(
-            array_map(function (ProductId $productId) {
-                return $productId->toInt();
-            }, $productIds)
-        );
+        $productKeyIndicators = $this->getProductsKeyIndicators->get($productIds);
 
         $additionalProperties = [];
         foreach ($productIds as $productIdentifier => $productId) {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/UpdateProductsIndex.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/UpdateProductsIndex.php
@@ -34,7 +34,7 @@ class UpdateProductsIndex
 
     public function execute(array $productIds): void
     {
-        $productIds = array_map(fn(int $productId) => new ProductId($productId), $productIds);
+        $productIds = array_map(fn (int $productId) => new ProductId($productId), $productIds);
 
         $productsAxesRanks = $this->getLatestProductAxesRanksQuery->byProductIds($productIds);
         $productsKeyIndicators = $this->getProductsKeyIndicators->get($productIds);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQuery.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
@@ -20,6 +11,10 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesB
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Doctrine\DBAL\Connection;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class GetProductsEnrichmentStatusQuery implements GetProductsKeyIndicator
 {
     private const GOOD_ENRICHMENT_RATIO = 80;
@@ -149,7 +144,7 @@ SQL;
 
     private function groupProductsByFamily(array $productIds): array
     {
-        $productIds = array_map(fn(ProductId $productId) => $productId->toInt(), $productIds);
+        $productIds = array_map(fn (ProductId $productId) => $productId->toInt(), $productIds);
 
         $query = <<<SQL
 SELECT JSON_OBJECTAGG(products_by_family.family_id, products_by_family.product_ids)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQuery.php
@@ -17,6 +17,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enri
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Doctrine\DBAL\Connection;
 
 final class GetProductsEnrichmentStatusQuery implements GetProductsKeyIndicator
@@ -148,6 +149,8 @@ SQL;
 
     private function groupProductsByFamily(array $productIds): array
     {
+        $productIds = array_map(fn(ProductId $productId) => $productId->toInt(), $productIds);
+
         $query = <<<SQL
 SELECT JSON_OBJECTAGG(products_by_family.family_id, products_by_family.product_ids)
 FROM (

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsWithAnImageQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/GetProductsWithAnImageQuery.php
@@ -2,23 +2,19 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class GetProductsWithAnImageQuery implements GetProductsKeyIndicator
 {
-    private $getLocalesByChannelQuery;
+    private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
 
     public function __construct(GetLocalesByChannelQueryInterface $getLocalesByChannelQuery)
     {
@@ -32,6 +28,7 @@ final class GetProductsWithAnImageQuery implements GetProductsKeyIndicator
 
     public function execute(array $productIds): array
     {
+        $productIds = array_map(fn (ProductId $productId) => $productId->toInt(), $productIds);
         $localesByChannel = $this->getLocalesByChannelQuery->getArray();
 
         $result = [];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -1,5 +1,5 @@
 services:
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\IndexProductRates:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\UpdateProductsIndex:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateLatestProductAxesRanksQuery'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -5,7 +5,7 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateLatestProductAxesRanksQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetRatesForProductProjection:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetDataQualityInsightsPropertiesForProductProjection:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateLatestProductAxesRanksQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQuery'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
@@ -103,7 +103,7 @@ services:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria'
             - '@akeneo.pim.automation.data_quality_insights.consolidate_product_axes_rates'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\IndexProductRates'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\UpdateProductsIndex'
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_ids_to_evaluate'
             - '@akeneo.pim.automation.data_quality_insights.evaluate_product_models_pending_criteria'
             - '@akeneo.pim.automation.data_quality_insights.consolidate_product_model_axes_rates'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/KeyIndicator/GetProductsEnrichmentStatusQueryIntegration.php
@@ -52,6 +52,7 @@ final class GetProductsEnrichmentStatusQueryIntegration extends DataQualityInsig
 
         $productIds = array_keys($expectedProductsEnrichmentStatus);
         $productIds[] = 12346; // Unknown product
+        $productIds = array_map(fn(int $productId) => new ProductId($productId), $productIds);
 
         $productsEnrichmentStatus = $this->get(GetProductsEnrichmentStatusQuery::class)->execute($productIds);
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductsKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductsKeyIndicatorsSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -32,7 +33,7 @@ final class GetProductsKeyIndicatorsSpec extends ObjectBehavior
             'mobile' => ['en_US'],
         ]);
 
-        $productIds = [13, 42];
+        $productIds = [new ProductId(13), new ProductId(42)];
 
         $expectedKeyIndicators = [
             13 => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
@@ -2,17 +2,9 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Axis\Enrichment;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRankCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisRankCollection;
@@ -25,18 +17,20 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
 use Akeneo\Pim\Automation\DataQualityInsights\tests\back\Specification\Domain\Model\Axis\Consistency;
 use PhpSpec\ObjectBehavior;
 
-final class GetRatesForProductProjectionSpec extends ObjectBehavior
+final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends ObjectBehavior
 {
     public function let(
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
-        GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery
+        GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery,
+        GetProductsKeyIndicators $getProductsKeyIndicators
     ) {
-        $this->beConstructedWith($getLatestProductAxesRanksQuery, $getProductIdsFromProductIdentifiersQuery);
+        $this->beConstructedWith($getLatestProductAxesRanksQuery, $getProductIdsFromProductIdentifiersQuery, $getProductsKeyIndicators);
     }
 
-    public function it_returns_product_rates_from_product_identifiers(
-        GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
-        GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery
+    public function it_returns_additional_properties_from_product_identifiers(
+        $getLatestProductAxesRanksQuery,
+        $getProductIdsFromProductIdentifiersQuery,
+        $getProductsKeyIndicators
     ) {
         $productId42 = new ProductId(42);
         $productId123 = new ProductId(123);
@@ -75,6 +69,47 @@ final class GetRatesForProductProjectionSpec extends ObjectBehavior
                 ),
         ]);
 
+        $productsKeyIndicators = [
+            42 => [
+                'ecommerce' => [
+                    'en_US' => [
+                        'good_enrichment' => true,
+                        'has_image' => true,
+                    ],
+                    'fr_FR' => [
+                        'good_enrichment' => false,
+                        'has_image' => null,
+                    ],
+                ],
+                'mobile' => [
+                    'en_US' => [
+                        'good_enrichment' => null,
+                        'has_image' => false,
+                    ],
+                ],
+            ],
+            123 => [
+                'ecommerce' => [
+                    'en_US' => [
+                        'good_enrichment' => true,
+                        'has_image' => true,
+                    ],
+                    'fr_FR' => [
+                        'good_enrichment' => false,
+                        'has_image' => true,
+                    ],
+                ],
+                'mobile' => [
+                    'en_US' => [
+                        'good_enrichment' => false,
+                        'has_image' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        $getProductsKeyIndicators->get($productIds)->willReturn($productsKeyIndicators);
+
         $this->fromProductIdentifiers($productIdentifiers)->shouldReturn([
             'product_1' => [
                 'rates' => [
@@ -93,6 +128,7 @@ final class GetRatesForProductProjectionSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'data_quality_insights' => ['key_indicators' => $productsKeyIndicators[42]],
             ],
             'product_2' => [
                 'rates' => [
@@ -102,9 +138,11 @@ final class GetRatesForProductProjectionSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'data_quality_insights' => ['key_indicators' => $productsKeyIndicators[123]],
             ],
             'product_without_rates' => [
                 'rates' => [],
+                'data_quality_insights' => ['key_indicators' => []],
             ],
         ]);
     }


### PR DESCRIPTION
I did a dedicated PR for several tasks:

1. Rename two ES services to reflect that they we don't only save the rates in ES anymore, but also the key indicators
2. Add missing specs
3. Use an array of `ProductId` as parameter in `GetProductsKeyIndicators` and `GetProductsEnrichmentStatusQuery` to facilitate the calls and the tests
4. Remove EE copyrights