### PR TITLE
DAPI-1414: Retrieve key indicators for the Dashboard

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetKeyIndicators implements GetKeyIndicatorsInterface
+{
+    private GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery;
+
+    /** @var KeyIndicatorCode[] */
+    private array $keyIndicatorCodes;
+
+    public function __construct(GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery, string... $keyIndicators)
+    {
+        $this->getProductKeyIndicatorsQuery = $getProductKeyIndicatorsQuery;
+        $this->keyIndicatorCodes = array_map(fn ($keyIndicator) => new KeyIndicatorCode($keyIndicator), $keyIndicators);
+    }
+
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->all($channelCode, $localeCode, ...$this->keyIndicatorCodes));
+    }
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->byFamily($channelCode, $localeCode, $family, ...$this->keyIndicatorCodes));
+    }
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category): array
+    {
+        return $this->formatKeyIndicators($this->getProductKeyIndicatorsQuery->byCategory($channelCode, $localeCode, $category, ...$this->keyIndicatorCodes));
+    }
+
+    private function formatKeyIndicators(array $keyIndicators): array
+    {
+        $formattedKeyIndicators = [];
+        foreach ($keyIndicators as $keyIndicator) {
+            Assert::isInstanceOf($keyIndicator, KeyIndicator::class);
+            $formattedKeyIndicators[strval($keyIndicator->getCode())] = [
+                'ratio' => $keyIndicator->getRatioGood(),
+                'total' => $keyIndicator->getTotalGood(),
+            ];
+        }
+
+        return $formattedKeyIndicators;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicatorsInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicatorsInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+
+interface GetKeyIndicatorsInterface
+{
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode): array;
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family): array;
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class KeyIndicator
+{
+    private KeyIndicatorCode $code;
+
+    private int $totalGood;
+
+    private int $totalToImprove;
+
+    public function __construct(KeyIndicatorCode $code, int $totalGood, int $totalToImprove)
+    {
+        $this->code = $code;
+        $this->totalGood = $totalGood;
+        $this->totalToImprove = $totalToImprove;
+    }
+
+    public function getCode(): KeyIndicatorCode
+    {
+        return $this->code;
+    }
+
+    public function getTotalGood(): int
+    {
+        return $this->totalGood;
+    }
+
+    public function getTotalToImprove(): int
+    {
+        return $this->totalToImprove;
+    }
+
+    public function getRatioGood(): int
+    {
+        $total = $this->totalGood + $this->totalToImprove;
+
+        return $total === 0 ? 0 : intval(round($this->totalGood / $total * 100));
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductKeyIndicatorsQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/GetProductKeyIndicatorsQueryInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Get key indicators related to products
+ */
+interface GetProductKeyIndicatorsQueryInterface
+{
+    /**
+     * @return KeyIndicator[]
+     */
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode, KeyIndicatorCode... $keyIndicatorCodes): array;
+
+    /**
+     * @return KeyIndicator[]
+     */
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array;
+
+    /**
+     * @return KeyIndicator[]
+     */
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/ValueObject/KeyIndicatorCode.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/ValueObject/KeyIndicatorCode.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class KeyIndicatorCode
+{
+    private string $code;
+
+    public function __construct(string $code)
+    {
+        if ('' === $code) {
+            throw new \InvalidArgumentException('A key indicator code cannot be empty');
+        }
+
+        $this->code = $code;
+    }
+
+    public function __toString()
+    {
+        return $this->code;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
@@ -35,17 +35,19 @@ final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQuery
 
     public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array
     {
-        // TODO: Implement byFamily() method.
-        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+        $terms = [['term' => ['family.code' => strval($family)]]];
+
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes, $terms);
     }
 
     public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array
     {
-        // TODO: Implement byCategory() method.
-        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+        $terms = [['terms' => ['categories' => [strval($category)]]]];
+
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes, $terms);
     }
 
-    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraSearch = []): array
+    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraTerms = []): array
     {
         if (empty($keyIndicatorCodes)) {
             return [];
@@ -53,13 +55,11 @@ final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQuery
 
         $query = [
             'bool' => [
-                'must' => [
-                    [
-                        'term' => [
-                            'document_type' => ProductInterface::class
-                        ],
+                'must' => array_merge([[
+                    'term' => [
+                        'document_type' => ProductInterface::class
                     ],
-                ],
+                ]], $extraTerms),
             ],
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Query/GetProductKeyIndicatorsQuery.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductKeyIndicatorsQuery implements GetProductKeyIndicatorsQueryInterface
+{
+    private Client $esClient;
+
+    public function __construct(Client $esClient)
+    {
+        $this->esClient = $esClient;
+    }
+
+    public function all(ChannelCode $channelCode, LocaleCode $localeCode, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    public function byFamily(ChannelCode $channelCode, LocaleCode $localeCode, FamilyCode $family, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        // TODO: Implement byFamily() method.
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    public function byCategory(ChannelCode $channelCode, LocaleCode $localeCode, CategoryCode $category, KeyIndicatorCode... $keyIndicatorCodes): array
+    {
+        // TODO: Implement byCategory() method.
+        return $this->executeQuery($channelCode, $localeCode, $keyIndicatorCodes);
+    }
+
+    private function executeQuery(ChannelCode $channelCode, LocaleCode $localeCode, array $keyIndicatorCodes, array $extraSearch = []): array
+    {
+        if (empty($keyIndicatorCodes)) {
+            return [];
+        }
+
+        $query = [
+            'bool' => [
+                'must' => [
+                    [
+                        'term' => [
+                            'document_type' => ProductInterface::class
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $aggregations = [];
+        foreach ($keyIndicatorCodes as $keyIndicatorCode) {
+            $aggregations[strval($keyIndicatorCode)]['terms']['field'] = sprintf(
+                'data_quality_insights.key_indicators.%s.%s.%s',
+                $channelCode,
+                $localeCode,
+                $keyIndicatorCode
+            );
+        }
+
+        $searchQuery = [
+            'size' => 0,
+            'query' => $query,
+            'aggs' => $aggregations,
+        ];
+
+        $result = $this->esClient->search($searchQuery);
+
+        $keyIndicators = [];
+        foreach ($result['aggregations'] ?? [] as $keyIndicatorCode => $aggregationResult) {
+            $aggregationBuckets = $aggregationResult['buckets'] ?? [];
+            if (empty($aggregationBuckets)) {
+                continue;
+            }
+
+            Assert::isArray($aggregationBuckets);
+            $keyIndicators[$keyIndicatorCode] = $this->formatKeyIndicator(strval($keyIndicatorCode), $aggregationBuckets);
+        }
+
+        return $keyIndicators;
+    }
+
+    private function formatKeyIndicator(string $keyIndicatorCode, array $aggregationBuckets): KeyIndicator
+    {
+        $totalGood = 0;
+        $totalToImprove = 0;
+
+        foreach ($aggregationBuckets as $bucket) {
+            $keyIndicatorValue = $bucket['key'] ?? null;
+
+            if (1 === $keyIndicatorValue) {
+                $totalGood = intval($bucket['doc_count'] ?? 0);
+            } elseif (0 === $keyIndicatorValue) {
+                $totalToImprove = intval($bucket['doc_count'] ?? 0);
+            }
+        }
+
+        return new KeyIndicator(new KeyIndicatorCode($keyIndicatorCode), $totalGood, $totalToImprove);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
@@ -2,41 +2,50 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\Dashboard;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicatorsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class DashboardKeyIndicatorsController
 {
+    private GetKeyIndicatorsInterface $getKeyIndicators;
+
+    public function __construct(GetKeyIndicatorsInterface $getKeyIndicators)
+    {
+        $this->getKeyIndicators = $getKeyIndicators;
+    }
+
     public function __invoke(Request $request, string $channel, string $locale)
     {
-        return new JsonResponse([
-            'has_image' => [
-                'ratio' => 18,
-                'total' => 5641,
-            ],
-            'good_enrichment' => [
-                'ratio' => 35.48,
-                'total' => 15479,
-            ],
-            'values_perfect_spelling' => [
-                'ratio' => 65,
-                'total' => 6548,
-            ],
-            'attributes_perfect_spelling' => [
-                'ratio' => 91,
-                'total' => 1244,
-            ],
-        ]);
+        try {
+            $channel = new ChannelCode($channel);
+            $locale = new LocaleCode($locale);
+
+            if ($request->query->has('category')) {
+                $category = new CategoryCode($request->query->get('category'));
+                $keyIndicators = $this->getKeyIndicators->byCategory($channel, $locale, $category);
+            } elseif ($request->query->has('family')) {
+                $family = new FamilyCode($request->query->get('family'));
+                $keyIndicators = $this->getKeyIndicators->byFamily($channel, $locale, $family);
+            } else {
+                $keyIndicators = $this->getKeyIndicators->all($channel, $locale);
+            }
+
+        } catch (\InvalidArgumentException $exception) {
+            return new JsonResponse(null, Response::HTTP_BAD_REQUEST);
+        }
+
+        return new JsonResponse($keyIndicators);
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
@@ -41,7 +41,6 @@ final class DashboardKeyIndicatorsController
             } else {
                 $keyIndicators = $this->getKeyIndicators->all($channel, $locale);
             }
-
         } catch (\InvalidArgumentException $exception) {
             return new JsonResponse(null, Response::HTTP_BAD_REQUEST);
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -19,6 +19,8 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\Dashboard\DashboardKeyIndicatorsController:
         public: true
+        arguments:
+            - '@akeneo.pim.automation.data_quality_insights.get_key_indicators'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\GetProductAxesRatesController:
         public: true

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -20,3 +20,7 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetUpdatedProductModelIdsQuery:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery:
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -177,4 +177,12 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - !tagged akeneo.pim.automation.data_quality_insights.compute_key_indicator_query
+            - !tagged akeneo.pim.automation.data_quality_insights.key_indicator_query
+
+    akeneo.pim.automation.data_quality_insights.get_key_indicators:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicators
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery'
+            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment::CODE
+            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage::CODE
+

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
@@ -29,6 +29,7 @@ $rules = [
             //External dependencies
             'Psr\Log\LoggerInterface',
             'Symfony\Component\EventDispatcher\EventDispatcherInterface',
+            'Webmozart\Assert\Assert',
         ]
     )->in('Akeneo\Pim\Automation\DataQualityInsights\Application'),
 
@@ -142,6 +143,7 @@ $rules = [
             'GuzzleHttp\Exception',
             'Mekras\Speller',
             'League\Flysystem',
+            'Webmozart\Assert\Assert',
 
             'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
         ]

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -17,6 +17,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -25,6 +26,9 @@ use Webmozart\Assert\Assert;
  */
 class DataQualityInsightsTestCase extends TestCase
 {
+    protected const MINIMAL_VARIANT_AXIS_CODE = 'color';
+    protected const MINIMAL_VARIANT_OPTIONS = ['red', 'blue', 'yellow', 'black', 'white'];
+
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
@@ -45,7 +49,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($product, $data);
             $errors = $this->get('pim_catalog.validator.product')->validate($product);
-            Assert::count($errors, 0, 'Invalid product');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product', $errors));
         }
 
         $this->get('pim_catalog.saver.product')->save($product);
@@ -61,6 +65,22 @@ class DataQualityInsightsTestCase extends TestCase
         return $product;
     }
 
+    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption): ProductInterface
+    {
+        Assert::oneOf($axisOption, self::MINIMAL_VARIANT_OPTIONS, 'Unknown minimal variant option');
+
+        $data = [
+            'parent' => $parent,
+            'values' => [
+                self::MINIMAL_VARIANT_AXIS_CODE => [
+                    ['data' => $axisOption, 'scope' => null, 'locale' => null],
+                ],
+            ],
+        ];
+
+        return $this->createProduct($identifier, $data);
+    }
+
     protected function createProductModel(string $code, string $familyVariant, array $data = []): ProductModelInterface
     {
         $productModel = $this->get('akeneo_integration_tests.catalog.product_model.builder')
@@ -71,7 +91,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
-            Assert::count($errors, 0, 'Invalid product model');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product model', $errors));
         }
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
@@ -90,7 +110,7 @@ class DataQualityInsightsTestCase extends TestCase
         if (!empty($data)) {
             $this->get('pim_catalog.updater.product')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
-            Assert::count($errors, 0, 'Invalid product model');
+            Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid sub-product model', $errors));
         }
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
@@ -105,7 +125,7 @@ class DataQualityInsightsTestCase extends TestCase
         $family = $this->get('akeneo_integration_tests.base.family.builder')->build($data);
 
         $errors = $this->get('validator')->validate($family);
-        Assert::count($errors, 0, 'Invalid family');
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid family', $errors));
 
         $this->get('pim_catalog.saver.family')->save($family);
 
@@ -120,11 +140,27 @@ class DataQualityInsightsTestCase extends TestCase
         $this->get('pim_catalog.updater.family_variant')->update($familyVariant, $data);
 
         $errors = $this->get('validator')->validate($familyVariant);
-        Assert::count($errors, 0);
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid family variant', $errors));
 
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
 
         return $familyVariant;
+    }
+
+    protected function createMinimalFamilyAndFamilyVariant(string $familyCode, string $familyVariantCode): void
+    {
+        $axis = $this->createSimpleSelectAttributeWithOptions(self::MINIMAL_VARIANT_AXIS_CODE, self::MINIMAL_VARIANT_OPTIONS);
+
+        $this->createFamily($familyCode, ['attributes' => [$axis->getCode()]]);
+        $this->createFamilyVariant($familyVariantCode, $familyCode, [
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => [$axis->getCode()],
+                    'attributes' => [],
+                ],
+            ]
+        ]);
     }
 
     protected function createAttribute(string $code, array $data = []): AttributeInterface
@@ -138,6 +174,21 @@ class DataQualityInsightsTestCase extends TestCase
 
         $attribute = $this->get('akeneo_integration_tests.base.attribute.builder')->build($data, true);
         $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    protected function createSimpleSelectAttributeWithOptions(string $code, array $optionCodes): AttributeInterface
+    {
+        $attribute = $this->createAttribute($code, ['type' => AttributeTypes::OPTION_SIMPLE_SELECT]);
+
+        foreach ($optionCodes as $sortOrder => $optionCode) {
+            $option = $this->get('pim_catalog.factory.attribute_option')->create();
+            $option->setCode($optionCode);
+            $option->setAttribute($attribute);
+            $option->setSortOrder($sortOrder);
+            $this->get('pim_catalog.saver.attribute_option')->save($option);
+        }
 
         return $attribute;
     }
@@ -235,7 +286,7 @@ SQL;
 
         $this->get('pim_catalog.updater.channel')->update($channel, $data);
         $errors = $this->get('validator')->validate($channel);
-        Assert::count($errors, 0, 'Invalid channel');
+        Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid channel', $errors));
 
         $this->get('pim_catalog.saver.channel')->save($channel);
 
@@ -250,5 +301,15 @@ SQL;
         )->fetchColumn();
 
         return intval($localeId);
+    }
+
+    private function formatValidationErrorMessage(string $mainMessage, ConstraintViolationListInterface $errors): string
+    {
+        $errorMessage = '';
+        foreach ($errors as $error) {
+            $errorMessage .= PHP_EOL.$error->getMessage();
+        }
+
+        return $mainMessage.$errorMessage;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -71,17 +71,13 @@ class DataQualityInsightsTestCase extends TestCase
         return $product;
     }
 
-    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption): ProductInterface
+    protected function createMinimalProductVariant(string $identifier, string $parent, string $axisOption, array $data = []): ProductInterface
     {
         Assert::oneOf($axisOption, self::MINIMAL_VARIANT_OPTIONS, 'Unknown minimal variant option');
 
-        $data = [
-            'parent' => $parent,
-            'values' => [
-                self::MINIMAL_VARIANT_AXIS_CODE => [
-                    ['data' => $axisOption, 'scope' => null, 'locale' => null],
-                ],
-            ],
+        $data['parent'] = $parent;
+        $data['values'][self::MINIMAL_VARIANT_AXIS_CODE] = [
+            ['data' => $axisOption, 'scope' => null, 'locale' => null],
         ];
 
         return $this->createProduct($identifier, $data);
@@ -95,7 +91,7 @@ class DataQualityInsightsTestCase extends TestCase
             ->build();
 
         if (!empty($data)) {
-            $this->get('pim_catalog.updater.product')->update($productModel, $data);
+            $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
             $errors = $this->get('pim_catalog.validator.product_model')->validate($productModel);
             Assert::count($errors, 0, $this->formatValidationErrorMessage('Invalid product model', $errors));
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -17,6 +17,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Webmozart\Assert\Assert;
 
@@ -32,6 +33,11 @@ class DataQualityInsightsTestCase extends TestCase
     protected function getConfiguration()
     {
         return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function getRandomCode(): string
+    {
+        return Uuid::uuid4()->toString();
     }
 
     protected function deleteProductCriterionEvaluations(int $productId): void

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Elasticsearch/Query/GetProductKeyIndicatorsQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Elasticsearch/Query/GetProductKeyIndicatorsQueryIntegration.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Elasticsearch\Query;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductKeyIndicatorsQueryIntegration extends DataQualityInsightsTestCase
+{
+    private Client $esClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->esClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $this->createMinimalFamilyAndFamilyVariant('family_V', 'family_V_1');
+    }
+
+    public function test_it_retrieves_key_indicators_for_all_the_products()
+    {
+        $this->createProductModel('product_model_with_perfect_enrichment', 'family_V_1');
+        $this->createProductModel('product_model_with_missing_enrichment', 'family_V_1');
+
+        $this->givenProductsWithoutValues(4);
+        $this->givenAProductVariantWithoutValues('product_model_with_missing_enrichment');
+
+        $this->givenAProductWithPerfectEnrichmentAndImage();
+        $this->givenAProductWithPerfectEnrichmentButWithoutAttributeImage();
+        $this->givenAProductWithImageButMissingEnrichment();
+        $this->givenAProductVariantWithPerfectEnrichmentAndImage('product_model_with_perfect_enrichment');
+        $this->givenAProductVariantWithPerfectEnrichmentButWithoutAttributeImage('product_model_with_perfect_enrichment');
+
+        $goodEnrichment = new KeyIndicatorCode('good_enrichment');
+        $hasImage = new KeyIndicatorCode('has_image');
+
+        $expectedKeyIndicators = [
+            'good_enrichment' => new KeyIndicator($goodEnrichment, 4, 6),
+            'has_image' => new KeyIndicator($hasImage, 3, 7),
+        ];
+
+        $keyIndicators = $this->get(GetProductKeyIndicatorsQuery::class)->all(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $goodEnrichment, $hasImage);
+
+        $this->assertEquals($expectedKeyIndicators, $keyIndicators);
+    }
+
+    private function givenProductsWithoutValues(int $nbProducts): void
+    {
+        for ($i = 1; $i <= $nbProducts; $i++) {
+            $product = $this->createProduct(sprintf('product_without_values_%d', $i));
+
+            $this->updateProductKeyIndicators($product->getId(), false, false);
+        }
+    }
+
+    private function givenAProductWithPerfectEnrichmentAndImage(): void
+    {
+        $product = $this->createProduct('product_with_perfect_enrichment_and_image');
+
+        $this->updateProductKeyIndicators($product->getId(), true, true);
+    }
+
+    private function givenAProductWithPerfectEnrichmentButWithoutAttributeImage(): void
+    {
+        $product = $this->createProduct('product_with_perfect_enrichment_but_without_attribute_image');
+
+        $this->updateProductKeyIndicators($product->getId(), true, false);
+    }
+
+    private function givenAProductWithImageButMissingEnrichment(): void
+    {
+        $product = $this->createProduct('product_with_image_but_missing_enrichment');
+
+        $this->updateProductKeyIndicators($product->getId(), false, true);
+    }
+
+    private function givenAProductVariantWithoutValues(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_without_values',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[0]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), false, false);
+    }
+
+    private function givenAProductVariantWithPerfectEnrichmentAndImage(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_with_perfect_enrichment',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[1]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), true, true);
+    }
+
+    private function givenAProductVariantWithPerfectEnrichmentButWithoutAttributeImage(string $parent): void
+    {
+        $productVariant = $this->createMinimalProductVariant(
+            'product_variant_with_perfect_enrichment_but_without_attribute_image',
+            $parent,
+            DataQualityInsightsTestCase::MINIMAL_VARIANT_OPTIONS[2]
+        );
+
+        $this->updateProductKeyIndicators($productVariant->getId(), true, false);
+    }
+
+    private function updateProductKeyIndicators(int $productId, bool $goodEnrichment, bool $hasImage): void
+    {
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        $keyIndicators = [
+            'ecommerce' => [
+                'en_US' => [
+                    'good_enrichment' => $goodEnrichment,
+                    'has_image' => $hasImage,
+                ],
+                'fr_FR' => [
+                    'good_enrichment' => !$goodEnrichment,
+                    'has_image' => !$hasImage,
+                ],
+            ],
+            'mobile' => [
+                'en_US' => [
+                    'good_enrichment' => !$goodEnrichment,
+                    'has_image' => !$hasImage,
+                ],
+            ],
+        ];
+
+        $this->esClient->refreshIndex();
+        $this->esClient->updateByQuery(
+            [
+                'script' => [
+                    'inline' => "ctx._source.rates = params.rates; ctx._source.data_quality_insights = params.data_quality_insights;",
+                    'params' => [
+                        'rates' => [],
+                        'data_quality_insights' => ['key_indicators' => $keyIndicators],
+                    ],
+                ],
+                'query' => [
+                    'term' => [
+                        'id' => sprintf('product_%d', $productId),
+                    ],
+                ],
+            ]
+        );
+
+        $this->esClient->refreshIndex();
+    }
+}


### PR DESCRIPTION
Controller, Application and ES query to retrieve the key indicators for the Dashboard.

The interface `GetKeyIndicatorsInterface` will allow to have an implementation in EE to add the key indicator on attributes. 
For the EE key indicators on products with perfect spelling, we will just have to add its code by decorating the service `akeneo.pim.automation.data_quality_insights.get_key_indicators`