### PR TITLE
RAC-280: feat add current step and total step when job process is started or starting

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
@@ -18,18 +18,25 @@ datagrid:
                 frontendType: label
             status:
                 label:         Status
-                template:      PimImportExportBundle:Property:status.html.twig
-                type:          twig
-                frontend_type: html
-                data_name:     statusLabel
+                frontend_type: react
+                type: field
+                component: pimimportexport/js/JobExecutionStatus
+                props:
+                    status: string
+                    currentStep: integer
+                    totalSteps: integer
+                    hasWarning: boolean
+                    hasError: boolean
             warning:
-                label:         Warnings
-                template:      PimImportExportBundle:Property:warning.html.twig
-                type:          twig
-                frontend_type: html
-                data_name:     warningCount
+                label: Warnings
+                frontendType: label
+                data_name: warningCount
         properties:
             id: ~
+            currentStep: ~
+            totalSteps: ~
+            hasWarning: ~
+            hasError: ~
             show_link:
                 type: url
                 params:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/data_sources.yml
@@ -103,7 +103,7 @@ services:
         class: '%pim_datagrid.datasource.repository.class%'
         arguments:
             - '@pim_enrich.repository.job_execution'
-            - '@pim_datagrid.datasource.result_record.hydrator.default'
+            - '@akeneo.platform.import_export.result_record.hydrator.job_execution'
         tags:
             - { name: oro_datagrid.datasource, type: pim_datasource_job_execution }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR : 
- Add information of current step in last job execution grid
- Remove badge around warning count in last job execution grid

![Capture du 2020-11-03 12-10-57](https://user-images.githubusercontent.com/7239572/97978350-beb58380-1dcd-11eb-923f-17f6e364378e.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
