### PR TITLE
PIM-9160bis: Fix the product association display also for ProductModels

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -144,7 +144,11 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
      */
     private function normalizeImage(?ValueInterface $data, array $context = []) : ?array
     {
-        return $this->imageNormalizer->normalize($data, $context['data_locale'], $context['data_channel']);
+        return $this->imageNormalizer->normalize(
+            $data,
+            $context['data_locale'] ?? null,
+            $context['data_channel'] ?? null
+        );
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Akeneo version 4.0.67 after a migration from Akeneo 2

The fix done for PIM-9160 applies only for the ProductNormalizer.
However, migrating from Akeneo 2 to 4 results in Association not working properly when the association is a Product model.
The Oro\Bundle\PimDataGridBundle\Normalizer\ProductModelNormalizer::normalizeImage fails because no data_channel value is set in the $context

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
