### PR TITLE
PIM-9516: Recalculate completeness after a bulk set attribute requirements on families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PIM-9496: Change date format in the locale it_IT from dd/MM/yy to dd/MM/yyyy
 - PIM-9519: Fix translation key for datagrid search field
 - PIM-9517: Fix locale selector default value on localizable attributes in product exports
+- PIM-9516: Recalculate completeness after a bulk set attribute requirements on families
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -171,6 +171,15 @@ services:
             - '@validator'
             - '%pim_job_product_batch_size%'
 
+    pim_connector.tasklet.mass_edit_family.compute_completeness_of_family_products:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeCompletenessOfFamilyProductsTasklet'
+        arguments:
+            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_enrich.connector.reader.mass_edit.family'
+            - '@pim_connector.doctrine.cache_clearer'
+            - '@akeneo_batch.job_repository'
+            - '@pim_catalog.completeness.product.compute_and_persist'
+
     pim_connector.tasklet.xlsx_family.compute_data_related_to_family_root_product_models:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyRootProductModelsTasklet'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -178,7 +178,8 @@ services:
             - '@pim_enrich.connector.reader.mass_edit.family'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
-            - '@pim_catalog.completeness.product.compute_and_persist'
+            - '@pim_catalog.completeness.calculator'
+            - '@akeneo.pim.enrichment.product.query.save_product_completenesses'
 
     pim_connector.tasklet.xlsx_family.compute_data_related_to_family_root_product_models:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyRootProductModelsTasklet'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -75,7 +75,7 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
 
         $familyCodes = [];
 
-        while(true) {
+        while (true) {
             $family = $this->familyReader->read();
 
             if (null === $family) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
+
+use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
+use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
+{
+    private const BATCH_SIZE = 1000;
+
+    /** @var StepExecution */
+    private $stepExecution;
+
+    /** @var ProductQueryBuilderFactoryInterface */
+    private $productQueryBuilderFactory;
+
+    /** @var ItemReaderInterface */
+    private $familyReader;
+
+    /** @var EntityManagerClearerInterface */
+    private $cacheClearer;
+
+    /** @var JobRepositoryInterface */
+    private $jobRepository;
+
+    /** @var ComputeAndPersistProductCompletenesses */
+    private $computeAndPersistProductCompletenesses;
+
+    public function __construct(
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        EntityManagerClearerInterface $cacheClearer,
+        JobRepositoryInterface $jobRepository,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses
+    ) {
+        $this->productQueryBuilderFactory = $productQueryBuilderFactory;
+        $this->familyReader = $familyReader;
+        $this->cacheClearer = $cacheClearer;
+        $this->jobRepository = $jobRepository;
+        $this->computeAndPersistProductCompletenesses = $computeAndPersistProductCompletenesses;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStepExecution(StepExecution $stepExecution)
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute()
+    {
+        if ($this->familyReader instanceof InitializableInterface) {
+            $this->familyReader->initialize();
+        }
+
+        $familyCodes = [];
+
+        while(true) {
+            $family = $this->familyReader->read();
+
+            if (null === $family) {
+                break;
+            }
+
+            Assert::isInstanceOf($family, FamilyInterface::class);
+
+            $familyCodes[] = $family->getCode();
+        }
+
+        if (empty($familyCodes)) {
+            return;
+        }
+
+        $productQueryBuilder = $this->productQueryBuilderFactory->create();
+        $productQueryBuilder->addFilter('family', 'IN', $familyCodes);
+        $products = $productQueryBuilder->execute();
+
+        $productsToCompute = [];
+        foreach ($products as $product) {
+            Assert::isInstanceOf($product, ProductInterface::class);
+            $productsToCompute[] = $product->getIdentifier();
+
+            if (count($productsToCompute) >= self::BATCH_SIZE) {
+                $this->computeCompleteness($productsToCompute);
+                $productsToCompute = [];
+            }
+        }
+
+        if (count($productsToCompute) > 0) {
+            $this->computeCompleteness($productsToCompute);
+        }
+    }
+
+    private function computeCompleteness(array $productIdentifiers): void
+    {
+        $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($productIdentifiers);
+        $this->stepExecution->incrementSummaryInfo('process', count($productIdentifiers));
+        $this->jobRepository->updateStepExecution($this->stepExecution);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
@@ -367,5 +367,6 @@ services:
             - '@akeneo_batch.job_repository'
             -
                 - '@pim_enrich.step.set_attribute_requirements.mass_edit'
+                - '@pim_connector.step.mass_edit_family.compute_data_related_to_family_products'
         tags:
             - { name: akeneo_batch.job, connector: '%pim_enrich.connector_name.mass_edit%', type: '%pim_enrich.job.mass_edit_type%' }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/steps.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/steps.yml
@@ -366,3 +366,11 @@ services:
             - '@pim_enrich.connector.processor.mass_edit.family.set_requirements'
             - '@pim_connector.writer.database.family'
             - '%pim_job_product_batch_size%'
+
+    pim_connector.step.mass_edit_family.compute_data_related_to_family_products:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - 'compute_data_related_to_family_products'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_connector.tasklet.mass_edit_family.compute_completeness_of_family_products'

--- a/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
+++ b/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
@@ -42,6 +42,11 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
      */
     public function read()
     {
+        if (null === $this->families) {
+            $filters = $this->getConfiguredFilters();
+            $this->families = $this->getFamilies($filters);
+        }
+
         if (false === $this->firstRead) {
             $this->families->next();
         }

--- a/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
+++ b/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Structure\Component\Reader\Database\MassEdit;
 
 use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
@@ -14,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface
+class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface, InitializableInterface
 {
     /** @var StepExecution */
     protected $stepExecution;
@@ -24,6 +25,9 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
 
     /** @var FamilyRepositoryInterface */
     protected $familyRepository;
+
+    /** @var bool */
+    private $firstRead = true;
 
     /**
      * @param FamilyRepositoryInterface $familyRepository
@@ -38,14 +42,12 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
      */
     public function read()
     {
-        if (null === $this->families) {
-            $filters = $this->getConfiguredFilters();
-            $this->families = $this->getFamilies($filters);
-        } else {
+        if (false === $this->firstRead) {
             $this->families->next();
         }
 
         $family = $this->families->current();
+        $this->firstRead = false;
 
         if (null !== $family) {
             $this->stepExecution->incrementSummaryInfo('read');
@@ -60,6 +62,13 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
     public function setStepExecution(StepExecution $stepExecution)
     {
         $this->stepExecution = $stepExecution;
+    }
+
+    public function initialize()
+    {
+        $filters = $this->getConfiguredFilters();
+        $this->families = $this->getFamilies($filters);
+        $this->firstRead = true;
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
@@ -4,6 +4,8 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeCompletenessOfFamilyProductsTasklet;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -62,7 +64,11 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
         StepExecution $stepExecution,
         JobRepositoryInterface $jobRepository,
         FamilyInterface $familyShoes,
-        FamilyInterface $familyTshirt
+        FamilyInterface $familyTshirt,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3,
+        ProductInterface $product4
     ) {
         $productQueryBuilderFactory->create()->willReturn($productQueryBuilder);
 
@@ -70,9 +76,14 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
         $familyShoes->getCode()->willReturn('Shoes');
         $familyTshirt->getCode()->willReturn('Tshirt');
 
+        $product1->getIdentifier()->willReturn('product_shoes_1');
+        $product2->getIdentifier()->willReturn('product_shoes_2');
+        $product3->getIdentifier()->willReturn('product_tshirt_1');
+        $product4->getIdentifier()->willReturn('product_tshirt_2');
+
         $productQueryBuilder->addFilter('family', 'IN', ['Shoes', 'Tshirt'])->shouldBeCalled();
         $productQueryBuilder->execute()->shouldBeCalled()->willReturn(
-            new ProductCursor(['product_shoes_1', 'product_shoes_2', 'product_tshirt_1', 'product_tshirt_2']),
+            new ProductCursor([$product1->getWrappedObject(), $product2->getWrappedObject(), $product3->getWrappedObject(), $product4->getWrappedObject()]),
         );
 
         $computeAndPersistProductCompletenesses->fromProductIdentifiers([
@@ -104,8 +115,8 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
 
         $productQueryBuilder->addFilter('family', 'IN', ['Shoes'])->shouldBeCalled();
         $productQueryBuilder->execute()->shouldBeCalled()->willReturn(
-            new ProductCursor(array_map(function (int $i): string {
-                return 'product_' . $i;
+            new ProductCursor(array_map(function (int $i): ProductInterface {
+                return (new Product())->setIdentifier('product_' . $i);
             }, range(1, 1006)))
         );
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
+
+use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeCompletenessOfFamilyProductsTasklet;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
+use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
+{
+    function let(
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        EntityManagerClearerInterface $cacheClearer,
+        JobRepositoryInterface $jobRepository,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        StepExecution $stepExecution
+    )
+    {
+        $this->beConstructedWith(
+            $productQueryBuilderFactory,
+            $familyReader,
+            $cacheClearer,
+            $jobRepository,
+            $computeAndPersistProductCompletenesses
+        );
+
+        $this->setStepExecution($stepExecution);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ComputeCompletenessOfFamilyProductsTasklet::class);
+    }
+
+    function it_does_nothing_if_there_is_no_family(
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses
+    ) {
+        $familyReader->read()->shouldBeCalledOnce()->willReturn(null);
+        $productQueryBuilderFactory->create()->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::any())->shouldNotBeCalled();
+
+        $this->execute();
+    }
+
+    function it_compute_and_persists_the_completeness_of_products_of_family(
+        ProductQueryBuilderInterface $productQueryBuilder,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        StepExecution $stepExecution,
+        JobRepositoryInterface $jobRepository,
+        FamilyInterface $familyShoes,
+        FamilyInterface $familyTshirt
+    ) {
+        $productQueryBuilderFactory->create()->willReturn($productQueryBuilder);
+
+        $familyReader->read()->shouldBeCalledTimes(3)->willReturn($familyShoes, $familyTshirt, null);
+        $familyShoes->getCode()->willReturn('Shoes');
+        $familyTshirt->getCode()->willReturn('Tshirt');
+
+        $productQueryBuilder->addFilter('family', 'IN', ['Shoes', 'Tshirt'])->shouldBeCalled();
+        $productQueryBuilder->execute()->shouldBeCalled()->willReturn(
+            new ProductCursor(['product_shoes_1', 'product_shoes_2', 'product_tshirt_1', 'product_tshirt_2']),
+        );
+
+        $computeAndPersistProductCompletenesses->fromProductIdentifiers([
+            'product_shoes_1',
+            'product_shoes_2',
+            'product_tshirt_1',
+            'product_tshirt_2',
+        ])->shouldBeCalled();
+
+        $stepExecution->incrementSummaryInfo('process', 4)->shouldBeCalled();
+        $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
+
+        $this->execute();
+    }
+
+    function it_compute_and_persists_the_completeness_of_more_than_1000_products(
+        ProductQueryBuilderInterface $productQueryBuilder,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ItemReaderInterface $familyReader,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        StepExecution $stepExecution,
+        JobRepositoryInterface $jobRepository,
+        FamilyInterface $familyShoes
+    ) {
+        $productQueryBuilderFactory->create()->willReturn($productQueryBuilder);
+
+        $familyReader->read()->shouldBeCalledTimes(2)->willReturn($familyShoes, null);
+        $familyShoes->getCode()->willReturn('Shoes');
+
+        $productQueryBuilder->addFilter('family', 'IN', ['Shoes'])->shouldBeCalled();
+        $productQueryBuilder->execute()->shouldBeCalled()->willReturn(
+            new ProductCursor(array_map(function (int $i): string {
+                return 'product_' . $i;
+            }, range(1, 1006)))
+        );
+
+        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::type('array'))->shouldBeCalledTimes(2);
+
+        $stepExecution->incrementSummaryInfo('process', 1000)->shouldBeCalled();
+        $stepExecution->incrementSummaryInfo('process', 6)->shouldBeCalled();
+        $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(2);
+
+        $this->execute();
+    }
+}
+
+class ProductCursor extends \ArrayIterator implements CursorInterface
+{
+}


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

You could have some completeness desynchronisation when you use the bulk action "set attribute requirements" on families. This PR fix the behavior to recalculate completeness after a bulk action on families.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
