### PR TITLE
PIM-9524: improve purge job command to avoid out of memory errors

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9518: Improve performance of SQL query about fetching images from product model codes
+- PIM-9524: improve purge job execution to limit the out of memory errors
 
 # 4.0.66 (2020-10-23)
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Persistence/Filesystem/DeleteOrphanJobExecutionDirectories.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Persistence/Filesystem/DeleteOrphanJobExecutionDirectories.php
@@ -29,7 +29,7 @@ final class DeleteOrphanJobExecutionDirectories
 
     public function execute(): void
     {
-        $pathsByBatch = $this->getPathsByBatch();
+        $pathsByBatch = $this->getPathsAtLevel3ByBatch();
 
         foreach ($pathsByBatch as $paths) {
             $jobExecutionIds = $this->getJobExecutionIdsFromPaths($paths);
@@ -38,7 +38,7 @@ final class DeleteOrphanJobExecutionDirectories
         }
     }
 
-    private function getPathsByBatch(): \Iterator
+    private function getPathsAtLevel3ByBatch(): \Iterator
     {
         $paths = [];
         $firstLevelPaths = $this->archivistFilesystem->listPaths('.', false);

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Persistence/Filesystem/DeleteOrphanJobExecutionDirectories.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Persistence/Filesystem/DeleteOrphanJobExecutionDirectories.php
@@ -38,6 +38,19 @@ final class DeleteOrphanJobExecutionDirectories
         }
     }
 
+    /**
+     * With flysystem v2 we have a memory leak when we fetch all files/paths recursively: the listContents
+     * method gathers all file/directory data in one array. An out of memory error occurred when there is too many
+     * files/directories. With flysystem v2 the problem should be resolved as the function uses a generator instead.
+     * To try to fix this error with flysystem v2, we list the paths step by step to prevent memory errors.
+     * We stop the listing at level 3 as for our use case we don't need to go deeper: the level 3
+     * contains the id of the jobs that we are looking for.
+     *
+     * @TIP-1536: when flysystem v2 will be out, try to replace this method
+     * by $this->archivistFilesystem->listPaths('.', true);
+     *
+     * @return \Iterator
+     */
     private function getPathsAtLevel3ByBatch(): \Iterator
     {
         $paths = [];


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix https://akeneo.atlassian.net/browse/PIM-9524

An out of memory error occurred when we have a lot of files to list. The error is thrown in the flysystem list function. Badly we cannot fix it efficiently because the `listContents` method builds and returns an array with all results: https://github.com/thephpleague/flysystem/blob/1.1.3/src/Adapter/Local.php#L288  
The flysystem v2 (not released yet) will return an iterator with a generator. So the problem will be fixed.  

For now, to try to fix the issue, instead of listing all files in the `.` directory recursively, I fetch all directories in level 1, then in level 2, finally in level 3 (no need to go further for this use case). And I use a generator to returns directories by group of 100.  
A memory error can still happen if there is too many files in a directory of level 2 so this solution is clearly not perfect.  


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
