### PR TITLE
DAPI-1414: Renaming

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ComputeProductsKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ComputeProductsKeyIndicators.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
@@ -12,11 +12,11 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class GetProductsKeyIndicators
+class ComputeProductsKeyIndicators
 {
     private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
 
-    /** @var GetProductsKeyIndicator[] */
+    /** @var ComputeProductsKeyIndicator[] */
     private iterable $keyIndicatorQueries;
 
     public function __construct(GetLocalesByChannelQueryInterface $getLocalesByChannelQuery, iterable $keyIndicatorQueries)
@@ -30,7 +30,7 @@ class GetProductsKeyIndicators
      *
      * @return array
      */
-    public function get(array $productIds): array
+    public function compute(array $productIds): array
     {
         $localesByChannel = $this->getLocalesByChannelQuery->getArray();
         $keyIndicatorsResultsByName = $this->executeAllKeyIndicatorsQueries($productIds);
@@ -54,7 +54,7 @@ class GetProductsKeyIndicators
     {
         $keyIndicatorsResults = [];
         foreach ($this->keyIndicatorQueries as $keyIndicatorQuery) {
-            $keyIndicatorResult = $keyIndicatorQuery->execute($productIds);
+            $keyIndicatorResult = $keyIndicatorQuery->compute($productIds);
             if (! empty($keyIndicatorResult)) {
                 $keyIndicatorsResults[$keyIndicatorQuery->getName()] = $keyIndicatorResult;
             }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetKeyIndicators implements GetKeyIndicatorsInterface
+{
+    private GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery;
+
+    /** @var KeyIndicatorCode[] */
+    private array $keyIndicatorCodes;
+
+    public function __construct(GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery, string... $keyIndicators)
+    {
+        $this->getProductKeyIndicatorsQuery = $getProductKeyIndicatorsQuery;
+        $this->keyIndicatorCodes = array_map(fn ($keyIndicator) => new KeyIndicatorCode($keyIndicator), $keyIndicators);
+    }
+
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->all($channelCode, $localeCode, ...$this->keyIndicatorCodes));
+    }
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->byFamily($channelCode, $localeCode, $family, ...$this->keyIndicatorCodes));
+    }
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->byCategory($channelCode, $localeCode, $category, ...$this->keyIndicatorCodes));
+    }
+
+    private function formatKeyIndicators(array $keyIndicators): array
+    {
+        $formattedKeyIndicators = [];
+        foreach ($keyIndicators as $keyIndicator) {
+            Assert::isInstanceOf($keyIndicator, KeyIndicator::class);
+            $formattedKeyIndicators[strval($keyIndicator->getCode())] = [
+                'ratio' => $keyIndicator->getRatioGood(),
+                'total' => $keyIndicator->getTotalGood(),
+            ];
+        }
+
+        return $formattedKeyIndicators;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicatorsInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicatorsInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+
+interface GetKeyIndicatorsInterface
+{
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode): array;
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family): array;
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/KeyIndicator/ProductsWithGoodEnrichment.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/KeyIndicator/ProductsWithGoodEnrichment.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductsWithGoodEnrichment
+{
+    public const CODE = 'good_enrichment';
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/KeyIndicator/ProductsWithImage.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/KeyIndicator/ProductsWithImage.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductsWithImage
+{
+    public const CODE = 'has_image';
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class KeyIndicator
+{
+    private KeyIndicatorCode $code;
+
+    private int $totalGood;
+
+    private int $totalToImprove;
+
+    public function __construct(KeyIndicatorCode $code, int $totalGood, int $totalToImprove)
+    {
+        $this->code = $code;
+        $this->totalGood = $totalGood;
+        $this->totalToImprove = $totalToImprove;
+    }
+
+    public function getCode(): KeyIndicatorCode
+    {
+        return $this->code;
+    }
+
+    public function getTotalGood(): int
+    {
+        return $this->totalGood;
+    }
+
+    public function getTotalToImprove(): int
+    {
+        return $this->totalToImprove;
+    }
+
+    public function getRatioGood(): int
+    {
+        $total = $this->totalGood + $this->totalToImprove;
+
+        return $total === 0 ? 0 : intval(round($this->totalGood / $total * 100));
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
@@ -10,12 +10,12 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface GetProductsKeyIndicator
+interface ComputeProductsKeyIndicator
 {
     public function getName(): string;
 
     /**
      * @param ProductId[] $productIds
      */
-    public function execute(array $productIds): array;
+    public function compute(array $productIds): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductKeyIndicatorsQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductKeyIndicatorsQueryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Get key indicators related to products
+ */
+interface GetProductKeyIndicatorsQueryInterface
+{
+    /**
+     * @return KeyIndicator[]
+     */
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode, KeyIndicatorCode... $keyIndicatorCodes): array;
+
+    /**
+     * @return KeyIndicator[]
+     */
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array;
+
+    /**
+     * @return KeyIndicator[]
+     */
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/ValueObject/KeyIndicatorCode.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/ValueObject/KeyIndicatorCode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class KeyIndicatorCode
+{
+    private string $code;
+
+    public function __construct(string $code)
+    {
+        if ('' === $code) {
+            throw new \InvalidArgumentException('A key indicator code cannot be empty');
+        }
+
+        $this->code = $code;
+    }
+
+    public function __toString()
+    {
+        return $this->code;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductAxesRanksQueryInterface;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetAdditionalPropertiesForProductProjectionInterface;
@@ -19,12 +19,12 @@ final class GetDataQualityInsightsPropertiesForProductProjection implements GetA
 
     private GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery;
 
-    private GetProductsKeyIndicators $getProductsKeyIndicators;
+    private ComputeProductsKeyIndicators $getProductsKeyIndicators;
 
     public function __construct(
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
         GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery,
-        GetProductsKeyIndicators $getProductsKeyIndicators
+        ComputeProductsKeyIndicators $getProductsKeyIndicators
     ) {
         $this->getProductIdsFromProductIdentifiersQuery = $getProductIdsFromProductIdentifiersQuery;
         $this->getLatestProductAxesRanksQuery = $getLatestProductAxesRanksQuery;
@@ -38,7 +38,7 @@ final class GetDataQualityInsightsPropertiesForProductProjection implements GetA
     {
         $productIds = $this->getProductIdsFromProductIdentifiersQuery->execute($productIdentifiers);
         $productAxesRanks = $this->getLatestProductAxesRanksQuery->byProductIds($productIds);
-        $productKeyIndicators = $this->getProductsKeyIndicators->get($productIds);
+        $productKeyIndicators = $this->getProductsKeyIndicators->compute($productIds);
 
         $additionalProperties = [];
         foreach ($productIds as $productIdentifier => $productId) {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
@@ -35,17 +35,19 @@ final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQuery
 
     public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array
     {
-        // TODO: Implement byFamily() method.
-        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+        $terms = [['term' => ['family.code' => strval($family)]]];
+
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes, $terms);
     }
 
     public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array
     {
-        // TODO: Implement byCategory() method.
-        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+        $terms = [['terms' => ['categories' => [strval($category)]]]];
+
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes, $terms);
     }
 
-    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraSearch = []): array
+    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraTerms = []): array
     {
         if (empty($keyIndicatorCodes)) {
             return [];
@@ -53,13 +55,11 @@ final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQuery
 
         $query = [
             'bool' => [
-                'must' => [
-                    [
-                        'term' => [
-                            'document_type' => ProductInterface::class
-                        ],
+                'must' => array_merge([[
+                    'term' => [
+                        'document_type' => ProductInterface::class
                     ],
-                ],
+                ]], $extraTerms),
             ],
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQueryInterface
+{
+    private Client $esClient;
+
+    public function __construct(Client $esClient)
+    {
+        $this->esClient = $esClient;
+    }
+
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        // TODO: Implement byFamily() method.
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        // TODO: Implement byCategory() method.
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraSearch = []): array
+    {
+        if (empty($keyIndicatorCodes)) {
+            return [];
+        }
+
+        $query = [
+            'bool' => [
+                'must' => [
+                    [
+                        'term' => [
+                            'document_type' => ProductInterface::class
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $aggregations = [];
+        foreach ($keyIndicatorCodes as $keyIndicatorCode) {
+            $aggregations[strval($keyIndicatorCode)]['terms']['field'] = sprintf(
+                'data_quality_insights.key_indicators.%s.%s.%s',
+                $channelCode,
+                $localeCode,
+                $keyIndicatorCode
+            );
+        }
+
+        $searchQuery = [
+            'size' => 0,
+            'query' => $query,
+            'aggs' => $aggregations,
+        ];
+
+        $result = $this->esClient->search($searchQuery);
+
+        $keyIndicators = [];
+        foreach ($result['aggregations'] ?? [] as $keyIndicatorCode => $aggregationResult) {
+            $aggregationBuckets = $aggregationResult['buckets'] ?? [];
+            if (empty($aggregationBuckets)) {
+                continue;
+            }
+
+            Assert::isArray($aggregationBuckets);
+            $keyIndicators[$keyIndicatorCode] = $this->formatKeyIndicator(strval($keyIndicatorCode), $aggregationBuckets);
+        }
+
+        return $keyIndicators;
+    }
+
+    private function formatKeyIndicator(string $keyIndicatorCode, array $aggregationBuckets): KeyIndicator
+    {
+        $totalGood = 0;
+        $totalToImprove = 0;
+
+        foreach ($aggregationBuckets as $bucket) {
+            $keyIndicatorValue = $bucket['key'] ?? null;
+
+            if (1 === $keyIndicatorValue) {
+                $totalGood = intval($bucket['doc_count'] ?? 0);
+            } elseif (0 === $keyIndicatorValue) {
+                $totalToImprove = intval($bucket['doc_count'] ?? 0);
+            }
+        }
+
+        return new KeyIndicator(new KeyIndicatorCode($keyIndicatorCode), $totalGood, $totalToImprove);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/UpdateProductsIndex.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/UpdateProductsIndex.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisRankCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductAxesRanksQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -20,12 +20,12 @@ class UpdateProductsIndex
 
     private GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery;
 
-    private GetProductsKeyIndicators $getProductsKeyIndicators;
+    private ComputeProductsKeyIndicators $getProductsKeyIndicators;
 
     public function __construct(
         Client $esClient,
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
-        GetProductsKeyIndicators $getProductsKeyIndicators
+        ComputeProductsKeyIndicators $getProductsKeyIndicators
     ) {
         $this->esClient = $esClient;
         $this->getLatestProductAxesRanksQuery = $getLatestProductAxesRanksQuery;
@@ -37,7 +37,7 @@ class UpdateProductsIndex
         $productIds = array_map(fn (int $productId) => new ProductId($productId), $productIds);
 
         $productsAxesRanks = $this->getLatestProductAxesRanksQuery->byProductIds($productIds);
-        $productsKeyIndicators = $this->getProductsKeyIndicators->get($productIds);
+        $productsKeyIndicators = $this->getProductsKeyIndicators->compute($productIds);
 
         foreach ($productIds as $productId) {
             $productId = $productId->toInt();

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -6,7 +6,7 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Q
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Doctrine\DBAL\Connection;
@@ -15,7 +15,7 @@ use Doctrine\DBAL\Connection;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GetProductsEnrichmentStatusQuery implements GetProductsKeyIndicator
+final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIndicator
 {
     private const GOOD_ENRICHMENT_RATIO = 80;
 
@@ -34,7 +34,7 @@ final class GetProductsEnrichmentStatusQuery implements GetProductsKeyIndicator
         return 'good_enrichment';
     }
 
-    public function execute(array $productIds): array
+    public function compute(array $productIds): array
     {
         $productIdsByFamilyId = $this->groupProductsByFamily($productIds);
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Q
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -31,7 +32,7 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
 
     public function getName(): string
     {
-        return 'good_enrichment';
+        return ProductsWithGoodEnrichment::CODE;
     }
 
     public function compute(array $productIds): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
@@ -23,7 +24,7 @@ final class ComputeProductsWithImageQuery implements ComputeProductsKeyIndicator
 
     public function getName(): string
     {
-        return 'has_image';
+        return ProductsWithImage::CODE;
     }
 
     public function compute(array $productIds): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 
@@ -12,7 +12,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GetProductsWithImageQuery implements GetProductsKeyIndicator
+final class ComputeProductsWithImageQuery implements ComputeProductsKeyIndicator
 {
     private GetEvaluationRatesByProductsAndCriterionQueryInterface $getEvaluationRatesByProductAndCriterionQuery;
 
@@ -26,7 +26,7 @@ final class GetProductsWithImageQuery implements GetProductsKeyIndicator
         return 'has_image';
     }
 
-    public function execute(array $productIds): array
+    public function compute(array $productIds): array
     {
         $productsWithImageRates = $this->getEvaluationRatesByProductAndCriterionQuery->toArrayInt(
             $productIds,

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
@@ -2,41 +2,50 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\Dashboard;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicatorsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class DashboardKeyIndicatorsController
 {
+    private GetKeyIndicatorsInterface $getKeyIndicators;
+
+    public function __construct(GetKeyIndicatorsInterface $getKeyIndicators)
+    {
+        $this->getKeyIndicators = $getKeyIndicators;
+    }
+
     public function __invoke(Request $request, string $channel, string $locale)
     {
-        return new JsonResponse([
-            'has_image' => [
-                'ratio' => 18,
-                'total' => 5641,
-            ],
-            'good_enrichment' => [
-                'ratio' => 35.48,
-                'total' => 15479,
-            ],
-            'values_perfect_spelling' => [
-                'ratio' => 65,
-                'total' => 6548,
-            ],
-            'attributes_perfect_spelling' => [
-                'ratio' => 91,
-                'total' => 1244,
-            ],
-        ]);
+        try {
+            $channel = new ChannelCode($channel);
+            $locale = new LocaleCode($locale);
+
+            if ($request->query->has('category')) {
+                $category = new CategoryCode($request->query->get('category'));
+                $keyIndicators = $this->getKeyIndicators->byCategory($channel, $locale, $category);
+            } elseif ($request->query->has('family')) {
+                $family = new FamilyCode($request->query->get('family'));
+                $keyIndicators = $this->getKeyIndicators->byFamily($channel, $locale, $family);
+            } else {
+                $keyIndicators = $this->getKeyIndicators->all($channel, $locale);
+            }
+
+        } catch (\InvalidArgumentException $exception) {
+            return new JsonResponse(null, Response::HTTP_BAD_REQUEST);
+        }
+
+        return new JsonResponse($keyIndicators);
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
@@ -41,7 +41,6 @@ final class DashboardKeyIndicatorsController
             } else {
                 $keyIndicators = $this->getKeyIndicators->all($channel, $locale);
             }
-
         } catch (\InvalidArgumentException $exception) {
             return new JsonResponse(null, Response::HTTP_BAD_REQUEST);
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -19,6 +19,8 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\Dashboard\DashboardKeyIndicatorsController:
         public: true
+        arguments:
+            - '@akeneo.pim.automation.data_quality_insights.get_key_indicators'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\GetProductAxesRatesController:
         public: true

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -3,13 +3,13 @@ services:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateLatestProductAxesRanksQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetDataQualityInsightsPropertiesForProductProjection:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateLatestProductAxesRanksQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators'
         tags:
             - { name: 'akeneo.pim.enrichment.product.query.indexing_additional_properties' }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -20,3 +20,7 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetUpdatedProductModelIdsQuery:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery:
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -208,15 +208,15 @@ services:
         arguments:
             - '@database_connection'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\GetProductsEnrichmentStatusQuery:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery:
         arguments:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
         tags:
-            - { name:  akeneo.pim.automation.data_quality_insights.key_indicator_query}
+            - { name:  akeneo.pim.automation.data_quality_insights.compute_key_indicator_query}
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\GetProductsWithImageQuery:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsWithImageQuery:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQuery'
         tags:
-            - { name:  akeneo.pim.automation.data_quality_insights.key_indicator_query}
+            - { name:  akeneo.pim.automation.data_quality_insights.compute_key_indicator_query}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -177,4 +177,12 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - !tagged akeneo.pim.automation.data_quality_insights.compute_key_indicator_query
+            - !tagged akeneo.pim.automation.data_quality_insights.key_indicator_query
+
+    akeneo.pim.automation.data_quality_insights.get_key_indicators:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicators
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery'
+            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment::CODE
+            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage::CODE
+

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -174,7 +174,7 @@ services:
     akeneo.pim.automation.data_quality_insights.synchronous_criterion_evaluations_filter:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\SynchronousCriterionEvaluationsFilter
 
-    Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators:
+    Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - !tagged akeneo.pim.automation.data_quality_insights.key_indicator_query
+            - !tagged akeneo.pim.automation.data_quality_insights.compute_key_indicator_query

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
@@ -29,6 +29,7 @@ $rules = [
             //External dependencies
             'Psr\Log\LoggerInterface',
             'Symfony\Component\EventDispatcher\EventDispatcherInterface',
+            'Webmozart\Assert\Assert',
         ]
     )->in('Akeneo\Pim\Automation\DataQualityInsights\Application'),
 
@@ -142,6 +143,7 @@ $rules = [
             'GuzzleHttp\Exception',
             'Mekras\Speller',
             'League\Flysystem',
+            'Webmozart\Assert\Assert',
 
             'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
         ]

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -17,6 +17,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -25,6 +26,9 @@ use Webmozart\Assert\Assert;
  */
 class DataQualityInsightsTestCase extends TestCase
 {
+    protected const MINIMAL_VARIANT_AXIS_CODE = 'color';
+    protected const MINIMAL_VARIANT_OPTIONS = ['red', 'blue', 'yellow', 'black', 'white'];
+
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
@@ -45,7 +49,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($product, $data);
             $errors = $this->get('pim_catalog.validator.product')->validate($product);
-            Assert::count($errors, 0, 'Invalid product');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product', $errors));
         }
 
         $this->get('pim_catalog.saver.product')->save($product);
@@ -61,6 +65,22 @@ class DataQualityInsightsTestCase extends TestCase
         return $product;
     }
 
+    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption): ProductInterface
+    {
+        Assert::oneOf($axisOption, self::MINIMAL_VARIANT_OPTIONS, 'Unknown minimal variant option');
+
+        $data = [
+            'parent' => $parent,
+            'values' => [
+                self::MINIMAL_VARIANT_AXIS_CODE => [
+                    ['data' => $axisOption, 'scope' => null, 'locale' => null],
+                ],
+            ],
+        ];
+
+        return $this->createProduct($identifier, $data);
+    }
+
     protected function createProductModel(string $code, string $familyVariant, array $data = []): ProductModelInterface
     {
         $productModel = $this->get('akeneo_integration_tests.catalog.product_model.builder')
@@ -71,7 +91,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
-            Assert::count($errors, 0, 'Invalid product model');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product model', $errors));
         }
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
@@ -90,7 +110,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
-            Assert::count($errors, 0, 'Invalid product model');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid sub-product model', $errors));
         }
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
@@ -105,7 +125,7 @@ class DataQualityInsightsTestCase extends TestCase
         $family = $this->get('akeneo_integration_tests.base.family.builder')->build($data);
 
         $errors = $this->get('validator')->validate($family);
-        Assert::count($errors, 0, 'Invalid family');
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid family', $errors));
 
         $this->get('pim_catalog.saver.family')->save($family);
 
@@ -120,11 +140,27 @@ class DataQualityInsightsTestCase extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $data);
 
         $errors = $this->get('validator')->validate($familyVariant);
-        Assert::count($errors, 0);
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid family variant', $errors));
 
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
 
         return $familyVariant;
+    }
+
+    protected function createMinimalFamilyAndFamilyVariant(string $familyCode, string $familyVariantCode): void
+    {
+        $axis = $this->createSimpleSelectAttributeWithOptions(self::MINIMAL_VARIANT_AXIS_CODE, self::MINIMAL_VARIANT_OPTIONS);
+
+        $this->createFamily($familyCode, ['attributes' => [$axis->getCode()]]);
+        $this->createFamilyVariant($familyVariantCode, $familyCode, [
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => [$axis->getCode()],
+                    'attributes' => [],
+                ],
+            ]
+        ]);
     }
 
     protected function createAttribute(string $code, array $data = []): AttributeInterface
@@ -138,6 +174,21 @@ class DataQualityInsightsTestCase extends TestCase
 
         $attribute = $this->get('akeneo_integration_tests.base.attribute.builder')->build($data, true);
         $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    protected function createSimpleSelectAttributeWithOptions(string $code, array $optionCodes): AttributeInterface
+    {
+        $attribute = $this->createAttribute($code, ['type' => AttributeTypes::OPTION_SIMPLE_SELECT]);
+
+        foreach ($optionCodes as $sortOrder => $optionCode) {
+            $option = $this->get('pim_catalog.factory.attribute_option')->create();
+            $option->setCode($optionCode);
+            $option->setAttribute($attribute);
+            $option->setSortOrder($sortOrder);
+            $this->get('pim_catalog.saver.attribute_option')->save($option);
+        }
 
         return $attribute;
     }
@@ -235,7 +286,7 @@ SQL;
 
         $this->get('pim_catalog.updater.channel')->update($channel, $data);
         $errors = $this->get('validator')->validate($channel);
-        Assert::count($errors, 0, 'Invalid channel');
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid channel', $errors));
 
         $this->get('pim_catalog.saver.channel')->save($channel);
 
@@ -250,5 +301,15 @@ SQL;
         )->fetchColumn();
 
         return intval($localeId);
+    }
+
+    private function formatValidationErrorMessage(string $mainMessage, ConstraintViolationListInterface $errors): string
+    {
+        $errorMessage = '';
+        foreach ($errors as $error) {
+            $errorMessage .= PHP_EOL.$error->getMessage();
+        }
+
+        return $mainMessage.$errorMessage;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -71,17 +71,13 @@ class DataQualityInsightsTestCase extends TestCase
         return $product;
     }
 
-    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption): ProductInterface
+    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption, array $data = []): ProductInterface
     {
         Assert::oneOf($axisOption, self::MINIMAL_VARIANT_OPTIONS, 'Unknown minimal variant option');
 
-        $data = [
-            'parent' => $parent,
-            'values' => [
-                self::MINIMAL_VARIANT_AXIS_CODE => [
-                    ['data' => $axisOption, 'scope' => null, 'locale' => null],
-                ],
-            ],
+        $data['parent'] = $parent;
+        $data['values'][self::MINIMAL_VARIANT_AXIS_CODE] = [
+            ['data' => $axisOption, 'scope' => null, 'locale' => null],
         ];
 
         return $this->createProduct($identifier, $data);
@@ -95,7 +91,7 @@ class DataQualityInsightsTestCase extends TestCase
             ->build();
 
         if (!empty($data)) {
-            $this->get('pim_catalog.updater.product')->update($productModel, $data);
+            $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
             Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product model', $errors));
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -17,6 +17,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Webmozart\Assert\Assert;
 
@@ -32,6 +33,11 @@ class DataQualityInsightsTestCase extends TestCase
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function getRandomCode(): string
+    {
+        return Uuid::uuid4()->toString();
     }
 
     protected function deleteProductCriterionEvaluations(int $productId): void

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Elasticsearch/Query/GetProductKeyIndicatorsQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Elasticsearch/Query/GetProductKeyIndicatorsQueryIntegration.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Elasticsearch\Query;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductKeyIndicatorsQueryIntegration extends DataQualityInsightsTestCase
+{
+    private Client $esClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->esClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $this->createMinimalFamilyAndFamilyVariant('family_V', 'family_V_1');
+    }
+
+    public function test_it_retrieves_key_indicators_for_all_the_products()
+    {
+        $this->createProductModel('product_model_with_perfect_enrichment', 'family_V_1');
+        $this->createProductModel('product_model_with_missing_enrichment', 'family_V_1');
+
+        $this->givenProductsWithoutValues(4);
+        $this->givenAProductVariantWithoutValues('product_model_with_missing_enrichment');
+
+        $this->givenAProductWithPerfectEnrichmentAndImage();
+        $this->givenAProductWithPerfectEnrichmentButWithoutAttributeImage();
+        $this->givenAProductWithImageButMissingEnrichment();
+        $this->givenAProductVariantWithPerfectEnrichmentAndImage('product_model_with_perfect_enrichment');
+        $this->givenAProductVariantWithPerfectEnrichmentButWithoutAttributeImage('product_model_with_perfect_enrichment');
+
+        $goodEnrichment = new KeyIndicatorCode('good_enrichment');
+        $hasImage = new KeyIndicatorCode('has_image');
+
+        $expectedKeyIndicators = [
+            'good_enrichment' => new KeyIndicator($goodEnrichment, 4, 6),
+            'has_image' => new KeyIndicator($hasImage, 3, 7),
+        ];
+
+        $keyIndicators = $this->get(GetProductKeyIndicatorsQuery::class)->all(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $goodEnrichment, $hasImage);
+
+        $this->assertEquals($expectedKeyIndicators, $keyIndicators);
+    }
+
+    private function givenProductsWithoutValues(int $nbProducts): void
+    {
+        for ($i = 1; $i <= $nbProducts; $i++) {
+            $product = $this->createProduct(sprintf('product_without_values_%d', $i));
+
+            $this->updateProductKeyIndicators($product->getId(), false, false);
+        }
+    }
+
+    private function givenAProductWithPerfectEnrichmentAndImage(): void
+    {
+        $product = $this->createProduct('product_with_perfect_enrichment_and_image');
+
+        $this->updateProductKeyIndicators($product->getId(), true, true);
+    }
+
+    private function givenAProductWithPerfectEnrichmentButWithoutAttributeImage(): void
+    {
+        $product = $this->createProduct('product_with_perfect_enrichment_but_without_attribute_image');
+
+        $this->updateProductKeyIndicators($product->getId(), true, false);
+    }
+
+    private function givenAProductWithImageButMissingEnrichment(): void
+    {
+        $product = $this->createProduct('product_with_image_but_missing_enrichment');
+
+        $this->updateProductKeyIndicators($product->getId(), false, true);
+    }
+
+    private function givenAProductVariantWithoutValues(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_without_values',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[0]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), false, false);
+    }
+
+    private function givenAProductVariantWithPerfectEnrichmentAndImage(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_with_perfect_enrichment',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[1]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), true, true);
+    }
+
+    private function givenAProductVariantWithPerfectEnrichmentButWithoutAttributeImage(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_with_perfect_enrichment_but_without_attribute_image',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[2]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), true, false);
+    }
+
+    private function updateProductKeyIndicators(int $productId, bool $goodEnrichment, bool $hasImage): void
+    {
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        $keyIndicators = [
+            'ecommerce' => [
+                'en_US' => [
+                    'good_enrichment' => $goodEnrichment,
+                    'has_image' => $hasImage,
+                ],
+                'fr_FR' => [
+                    'good_enrichment' => !$goodEnrichment,
+                    'has_image' => !$hasImage,
+                ],
+            ],
+            'mobile' => [
+                'en_US' => [
+                    'good_enrichment' => !$goodEnrichment,
+                    'has_image' => !$hasImage,
+                ],
+            ],
+        ];
+
+        $this->esClient->refreshIndex();
+        $this->esClient->updateByQuery(
+            [
+                'script' => [
+                    'inline' => "ctx._source.rates = params.rates; ctx._source.data_quality_insights = params.data_quality_insights;",
+                    'params' => [
+                        'rates' => [],
+                        'data_quality_insights' => ['key_indicators' => $keyIndicators],
+                    ],
+                ],
+                'query' => [
+                    'term' => [
+                        'id' => sprintf('product_%d', $productId),
+                    ],
+                ],
+            ]
+        );
+
+        $this->esClient->refreshIndex();
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQueryIntegration.php
@@ -13,14 +13,14 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\GetProductsEnrichmentStatusQuery;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery;
 use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GetProductsEnrichmentStatusQueryIntegration extends DataQualityInsightsTestCase
+final class ComputeProductsEnrichmentStatusQueryIntegration extends DataQualityInsightsTestCase
 {
     /** @var CriterionEvaluationRepositoryInterface */
     private $productCriterionEvaluationRepository;
@@ -32,7 +32,7 @@ final class GetProductsEnrichmentStatusQueryIntegration extends DataQualityInsig
         $this->productCriterionEvaluationRepository = $this->get('akeneo.pim.automation.data_quality_insights.repository.product_criterion_evaluation');
     }
 
-    public function test_it_retrieves_products_enrichment_status()
+    public function test_it_computes_products_enrichment_status()
     {
         $this->createChannel('ecommerce', ['locales' => ['en_US', 'fr_FR']]);
         $this->createChannel('mobile', ['locales' => ['en_US']]);
@@ -54,7 +54,7 @@ final class GetProductsEnrichmentStatusQueryIntegration extends DataQualityInsig
         $productIds[] = 12346; // Unknown product
         $productIds = array_map(fn(int $productId) => new ProductId($productId), $productIds);
 
-        $productsEnrichmentStatus = $this->get(GetProductsEnrichmentStatusQuery::class)->execute($productIds);
+        $productsEnrichmentStatus = $this->get(ComputeProductsEnrichmentStatusQuery::class)->compute($productIds);
 
         $this->assertEquals($expectedProductsEnrichmentStatus, $productsEnrichmentStatus);
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ComputeProductsKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ComputeProductsKeyIndicatorsSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use PhpSpec\ObjectBehavior;
@@ -13,17 +13,17 @@ use PhpSpec\ObjectBehavior;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GetProductsKeyIndicatorsSpec extends ObjectBehavior
+final class ComputeProductsKeyIndicatorsSpec extends ObjectBehavior
 {
     public function let(
         GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        GetProductsKeyIndicator $goodEnrichment,
-        GetProductsKeyIndicator $hasImage
+        ComputeProductsKeyIndicator $goodEnrichment,
+        ComputeProductsKeyIndicator $hasImage
     ) {
         $this->beConstructedWith($getLocalesByChannelQuery, [$goodEnrichment, $hasImage]);
     }
 
-    public function it_gives_all_the_key_indicators_for_a_given_list_of_products(
+    public function it_computes_all_the_key_indicators_for_a_given_list_of_products(
         $getLocalesByChannelQuery,
         $goodEnrichment,
         $hasImage
@@ -77,7 +77,7 @@ final class GetProductsKeyIndicatorsSpec extends ObjectBehavior
         $goodEnrichment->getName()->willReturn('good_enrichment');
         $hasImage->getName()->willReturn('has_image');
 
-        $goodEnrichment->execute($productIds)->willReturn([
+        $goodEnrichment->compute($productIds)->willReturn([
             13 => [
                 'ecommerce' => [
                     'en_US' => true,
@@ -95,7 +95,7 @@ final class GetProductsKeyIndicatorsSpec extends ObjectBehavior
             ],
         ]);
 
-        $hasImage->execute($productIds)->willReturn([
+        $hasImage->compute($productIds)->willReturn([
             13 => [
                 'ecommerce' => [
                     'en_US' => true,
@@ -106,6 +106,6 @@ final class GetProductsKeyIndicatorsSpec extends ObjectBehavior
             ],
         ]);
 
-        $this->get($productIds)->shouldBeLike($expectedKeyIndicators);
+        $this->compute($productIds)->shouldBeLike($expectedKeyIndicators);
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Axis\Enrichment;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRankCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisRankCollection;
@@ -22,15 +22,15 @@ final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends Obj
     public function let(
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
         GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery,
-        GetProductsKeyIndicators $getProductsKeyIndicators
+        ComputeProductsKeyIndicators $computeProductsKeyIndicators
     ) {
-        $this->beConstructedWith($getLatestProductAxesRanksQuery, $getProductIdsFromProductIdentifiersQuery, $getProductsKeyIndicators);
+        $this->beConstructedWith($getLatestProductAxesRanksQuery, $getProductIdsFromProductIdentifiersQuery, $computeProductsKeyIndicators);
     }
 
     public function it_returns_additional_properties_from_product_identifiers(
         $getLatestProductAxesRanksQuery,
         $getProductIdsFromProductIdentifiersQuery,
-        $getProductsKeyIndicators
+        $computeProductsKeyIndicators
     ) {
         $productId42 = new ProductId(42);
         $productId123 = new ProductId(123);
@@ -108,7 +108,7 @@ final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends Obj
             ],
         ];
 
-        $getProductsKeyIndicators->get($productIds)->willReturn($productsKeyIndicators);
+        $computeProductsKeyIndicators->compute($productIds)->willReturn($productsKeyIndicators);
 
         $this->fromProductIdentifiers($productIdentifiers)->shouldReturn([
             'product_1' => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/UpdateProductsIndexSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/UpdateProductsIndexSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Axis\Enrichment;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRankCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisRankCollection;
@@ -22,15 +22,15 @@ class UpdateProductsIndexSpec extends ObjectBehavior
     public function let(
         Client $esClient,
         GetLatestProductAxesRanksQueryInterface $getLatestProductAxesRanksQuery,
-        GetProductsKeyIndicators $getProductsKeyIndicators
+        ComputeProductsKeyIndicators $computeProductsKeyIndicators
     ) {
-        $this->beConstructedWith($esClient, $getLatestProductAxesRanksQuery, $getProductsKeyIndicators);
+        $this->beConstructedWith($esClient, $getLatestProductAxesRanksQuery, $computeProductsKeyIndicators);
     }
 
     public function it_updates_products_index(
         $esClient,
         $getLatestProductAxesRanksQuery,
-        $getProductsKeyIndicators
+        $computeProductsKeyIndicators
     ) {
         $consistency = new Consistency();
         $enrichment = new Enrichment();
@@ -82,7 +82,7 @@ class UpdateProductsIndexSpec extends ObjectBehavior
             ],
         ];
 
-        $getProductsKeyIndicators->get($productIds)->willReturn($productsKeyIndicators);
+        $computeProductsKeyIndicators->compute($productIds)->willReturn($productsKeyIndicators);
 
         $esClient->updateByQuery([
             'script' => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuerySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuerySpec.php
@@ -13,14 +13,14 @@ use PhpSpec\ObjectBehavior;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class GetProductsWithImageQuerySpec extends ObjectBehavior
+final class ComputeProductsWithImageQuerySpec extends ObjectBehavior
 {
     public function let(GetEvaluationRatesByProductsAndCriterionQueryInterface $getEvaluationRatesByProductAndCriterionQuery)
     {
         $this->beConstructedWith($getEvaluationRatesByProductAndCriterionQuery);
     }
 
-    public function it_gives_products_with_image_key_indicator($getEvaluationRatesByProductAndCriterionQuery)
+    public function it_computes_products_with_image_key_indicator($getEvaluationRatesByProductAndCriterionQuery)
     {
         $productIds = [new ProductId(13), new ProductId(42), new ProductId(999)];
         $criterionCode = new CriterionCode('enrichment_has_image'); // @todo Use constant when it will be defined
@@ -42,7 +42,7 @@ final class GetProductsWithImageQuerySpec extends ObjectBehavior
             ],
         ]);
 
-        $this->execute($productIds)->shouldBeLike([
+        $this->compute($productIds)->shouldBeLike([
             13 => [
                 'ecommerce' => [
                     'en_US' => true,


### PR DESCRIPTION
Renaming to clarify if the services and queries are for writing (compute the key indicators form MySQL or store them in ES) or for reading (from ES)

I added two minimal interfaces to hold the codes of the key indicators.