### PR TITLE
PIM-9538: Fix sorting on rule engine list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - PIM-9532: Fix the family selection in mass action when a filter on label is set
 - PIM-9535: Fix export with condition on localisable attribute does not work if selected locale is not changed
 - PIM-9542: Fix product creation if the family has a numeric code
+- PIM-9538: Fix sorting on rule engine list page
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
@@ -30,7 +30,8 @@ const TableCell = styled.td.attrs((props: Props) => ({
 
   ${props => props.isDraggable && props.isActive === false && dragDisabledStyle}
   
-  ${props => props.isActive === false && inactiveStyle}
+  ${props =>
+    props.isActive === false && inactiveStyle}
 `;
 
 export {TableCell};

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
@@ -30,8 +30,7 @@ const TableCell = styled.td.attrs((props: Props) => ({
 
   ${props => props.isDraggable && props.isActive === false && dragDisabledStyle}
   
-  ${props =>
-    props.isActive === false && inactiveStyle}
+  ${props => props.isActive === false && inactiveStyle}
 `;
 
 export {TableCell};

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
@@ -479,15 +479,26 @@ define(['underscore', 'backbone', 'backbone/pageable-collection', 'oro/app'], fu
       }
 
       // set sorting parameters
+      var hasSorterParameterInState = false;
       if (state.sorters) {
         _.each(
           state.sorters,
           function (direction, field) {
             var key = this.queryParams.sortBy.replace('%field%', field);
             data[key] = this.queryParams.directions[direction];
+            hasSorterParameterInState = true;
           },
           this
         );
+      }
+
+      // We can have sorter parameters in the url (saved in the session) and in the current state.
+      // To avoid to have multiple sorters (and strange display), when the user choose a new sorter, we
+      // remove the old one.
+      if (hasSorterParameterInState && !this.multipleSorting) {
+        if ('undefined' !== typeof data[this.inputName]) {
+          delete data[this.inputName]['_sort_by'];
+        }
       }
 
       // map extra query parameters

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
@@ -492,13 +492,11 @@ define(['underscore', 'backbone', 'backbone/pageable-collection', 'oro/app'], fu
         );
       }
 
-      // We can have sorter parameters in the url (saved in the session) and in the current state.
-      // To avoid to have multiple sorters (and strange display), when the user choose a new sorter, we
+      // We can have sorter parameters in the url (saved in session) and in the current state.
+      // To avoid to have multiple sorters and a strange display, when the user chooses a new sorter, we
       // remove the old one.
-      if (hasSorterParameterInState && !this.multipleSorting) {
-        if ('undefined' !== typeof data[this.inputName]) {
-          delete data[this.inputName]['_sort_by'];
-        }
+      if (hasSorterParameterInState && !this.multipleSorting && 'undefined' !== typeof data[this.inputName]) {
+        delete data[this.inputName]['_sort_by'];
       }
 
       // map extra query parameters


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Sorters are handled in 2 ways:
- sorter stored in session when user sorted the results in a previous usecase
- sorter stored in actual state, when user is selecting a new sorter

So we can have 2 sorters in the same time, that causes weird displays. And the sorter in the session cannot be removed (except a logout action) so the user is stucked.

In this PR, when a new sorter is detected, we remove the old sorter.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
