### PR TITLE
RAC-335: Re-use job execution status in tracking endpoint

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
@@ -30,7 +30,8 @@ const TableCell = styled.td.attrs((props: Props) => ({
 
   ${props => props.isDraggable && props.isActive === false && dragDisabledStyle}
   
-  ${props => props.isActive === false && inactiveStyle}
+  ${props =>
+    props.isActive === false && inactiveStyle}
 `;
 
 export {TableCell};

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/layouts/tables/TableCell.tsx
@@ -30,8 +30,7 @@ const TableCell = styled.td.attrs((props: Props) => ({
 
   ${props => props.isDraggable && props.isActive === false && dragDisabledStyle}
   
-  ${props =>
-    props.isActive === false && inactiveStyle}
+  ${props => props.isActive === false && inactiveStyle}
 `;
 
 export {TableCell};

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/tests/front/unit/components/JobExecutionStatus.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/tests/front/unit/components/JobExecutionStatus.unit.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {screen} from '@testing-library/react';
 import {renderWithProviders} from '@akeneo-pim-community/shared/tests/front/unit/utils';
-import JobExecutionStatus, {JobStatus} from "../../../../Resources/public/js/JobExecutionStatus";
+import JobExecutionStatus, {JobStatus} from '../../../../Resources/public/js/JobExecutionStatus';
 
 declare global {
   namespace NodeJS {
@@ -11,25 +11,30 @@ declare global {
   }
 }
 
-test.each<JobStatus>(['COMPLETED', 'STOPPING', 'STOPPED', 'FAILED', 'ABANDONED', 'UNKNOWN'])
-('It displays the job status "%s" without the progress', (jobStatus) => {
+test.each<JobStatus>(['COMPLETED', 'STOPPING', 'STOPPED', 'FAILED', 'ABANDONED', 'UNKNOWN'])(
+  'It displays the job status "%s" without the progress',
+  jobStatus => {
+    renderWithProviders(
+      <JobExecutionStatus status={jobStatus} currentStep={1} totalSteps={3} hasError={false} hasWarning={false} />
+    );
 
-  renderWithProviders(
-    <JobExecutionStatus status={jobStatus} currentStep={1} totalSteps={3} hasError={false} hasWarning={false} />
-  );
+    expect(screen.getByText(jobStatus)).toBeInTheDocument();
+  }
+);
 
-  expect(screen.getByText(jobStatus)).toBeInTheDocument()
-});
-
-test.each<JobStatus>(['STARTING', 'STARTED'])
-('It displays the job status "%s" with the progress', (jobStatus) => {
+test.each<JobStatus>(['STARTING', 'STARTED'])('It displays the job status "%s" with the progress', jobStatus => {
   const currentStep = 1;
   const totalSteps = 10;
 
   renderWithProviders(
-    <JobExecutionStatus status={jobStatus} currentStep={currentStep} totalSteps={totalSteps} hasError={false}
-                        hasWarning={false}/>
+    <JobExecutionStatus
+      status={jobStatus}
+      currentStep={currentStep}
+      totalSteps={totalSteps}
+      hasError={false}
+      hasWarning={false}
+    />
   );
 
-  expect(screen.getByText(`${jobStatus} ${currentStep}/${totalSteps}`)).toBeInTheDocument()
+  expect(screen.getByText(`${jobStatus} ${currentStep}/${totalSteps}`)).toBeInTheDocument();
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/intl-duration.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/intl-duration.ts
@@ -3,7 +3,7 @@ const __ = require('oro/translator');
 type IntlDuration = {
   translationKey: string;
   value: number;
-}
+};
 
 const translateDuration = (...args: IntlDuration[]): string => {
   let values = args.filter((duration: IntlDuration) => duration.value > 0);
@@ -19,31 +19,29 @@ const translateDuration = (...args: IntlDuration[]): string => {
 
 export const formatSecondsIntl = (duration: number): string => {
   const days = Math.floor(duration / 86400);
-  duration = duration - (days * 86400);
+  duration = duration - days * 86400;
   const hours = Math.floor(duration / 3600);
-  duration = duration - (hours * 3600);
+  duration = duration - hours * 3600;
   const minutes = Math.floor(duration / 60);
-  const seconds = duration - (minutes * 60);
+  const seconds = duration - minutes * 60;
 
   if (days > 0) {
     return translateDuration(
       {translationKey: 'duration.days', value: days},
-      {translationKey: 'duration.hours', value: hours},
+      {translationKey: 'duration.hours', value: hours}
     );
   }
   if (hours > 0) {
     return translateDuration(
       {translationKey: 'duration.hours', value: hours},
-      {translationKey: 'duration.minutes', value: minutes},
+      {translationKey: 'duration.minutes', value: minutes}
     );
   }
   if (minutes > 0) {
     return translateDuration(
       {translationKey: 'duration.minutes', value: minutes},
-      {translationKey: 'duration.seconds', value: seconds},
+      {translationKey: 'duration.seconds', value: seconds}
     );
   }
-  return translateDuration(
-    {translationKey: 'duration.seconds', value: seconds},
-  );
+  return translateDuration({translationKey: 'duration.seconds', value: seconds});
 };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
@@ -17,7 +17,7 @@ type StepExecutionTracking = {
   duration: number;
   processedItems: number;
   totalItems: number;
-}
+};
 
 const Container = styled.div`
   display: grid;
@@ -80,10 +80,10 @@ const getStepExecutionTrackingProgressLabel = (step: StepExecutionTracking): str
 
 class JobExecutionProgress extends ReactView {
   /* istanbul ignore next */
-  configure () {
-      this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.render);
+  configure() {
+    this.listenTo(this.getRoot(), 'pim_enrich:form:entity:post_update', this.render);
 
-      return super.configure();
+    return super.configure();
   }
 
   reactElementToMount() {

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
@@ -23,10 +23,7 @@ abstract class BaseViewMock {
   abstract reactElementToMount(): JSX.Element;
 
   render() {
-    ReactDOM.render(
-      this.reactElementToMount(),
-      this.el
-    );
+    ReactDOM.render(this.reactElementToMount(), this.el);
   }
 
   getRoot() {
@@ -58,14 +55,14 @@ const JobExecutionProgress = require('pimui/js/job/execution/progress');
 
 test('it render a progress bar with the correct label of the job step', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'COMPLETED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'COMPLETED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'export',
+          jobName: 'csv_product_export',
+          stepName: 'export',
         },
       ],
     },
@@ -79,21 +76,21 @@ test('it render a progress bar with the correct label of the job step', () => {
 
 test('it render the progress bar of one completed job step', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'COMPLETED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'COMPLETED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'export',
-          'status': 'COMPLETED',
-          'isTrackable': true,
-          'hasWarning': false,
-          'hasError': false,
-          'duration': 0,
-          'processedItems': 0,
-          'totalItems': 0,
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'COMPLETED',
+          isTrackable: true,
+          hasWarning: false,
+          hasError: false,
+          duration: 0,
+          processedItems: 0,
+          totalItems: 0,
         },
       ],
     },
@@ -108,21 +105,21 @@ test('it render the progress bar of one completed job step', () => {
 
 test('it render the progress bar of one job step in progress', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'IN_PROGRESS',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'IN_PROGRESS',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'export',
-          'status': 'IN_PROGRESS',
-          'isTrackable': true,
-          'hasWarning': false,
-          'hasError': false,
-          'duration': 10,
-          'processedItems': 50,
-          'totalItems': 100,
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'IN_PROGRESS',
+          isTrackable: true,
+          hasWarning: false,
+          hasError: false,
+          duration: 10,
+          processedItems: 50,
+          totalItems: 100,
         },
       ],
     },
@@ -137,21 +134,21 @@ test('it render the progress bar of one job step in progress', () => {
 
 test('it render the progress bar of one pending job step', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'NOT_STARTED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'NOT_STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'export',
-          'status': 'NOT_STARTED',
-          'isTrackable': true,
-          'hasWarning': false,
-          'hasError': false,
-          'duration': 0,
-          'processedItems': 0,
-          'totalItems': 0,
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'NOT_STARTED',
+          isTrackable: true,
+          hasWarning: false,
+          hasError: false,
+          duration: 0,
+          processedItems: 0,
+          totalItems: 0,
         },
       ],
     },
@@ -166,21 +163,21 @@ test('it render the progress bar of one pending job step', () => {
 
 test('it render the progress bar of one untrackable job step', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'NOT_STARTED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'NOT_STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'export',
-          'status': 'NOT_STARTED',
-          'isTrackable': false,
-          'hasWarning': false,
-          'hasError': false,
-          'duration': 0,
-          'processedItems': 0,
-          'totalItems': 0,
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'NOT_STARTED',
+          isTrackable: false,
+          hasWarning: false,
+          hasError: false,
+          duration: 0,
+          processedItems: 0,
+          totalItems: 0,
         },
       ],
     },
@@ -195,13 +192,13 @@ test('it render the progress bar of one untrackable job step', () => {
 
 test('it render without error the progress bar of one job step with warning', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'NOT_STARTED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'NOT_STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'hasWarning': true,
+          hasWarning: true,
         },
       ],
     },
@@ -215,13 +212,13 @@ test('it render without error the progress bar of one job step with warning', ()
 
 test('it render without error the progress bar of one job step with error', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'NOT_STARTED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'NOT_STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'hasError': true,
+          hasError: true,
         },
       ],
     },
@@ -235,14 +232,14 @@ test('it render without error the progress bar of one job step with error', () =
 
 test('it fallback on default job step label when missing', () => {
   mockGetFormData.mockImplementationOnce(() => ({
-    'tracking': {
-      'status': 'NOT_STARTED',
-      'currentStep': 1,
-      'totalSteps': 1,
-      'steps': [
+    tracking: {
+      status: 'NOT_STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
         {
-          'jobName': 'csv_product_export',
-          'stepName': 'unknown_step',
+          jobName: 'csv_product_export',
+          stepName: 'unknown_step',
         },
       ],
     },

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/intl-duration.unit.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/intl-duration.unit.ts
@@ -1,7 +1,7 @@
 import {formatSecondsIntl} from 'pimui/js/intl-duration';
 
 jest.mock('oro/translator', () => (key: string, _params: any, count: number): string => {
-  switch(key){
+  switch (key) {
     case 'duration.days':
       return `${count} day(s)`;
     case 'duration.hours':
@@ -16,10 +16,7 @@ jest.mock('oro/translator', () => (key: string, _params: any, count: number): st
 });
 
 const createDuration = (days: number, hours: number, minutes: number, seconds: number): number => {
-  return seconds +
-    (minutes * 60) +
-    (hours * 3600) +
-    (days * 86400);
+  return seconds + minutes * 60 + hours * 3600 + days * 86400;
 };
 
 describe('>>>TOOLS --- intl-duration', () => {

--- a/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
+++ b/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
@@ -9,6 +9,7 @@ use Akeneo\Platform\Bundle\ImportExportBundle\Model\StepExecutionTracking;
 use Akeneo\Platform\Bundle\ImportExportBundle\Query\GetJobExecutionTracking;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use AkeneoTest\Platform\Integration\ImportExport\Utils\FrozenClock;
 use Doctrine\DBAL\Connection;
 
@@ -186,7 +187,7 @@ SQL;
     private function expectedJobExecutionTrackingNotStarted(): JobExecutionTracking
     {
         $expectedJobExecutionTracking = new JobExecutionTracking();
-        $expectedJobExecutionTracking->status = 'NOT_STARTED';
+        $expectedJobExecutionTracking->status = 'STARTING';
         $expectedJobExecutionTracking->currentStep = 0;
         $expectedJobExecutionTracking->totalSteps = 3;
 
@@ -194,7 +195,7 @@ SQL;
         $expectedStepExecutionTracking1->isTrackable = false;
         $expectedStepExecutionTracking1->jobName = 'csv_product_import';
         $expectedStepExecutionTracking1->stepName = 'validation';
-        $expectedStepExecutionTracking1->status = 'NOT_STARTED';
+        $expectedStepExecutionTracking1->status = 'STARTING';
         $expectedStepExecutionTracking1->duration = 0;
         $expectedStepExecutionTracking1->hasError = false;
         $expectedStepExecutionTracking1->hasWarning = false;
@@ -205,7 +206,7 @@ SQL;
         $expectedStepExecutionTracking2->isTrackable = true;
         $expectedStepExecutionTracking2->jobName = 'csv_product_import';
         $expectedStepExecutionTracking2->stepName = 'import';
-        $expectedStepExecutionTracking2->status = 'NOT_STARTED';
+        $expectedStepExecutionTracking2->status = 'STARTING';
         $expectedStepExecutionTracking2->duration = 0;
         $expectedStepExecutionTracking2->hasError = false;
         $expectedStepExecutionTracking2->hasWarning = false;
@@ -216,7 +217,7 @@ SQL;
         $expectedStepExecutionTracking3->isTrackable = true;
         $expectedStepExecutionTracking3->jobName = 'csv_product_import';
         $expectedStepExecutionTracking3->stepName = 'import_associations';
-        $expectedStepExecutionTracking3->status = 'NOT_STARTED';
+        $expectedStepExecutionTracking3->status = 'STARTING';
         $expectedStepExecutionTracking3->duration = 0;
         $expectedStepExecutionTracking3->hasError = false;
         $expectedStepExecutionTracking3->hasWarning = false;
@@ -235,7 +236,7 @@ SQL;
     private function expectedJobExecutionTrackingInProgress(): JobExecutionTracking
     {
         $expectedJobExecutionTracking = new JobExecutionTracking();
-        $expectedJobExecutionTracking->status = 'IN_PROGRESS';
+        $expectedJobExecutionTracking->status = 'STARTED';
         $expectedJobExecutionTracking->currentStep = 2;
         $expectedJobExecutionTracking->totalSteps = 3;
 
@@ -254,7 +255,7 @@ SQL;
         $expectedStepExecutionTracking2->isTrackable = true;
         $expectedStepExecutionTracking2->jobName = 'csv_product_import';
         $expectedStepExecutionTracking2->stepName = 'import';
-        $expectedStepExecutionTracking2->status = 'IN_PROGRESS';
+        $expectedStepExecutionTracking2->status = 'STARTED';
         $expectedStepExecutionTracking2->duration = 7;
         $expectedStepExecutionTracking2->hasError = false;
         $expectedStepExecutionTracking2->hasWarning = false;
@@ -265,7 +266,7 @@ SQL;
         $expectedStepExecutionTracking3->isTrackable = true;
         $expectedStepExecutionTracking3->jobName = 'csv_product_import';
         $expectedStepExecutionTracking3->stepName = 'import_associations';
-        $expectedStepExecutionTracking3->status = 'NOT_STARTED';
+        $expectedStepExecutionTracking3->status = 'STARTING';
         $expectedStepExecutionTracking3->duration = 0;
         $expectedStepExecutionTracking3->hasError = false;
         $expectedStepExecutionTracking3->hasWarning = false;
@@ -333,7 +334,7 @@ SQL;
     private function expectedJobExecutionTrackingFailed()
     {
         $expectedJobExecutionTracking = new JobExecutionTracking();
-        $expectedJobExecutionTracking->status = 'COMPLETED';
+        $expectedJobExecutionTracking->status = 'FAILED';
         $expectedJobExecutionTracking->currentStep = 2;
         $expectedJobExecutionTracking->totalSteps = 3;
 
@@ -352,7 +353,7 @@ SQL;
         $expectedStepExecutionTracking2->isTrackable = true;
         $expectedStepExecutionTracking2->jobName = 'csv_product_import';
         $expectedStepExecutionTracking2->stepName = 'import';
-        $expectedStepExecutionTracking2->status = 'COMPLETED';
+        $expectedStepExecutionTracking2->status = 'FAILED';
         $expectedStepExecutionTracking2->duration = 14;
         $expectedStepExecutionTracking2->hasError = true;
         $expectedStepExecutionTracking2->hasWarning = false;
@@ -363,7 +364,7 @@ SQL;
         $expectedStepExecutionTracking3->isTrackable = true;
         $expectedStepExecutionTracking3->jobName = 'csv_product_import';
         $expectedStepExecutionTracking3->stepName = 'import_associations';
-        $expectedStepExecutionTracking3->status = 'NOT_STARTED';
+        $expectedStepExecutionTracking3->status = 'STARTING';
         $expectedStepExecutionTracking3->duration = 0;
         $expectedStepExecutionTracking3->hasError = false;
         $expectedStepExecutionTracking3->hasWarning = false;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Instead of mapping the batch status to a tracking status, we should reuse the batch status which is already translated and expected in the front.
It also support the cases expected by the badge (see https://github.com/akeneo/pim-community-dev/pull/13053)

```
    const COMPLETED = 1;
    const STARTING = 2;
    const STARTED = 3;
    const STOPPING = 4;
    const STOPPED = 5;
    const FAILED = 6;
    const ABANDONED = 7;
    const UNKNOWN = 8;
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
