### PR TITLE
PIM-9535: fix localizable attribute are filled with locale undefined on export builder by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - PIM-9517: Fix locale selector default value on localizable attributes in product exports
 - PIM-9516: Recalculate completeness after a bulk set attribute requirements on families
 - PIM-9532: Fix the family selection in mass action when a filter on label is set
+- PIM-9535: Fix export with condition on localisable attribute does not work if selected locale is not changed
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
@@ -60,20 +60,26 @@ define([
       this.getDisplayedLocales().done(
         function (locales) {
           this.$el.removeClass('open');
+          let defaultLocaleCode = _.first(locales).code;
+          const catalogLocaleCode = locales.find(locale => {
+            return locale.code === UserContext.get('catalogLocale');
+          });
 
-          const params = {};
+          if (catalogLocaleCode) {
+              defaultLocaleCode = catalogLocaleCode.code;
+          }
+
+          const params = {
+              localeCode: defaultLocaleCode,
+              context: this.config.context,
+          };
+
           this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);
 
-          const defaultLocaleCode = this.selectedLocale
-            ? this.selectedLocale
-            : params.localeCode
-            ? params.localeCode
-            : UserContext.get('catalogLocale');
-
           let currentLocale =
-            defaultLocaleCode &&
+            params.localeCode &&
             locales.find(locale => {
-              return locale.code === defaultLocaleCode;
+              return locale.code === params.localeCode;
             });
 
           if (undefined === currentLocale) {
@@ -116,7 +122,6 @@ define([
         localeCode: event.currentTarget.dataset.locale,
         context: this.config.context,
       });
-      this.selectedLocale = event.currentTarget.dataset.locale;
 
       this.render();
     },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js
@@ -66,12 +66,12 @@ define([
           });
 
           if (catalogLocaleCode) {
-              defaultLocaleCode = catalogLocaleCode.code;
+            defaultLocaleCode = catalogLocaleCode.code;
           }
 
           const params = {
-              localeCode: defaultLocaleCode,
-              context: this.config.context,
+            localeCode: defaultLocaleCode,
+            context: this.config.context,
           };
 
           this.getRoot().trigger('pim_enrich:form:locale_switcher:pre_render', params);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Fix regression introduced by https://github.com/akeneo/pim-community-dev/pull/13046 and https://github.com/akeneo/pim-community-dev/pull/12835.

Why we have a problem ? The switcher (visual element)[src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/locale-switcher.js] and the attribute filter (form data)[src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/attribute/attribute.js] are desynchronized on first display. The locale-switcher doesn't provide a default locale to the attribute filter on event `pim_enrich:form:locale_switcher:pre_render`, if the user does not change the locale, the locale remains undefined in form data. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
