### PR TITLE
PIM-9518: improve query to fetch images from product model codes

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9518: Improve performance of SQL query about fetching images from product model codes
+
 # 4.0.66 (2020-10-23)
 
 # 4.0.65 (2020-10-19)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -358,7 +358,8 @@ SQL;
                 continue;
             }
 
-            $productModels[$row['code']] = [$row['attribute_code'] => \json_decode($row['image_values'], true)];
+            $imageValues = \json_decode($row['image_values'], true);
+            $productModels[$row['code']] = $imageValues ? [$row['attribute_code'] => $imageValues] : [];
             $productModelsInfo[$row['code']]['is_scopable'] = $row['is_scopable'] ? $channelCode : null;
             $productModelsInfo[$row['code']]['is_localizable'] = $row['is_localizable'] ? $channelCode : null;
             $productModelsInfo[$row['code']]['attribute_code'] = $row['attribute_code'];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -317,10 +317,12 @@ SQL;
                 FROM pim_catalog_product_model root
                     INNER JOIN pim_catalog_product_model sub ON sub.parent_id = root.id
                     INNER JOIN pim_catalog_product product ON product.product_model_id = sub.id
+                WHERE root.code = :code
                 UNION ALL
                 SELECT root.code as root_code, product.family_id, product.raw_values, product.created
                 FROM pim_catalog_product_model root
                     INNER JOIN pim_catalog_product product ON product.product_model_id = root.id
+                WHERE root.code = :code
             )
             SELECT product_child.root_code as code,
                    a_image.code as attribute_code,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -328,7 +328,7 @@ SQL;
                    a_image.code as attribute_code,
                    a_image.is_localizable,
                    a_image.is_scopable,
-                   product_child.raw_values,
+                   JSON_EXTRACT(product_child.raw_values, CONCAT('$.', a_image.code)) as image_values,
                    JSON_EXTRACT(
                        product_child.raw_values,
                        CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
@@ -358,9 +358,7 @@ SQL;
                 continue;
             }
 
-            $rawValues = json_decode($row['raw_values'], true);
-            $filteredRawValues = array_intersect_key($rawValues, [$row['attribute_code'] => true]);
-            $productModels[$row['code']] = $filteredRawValues;
+            $productModels[$row['code']] = [$row['attribute_code'] => \json_decode($row['image_values'], true)];
             $productModelsInfo[$row['code']]['is_scopable'] = $row['is_scopable'] ? $channelCode : null;
             $productModelsInfo[$row['code']]['is_localizable'] = $row['is_localizable'] ? $channelCode : null;
             $productModelsInfo[$row['code']]['attribute_code'] = $row['attribute_code'];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -336,8 +336,6 @@ SQL;
             FROM product_child
                 JOIN pim_catalog_family f ON f.id = product_child.family_id
                 JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
-            WHERE
-                product_child.root_code = :code
             HAVING
                 image_value IS NOT NULL AND JSON_TYPE(image_value) != 'NULL'
             ORDER BY 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

Fix https://akeneo.atlassian.net/browse/PIM-9518

- Add condition in sub query in order to have only needed variant products
- Fetch entire raw values is useless as we only need the images information


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
