### PR TITLE
PIM-9532: use grid filters in family mass action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - PIM-9519: Fix translation key for datagrid search field
 - PIM-9517: Fix locale selector default value on localizable attributes in product exports
 - PIM-9516: Recalculate completeness after a bulk set attribute requirements on families
+- PIM-9532: Fix the family selection in mass action when a filter on label is set
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -81,7 +81,6 @@ define(['underscore', 'oro/messenger', 'oro/translator', 'pim/dialog', 'oro/data
 
       if ('family-grid' === this.datagrid.name) {
         locale = this.getLocaleFromUrl('localeCode');
-        delete params['filters[label][value]'];
       }
 
       if (locale) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When the user filters on a label in family grid, and selects "All" the results, the mass action should concern only the filtered families. Actually it's not the case, all the families are concerned.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
