### PR TITLE
CXP-493: Do not save a product when it was not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,11 +204,13 @@
 - Change `Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface` interface to add `getWithVariants()`
 - Change constructor of `Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup` to replace `Doctrine\DBAL\Driver\Connection $connection` by `Doctrine\DBAL\Connection $connection`
 - Add `clearCache` method in `Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface`
-- Remove method `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface::setFamilyId()`
+- Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface` to
+    - remove the `setFamilyId()` method
+    - add `isDirty()` and `cleanup()` methods
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct` to
     - remove the `setFamilyId()` method
     - remove the `$categoryIds` public property and  the `$familyId` and `$groupIds` protected properties
-    - add `wasUpdated()` and `cleanup()` methods
+    - add `isDirty()` and `cleanup()` methods 
 - Remove the `findDatagridViewByAlias()` method in `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface`
 
 ### CLI commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
 - RAC-178: When launching a job, the notification contains a link to the job status
 - PIM-9485: Change ACL name “Remove a product model” to “Remove a product model (including children)”
 - BH-138: clear Locale cache on save
+- CXP-493: Do not save products when if were not actually updated. In order to do so, the product now returns copies of
+  its collections (values, categories, groups and associations). Practically, this means that such a collection cannot be directly
+  updated "from outside" anymore (e.g: `$product->getCategories()->add($category)` **won't update the product anymore**,
+  you should now use `$product->addCategory($category)` to achieve it)  
 
 # Technical Improvements
 
@@ -204,6 +208,7 @@
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct` to
     - remove the `setFamilyId()` method
     - remove the `$categoryIds` public property and  the `$familyId` and `$groupIds` protected properties
+    - add `wasUpdated()` and `cleanup()` methods
 - Remove the `findDatagridViewByAlias()` method in `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface`
 
 ### CLI commands

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceBusinessProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceBusinessProductEventEndToEnd.php
@@ -75,7 +75,7 @@ JSON;
 
         $data =
             <<<JSON
-    {"identifier": "product_update_test", "updated": "2020-10-01T11:56:12+02:00"}
+    {"identifier": "another_product_update_test"}
 JSON;
 
         $apiClient->request('PATCH', 'api/rest/v1/products/product_update_test', [], [], [], $data);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/RefreshProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/RefreshProductCommand.php
@@ -81,7 +81,7 @@ class RefreshProductCommand extends Command
             $productsToSave[$product instanceof ProductModelInterface ? 'product_models' : 'products'][] = $product;
         }
 
-        $this->productSaver->saveAll($productsToSave['products']);
+        $this->productSaver->saveAll($productsToSave['products'], ['force_save' => true]);
         $this->productModelSaver->saveAll($productsToSave['product_models']);
 
         return 0;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
@@ -45,7 +45,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
     public function save($product, array $options = [])
     {
         $this->validateProduct($product);
-        if (!$product->wasUpdated() && true !== ($options['force_save'] ?? false)) {
+        if (!$product->isDirty() && true !== ($options['force_save'] ?? false)) {
             return;
         }
 
@@ -79,7 +79,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
                 array_filter(
                     $products,
                     function (ProductInterface $product): bool {
-                        return $product->wasUpdated();
+                        return $product->isDirty();
                     }
                 )
             );

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
@@ -59,9 +59,9 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
         $this->objectManager->persist($product);
         $this->objectManager->flush();
 
-        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
-
         $product->cleanup();
+
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($product, $options));
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/ProductSaver.php
@@ -45,7 +45,7 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
     public function save($product, array $options = [])
     {
         $this->validateProduct($product);
-        if (!$product->wasUpdated()) {
+        if (!$product->wasUpdated() && true !== ($options['force_save'] ?? false)) {
             return;
         }
 
@@ -74,9 +74,16 @@ class ProductSaver implements SaverInterface, BulkSaverInterface
             $this->validateProduct($product);
         }
 
-        $products = array_values(array_filter($products, function (ProductInterface $product): bool {
-            return $product->wasUpdated();
-        }));
+        if (true !== ($options['force_save'] ?? false)) {
+            $products = array_values(
+                array_filter(
+                    $products,
+                    function (ProductInterface $product): bool {
+                        return $product->wasUpdated();
+                    }
+                )
+            );
+        }
 
         if (empty($products)) {
             return;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
@@ -28,33 +28,33 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function createInversedAssociation(
         AssociationInterface $association,
-        EntityWithAssociationsInterface $associatedEntity
+        EntityWithAssociationsInterface $owner
     ): void {
         $associationType = $association->getAssociationType();
-        $owner = $association->getOwner();
+        $entityToAssociate = $association->getOwner();
 
-        /** @var AssociationInterface $inversedAssociation */
-        $inversedAssociation = $associatedEntity->getAssociationForType($associationType);
-        if (null === $inversedAssociation) {
-            $this->missingAssociationAdder->addMissingAssociations($associatedEntity);
-            $inversedAssociation = $associatedEntity->getAssociationForType($associationType);
+        /** @var AssociationInterface $associationToUpdate */
+        $associationToUpdate = $owner->getAssociationForType($associationType);
+        if (null === $associationToUpdate) {
+            $this->missingAssociationAdder->addMissingAssociations($owner);
+            $associationToUpdate = $owner->getAssociationForType($associationType);
         }
 
-        if ($owner instanceof ProductInterface) {
-            $this->addInversedAssociatedProduct($inversedAssociation, $owner, $associatedEntity);
-        } elseif ($owner instanceof ProductModelInterface) {
-            $this->addInversedAssociatedProductModel($inversedAssociation, $owner);
+        if ($entityToAssociate instanceof ProductInterface) {
+            $this->addInversedAssociatedProduct($associationToUpdate, $entityToAssociate, $owner);
+        } elseif ($entityToAssociate instanceof ProductModelInterface) {
+            $this->addInversedAssociatedProductModel($associationToUpdate, $entityToAssociate);
         } else {
             throw new \LogicException(
                 sprintf(
                     'Inversed associations are only for the classes "%s" and "%s". "%s" given.',
                     ProductInterface::class,
                     ProductModelInterface::class,
-                    get_class($owner)
+                    get_class($entityToAssociate)
                 )
             );
         }
@@ -67,21 +67,20 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
      * To fix this, we look for cloned objects by comparing the identifier.
      */
     private function addInversedAssociatedProduct(
-        AssociationInterface $inversedAssociation,
-        ProductInterface $owner,
-        EntityWithAssociationsInterface $associatedProduct
+        AssociationInterface $associationToUpdate,
+        ProductInterface $associatedProduct,
+        EntityWithAssociationsInterface $owner
     ): void {
         /** @var ProductInterface $product */
-        foreach ($inversedAssociation->getProducts() as $product) {
-            if ($product->getIdentifier() === $owner->getIdentifier()
-                && $product !== $owner) {
-                $inversedAssociation->removeProduct($product);
+        foreach ($associationToUpdate->getProducts() as $product) {
+            if ($product->getIdentifier() === $associatedProduct->getIdentifier() && $product !== $associatedProduct) {
+                $associationToUpdate->removeProduct($product);
             }
         }
 
-        $associatedProduct->removeAssociation($inversedAssociation);
-        $inversedAssociation->addProduct($owner);
-        $associatedProduct->addAssociation($inversedAssociation);
+        $owner->removeAssociation($associationToUpdate);
+        $associationToUpdate->addProduct($associatedProduct);
+        $owner->addAssociation($associationToUpdate);
     }
 
     /**
@@ -91,49 +90,51 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
      * To fix this, we look for cloned objects by comparing the identifier.
      */
     private function addInversedAssociatedProductModel(
-        AssociationInterface $association,
+        AssociationInterface $associationToUpdate,
         ProductModelInterface $associatedProductModel
     ): void {
         /** @var ProductModelInterface $productModel */
-        foreach ($association->getProductModels() as $productModel) {
-            if ($productModel->getCode() === $associatedProductModel->getCode()
-                && $productModel !== $associatedProductModel) {
-                $association->removeProductModel($productModel);
+        foreach ($associationToUpdate->getProductModels() as $productModel) {
+            if (
+                $productModel->getCode() === $associatedProductModel->getCode() &&
+                $productModel !== $associatedProductModel
+            ) {
+                $associationToUpdate->removeProductModel($productModel);
             }
         }
 
-        $association->addProductModel($associatedProductModel);
+        $associationToUpdate->addProductModel($associatedProductModel);
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function removeInversedAssociation(
         AssociationInterface $association,
-        EntityWithAssociationsInterface $associatedEntity
+        EntityWithAssociationsInterface $owner
     ): void {
         $associationType = $association->getAssociationType();
-        $owner = $association->getOwner();
+        $associatedEntityToRemove = $association->getOwner();
 
         /** @var AssociationInterface $inversedAssociation */
-        $inversedAssociation = $associatedEntity->getAssociationForType($associationType);
+        $inversedAssociation = $owner->getAssociationForType($associationType);
         if (null === $inversedAssociation) {
             return;
         }
 
-        if ($owner instanceof ProductInterface) {
-            $associatedEntity->removeAssociation($inversedAssociation);
-            $inversedAssociation->removeProduct($owner);
-            $associatedEntity->addAssociation($inversedAssociation);
-        } elseif ($owner instanceof ProductModelInterface) {
-            $inversedAssociation->removeProductModel($owner);
+        if ($associatedEntityToRemove instanceof ProductInterface) {
+            $owner->removeAssociation($inversedAssociation);
+            $inversedAssociation->removeProduct($associatedEntityToRemove);
+            $owner->addAssociation($inversedAssociation);
+        } elseif ($associatedEntityToRemove instanceof ProductModelInterface) {
+            $inversedAssociation->removeProductModel($associatedEntityToRemove);
         } else {
             throw new \LogicException(
                 sprintf(
                     'Inversed associations are only for the classes "%s" and "%s". "%s" given.',
                     ProductInterface::class,
                     ProductModelInterface::class,
-                    get_class($owner)
+                    get_class($associatedEntityToRemove)
                 )
             );
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
@@ -45,7 +45,7 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
         }
 
         if ($owner instanceof ProductInterface) {
-            $this->addInversedAssociatedProduct($inversedAssociation, $owner);
+            $this->addInversedAssociatedProduct($inversedAssociation, $owner, $associatedEntity);
         } elseif ($owner instanceof ProductModelInterface) {
             $this->addInversedAssociatedProductModel($inversedAssociation, $owner);
         } else {
@@ -68,17 +68,20 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
      */
     private function addInversedAssociatedProduct(
         AssociationInterface $association,
-        ProductInterface $associatedProduct
+        ProductInterface $owner,
+        EntityWithAssociationsInterface $associatedProduct
     ): void {
         /** @var ProductInterface $product */
         foreach ($association->getProducts() as $product) {
-            if ($product->getIdentifier() === $associatedProduct->getIdentifier()
-                && $product !== $associatedProduct) {
+            if ($product->getIdentifier() === $owner->getIdentifier()
+                && $product !== $owner) {
                 $association->removeProduct($product);
             }
         }
 
-        $association->addProduct($associatedProduct);
+        $associatedProduct->removeAssociation($association);
+        $association->addProduct($owner);
+        $associatedProduct->addAssociation($association);
     }
 
     /**
@@ -119,7 +122,9 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
         }
 
         if ($owner instanceof ProductInterface) {
+            $associatedEntity->removeAssociation($inversedAssociation);
             $inversedAssociation->removeProduct($owner);
+            $associatedEntity->addAssociation($inversedAssociation);
         } elseif ($owner instanceof ProductModelInterface) {
             $inversedAssociation->removeProductModel($owner);
         } else {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Updater/TwoWayAssociationUpdater.php
@@ -67,21 +67,21 @@ class TwoWayAssociationUpdater implements TwoWayAssociationUpdaterInterface
      * To fix this, we look for cloned objects by comparing the identifier.
      */
     private function addInversedAssociatedProduct(
-        AssociationInterface $association,
+        AssociationInterface $inversedAssociation,
         ProductInterface $owner,
         EntityWithAssociationsInterface $associatedProduct
     ): void {
         /** @var ProductInterface $product */
-        foreach ($association->getProducts() as $product) {
+        foreach ($inversedAssociation->getProducts() as $product) {
             if ($product->getIdentifier() === $owner->getIdentifier()
                 && $product !== $owner) {
-                $association->removeProduct($product);
+                $inversedAssociation->removeProduct($product);
             }
         }
 
-        $associatedProduct->removeAssociation($association);
-        $association->addProduct($owner);
-        $associatedProduct->addAssociation($association);
+        $associatedProduct->removeAssociation($inversedAssociation);
+        $inversedAssociation->addProduct($owner);
+        $associatedProduct->addAssociation($inversedAssociation);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/LoadEntityWithValuesSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/LoadEntityWithValuesSubscriber.php
@@ -4,6 +4,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues;
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
@@ -59,5 +60,8 @@ final class LoadEntityWithValuesSubscriber implements EventSubscriber
 
         $values = $this->valueCollectionFactory->createFromStorageFormat($rawValues);
         $entity->setValues($values);
+        if ($entity instanceof ProductInterface) {
+            $entity->cleanup();
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Job/ComputeCompletenessOfProductsFamilyTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Job/ComputeCompletenessOfProductsFamilyTasklet.php
@@ -113,13 +113,13 @@ class ComputeCompletenessOfProductsFamilyTasklet implements TaskletInterface
             $productBatch[] = $product;
 
             if (self::BATCH_SIZE === count($productBatch)) {
-                $this->bulkProductSaver->saveAll($productBatch);
+                $this->bulkProductSaver->saveAll($productBatch, ['force_save' => true]);
                 $this->cacheClearer->clear();
                 $productBatch = [];
             }
         }
 
-        $this->bulkProductSaver->saveAll($productBatch);
+        $this->bulkProductSaver->saveAll($productBatch, ['force_save' => true]);
         $this->cacheClearer->clear();
     }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Job/RemoveNonExistingProductValuesTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Job/RemoveNonExistingProductValuesTasklet.php
@@ -104,7 +104,7 @@ final class RemoveNonExistingProductValuesTasklet implements TaskletInterface
 
         foreach ($batchIdentifiers as $identifiers) {
             $products = $this->productRepository->getItemsFromIdentifiers($identifiers);
-            $this->productSaver->saveAll($products);
+            $this->productSaver->saveAll($products, ['force_save' => true]);
 
             $productModels = $this->productModelRepository->getItemsFromIdentifiers($identifiers);
             $this->productModelSaver->saveAll($productModels);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
@@ -79,7 +79,6 @@ abstract class AbstractAssociation implements AssociationInterface
     {
         if (!$this->owner) {
             $this->owner = $owner;
-            $owner->addAssociation($this);
         }
 
         return $this;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
@@ -235,8 +235,8 @@ abstract class AbstractAssociation implements AssociationInterface
 
     public function __clone()
     {
-        $this->products = clone $this->products;
-        $this->productModels = clone $this->productModels;
-        $this->groups = clone $this->groups;
+        $this->products = clone $this->getProducts();
+        $this->productModels = clone $this->getProductModels();
+        $this->groups = clone $this->getGroups();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractAssociation.php
@@ -232,4 +232,11 @@ abstract class AbstractAssociation implements AssociationInterface
 
         return $this->owner->getIdentifier() . '.' . $this->associationType->getCode();
     }
+
+    public function __clone()
+    {
+        $this->products = clone $this->products;
+        $this->productModels = clone $this->productModels;
+        $this->groups = clone $this->groups;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -282,7 +282,7 @@ abstract class AbstractProduct implements ProductInterface
     public function getValues(): WriteValueCollection
     {
         if (!$this->isVariant()) {
-            return $this->values;
+            return WriteValueCollection::fromCollection($this->values);
         }
 
         $values = WriteValueCollection::fromCollection($this->values);
@@ -652,7 +652,7 @@ abstract class AbstractProduct implements ProductInterface
     {
         foreach ($this->getAssociations() as $association) {
             if ($association->getAssociationType()->getCode() === $typeCode) {
-                return clone $association;
+                return $association;
             }
         }
 
@@ -805,15 +805,8 @@ abstract class AbstractProduct implements ProductInterface
             return $needleAssociation;
         }
 
-        $needleAssociationType = $needleAssociation->getAssociationType();
         foreach ($this->associations as $current) {
-            if (
-                $current->getReference() === $needleAssociation->getReference() ||
-                (
-                    null !== $needleAssociationType &&
-                    null !== $this->getAssociationForType($needleAssociationType)
-                )
-            ) {
+            if ($current->getReference() === $needleAssociation->getReference()) {
                 return $current;
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -237,7 +237,9 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setFamily(FamilyInterface $family = null)
     {
-        if ($family !== $this->family) {
+        $formerFamilyCode = $this->family ? $this->family->getCode() : null;
+        $newFamilyCode = $family ? $family->getCode() : null;
+        if ($formerFamilyCode !== $newFamilyCode) {
             $this->dirty = true;
         }
         $this->family = $family;
@@ -298,12 +300,16 @@ abstract class AbstractProduct implements ProductInterface
             $matching = $values->getSame($formerValue);
             if (null === $matching || !$formerValue->isEqual($matching)) {
                 $this->dirty = true;
+                break;
             }
         }
-        foreach ($values as $value) {
-            $matching = $formerValues->getSame($value);
-            if (null === $matching) {
-                $this->dirty = true;
+        if (!$this->dirty) {
+            foreach ($values as $value) {
+                $matching = $formerValues->getSame($value);
+                if (null === $matching) {
+                    $this->dirty = true;
+                    break;
+                }
             }
         }
         $this->values = $values;
@@ -717,10 +723,12 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setParent(ProductModelInterface $parent = null): void
     {
-        if ($parent !== $this->parent) {
-            $this->parent = $parent;
+        $formerParentCode = $this->parent ? $this->parent->getCode() : null;
+        $newParentCode = $parent ? $parent->getCode() : null;
+        if ($formerParentCode !== $newParentCode) {
             $this->dirty = true;
         }
+        $this->parent = $parent;
     }
 
     /**
@@ -736,10 +744,12 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setFamilyVariant(FamilyVariantInterface $familyVariant): void
     {
-        if ($familyVariant !== $this->familyVariant) {
-            $this->familyVariant = $familyVariant;
+        $formerFamilyVariantCode = $this->familyVariant ? $this->familyVariant->getCode() : null;
+        $newFamilyVariantCode = $familyVariant ? $familyVariant->getCode() : null;
+        if ($formerFamilyVariantCode !== $newFamilyVariantCode) {
             $this->dirty = true;
         }
+        $this->familyVariant = $familyVariant;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -81,6 +81,9 @@ abstract class AbstractProduct implements ProductInterface
     /** @var FamilyVariantInterface|null */
     protected $familyVariant;
 
+    /** @var bool */
+    protected bool $wasUpdated = false;
+
     /**
      * Constructor
      */
@@ -93,6 +96,7 @@ abstract class AbstractProduct implements ProductInterface
         $this->associations = new ArrayCollection();
         $this->uniqueData = new ArrayCollection();
         $this->quantifiedAssociationCollection = QuantifiedAssociationCollection::createFromNormalized([]);
+        $this->wasUpdated = true;
     }
 
     /**
@@ -695,6 +699,22 @@ abstract class AbstractProduct implements ProductInterface
     public function isVariant(): bool
     {
         return null !== $this->getParent();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wasUpdated(): bool
+    {
+        return $this->wasUpdated;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cleanup(): void
+    {
+        $this->wasUpdated = false;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -652,7 +652,7 @@ abstract class AbstractProduct implements ProductInterface
     {
         foreach ($this->getAssociations() as $association) {
             if ($association->getAssociationType()->getCode() === $typeCode) {
-                return $association;
+                return clone $association;
             }
         }
 
@@ -955,5 +955,17 @@ abstract class AbstractProduct implements ProductInterface
         $associationsCollection->add($association);
 
         return $associationsCollection;
+    }
+
+    public function __clone()
+    {
+        $this->values = clone $this->values;
+        $this->categories = clone $this->categories;
+        $this->groups = clone $this->groups;
+        $clonedAssociations = $this->associations->map(
+            fn (AssociationInterface $association): AssociationInterface => clone $association
+        );
+        $this->associations = $clonedAssociations;
+        $this->quantifiedAssociationCollection = clone $this->quantifiedAssociationCollection;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -365,6 +365,7 @@ abstract class AbstractProduct implements ProductInterface
     {
         if (!$this->categories->contains($category) && !$this->hasAncestryCategory($category)) {
             $this->categories->add($category);
+            $this->wasUpdated = true;
         }
 
         return $this;
@@ -383,7 +384,9 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function removeCategory(BaseCategoryInterface $category)
     {
-        $this->categories->removeElement($category);
+        if (true === $this->categories->removeElement($category)) {
+            $this->wasUpdated = true;
+        }
 
         return $this;
     }
@@ -494,6 +497,7 @@ abstract class AbstractProduct implements ProductInterface
         if (!$this->groups->contains($group)) {
             $this->groups->add($group);
             $group->addProduct($this);
+            $this->wasUpdated = true;
         }
 
         return $this;
@@ -504,7 +508,9 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function removeGroup(GroupInterface $group)
     {
-        $this->groups->removeElement($group);
+        if (true === $this->groups->removeElement($group)) {
+            $this->wasUpdated = true;
+        }
 
         return $this;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -81,7 +81,6 @@ abstract class AbstractProduct implements ProductInterface
     /** @var FamilyVariantInterface|null */
     protected $familyVariant;
 
-    /** @var bool */
     protected bool $wasUpdated = false;
 
     /**
@@ -266,7 +265,10 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setIdentifier(?string $identifierValue): ProductInterface
     {
-        $this->identifier = $identifierValue;
+        if ($identifierValue !== $this->identifier) {
+            $this->identifier = $identifierValue;
+            $this->wasUpdated = true;
+        }
 
         return $this;
     }
@@ -469,7 +471,10 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setEnabled($enabled)
     {
-        $this->enabled = $enabled;
+        if ($enabled !== $this->enabled) {
+            $this->enabled = $enabled;
+            $this->wasUpdated = true;
+        }
 
         return $this;
     }
@@ -685,7 +690,10 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setParent(ProductModelInterface $parent = null): void
     {
-        $this->parent = $parent;
+        if ($parent !== $this->parent) {
+            $this->parent = $parent;
+            $this->wasUpdated = true;
+        }
     }
 
     /**
@@ -697,11 +705,14 @@ abstract class AbstractProduct implements ProductInterface
     }
 
     /**
-     * @param FamilyVariantInterface $familyVariant
+     * {@inheritdoc}
      */
     public function setFamilyVariant(FamilyVariantInterface $familyVariant): void
     {
-        $this->familyVariant = $familyVariant;
+        if ($familyVariant !== $this->familyVariant) {
+            $this->familyVariant = $familyVariant;
+            $this->wasUpdated = true;
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -371,10 +371,6 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getCategories()
     {
-        if (!$this->isVariant()) {
-            return $this->categories;
-        }
-
         $categories = new ArrayCollection($this->categories->toArray());
 
         return $this->getAllCategories($this, $categories);
@@ -537,7 +533,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getGroups()
     {
-        return $this->groups;
+        return new ArrayCollection($this->groups->toArray());
     }
 
     /**
@@ -745,7 +741,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getValuesForVariation(): WriteValueCollection
     {
-        return $this->values;
+        return WriteValueCollection::fromCollection($this->values);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -779,6 +779,61 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
+    public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
+    {
+        if (null === $this->quantifiedAssociationCollection) {
+            return;
+        }
+
+        $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection
+            ->filterProductIdentifiers($productIdentifiersToKeep)
+            ->filterProductModelCodes($productModelCodesToKeep);
+        $this->wasUpdated = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function mergeQuantifiedAssociations(QuantifiedAssociationCollection $quantifiedAssociations): void
+    {
+        if ($this->quantifiedAssociationCollection === null) {
+            return;
+        }
+        $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->merge($quantifiedAssociations);
+        $this->wasUpdated = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function patchQuantifiedAssociations(array $submittedQuantifiedAssociations): void
+    {
+        if (null === $this->quantifiedAssociationCollection) {
+            return;
+        }
+
+        $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->patchQuantifiedAssociations(
+            $submittedQuantifiedAssociations
+        );
+        $this->wasUpdated = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clearQuantifiedAssociations(): void
+    {
+        if (null === $this->quantifiedAssociationCollection) {
+            return;
+        }
+
+        $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->clearQuantifiedAssociations();
+        $this->wasUpdated = true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function wasUpdated(): bool
     {
         return $this->wasUpdated;
@@ -790,6 +845,18 @@ abstract class AbstractProduct implements ProductInterface
     public function cleanup(): void
     {
         $this->wasUpdated = false;
+    }
+
+    public function __clone()
+    {
+        $this->values = clone $this->values;
+        $this->categories = clone $this->categories;
+        $this->groups = clone $this->groups;
+        $clonedAssociations = $this->associations->map(
+            fn (AssociationInterface $association): AssociationInterface => clone $association
+        );
+        $this->associations = $clonedAssociations;
+        $this->quantifiedAssociationCollection = clone $this->quantifiedAssociationCollection;
     }
 
     /**
@@ -948,17 +1015,5 @@ abstract class AbstractProduct implements ProductInterface
         $associationsCollection->add($association);
 
         return $associationsCollection;
-    }
-
-    public function __clone()
-    {
-        $this->values = clone $this->values;
-        $this->categories = clone $this->categories;
-        $this->groups = clone $this->groups;
-        $clonedAssociations = $this->associations->map(
-            fn (AssociationInterface $association): AssociationInterface => clone $association
-        );
-        $this->associations = $clonedAssociations;
-        $this->quantifiedAssociationCollection = clone $this->quantifiedAssociationCollection;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
@@ -49,9 +49,9 @@ interface ProductInterface extends
     /**
      * @param string|null $identifierValue
      *
-     * @return ProductInterface
+     * @return self
      */
-    public function setIdentifier(?string $identifierValue): ProductInterface;
+    public function setIdentifier(?string $identifierValue): self;
 
     /**
      * Get the product groups
@@ -86,7 +86,7 @@ interface ProductInterface extends
     /**
      * Get groups code
      *
-     * @return array
+     * @return string[]
      */
     public function getGroupCodes();
 
@@ -141,8 +141,8 @@ interface ProductInterface extends
     /**
      * Get product label
      *
-     * @param string $locale
-     * @param string $scopeCode
+     * @param ?string $locale
+     * @param ?string $scopeCode
      *
      * @return mixed|string
      */
@@ -151,7 +151,7 @@ interface ProductInterface extends
     /**
      * Set family
      *
-     * @param FamilyInterface $family
+     * @param ?FamilyInterface $family
      *
      * @return ProductInterface
      */
@@ -192,4 +192,16 @@ interface ProductInterface extends
      * @return Collection
      */
     public function getCategoriesForVariation(): Collection;
+
+    /**
+     * Whether the product was updated
+     *
+     * @return bool
+     */
+    public function wasUpdated(): bool;
+
+    /**
+     * Resets the updated state (to false)
+     */
+    public function cleanup(): void;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
@@ -198,7 +198,7 @@ interface ProductInterface extends
      *
      * @return bool
      */
-    public function wasUpdated(): bool;
+    public function isDirty(): bool;
 
     /**
      * Resets the updated state (to false)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/AssociationFieldClearer.php
@@ -38,12 +38,14 @@ final class AssociationFieldClearer implements ClearerInterface
         if ($entity instanceof EntityWithAssociationsInterface) {
             // getAssociations() can return an array or a Collection. We handle both.
             // We cannot clear the association directly, doctrine does not understand. We have to clear the
-            // products,m product models and groups of each assocations.
-            foreach ($entity->getAssociations() as $association) {
+            // products, product models and groups of each assocations.
+            $associations = $entity->getAssociations();
+            foreach ($associations as $association) {
                 $association->getProducts()->clear();
                 $association->getProductModels()->clear();
                 $association->getGroups()->clear();
             }
+            $entity->setAssociations($associations);
         }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
@@ -43,6 +43,8 @@ final class GroupFieldClearer implements ClearerInterface
             sprintf('The clearer does not handle the "%s" property.', $property)
         );
 
-        $entity->getGroups()->clear();
+        foreach ($entity->getGroups() as $group) {
+            $group->removeProduct($entity);
+        };
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Clearer/Field/GroupFieldClearer.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\ClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
+use Doctrine\Common\Collections\ArrayCollection;
 use Webmozart\Assert\Assert;
 
 /**
@@ -43,8 +44,6 @@ final class GroupFieldClearer implements ClearerInterface
             sprintf('The clearer does not handle the "%s" property.', $property)
         );
 
-        foreach ($entity->getGroups() as $group) {
-            $group->removeProduct($entity);
-        };
+        $entity->setGroups(new ArrayCollection());
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/CategoryFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/CategoryFieldSetter.php
@@ -9,6 +9,7 @@ use Akeneo\Tool\Component\Classification\CategoryAwareInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Sets the category field
@@ -57,14 +58,7 @@ class CategoryFieldSetter extends AbstractFieldSetter
             $categories[] = $category;
         }
 
-        $oldCategories = $entity->getCategories();
-        foreach ($oldCategories as $category) {
-            $entity->removeCategory($category);
-        }
-
-        foreach ($categories as $category) {
-            $entity->addCategory($category);
-        }
+        $entity->setCategories(new ArrayCollection($categories));
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/CategoryFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/CategoryFieldSetter.php
@@ -48,17 +48,34 @@ class CategoryFieldSetter extends AbstractFieldSetter
 
         $this->checkData($field, $data);
 
-        $categories = [];
+        $categories = new ArrayCollection();
         foreach ($data as $categoryCode) {
             $category = $this->getCategory($categoryCode);
 
             if (null === $category) {
                 throw new UnknownCategoryException($field, $categoryCode, static::class);
             }
-            $categories[] = $category;
+            $categories->add($category);
         }
 
-        $entity->setCategories(new ArrayCollection($categories));
+        $formerCategories = $entity->getCategories();
+        $categoriesToAdd = $categories->filter(
+            function (CategoryInterface $category) use ($formerCategories) {
+                return !$formerCategories->contains($category);
+            }
+        );
+        foreach ($categoriesToAdd as $categoryToAdd) {
+            $entity->addCategory($categoryToAdd);
+        }
+
+        $categoriesToRemove = $formerCategories->filter(
+            function (Categoryinterface $category) use ($categories) {
+                return !$categories->contains($category);
+            }
+        );
+        foreach ($categoriesToRemove as $categoryToRemove) {
+            $entity->removeCategory($categoryToRemove);
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/GroupFieldSetter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/Setter/GroupFieldSetter.php
@@ -7,6 +7,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Sets the group field, for now, it handles groups
@@ -64,15 +65,7 @@ class GroupFieldSetter extends AbstractFieldSetter
                 $groups[] = $group;
             }
         }
-
-        $oldGroups = $product->getGroups();
-        foreach ($oldGroups as $group) {
-            $product->removeGroup($group);
-        }
-
-        foreach ($groups as $group) {
-            $product->addGroup($group);
-        }
+        $product->setGroups(new ArrayCollection($groups));
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/TwoWayAssociationUpdaterInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/TwoWayAssociationUpdaterInterface.php
@@ -11,21 +11,21 @@ interface TwoWayAssociationUpdaterInterface
      * An association has been created, this method should create the inversed association.
      *
      * @param AssociationInterface $association
-     * @param EntityWithAssociationsInterface $associatedEntity
+     * @param EntityWithAssociationsInterface $owner
      */
     public function createInversedAssociation(
         AssociationInterface $association,
-        EntityWithAssociationsInterface $associatedEntity
+        EntityWithAssociationsInterface $owner
     ): void;
 
     /**
      * An association has been removed, this method should remove the inversed association if there is one.
      *
      * @param AssociationInterface $association
-     * @param EntityWithAssociationsInterface $associatedEntity
+     * @param EntityWithAssociationsInterface $owner
      */
     public function removeInversedAssociation(
         AssociationInterface $association,
-        EntityWithAssociationsInterface $associatedEntity
+        EntityWithAssociationsInterface $owner
     ): void;
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -131,6 +131,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
     protected function assertSameProducts(array $expectedProduct, $identifier)
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+        $this->get('doctrine.orm.entity_manager')->refresh($product);
 
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -130,8 +130,8 @@ abstract class AbstractProductTestCase extends ApiTestCase
      */
     protected function assertSameProducts(array $expectedProduct, $identifier)
     {
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-        $this->get('doctrine.orm.entity_manager')->refresh($product);
 
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 

--- a/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
@@ -87,7 +87,7 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
     private function deleteUniqueValueForAttribute(string $attributeCode): void
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $uniqueValue = $product->getValue('name');
+        $uniqueValue = $product->getValue($attributeCode);
         if (null !== $uniqueValue) {
             $product->removeValue($uniqueValue);
         }

--- a/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Common\EntityBuilder;
@@ -31,30 +32,6 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         Assert::assertTrue((bool) $isValueExistingInUniqueTable, 'Unique value should exist in database.');
 
         $this->deleteUniqueValueForAttribute('name');
-
-        $isValueExistingInUniqueTable = $this
-            ->get('database_connection')
-            ->fetchColumn('SELECT EXISTS(SELECT * FROM pim_catalog_product_unique_data where attribute_id = :attribute_id)', [
-                'attribute_id' => $attributeId
-            ], 0);
-
-        Assert::assertFalse((bool) $isValueExistingInUniqueTable, 'Unique value is not deleted in pim_catalog_product_unique_data when deleting a product value.');
-    }
-
-    public function test_that_unique_value_is_deleted_in_database_when_values_are_set_at_null()
-    {
-        $attributeId = $this->createAttributeWithUniqueConstraint('name');
-        $this->createProductWithUniqueValue('name', 'my_unique_value');
-
-        $isValueExistingInUniqueTable = $this
-            ->get('database_connection')
-            ->fetchColumn('SELECT EXISTS(SELECT * FROM pim_catalog_product_unique_data WHERE attribute_id = :attribute_id)', [
-                'attribute_id' => $attributeId
-            ], 0);
-
-        Assert::assertTrue((bool) $isValueExistingInUniqueTable, 'Unique value should exist in database.');
-
-        $this->setUniqueValueAtNullForAttribute('name');
 
         $isValueExistingInUniqueTable = $this
             ->get('database_connection')
@@ -107,23 +84,13 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         $this->get('pim_catalog.validator.unique_value_set')->reset();
     }
 
-    private function setUniqueValueAtNullForAttribute(string $attributeCode): void
-    {
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $product->getValues()->removeByAttributeCode($attributeCode);
-        $product->getValues()->add(ScalarValue::value('name', null));
-
-        $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
-        $this->assertEquals(0, $constraintList->count());
-
-        $this->get('pim_catalog.saver.product')->save($product);
-    }
-
-
     private function deleteUniqueValueForAttribute(string $attributeCode): void
     {
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $product->getValues()->removeByAttributeCode($attributeCode);
+        $uniqueValue = $product->getValue('name');
+        if (null !== $uniqueValue) {
+            $product->removeValue($uniqueValue);
+        }
         $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
         $this->assertEquals(0, $constraintList->count());
 

--- a/tests/back/Pim/Enrichment/Integration/Product/LoadProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/LoadProductIntegration.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product;
+
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class LoadProductIntegration extends TestCase
+{
+    public function test_product_is_not_dirty_after_fetching_it_from_database()
+    {
+        $this->createProduct(
+            'baz',
+            [
+                'family' => 'familyA',
+                'values' => [
+                    'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
+                    'a_text' => [['locale' => null, 'scope' => null, 'data' => 'Lorem ipsum dolor sit amet']],
+                ],
+                'groups' => ['groupA'],
+                'categories' => ['categoryA'],
+                'associations' => [
+                    'X_SELL' => [
+                        'products' => ['foo'],
+                        'product_models' => ['bar'],
+                        'groups' => ['groupB'],
+                    ],
+                    'TWOWAY' => [
+                        'products' => ['foo'],
+                        'product_models' => ['bar'],
+                    ]
+                ],
+                'quantified_associations' => [
+                    'QUANTIFIED' => [
+                        'products' => [
+                            [
+                                'identifier' => 'foo',
+                                'quantity' => 2,
+                            ],
+                        ],
+                        'product_models' => [
+                            [
+                                'identifier' => 'bar',
+                                'quantity' => 5,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        $baz = $this->get('pim_catalog.repository.product')->findOneByIdentifier('baz');
+        Assert::assertFalse($baz->isDirty(), 'The product should not be dirty after loading it from the database');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // create a 2-way association type
+        $twoWayAssociationType = $this->get('pim_catalog.factory.association_type')->create();
+        $this->get('pim_catalog.updater.association_type')->update(
+            $twoWayAssociationType,
+            [
+                'code' => 'TWOWAY',
+                'is_two_way' => true,
+            ]
+        );
+        $this->get('pim_catalog.saver.association_type')->save($twoWayAssociationType);
+
+        // create a quantified association type
+        $quantifiedAssociationType = $this->get('pim_catalog.factory.association_type')->create();
+        $this->get('pim_catalog.updater.association_type')->update(
+            $quantifiedAssociationType,
+            [
+                'code' => 'QUANTIFIED',
+                'is_quantified' => true,
+            ]
+        );
+        $this->get('pim_catalog.saver.association_type')->save($quantifiedAssociationType);
+
+        $this->createProduct('foo', []);
+        $this->createProductModel(
+            [
+                'code' => 'bar',
+                'family_variant' => 'familyVariantA1',
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createProduct(string $identifier, array $data): void
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $violations = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertCount(0, $violations, \sprintf('The product is not valid: %s', (string)$violations));
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+    }
+
+    private function createProductModel(array $data): void
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $violations = $this->get('pim_catalog.validator.product_model')->validate($productModel);
+        Assert::assertCount(0, $violations, \sprintf('The product model is not valid: %s', (string)$violations));
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -110,7 +110,7 @@ class PropertyClearerIntegration extends TestCase
         ];
         $product = $this->createProduct('a_product_with_association', $parameters);
 
-        $this->assertGreaterThan(0, $this->getAssociationsCount($product));
+        $this->assertSame(2, $this->getAssociationsCount($product));
 
         $this->propertyClearer->clear($product, 'associations');
         $this->assertSame(0, $this->getAssociationsCount($product));

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -39,7 +39,7 @@ class ProductSaverSpec extends ObjectBehavior
         ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
-        $product->wasUpdated()->willReturn(true);
+        $product->isDirty()->willReturn(true);
         $product->getId()->willReturn(null);
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $objectManager->persist($product)->shouldBeCalled();
@@ -65,7 +65,7 @@ class ProductSaverSpec extends ObjectBehavior
         ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
-        $product->wasUpdated()->willReturn(true);
+        $product->isDirty()->willReturn(true);
         $product->getId()->willReturn(1);
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $objectManager->persist($product)->shouldBeCalled();
@@ -90,7 +90,7 @@ class ProductSaverSpec extends ObjectBehavior
         ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
-        $product->wasUpdated()->willReturn(false);
+        $product->isDirty()->willReturn(false);
 
         $uniqueDataSynchronizer->synchronize($product)->shouldNotBeCalled();
         $eventDispatcher->dispatch(Argument::cetera())->shouldNotBeCalled();
@@ -107,9 +107,9 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product2
     ) {
         $product1->getId()->willReturn(42);
-        $product1->wasUpdated()->willReturn(true);
+        $product1->isDirty()->willReturn(true);
         $product2->getId()->willReturn(44);
-        $product2->wasUpdated()->willReturn(true);
+        $product2->isDirty()->willReturn(true);
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
@@ -151,9 +151,9 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product2
     ) {
         $product1->getId()->willReturn(null);
-        $product1->wasUpdated()->willReturn(true);
+        $product1->isDirty()->willReturn(true);
         $product2->getId()->willReturn(42);
-        $product2->wasUpdated()->willReturn(true);
+        $product2->isDirty()->willReturn(true);
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, Argument::cetera())->shouldBeCalled();
@@ -182,11 +182,11 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product3
     ) {
         $product1->getId()->willReturn(1);
-        $product1->wasUpdated()->willReturn(true);
+        $product1->isDirty()->willReturn(true);
         $product2->getId()->willReturn(2);
-        $product2->wasUpdated()->willReturn(false);
+        $product2->isDirty()->willReturn(false);
         $product3->getId()->willReturn(3);
-        $product3->wasUpdated()->willReturn(true);
+        $product3->isDirty()->willReturn(true);
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
@@ -218,9 +218,9 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product2,
         ProductInterface $product3
     ) {
-        $product1->wasUpdated()->willReturn(false);
-        $product2->wasUpdated()->willReturn(false);
-        $product3->wasUpdated()->willReturn(false);
+        $product1->isDirty()->willReturn(false);
+        $product2->isDirty()->willReturn(false);
+        $product3->isDirty()->willReturn(false);
 
         $uniqueDataSynchronizer->synchronize(Argument::any())->shouldNotBeCalled();
         $eventDispatcher->dispatch(Argument::cetera())->shouldNotBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Persistence\ObjectManager;
+use PhpParser\Node\Arg;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -33,27 +34,13 @@ class ProductSaverSpec extends ObjectBehavior
         $this->shouldHaveType(BulkSaverInterface::class);
     }
 
-    function it_saves_a_single_product(
+    function it_saves_a_new_product(
         ObjectManager $objectManager,
         EventDispatcherInterface $eventDispatcher,
         ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
-        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
-        $objectManager->persist($product)->shouldBeCalled();
-        $uniqueDataSynchronizer->synchronize($product)->shouldBeCalled();
-        $objectManager->flush()->shouldBeCalled();
-        $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();
-
-        $this->save($product);
-    }
-
-    function it_saves_a_just_created_single_product(
-        ObjectManager $objectManager,
-        EventDispatcherInterface $eventDispatcher,
-        ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
-        ProductInterface $product
-    ) {
+        $product->wasUpdated()->willReturn(true);
         $product->getId()->willReturn(null);
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $objectManager->persist($product)->shouldBeCalled();
@@ -68,15 +55,18 @@ class ProductSaverSpec extends ObjectBehavior
             )
         )->shouldBeCalled();
 
+        $product->cleanup()->shouldBeCalled();
+
         $this->save($product);
     }
 
-    function it_saves_an_already_created_single_product(
+    function it_saves_an_existing_product(
         ObjectManager $objectManager,
         EventDispatcherInterface $eventDispatcher,
         ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
         ProductInterface $product
     ) {
+        $product->wasUpdated()->willReturn(true);
         $product->getId()->willReturn(1);
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $objectManager->persist($product)->shouldBeCalled();
@@ -90,6 +80,22 @@ class ProductSaverSpec extends ObjectBehavior
                 ['unitary' => true, 'is_new' => false]
             )
         )->shouldBeCalled();
+        $product->cleanup()->shouldBeCalled();
+
+        $this->save($product);
+    }
+
+    function it_does_not_save_an_unchanged_product(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
+        ProductInterface $product
+    ) {
+        $product->wasUpdated()->willReturn(false);
+
+        $uniqueDataSynchronizer->synchronize($product)->shouldNotBeCalled();
+        $eventDispatcher->dispatch(Argument::cetera())->shouldNotBeCalled();
+        $objectManager->persist(Argument::any())->shouldNotBeCalled();
 
         $this->save($product);
     }
@@ -101,6 +107,11 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product1,
         ProductInterface $product2
     ) {
+        $product1->getId()->willReturn(42);
+        $product1->wasUpdated()->willReturn(true);
+        $product2->getId()->willReturn(44);
+        $product2->wasUpdated()->willReturn(true);
+
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
 
@@ -113,11 +124,13 @@ class ProductSaverSpec extends ObjectBehavior
 
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, Argument::cetera())->shouldBeCalled();
+        $product1->cleanup()->shouldBeCalled();
+        $product2->cleanup()->shouldBeCalled();
 
         $this->saveAll([$product1, $product2]);
     }
 
-    function it_throws_an_exception_when_try_to_save_something_else_than_a_product(ObjectManager $objectManager)
+    function it_throws_an_exception_when_trying_to_save_anything_but_a_product(ObjectManager $objectManager)
     {
         $otherObject = new \stdClass();
         $objectManager->persist(Argument::any())->shouldNotBeCalled();
@@ -138,6 +151,11 @@ class ProductSaverSpec extends ObjectBehavior
         ProductInterface $product1,
         ProductInterface $product2
     ) {
+        $product1->getId()->willReturn(null);
+        $product1->wasUpdated()->willReturn(true);
+        $product2->getId()->willReturn(42);
+        $product2->wasUpdated()->willReturn(true);
+
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, Argument::cetera())->shouldBeCalled();
 
@@ -150,7 +168,66 @@ class ProductSaverSpec extends ObjectBehavior
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
+        $product1->cleanup()->shouldBeCalled();
+        $product2->cleanup()->shouldBeCalled();
 
         $this->saveAll([$product1, $product2, $product1]);
+    }
+
+    function it_only_saves_changed_products(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $product1->getId()->willReturn(1);
+        $product1->wasUpdated()->willReturn(true);
+        $product2->getId()->willReturn(2);
+        $product2->wasUpdated()->willReturn(false);
+        $product3->getId()->willReturn(3);
+        $product3->wasUpdated()->willReturn(true);
+
+        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, Argument::cetera())->shouldBeCalled();
+        $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
+
+        $uniqueDataSynchronizer->synchronize($product1)->shouldBeCalled();
+        $uniqueDataSynchronizer->synchronize($product2)->shouldNotBeCalled();
+        $uniqueDataSynchronizer->synchronize($product3)->shouldBeCalled();
+
+        $objectManager->persist($product1)->shouldBeCalled();
+        $objectManager->persist($product2)->shouldNotBeCalled();
+        $objectManager->persist($product3)->shouldBeCalled();
+
+        $objectManager->flush()->shouldBeCalled();
+
+        $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalledTimes(2);
+        $eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, Argument::cetera())->shouldBeCalled();
+
+        $product1->cleanup()->shouldBeCalled();
+        $product3->cleanup()->shouldBeCalled();
+
+        $this->saveAll([$product1, $product2, $product3]);
+    }
+
+    function it_does_not_save_multiple_products_if_none_was_updated(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        ProductUniqueDataSynchronizer $uniqueDataSynchronizer,
+        ProductInterface $product1,
+        ProductInterface $product2,
+        ProductInterface $product3
+    ) {
+        $product1->wasUpdated()->willReturn(false);
+        $product2->wasUpdated()->willReturn(false);
+        $product3->wasUpdated()->willReturn(false);
+
+        $uniqueDataSynchronizer->synchronize(Argument::any())->shouldNotBeCalled();
+        $eventDispatcher->dispatch(Argument::cetera())->shouldNotBeCalled();
+        $objectManager->persist(Argument::any())->shouldNotBeCalled();
+        $objectManager->flush()->shouldNotBeCalled();
+
+        $this->saveAll([$product1, $product2, $product3]);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/ProductSaverSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Doctrine\Common\Persistence\ObjectManager;
-use PhpParser\Node\Arg;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/LoadEntityWithValuesSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/LoadEntityWithValuesSubscriberSpec.php
@@ -43,6 +43,7 @@ class LoadEntityWithValuesSubscriberSpec extends ObjectBehavior
             ->willReturn($values);
 
         $product->setValues($values)->shouldBeCalled();
+        $product->cleanup()->shouldBeCalled();
 
         $this->postLoad($event);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -73,7 +73,7 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $cursor->next()->shouldBeCalled();
         $cursor->rewind()->shouldBeCalled();
 
-        $bulkProductSaver->saveAll([$product1, $product2, $product3])->shouldBeCalled();
+        $bulkProductSaver->saveAll([$product1, $product2, $product3], ['force_save' => true])->shouldBeCalled();
         $cacheClearer->clear()->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveNonExistingProductValuesTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveNonExistingProductValuesTaskletSpec.php
@@ -74,9 +74,9 @@ class RemoveNonExistingProductValuesTaskletSpec extends ObjectBehavior
         $productRepository->getItemsFromIdentifiers(['code3'])->willReturn([]);
         $productModelRepository->getItemsFromIdentifiers(['code3'])->willReturn([$productModel]);
 
-        $productSaver->saveAll([$product1, $product2])->shouldBeCalled();
+        $productSaver->saveAll([$product1, $product2], ['force_save' => true])->shouldBeCalled();
         $productModelSaver->saveAll([$productModel])->shouldBeCalled();
-        $productSaver->saveAll([])->shouldBeCalled();
+        $productSaver->saveAll([], ['force_save' => true])->shouldBeCalled();
         $productModelSaver->saveAll([])->shouldBeCalled();
         $entityManagerClearer->clear()->shouldBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -27,6 +27,7 @@ class ProductSpec extends ObjectBehavior
     function it_has_family(FamilyInterface $family)
     {
         $family->getId()->willReturn(42);
+        $family->getCode()->willReturn('clothes');
         $this->setFamily($family);
         $this->getFamily()->shouldReturn($family);
         $this->getFamilyId()->shouldReturn(42);
@@ -94,6 +95,7 @@ class ProductSpec extends ObjectBehavior
     ) {
         $attributes->contains($attribute)->willReturn(false);
         $family->getAttributes()->willReturn($attributes);
+        $family->getCode()->willReturn('furniture');
         $this->setFamily($family);
         $this->hasAttributeInfamily($attribute)->shouldReturn(false);
     }
@@ -105,6 +107,7 @@ class ProductSpec extends ObjectBehavior
     ) {
         $attributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($attributes);
+        $family->getCode()->willReturn('furniture');
         $this->setFamily($family);
         $this->hasAttributeInfamily($attribute)->shouldReturn(true);
     }
@@ -121,15 +124,14 @@ class ProductSpec extends ObjectBehavior
     ) {
         $familyAttributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($familyAttributes);
+        $family->getCode()->willReturn('furniture');
         $this->setFamily($family);
 
         $this->isAttributeEditable($attribute)->shouldReturn(true);
     }
 
     function it_is_not_attribute_removable_if_attribute_is_an_identifier(
-        AttributeInterface $attribute,
-        FamilyInterface $family,
-        ArrayCollection $familyAttributes
+        AttributeInterface $attribute
     ) {
         $attribute->getType()->willReturn(AttributeTypes::IDENTIFIER);
 
@@ -143,6 +145,7 @@ class ProductSpec extends ObjectBehavior
     ) {
         $familyAttributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($familyAttributes);
+        $family->getCode()->willReturn('furniture');
 
         $this->setFamily($family);
         $this->isAttributeRemovable($attribute)->shouldReturn(false);
@@ -158,6 +161,7 @@ class ProductSpec extends ObjectBehavior
         AttributeInterface $attributeAsLabel
     ) {
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getCode()->willReturn('gardening');
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
@@ -181,6 +185,7 @@ class ProductSpec extends ObjectBehavior
         AttributeInterface $attributeAsLabel
     ) {
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getCode()->willReturn('gardening');
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(true);
@@ -221,6 +226,7 @@ class ProductSpec extends ObjectBehavior
         ValueInterface $identifier
     ) {
         $family->getAttributeAsLabel()->willReturn(null);
+        $family->getCode()->willReturn('gardening');
 
         $identifier->getData()->willReturn('shovel');
         $identifier->getAttributeCode()->willReturn('name');
@@ -239,6 +245,7 @@ class ProductSpec extends ObjectBehavior
         AttributeInterface $attributeAsLabel
     ) {
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
+        $family->getCode()->willReturn('gardening');
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
@@ -256,6 +263,7 @@ class ProductSpec extends ObjectBehavior
     ) {
         $attributeAsImage->getCode()->willReturn('picture');
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $family->getCode()->willReturn('gardening');
 
         $pictureValue->getAttributeCode()->willReturn('picture');
         $pictureValue->getScopeCode()->willReturn(null);
@@ -283,6 +291,7 @@ class ProductSpec extends ObjectBehavior
         FamilyInterface $family
     ) {
         $family->getAttributeAsImage()->willReturn(null);
+        $family->getCode()->willReturn('gardening');
 
         $this->setFamily($family);
 
@@ -294,8 +303,8 @@ class ProductSpec extends ObjectBehavior
         AttributeInterface $attributeAsImage
     ) {
         $attributeAsImage->getCode()->willReturn('picture');
-
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
+        $family->getCode()->willReturn('gardening');
 
         $values = new WriteValueCollection();
 
@@ -312,6 +321,7 @@ class ProductSpec extends ObjectBehavior
 
     function it_is_a_variant_product(ProductModelInterface $parent)
     {
+        $parent->getCode()->willReturn('model_1');
         $this->setParent($parent);
         $this->isVariant()->shouldReturn(true);
     }
@@ -335,7 +345,6 @@ class ProductSpec extends ObjectBehavior
 
     function it_has_values_of_its_parent_when_it_is_variant(
         ProductModelInterface $productModel,
-        \Iterator $iterator,
         ValueInterface $value,
         ValueInterface $otherValue
     ) {
@@ -345,6 +354,7 @@ class ProductSpec extends ObjectBehavior
 
         $valueCollection = new WriteValueCollection([$value->getWrappedObject()]);
         $this->setValues($valueCollection);
+        $productModel->getCode()->willReturn('model_parent');
         $this->setParent($productModel);
 
         $otherValue->getAttributeCode()->willReturn('otherValue');
@@ -366,6 +376,7 @@ class ProductSpec extends ObjectBehavior
 
     function it_has_a_variation_level(ProductModelInterface $productModel)
     {
+        $productModel->getCode()->willReturn('model_parent');
         $this->setParent($productModel);
         $productModel->getVariationLevel()->willReturn(7);
         $this->getVariationLevel()->shouldReturn(8);
@@ -373,12 +384,14 @@ class ProductSpec extends ObjectBehavior
 
     function it_has_a_product_model(ProductModelInterface $productModel)
     {
+        $productModel->getCode()->willReturn('model_parent');
         $this->setParent($productModel);
         $this->getParent()->shouldReturn($productModel);
     }
 
     function it_has_a_family_variant(FamilyVariantInterface $familyVariant)
     {
+        $familyVariant->getCode()->willReturn('by_size');
         $this->setFamilyVariant($familyVariant);
         $this->getFamilyVariant()->shouldReturn($familyVariant);
     }
@@ -535,8 +548,11 @@ class ProductSpec extends ObjectBehavior
         ProductModelInterface $productModel,
         ProductModelInterface $otherProductModel
     ) {
+        $productModel->getCode()->willReturn('former_parent');
         $this->setParent($productModel);
         $this->cleanup();
+
+        $otherProductModel->getCode()->willReturn('new_parent');
 
         $this->setParent($otherProductModel);
         $this->isDirty()->shouldBe(true);
@@ -544,6 +560,7 @@ class ProductSpec extends ObjectBehavior
 
     function it_is_not_updated_when_setting_the_same_parent_model(ProductModelInterface $parent)
     {
+        $parent->getCode()->willReturn('parent');
         $this->setParent($parent);
         $this->cleanup();
 
@@ -555,9 +572,11 @@ class ProductSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariant,
         FamilyVariantInterface $otherFamilyVariant
     ) {
+        $familyVariant->getCode()->willReturn('by_size');
         $this->setFamilyVariant($familyVariant);
         $this->cleanup();
 
+        $otherFamilyVariant->getCode()->willReturn('by_color_and_size');
         $this->setFamilyVariant($otherFamilyVariant);
         $this->isDirty()->shouldBe(true);
     }
@@ -565,6 +584,7 @@ class ProductSpec extends ObjectBehavior
     function it_is_not_updated_when_setting_the_same_family_variant(
         FamilyVariantInterface $familyVariant
     ) {
+        $familyVariant->getCode()->willReturn('by_size');
         $this->setFamilyVariant($familyVariant);
         $this->cleanup();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -7,8 +7,8 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\AssociationInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\QuantifiedAssociation\QuantifiedAssociationCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
@@ -20,7 +20,6 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 
 class ProductSpec extends ObjectBehavior
@@ -388,7 +387,7 @@ class ProductSpec extends ObjectBehavior
     {
         $this->setEnabled(false);
         $this->cleanup();
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_category_is_added(CategoryInterface $category)
@@ -396,7 +395,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addCategory($category);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_already_existing_category_is_added(
@@ -406,7 +405,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addCategory($category);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_category_is_removed(CategoryInterface $category)
@@ -415,7 +414,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeCategory($category);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_non_existing_category_is_removed(CategoryInterface $category)
@@ -423,7 +422,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeCategory($category);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_or_removing_categories(
@@ -434,7 +433,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setCategories(new ArrayCollection([$category2->getWrappedObject()]));
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_updated_when_setting_the_same_categories(
@@ -445,7 +444,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setCategories(new ArrayCollection([$category2->getWrappedObject(), $category1->getWrappedObject()]));
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_group_is_added(GroupInterface $group)
@@ -453,7 +452,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addGroup($group);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_existing_group_is_added(GroupInterface $group)
@@ -462,7 +461,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addGroup($group);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_group_is_removed(GroupInterface $group)
@@ -471,7 +470,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeGroup($group);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_non_existing_group_is_removed(GroupInterface $group)
@@ -479,7 +478,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeGroup($group);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_or_removing_groups(GroupInterface $group1, GroupInterface $group2)
@@ -488,7 +487,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setGroups(new ArrayCollection([$group2->getWrappedObject()]));
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_groups(GroupInterface $group1, GroupInterface $group2)
@@ -497,7 +496,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setGroups(new ArrayCollection([$group2->getWrappedObject(), $group1->getWrappedObject()]));
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_changing_the_identifier()
@@ -506,7 +505,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setIdentifier('baz');
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_identifier()
@@ -515,21 +514,21 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setIdentifier('foo');
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_updating_the_status()
     {
         $this->cleanup();
         $this->setEnabled(false);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_the_status_is_not_updated()
     {
         $this->cleanup();
         $this->setEnabled(true);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_updating_the_parent_model(
@@ -540,7 +539,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setParent($otherProductModel);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_parent_model(ProductModelInterface $parent)
@@ -549,7 +548,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setParent($parent);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_changing_the_family_variant(
@@ -560,7 +559,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setFamilyVariant($otherFamilyVariant);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_family_variant(
@@ -570,7 +569,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setFamilyVariant($familyVariant);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_value_is_added()
@@ -578,7 +577,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
         $this->addValue(ScalarValue::value('name', 'My great product'));
 
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_value_fails_to_be_added()
@@ -587,7 +586,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addValue(ScalarValue::value('name', 'Another name'));
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_a_value_is_removed()
@@ -597,7 +596,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeValue($value);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_value_fails_to_be_removed()
@@ -605,7 +604,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
         $this->removeValue(ScalarValue::value('name', 'My great product'));
 
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_new_values()
@@ -619,7 +618,7 @@ class ProductSpec extends ObjectBehavior
             )
         );
 
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_updated_when_setting_a_new_value()
@@ -634,7 +633,7 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_values()
@@ -651,7 +650,7 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_updated_when_removing_a_value()
@@ -667,7 +666,43 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
+    }
+
+    function it_is_updated_when_filtering_quantified_associations()
+    {
+        $this->filterQuantifiedAssociations(['foo', 'bar'], ['baz']);
+        $this->wasUpdated()->shouldBe(true);
+    }
+
+    function it_is_updated_when_patching_quantified_associations(
+        QuantifiedAssociationCollection $quantifiedAssociations
+    ) {
+        $quantifiedAssociations->normalize()->willReturn([
+            'type' => [
+                'products' => [
+                    [
+                        'identifier' => 'foo',
+                        'quantity' => 2,
+                    ]
+                ],
+                'product_models' => [
+                    [
+                        'identifier' => 'bar',
+                        'quantity' => 1
+                    ],
+                ],
+            ],
+        ]);
+        $this->mergeQuantifiedAssociations($quantifiedAssociations);
+        $this->wasUpdated()->shouldBe(true);
+    }
+
+    function it_is_updated_when_clearing_quantified_associations()
+    {
+        $this->wasUpdated()->shouldBe(false);
+        $this->clearQuantifiedAssociations();
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_updated_when_adding_a_non_empty_association(
@@ -682,7 +717,7 @@ class ProductSpec extends ObjectBehavior
         $association->setOwner($this)->shouldBeCalled();
 
         $this->addAssociation($association);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_adding_an_empty_association(
@@ -700,7 +735,7 @@ class ProductSpec extends ObjectBehavior
         $association->setOwner($this)->shouldBeCalled();
 
         $this->addAssociation($association);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_not_updated_when_adding_an_already_existing_association()
@@ -717,7 +752,7 @@ class ProductSpec extends ObjectBehavior
             ->shouldThrow(\LogicException::class)
             ->during('addAssociation', [$upsellAssociation]);
 
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_throws_an_exception_if_a_similar_association_already_exists()
@@ -748,7 +783,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($association);
-        $this->wasUpdated()->shouldReturn(true);
+        $this->wasUpdated()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_empty_association_is_removed()
@@ -762,7 +797,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($upsellAssociation);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
     function it_is_not_updated_when_removing_a_non_existent_association(
@@ -771,211 +806,14 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($association);
-        $this->wasUpdated()->shouldReturn(false);
+        $this->wasUpdated()->shouldBe(false);
     }
 
-    // TODO: check the new association has products, models or groups
-//    function it_is_updated_when_setting_new_associations(
-//        AssociationInterface $association
-//    ) {
-//        $this->cleanup();
-//        $this->setAssociations(new ArrayCollection([$association->getWrappedObject()]));
-//
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    // TODO: check the former association had products, models or groups
-//    function it_is_updated_when_removing_an_association(
-//        AssociationInterface $association1,
-//        AssociationInterface $association2
-//    ) {
-//        $this->setAssociations(new ArrayCollection([
-//            $association1->getWrappedObject(),
-//            $association2->getWrappedObject(),
-//        ]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$association1->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_product_is_added(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        ProductInterface $associatedProduct
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection([$associatedProduct->getWrappedObject()]));
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_product_model_is_added(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        ProductModelInterface $associatedProductModel
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $newAssociation->getProductModels()->willReturn(
-//            new ArrayCollection([$associatedProductModel->getWrappedObject()])
-//        );
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_group_is_added(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        GroupInterface $associatedGroup
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection([$associatedGroup->getWrappedObject()]));
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_product_is_removed(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        ProductInterface $associatedProduct
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection([$associatedProduct->getWrappedObject()]));
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_product_model_is_removed(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        ProductModelInterface $associatedProductModel
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $formerAssociation->getProductModels()->willReturn(
-//            new ArrayCollection([$associatedProductModel->getWrappedObject()])
-//        );
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_updated_when_an_associated_group_is_removed(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        GroupInterface $associatedGroup
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection([$associatedGroup->getWrappedObject()]));
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection());
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection());
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection());
-//
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//        $this->wasUpdated()->shouldReturn(true);
-//    }
-//
-//    function it_is_not_updated_when_setting_similar_associations(
-//        AssociationInterface $formerAssociation,
-//        AssociationInterface $newAssociation,
-//        AssociationTypeInterface $associationType,
-//        ProductInterface $product,
-//        ProductModelInterface $productModel,
-//        GroupInterface $group
-//    ) {
-//        $associationType->getCode()->willReturn('X_SELL');
-//        $formerAssociation->getAssociationType()->willReturn($associationType);
-//        $formerAssociation->getProducts()->willReturn(new ArrayCollection([$product->getWrappedObject()]));
-//        $formerAssociation->getProductModels()->willReturn(new ArrayCollection([$productModel->getWrappedObject()]));
-//        $formerAssociation->getGroups()->willReturn(new ArrayCollection([$group->getWrappedObject()]));
-//        $this->setAssociations(new ArrayCollection([$formerAssociation->getWrappedObject()]));
-//        $this->cleanup();
-//
-//        $newAssociation->getAssociationType()->willReturn($associationType);
-//        $newAssociation->getProducts()->willReturn(new ArrayCollection([$product->getWrappedObject()]));
-//        $newAssociation->getProductModels()->willReturn(new ArrayCollection([$productModel->getWrappedObject()]));
-//        $newAssociation->getGroups()->willReturn(new ArrayCollection([$group->getWrappedObject()]));
-//
-//        $this->setAssociations(new ArrayCollection([$newAssociation->getWrappedObject()]));
-//
-//        $this->wasUpdated()->shouldReturn(false);
-//    }
+    // TODO: the product should only be updated when associated products, models and/or groups are added or removed
+    function it_is_updated_when_setting_associations(
+        AssociationInterface $association
+    ) {
+        $this->setAssociations(new ArrayCollection([$association->getWrappedObject()]));
+        $this->wasUpdated()->shouldbe(true);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -570,4 +570,77 @@ class ProductSpec extends ObjectBehavior
         $this->setGroups(new ArrayCollection([$group2->getWrappedObject(), $group1->getWrappedObject()]));
         $this->wasUpdated()->shouldReturn(false);
     }
+
+    function it_is_updated_when_changing_the_identifier()
+    {
+        $this->setIdentifier('foo');
+        $this->cleanup();
+
+        $this->setIdentifier('baz');
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_setting_the_same_identifier()
+    {
+        $this->setIdentifier('foo');
+        $this->cleanup();
+
+        $this->setIdentifier('foo');
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_updating_the_status()
+    {
+        $this->cleanup();
+        $this->setEnabled(false);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_the_status_is_not_updated()
+    {
+        $this->cleanup();
+        $this->setEnabled(true);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_updating_the_parent_model(
+        ProductModelInterface $productModel,
+        ProductModelInterface $otherProductModel
+    ) {
+        $this->setParent($productModel);
+        $this->cleanup();
+
+        $this->setParent($otherProductModel);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_setting_the_same_parent_model(ProductModelInterface $parent)
+    {
+        $this->setParent($parent);
+        $this->cleanup();
+
+        $this->setParent($parent);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_changing_the_family_variant(
+        FamilyVariantInterface $familyVariant,
+        FamilyVariantInterface $otherFamilyVariant
+    ) {
+        $this->setFamilyVariant($familyVariant);
+        $this->cleanup();
+
+        $this->setFamilyVariant($otherFamilyVariant);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_setting_the_same_family_variant(
+        FamilyVariantInterface $familyVariant
+    ) {
+        $this->setFamilyVariant($familyVariant);
+        $this->cleanup();
+
+        $this->setFamilyVariant($familyVariant);
+        $this->wasUpdated()->shouldReturn(false);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -387,7 +387,7 @@ class ProductSpec extends ObjectBehavior
     {
         $this->setEnabled(false);
         $this->cleanup();
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_category_is_added(CategoryInterface $category)
@@ -395,7 +395,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addCategory($category);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_already_existing_category_is_added(
@@ -405,7 +405,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addCategory($category);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_category_is_removed(CategoryInterface $category)
@@ -414,7 +414,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeCategory($category);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_non_existing_category_is_removed(CategoryInterface $category)
@@ -422,7 +422,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeCategory($category);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_or_removing_categories(
@@ -433,7 +433,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setCategories(new ArrayCollection([$category2->getWrappedObject()]));
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_setting_the_same_categories(
@@ -444,7 +444,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setCategories(new ArrayCollection([$category2->getWrappedObject(), $category1->getWrappedObject()]));
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_group_is_added(GroupInterface $group)
@@ -452,7 +452,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addGroup($group);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_existing_group_is_added(GroupInterface $group)
@@ -461,7 +461,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addGroup($group);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_group_is_removed(GroupInterface $group)
@@ -470,7 +470,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeGroup($group);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_non_existing_group_is_removed(GroupInterface $group)
@@ -478,7 +478,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeGroup($group);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_or_removing_groups(GroupInterface $group1, GroupInterface $group2)
@@ -487,7 +487,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setGroups(new ArrayCollection([$group2->getWrappedObject()]));
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_groups(GroupInterface $group1, GroupInterface $group2)
@@ -496,7 +496,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setGroups(new ArrayCollection([$group2->getWrappedObject(), $group1->getWrappedObject()]));
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_changing_the_identifier()
@@ -505,7 +505,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setIdentifier('baz');
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_identifier()
@@ -514,21 +514,21 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setIdentifier('foo');
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_updating_the_status()
     {
         $this->cleanup();
         $this->setEnabled(false);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_the_status_is_not_updated()
     {
         $this->cleanup();
         $this->setEnabled(true);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_updating_the_parent_model(
@@ -539,7 +539,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setParent($otherProductModel);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_parent_model(ProductModelInterface $parent)
@@ -548,7 +548,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setParent($parent);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_changing_the_family_variant(
@@ -559,7 +559,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setFamilyVariant($otherFamilyVariant);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_family_variant(
@@ -569,7 +569,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->setFamilyVariant($familyVariant);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_value_is_added()
@@ -577,7 +577,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
         $this->addValue(ScalarValue::value('name', 'My great product'));
 
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_value_fails_to_be_added()
@@ -586,7 +586,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->addValue(ScalarValue::value('name', 'Another name'));
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_a_value_is_removed()
@@ -596,7 +596,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeValue($value);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_a_value_fails_to_be_removed()
@@ -604,7 +604,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
         $this->removeValue(ScalarValue::value('name', 'My great product'));
 
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_setting_new_values()
@@ -618,7 +618,7 @@ class ProductSpec extends ObjectBehavior
             )
         );
 
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_setting_a_new_value()
@@ -633,7 +633,7 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_setting_the_same_values()
@@ -650,7 +650,7 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_updated_when_removing_a_value()
@@ -666,13 +666,13 @@ class ProductSpec extends ObjectBehavior
                 ]
             )
         );
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_filtering_quantified_associations()
     {
         $this->filterQuantifiedAssociations(['foo', 'bar'], ['baz']);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_patching_quantified_associations(
@@ -695,14 +695,14 @@ class ProductSpec extends ObjectBehavior
             ],
         ]);
         $this->mergeQuantifiedAssociations($quantifiedAssociations);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_clearing_quantified_associations()
     {
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
         $this->clearQuantifiedAssociations();
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_updated_when_adding_a_non_empty_association(
@@ -717,7 +717,7 @@ class ProductSpec extends ObjectBehavior
         $association->setOwner($this)->shouldBeCalled();
 
         $this->addAssociation($association);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_adding_an_empty_association(
@@ -735,7 +735,7 @@ class ProductSpec extends ObjectBehavior
         $association->setOwner($this)->shouldBeCalled();
 
         $this->addAssociation($association);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_not_updated_when_adding_an_already_existing_association()
@@ -752,7 +752,7 @@ class ProductSpec extends ObjectBehavior
             ->shouldThrow(\LogicException::class)
             ->during('addAssociation', [$upsellAssociation]);
 
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_throws_an_exception_if_a_similar_association_already_exists()
@@ -783,7 +783,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($association);
-        $this->wasUpdated()->shouldBe(true);
+        $this->isDirty()->shouldBe(true);
     }
 
     function it_is_not_updated_when_an_empty_association_is_removed()
@@ -797,7 +797,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($upsellAssociation);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     function it_is_not_updated_when_removing_a_non_existent_association(
@@ -806,7 +806,7 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeAssociation($association);
-        $this->wasUpdated()->shouldBe(false);
+        $this->isDirty()->shouldBe(false);
     }
 
     // TODO: the product should only be updated when associated products, models and/or groups are added or removed
@@ -814,6 +814,6 @@ class ProductSpec extends ObjectBehavior
         AssociationInterface $association
     ) {
         $this->setAssociations(new ArrayCollection([$association->getWrappedObject()]));
-        $this->wasUpdated()->shouldbe(true);
+        $this->isDirty()->shouldbe(true);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Model;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
@@ -458,6 +459,75 @@ class ProductSpec extends ObjectBehavior
     function it_can_reset_its_updated_state()
     {
         $this->cleanup();
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_category_is_added(CategoryInterface $category)
+    {
+        $this->cleanup();
+
+        $this->addCategory($category);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_an_already_existing_category_is_added(
+        CategoryInterface $category
+    ) {
+        $this->setCategories(new ArrayCollection([$category->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->addCategory($category);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_category_is_removed(CategoryInterface $category)
+    {
+        $this->setCategories(new ArrayCollection([$category->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->removeCategory($category);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_a_non_existing_category_is_removed(CategoryInterface $category)
+    {
+        $this->cleanup();
+
+        $this->removeCategory($category);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_group_is_added(GroupInterface $group)
+    {
+        $this->cleanup();
+
+        $this->addGroup($group);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_an_existing_group_is_added(GroupInterface $group)
+    {
+        $this->setGroups(new ArrayCollection([$group->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->addGroup($group);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_group_is_removed(GroupInterface $group)
+    {
+        $this->setGroups(new ArrayCollection([$group->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->removeGroup($group);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_a_non_existing_group_is_removed(GroupInterface $group)
+    {
+        $this->cleanup();
+
+        $this->removeGroup($group);
         $this->wasUpdated()->shouldReturn(false);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -2,20 +2,20 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Model;
 
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
-use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
 class ProductSpec extends ObjectBehavior
 {
@@ -497,6 +497,28 @@ class ProductSpec extends ObjectBehavior
         $this->wasUpdated()->shouldReturn(false);
     }
 
+    function it_is_updated_when_setting_or_removing_categories(
+        CategoryInterface $category1,
+        CategoryInterface $category2
+    ) {
+        $this->setCategories(new ArrayCollection([$category1->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->setCategories(new ArrayCollection([$category2->getWrappedObject()]));
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_updated_when_setting_the_same_categories(
+        CategoryInterface $category1,
+        CategoryInterface $category2
+    ) {
+        $this->setCategories(new ArrayCollection([$category1->getWrappedObject(), $category2->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->setCategories(new ArrayCollection([$category2->getWrappedObject(), $category1->getWrappedObject()]));
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
     function it_is_updated_when_a_group_is_added(GroupInterface $group)
     {
         $this->cleanup();
@@ -528,6 +550,24 @@ class ProductSpec extends ObjectBehavior
         $this->cleanup();
 
         $this->removeGroup($group);
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_setting_or_removing_groups(GroupInterface $group1, GroupInterface $group2)
+    {
+        $this->setGroups(new ArrayCollection([$group1->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->setGroups(new ArrayCollection([$group2->getWrappedObject()]));
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_setting_the_same_groups(GroupInterface $group1, GroupInterface $group2)
+    {
+        $this->setGroups(new ArrayCollection([$group1->getWrappedObject(), $group2->getWrappedObject()]));
+        $this->cleanup();
+
+        $this->setGroups(new ArrayCollection([$group2->getWrappedObject(), $group1->getWrappedObject()]));
         $this->wasUpdated()->shouldReturn(false);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -8,6 +8,8 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductAssociation;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
@@ -94,16 +96,22 @@ class ProductSpec extends ObjectBehavior
         $this->hasAttributeInfamily($attribute)->shouldReturn(false);
     }
 
-    function it_has_not_attribute_in_family(AttributeInterface $attribute, FamilyInterface $family, ArrayCollection $attributes)
-    {
+    function it_has_not_attribute_in_family(
+        AttributeInterface $attribute,
+        FamilyInterface $family,
+        ArrayCollection $attributes
+    ) {
         $attributes->contains($attribute)->willReturn(false);
         $family->getAttributes()->willReturn($attributes);
         $this->setFamily($family);
         $this->hasAttributeInfamily($attribute)->shouldReturn(false);
     }
 
-    function it_has_attribute_in_family(AttributeInterface $attribute, FamilyInterface $family, ArrayCollection $attributes)
-    {
+    function it_has_attribute_in_family(
+        AttributeInterface $attribute,
+        FamilyInterface $family,
+        ArrayCollection $attributes
+    ) {
         $attributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($attributes);
         $this->setFamily($family);
@@ -116,8 +124,10 @@ class ProductSpec extends ObjectBehavior
     }
 
     function it_is_attribute_editable_with_family_containing_attribute(
-        AttributeInterface $attribute, FamilyInterface $family, ArrayCollection $familyAttributes)
-    {
+        AttributeInterface $attribute,
+        FamilyInterface $family,
+        ArrayCollection $familyAttributes
+    ) {
         $familyAttributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($familyAttributes);
         $this->setFamily($family);
@@ -125,16 +135,21 @@ class ProductSpec extends ObjectBehavior
         $this->isAttributeEditable($attribute)->shouldReturn(true);
     }
 
-    function it_is_not_attribute_removable_if_attribute_is_an_identifier(AttributeInterface $attribute, FamilyInterface $family, ArrayCollection $familyAttributes)
-    {
+    function it_is_not_attribute_removable_if_attribute_is_an_identifier(
+        AttributeInterface $attribute,
+        FamilyInterface $family,
+        ArrayCollection $familyAttributes
+    ) {
         $attribute->getType()->willReturn(AttributeTypes::IDENTIFIER);
 
         $this->isAttributeRemovable($attribute)->shouldReturn(false);
     }
 
     function it_is_not_attribute_removable_with_family_containing_attribute(
-        AttributeInterface $attribute, FamilyInterface $family, ArrayCollection $familyAttributes)
-    {
+        AttributeInterface $attribute,
+        FamilyInterface $family,
+        ArrayCollection $familyAttributes
+    ) {
         $familyAttributes->contains($attribute)->willReturn(true);
         $family->getAttributes()->willReturn($familyAttributes);
 
@@ -147,50 +162,21 @@ class ProductSpec extends ObjectBehavior
         $this->isAttributeRemovable($attribute)->shouldReturn(true);
     }
 
-    function it_gets_the_label_of_the_product_without_specified_scope(
-        FamilyInterface $family,
-        AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
-        ValueInterface $nameValue,
-        ValueInterface $identifier
-    ) {
-        $identifier->getData()->willReturn('shovel');
-        $identifier->getAttributeCode()->willReturn('name');
-
-        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
-        $attributeAsLabel->getCode()->willReturn('name');
-        $attributeAsLabel->isLocalizable()->willReturn(true);
-        $attributeAsLabel->isScopable()->willReturn(true);
-
-        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
-
-        $nameValue->getData()->willReturn('Petit outil agricole authentique');
-
-        $this->setFamily($family);
-        $this->setValues($values);
-        $this->setIdentifier('shovel');
-
-        $this->getLabel('fr_FR')->shouldReturn('Petit outil agricole authentique');
-    }
-
     function it_gets_the_label_regardless_of_the_specified_scope_if_the_attribute_as_label_is_not_scopable(
         FamilyInterface $family,
-        AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
-        ValueInterface $nameValue,
-        ValueInterface $identifier
+        AttributeInterface $attributeAsLabel
     ) {
-        $identifier->getData()->willReturn('shovel');
-        $identifier->getAttributeCode()->willReturn('name');
-
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
-
-        $nameValue->getData()->willReturn('Petit outil agricole authentique');
+        $values = new WriteValueCollection(
+            [
+                ScalarValue::value('sku', 'shovel'),
+                ScalarValue::localizableValue('name', 'Petit outil agricole authentique', 'fr_FR'),
+            ]
+        );
 
         $this->setFamily($family);
         $this->setValues($values);
@@ -201,22 +187,19 @@ class ProductSpec extends ObjectBehavior
 
     function it_gets_the_label_if_the_scope_is_specified_and_the_attribute_as_label_is_scopable(
         FamilyInterface $family,
-        AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
-        ValueInterface $nameValue,
-        ValueInterface $identifier
+        AttributeInterface $attributeAsLabel
     ) {
-        $identifier->getData()->willReturn('shovel');
-        $identifier->getAttributeCode()->willReturn('name');
-
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(true);
 
-        $values->getByCodes('name', 'mobile', 'fr_FR')->willReturn($nameValue);
-
-        $nameValue->getData()->willReturn('Petite pelle');
+        $values = new WriteValueCollection(
+            [
+                ScalarValue::value('sku', 'shovel'),
+                ScalarValue::scopableLocalizableValue('name', 'Petite pelle', 'mobile', 'fr_FR'),
+            ]
+        );
 
         $this->setFamily($family);
         $this->setValues($values);
@@ -227,7 +210,6 @@ class ProductSpec extends ObjectBehavior
 
     function it_gets_the_identifier_as_label_if_there_is_no_family(
         AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
         ValueInterface $identifier
     ) {
         $identifier->getData()->willReturn('shovel');
@@ -236,7 +218,7 @@ class ProductSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
 
         $this->setFamily(null);
-        $this->setValues($values);
+        $this->setValues(new WriteValueCollection());
         $this->setIdentifier('shovel');
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
@@ -245,7 +227,6 @@ class ProductSpec extends ObjectBehavior
     function it_gets_the_identifier_as_label_if_there_is_no_attribute_as_label(
         FamilyInterface $family,
         AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
         ValueInterface $identifier
     ) {
         $family->getAttributeAsLabel()->willReturn(null);
@@ -256,7 +237,7 @@ class ProductSpec extends ObjectBehavior
         $attributeAsLabel->getCode()->willReturn('name');
 
         $this->setFamily($family);
-        $this->setValues($values);
+        $this->setValues(new WriteValueCollection());
         $this->setIdentifier('shovel');
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
@@ -264,49 +245,14 @@ class ProductSpec extends ObjectBehavior
 
     function it_gets_the_identifier_as_label_if_the_label_value_is_null(
         FamilyInterface $family,
-        AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
-        ValueInterface $nameValue,
-        ValueInterface $identifier
+        AttributeInterface $attributeAsLabel
     ) {
-        $identifier->getData()->willReturn('shovel');
-        $identifier->getAttributeCode()->willReturn('name');
-
         $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
         $attributeAsLabel->getCode()->willReturn('name');
         $attributeAsLabel->isLocalizable()->willReturn(true);
         $attributeAsLabel->isScopable()->willReturn(false);
 
-        $values->getByCodes('name', null, 'fr_FR')->willReturn(null);
-
         $this->setFamily($family);
-        $this->setValues($values);
-        $this->setIdentifier('shovel');
-
-        $this->getLabel('fr_FR')->shouldReturn('shovel');
-    }
-
-    function it_gets_the_identifier_as_label_if_the_label_value_data_is_empty(
-        FamilyInterface $family,
-        AttributeInterface $attributeAsLabel,
-        WriteValueCollection $values,
-        ValueInterface $nameValue,
-        ValueInterface $identifier
-    ) {
-        $identifier->getData()->willReturn('shovel');
-        $identifier->getAttributeCode()->willReturn('name');
-
-        $family->getAttributeAsLabel()->willReturn($attributeAsLabel);
-        $attributeAsLabel->getCode()->willReturn('name');
-        $attributeAsLabel->isLocalizable()->willReturn(true);
-        $attributeAsLabel->isScopable()->willReturn(false);
-
-        $values->getByCodes('name', null, 'fr_FR')->willReturn($nameValue);
-
-        $nameValue->getData()->willReturn(null);
-
-        $this->setFamily($family);
-        $this->setValues($values);
         $this->setIdentifier('shovel');
 
         $this->getLabel('fr_FR')->shouldReturn('shovel');
@@ -315,14 +261,20 @@ class ProductSpec extends ObjectBehavior
     function it_gets_the_image_of_the_product(
         FamilyInterface $family,
         AttributeInterface $attributeAsImage,
-        WriteValueCollection $values,
         ValueInterface $pictureValue
     ) {
         $attributeAsImage->getCode()->willReturn('picture');
-
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
 
-        $values->getByCodes('picture', null, null)->willReturn($pictureValue);
+        $pictureValue->getAttributeCode()->willReturn('picture');
+        $pictureValue->getScopeCode()->willReturn(null);
+        $pictureValue->getLocaleCode()->willReturn(null);
+
+        $values = new WriteValueCollection(
+            [
+                $pictureValue->getWrappedObject(),
+            ]
+        );
 
         $this->setFamily($family);
         $this->setValues($values);
@@ -340,6 +292,7 @@ class ProductSpec extends ObjectBehavior
         FamilyInterface $family
     ) {
         $family->getAttributeAsImage()->willReturn(null);
+
         $this->setFamily($family);
 
         $this->getImage()->shouldReturn(null);
@@ -347,13 +300,13 @@ class ProductSpec extends ObjectBehavior
 
     function it_gets_no_image_if_the_value_of_image_is_empty(
         FamilyInterface $family,
-        AttributeInterface $attributeAsImage,
-        WriteValueCollection $values
+        AttributeInterface $attributeAsImage
     ) {
         $attributeAsImage->getCode()->willReturn('picture');
 
         $family->getAttributeAsImage()->willReturn($attributeAsImage);
-        $values->getByCodes('picture', null, null)->willReturn(null);
+
+        $values = new WriteValueCollection();
 
         $this->setFamily($family);
         $this->setValues($values);
@@ -372,17 +325,17 @@ class ProductSpec extends ObjectBehavior
         $this->isVariant()->shouldReturn(true);
     }
 
-    function it_has_the_values_of_the_variation(
-        WriteValueCollection $valueCollection
-    ) {
+    function it_has_the_values_of_the_variation()
+    {
+        $valueCollection = new WriteValueCollection();
         $this->setValues($valueCollection);
 
         $this->getValuesForVariation()->shouldBeLike($valueCollection);
     }
 
-    function it_has_values_when_it_is_not_variant(
-        WriteValueCollection $valueCollection
-    ) {
+    function it_has_values_when_it_is_not_variant()
+    {
+        $valueCollection = new WriteValueCollection();
         $this->setValues($valueCollection);
         $this->setParent(null);
 
@@ -390,45 +343,34 @@ class ProductSpec extends ObjectBehavior
     }
 
     function it_has_values_of_its_parent_when_it_is_variant(
-        WriteValueCollection $valueCollection,
         ProductModelInterface $productModel,
-        WriteValueCollection $parentValuesCollection,
         \Iterator $iterator,
         ValueInterface $value,
-        AttributeInterface $valueAttribute,
-        ValueInterface $otherValue,
-        AttributeInterface $otherValueAttribute
+        ValueInterface $otherValue
     ) {
-        $this->setValues($valueCollection);
-        $this->setParent($productModel);
-
-        $valueCollection->toArray()->willReturn([$value]);
-
-        $valueAttribute->getCode()->willReturn('value');
-        $valueAttribute->isUnique()->willReturn(false);
         $value->getAttributeCode()->willReturn('value');
         $value->getScopeCode()->willReturn(null);
         $value->getLocaleCode()->willReturn(null);
 
-        $otherValueAttribute->getCode()->willReturn('otherValue');
-        $otherValueAttribute->isUnique()->willReturn(false);
+        $valueCollection = new WriteValueCollection([$value->getWrappedObject()]);
+        $this->setValues($valueCollection);
+        $this->setParent($productModel);
+
         $otherValue->getAttributeCode()->willReturn('otherValue');
         $otherValue->getScopeCode()->willReturn(null);
         $otherValue->getLocaleCode()->willReturn(null);
+        $parentValuesCollection = new WriteValueCollection([$otherValue->getWrappedObject()]);
 
         $productModel->getParent()->willReturn(null);
         $productModel->getValuesForVariation()->willReturn($parentValuesCollection);
-        $parentValuesCollection->getIterator()->willreturn($iterator);
-        $iterator->rewind()->shouldBeCalled();
-        $iterator->valid()->willReturn(true, false);
-        $iterator->current()->willReturn($otherValue);
-        $iterator->next()->shouldBeCalled();
 
         $values = $this->getValues();
-        $values->toArray()->shouldBeLike([
-            'value-<all_channels>-<all_locales>' => $value,
-            'otherValue-<all_channels>-<all_locales>' => $otherValue
-        ]);
+        $values->toArray()->shouldBeLike(
+            [
+                'value-<all_channels>-<all_locales>' => $value,
+                'otherValue-<all_channels>-<all_locales>' => $otherValue,
+            ]
+        );
     }
 
     function it_has_a_variation_level(ProductModelInterface $productModel)
@@ -642,5 +584,102 @@ class ProductSpec extends ObjectBehavior
 
         $this->setFamilyVariant($familyVariant);
         $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_value_is_added()
+    {
+        $this->cleanup();
+        $this->addValue(ScalarValue::value('name', 'My great product'));
+
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_a_value_fails_to_be_added()
+    {
+        $this->addValue(ScalarValue::value('name', 'My great product'));
+        $this->cleanup();
+
+        $this->addValue(ScalarValue::value('name', 'Another name'));
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_a_value_is_removed()
+    {
+        $value = ScalarValue::value('name', 'My great product');
+        $this->addValue($value);
+        $this->cleanup();
+
+        $this->removeValue($value);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_a_value_fails_to_be_removed()
+    {
+        $this->cleanup();
+        $this->removeValue(ScalarValue::value('name', 'My great product'));
+
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_setting_new_values()
+    {
+        $this->cleanup();
+        $this->setValues(
+            new WriteValueCollection(
+                [
+                    ScalarValue::value('name', 'My great product'),
+                ]
+            )
+        );
+
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_updated_when_setting_a_new_value()
+    {
+        $this->addValue(ScalarValue::value('name', 'My great product'));
+        $this->cleanup();
+
+        $this->setValues(
+            new WriteValueCollection(
+                [
+                    ScalarValue::value('name', 'Another name for my great product'),
+                ]
+            )
+        );
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_is_not_updated_when_setting_the_same_values()
+    {
+        $this->addValue(ScalarValue::value('name', 'My great product'));
+        $this->addValue(OptionValue::scopableLocalizableValue('color', 'red', 'ecommerce', 'en_US'));
+        $this->cleanup();
+
+        $this->setValues(
+            new WriteValueCollection(
+                [
+                    ScalarValue::value('name', 'My great product'),
+                    OptionValue::scopableLocalizableValue('color', 'red', 'ecommerce', 'en_US'),
+                ]
+            )
+        );
+        $this->wasUpdated()->shouldReturn(false);
+    }
+
+    function it_is_updated_when_removing_a_value()
+    {
+        $this->addValue(ScalarValue::value('name', 'My great product'));
+        $this->addValue(OptionValue::scopableLocalizableValue('color', 'red', 'ecommerce', 'en_US'));
+        $this->cleanup();
+
+        $this->setValues(
+            new WriteValueCollection(
+                [
+                    OptionValue::scopableLocalizableValue('color', 'red', 'ecommerce', 'en_US'),
+                ]
+            )
+        );
+        $this->wasUpdated()->shouldReturn(true);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -448,4 +448,16 @@ class ProductSpec extends ObjectBehavior
         $this->setFamilyVariant($familyVariant);
         $this->getFamilyVariant()->shouldReturn($familyVariant);
     }
+
+    function it_is_updated_at_instantiation()
+    {
+        $this->beConstructedWith([]);
+        $this->wasUpdated()->shouldReturn(true);
+    }
+
+    function it_can_reset_its_updated_state()
+    {
+        $this->cleanup();
+        $this->wasUpdated()->shouldReturn(false);
+    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -54,7 +54,7 @@ class ProductSpec extends ObjectBehavior
         $xSellAssociation->setAssociationType($xSellType);
 
         $this->setAssociations(new ArrayCollection([$upsellAssociation, $xSellAssociation]));
-        $this->getAssociationForType($upsellType)->shouldReturn($upsellAssociation);
+        $this->getAssociationForType($upsellType)->shouldBeLike($upsellAssociation);
     }
 
     function it_returns_association_from_an_association_type_code()
@@ -71,7 +71,7 @@ class ProductSpec extends ObjectBehavior
 
         $this->setAssociations(new ArrayCollection([$upsellAssociation, $xSellAssociation]));
 
-        $this->getAssociationForTypeCode('X_SELL')->shouldReturn($xSellAssociation);
+        $this->getAssociationForTypeCode('X_SELL')->shouldBeLike($xSellAssociation);
     }
 
     function it_returns_null_when_i_try_to_get_an_association_with_an_empty_collection()

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/AssociationFieldAdderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Adder/AssociationFieldAdderSpec.php
@@ -10,9 +10,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\AdderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\AssociationFieldAdder;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\FieldAdderInterface;
+use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 
 class AssociationFieldAdderSpec extends ObjectBehavior
@@ -102,18 +104,27 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $productRepository,
         MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $xsellAssociation,
         ProductInterface $associated1,
         ProductInterface $associated2
     ) {
-        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
+        $associationType->getCode()->willReturn('X_SELL');
+        $xsellAssociation->getAssociationType()->willReturn($associationType);
+
+        $associations = new ArrayCollection([
+            $xsellAssociation->getWrappedObject(),
+        ]);
+        $product->getAssociations()->willReturn($associations);
 
         $productRepository->findOneByIdentifier('associated_1')->willReturn($associated1);
         $productRepository->findOneByIdentifier('associated_2')->willReturn($associated2);
 
-        $product->getAssociationForTypeCode('X_SELL')->willReturn($xsellAssociation);
+        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $xsellAssociation->addProduct($associated1)->shouldBeCalled();
         $xsellAssociation->addProduct($associated2)->shouldBeCalled();
+
+        $product->setAssociations($associations)->shouldBeCalled();
 
         $data = [
             'X_SELL' => [
@@ -128,18 +139,26 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $productModelRepository,
         MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $xsellAssociation,
         ProductModelInterface $model1,
         ProductModelInterface $model2
     ) {
-        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
+        $associationType->getCode()->willReturn('X_SELL');
+        $xsellAssociation->getAssociationType()->willReturn($associationType);
+
+        $associations = new ArrayCollection([
+            $xsellAssociation->getWrappedObject(),
+        ]);
+        $product->getAssociations()->willReturn($associations);
 
         $productModelRepository->findOneByIdentifier('model_1')->willReturn($model1);
         $productModelRepository->findOneByIdentifier('model_2')->willReturn($model2);
 
-        $product->getAssociationForTypeCode('X_SELL')->willReturn($xsellAssociation);
+        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $xsellAssociation->addProductModel($model1)->shouldBeCalled();
         $xsellAssociation->addProductModel($model2)->shouldBeCalled();
+        $product->setAssociations($associations)->shouldBeCalled()->willReturn($product);
 
         $data = [
             'X_SELL' => [
@@ -154,18 +173,28 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $groupRepository,
         MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $xsellAssociation,
         GroupInterface $blackFriday,
         GroupInterface $halloween
     ) {
-        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
+        $associationType->getCode()->willReturn('X_SELL');
+        $xsellAssociation->getAssociationType()->willReturn($associationType);
+
+        $associations = new ArrayCollection([
+            $xsellAssociation->getWrappedObject(),
+        ]);
+        $product->getAssociations()->willReturn($associations);
+
 
         $groupRepository->findOneByIdentifier('black_friday')->willReturn($blackFriday);
         $groupRepository->findOneByIdentifier('halloween')->willReturn($halloween);
 
-        $product->getAssociationForTypeCode('X_SELL')->willReturn($xsellAssociation);
+        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $xsellAssociation->addGroup($blackFriday)->shouldBeCalled();
         $xsellAssociation->addGroup($halloween)->shouldBeCalled();
+
+        $product->setAssociations($associations)->shouldBeCalled()->willReturn($product);
 
         $data = [
             'X_SELL' => [
@@ -182,7 +211,9 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $groupRepository,
         MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product,
+        AssociationTypeInterface $xsellType,
         AssociationInterface $xsellAssociation,
+        AssociationTypeInterface $upsellType,
         AssociationInterface $upsellAssociation,
         ProductInterface $assocProductOne,
         ProductInterface $assocProductTwo,
@@ -193,10 +224,16 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         GroupInterface $assocGroupOne,
         GroupInterface $assocGroupTwo
     ) {
-        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
+        $xsellType->getCode()->willReturn('xsell');
+        $xsellAssociation->getAssociationType()->willReturn($xsellType);
+        $upsellType->getCode()->willReturn('upsell');
+        $upsellAssociation->getAssociationType()->willReturn($upsellType);
 
-        $product->getAssociationForTypeCode('xsell')->willReturn($xsellAssociation);
-        $product->getAssociationForTypeCode('upsell')->willReturn($upsellAssociation);
+        $associations = new ArrayCollection([
+            $xsellAssociation->getWrappedObject(),
+            $upsellAssociation->getWrappedObject(),
+        ]);
+        $product->getAssociations()->willReturn($associations);
 
         $productRepository->findOneByIdentifier('assocProductOne')->willReturn($assocProductOne);
         $productRepository->findOneByIdentifier('assocProductTwo')->willReturn($assocProductTwo);
@@ -209,6 +246,7 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('assocGroupOne')->willReturn($assocGroupOne);
         $groupRepository->findOneByIdentifier('assocGroupTwo')->willReturn($assocGroupTwo);
 
+        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $xsellAssociation->addProduct($assocProductOne)->shouldBeCalled();
         $xsellAssociation->addProduct($assocProductTwo)->shouldBeCalled();
         $xsellAssociation->addGroup($assocGroupOne)->shouldBeCalled();
@@ -218,6 +256,8 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $upsellAssociation->addProduct($assocProductThree)->shouldBeCalled();
         $upsellAssociation->addProductModel($assocProductModelThree)->shouldBeCalled();
         $upsellAssociation->addGroup($assocGroupTwo)->shouldBeCalled();
+
+        $product->setAssociations($associations)->shouldBeCalled()->willReturn($product);
 
         $this->addFieldData(
             $product,
@@ -238,18 +278,23 @@ class AssociationFieldAdderSpec extends ObjectBehavior
     }
 
     function it_adds_association_field_even_when_the_association_type_code_is_a_string_representing_an_integer(
-        $productRepository,
-        $groupRepository,
-        $missingAssociationAdder,
+        IdentifiableObjectRepositoryInterface $productRepository,
+        IdentifiableObjectRepositoryInterface $groupRepository,
+        MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $assoc666,
         ProductInterface $assocProductOne,
         ProductInterface $assocProductTwo,
         GroupInterface $assocGroupOne,
         GroupInterface $assocGroupTwo
     ) {
-        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
-        $product->getAssociationForTypeCode('666')->willReturn($assoc666);
+        $associationType->getCode()->willReturn('666');
+        $assoc666->getAssociationType()->willReturn($associationType);
+        $associations = new ArrayCollection([
+            $assoc666->getWrappedObject(),
+        ]);
+        $product->getAssociations()->willReturn($associations);
 
         $productRepository->findOneByIdentifier('assocProductOne')->willReturn($assocProductOne);
         $productRepository->findOneByIdentifier('assocProductTwo')->willReturn($assocProductTwo);
@@ -257,9 +302,12 @@ class AssociationFieldAdderSpec extends ObjectBehavior
         $groupRepository->findOneByIdentifier('assocGroupOne')->willReturn($assocGroupOne);
         $groupRepository->findOneByIdentifier('assocGroupTwo')->willReturn($assocGroupTwo);
 
+        $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $assoc666->addProduct($assocProductOne)->shouldBeCalled();
         $assoc666->addProduct($assocProductTwo)->shouldBeCalled();
         $assoc666->addGroup($assocGroupOne)->shouldBeCalled();
+
+        $product->setAssociations($associations)->shouldBeCalled()->willReturn($product);
 
         $this->addFieldData(
             $product,
@@ -275,12 +323,11 @@ class AssociationFieldAdderSpec extends ObjectBehavior
     }
 
     function it_fails_if_one_of_the_association_type_code_does_not_exist(
-        $missingAssociationAdder,
+        MissingAssociationAdder $missingAssociationAdder,
         ProductInterface $product
     ) {
-        $product->getAssociations()->willReturn([]);
+        $product->getAssociations()->willReturn(new ArrayCollection());
         $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
-        $product->getAssociationForTypeCode('non valid association type code')->willReturn(null);
 
         $this->shouldThrow(
             InvalidPropertyException::validEntityCodeExpected(
@@ -301,12 +348,15 @@ class AssociationFieldAdderSpec extends ObjectBehavior
     }
 
     function it_fails_if_one_of_the_associated_product_does_not_exist(
-        $missingAssociationAdder,
-        $productRepository,
+        MissingAssociationAdder $missingAssociationAdder,
+        IdentifiableObjectRepositoryInterface $productRepository,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $xsellAssociation
     ) {
-        $product->getAssociations()->willReturn([$xsellAssociation]);
+        $associationType->getCode()->willReturn('xsell');
+        $xsellAssociation->getAssociationType()->willReturn($associationType);
+        $product->getAssociations()->willReturn(new ArrayCollection([$xsellAssociation->getWrappedObject()]));
         $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $product->getAssociationForTypeCode('xsell')->willReturn($xsellAssociation);
 
@@ -331,12 +381,15 @@ class AssociationFieldAdderSpec extends ObjectBehavior
     }
 
     function it_fails_if_one_of_the_associated_group_does_not_exist(
-        $missingAssociationAdder,
-        $groupRepository,
+        MissingAssociationAdder $missingAssociationAdder,
+        IdentifiableObjectRepositoryInterface $groupRepository,
         ProductInterface $product,
+        AssociationTypeInterface $associationType,
         AssociationInterface $xsellAssociation
     ) {
-        $product->getAssociations()->willReturn([$xsellAssociation]);
+        $associationType->getCode()->willReturn('xsell');
+        $xsellAssociation->getAssociationType()->willReturn($associationType);
+        $product->getAssociations()->willReturn(new ArrayCollection([$xsellAssociation->getWrappedObject()]));
         $missingAssociationAdder->addMissingAssociations($product)->shouldBeCalled();
         $product->getAssociationForTypeCode('xsell')->willReturn($xsellAssociation);
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Clearer/Field/CategoryFieldClearerSpec.php
@@ -37,6 +37,7 @@ class CategoryFieldClearerSpec extends ObjectBehavior
         $categories->add(new Category());
         $categories->add(new Category());
         $product->setCategories($categories);
+        Assert::count($product->getCategories(), 2);
 
         $this->clear($product, 'categories');
         Assert::count($product->getCategories(), 0);
@@ -49,6 +50,7 @@ class CategoryFieldClearerSpec extends ObjectBehavior
         $categories->add(new Category());
         $categories->add(new Category());
         $productModel->setCategories($categories);
+        Assert::count($productModel->getCategories(), 2);
 
         $this->clear($productModel, 'categories');
         Assert::count($productModel->getCategories(), 0);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/AssociationFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/AssociationFieldSetterSpec.php
@@ -147,6 +147,11 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $product->getAssociationForTypeCode('xsell')->willReturn($xsellAssociation);
         $product->getAssociationForTypeCode('upsell')->willReturn($upsellAssociation);
 
+        $product->removeAssociation($xsellAssociation)->shouldBeCalled();
+        $product->removeAssociation($upsellAssociation)->shouldBeCalled();
+        $product->addAssociation($xsellAssociation)->shouldBeCalled();
+        $product->addAssociation($upsellAssociation)->shouldBeCalled();
+
         $productRepository->findOneByIdentifier('assocProductOne')->willReturn($assocProductOne);
         $productRepository->findOneByIdentifier('assocProductTwo')->willReturn($assocProductTwo);
         $productRepository->findOneByIdentifier('assocProductThree')->willReturn($assocProductThree);
@@ -186,7 +191,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         );
     }
 
-    function it_create_inversed_association_on_create_association(
+    function it_creates_inversed_association_on_create_association(
         AssociationTypeInterface $compatibilityAssociationType,
         AssociationInterface $compatibilityAssociation,
         ProductInterface $product,
@@ -206,6 +211,8 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $compatibilityAssociation->getProductModels()->willReturn(new ArrayCollection());
 
         $product->getAssociationForTypeCode('COMPATIBILITY')->willReturn($compatibilityAssociation);
+        $product->removeAssociation($compatibilityAssociation)->shouldBeCalled();
+        $product->addAssociation($compatibilityAssociation)->shouldBeCalled();
 
         $productRepository->findOneByIdentifier('productAssociated')->willReturn($productAssociated);
         $productModelRepository->findOneByIdentifier('productModelAssociated')->willReturn($productModelAssociated);
@@ -230,7 +237,7 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         );
     }
 
-    function it_remove_inversed_association_on_remove_association(
+    function it_removes_inversed_association_on_remove_association(
         AssociationTypeInterface $compatibilityAssociationType,
         AssociationInterface $compatibilityAssociation,
         ProductInterface $product,
@@ -254,6 +261,8 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $compatibilityAssociation->getGroups()->willReturn(new ArrayCollection([$groupAssociated->getWrappedObject()]));
 
         $product->getAssociationForTypeCode('COMPATIBILITY')->willReturn($compatibilityAssociation);
+        $product->removeAssociation($compatibilityAssociation)->shouldBeCalled();
+        $product->addAssociation($compatibilityAssociation)->shouldBeCalled();
 
         $compatibilityAssociation->removeProduct($productAssociated)->shouldBeCalled();
         $compatibilityAssociation->removeProductModel($productModelAssociated)->shouldBeCalled();
@@ -400,6 +409,8 @@ class AssociationFieldSetterSpec extends ObjectBehavior
         $product->getAssociations()->willReturn(
             new ArrayCollection([$xsellAssociation->getWrappedObject(), $upsellAssociation->getWrappedObject()])
         );
+        $product->removeAssociation($xsellAssociation)->shouldBeCalled();
+        $product->addAssociation($xsellAssociation)->shouldBeCalled();
 
         $xsellAssociation->removeProduct($product1)->shouldBeCalled();
         $xsellAssociation->removeProduct($product2)->shouldBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/CategoryFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/CategoryFieldSetterSpec.php
@@ -2,15 +2,18 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
 
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\CategoryFieldSetter;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\FieldSetterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\SetterInterface;
 use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownCategoryException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Prophecy\Argument;
 
 class CategoryFieldSetterSpec extends ObjectBehavior
 {
@@ -57,20 +60,16 @@ class CategoryFieldSetterSpec extends ObjectBehavior
 
     function it_sets_category_field(
         $categoryRepository,
-        ProductInterface $product,
-        CategoryInterface $mug,
-        CategoryInterface $shirt,
-        CategoryInterface $men
+        ProductInterface $product
     ) {
+        $mug = (new Category())->setCode('mug');
+        $shirt = (new Category())->setCode('shirt');
         $categoryRepository->findOneByIdentifier('mug')->willReturn($mug);
         $categoryRepository->findOneByIdentifier('shirt')->willReturn($shirt);
 
-        $product->getCategories()->willReturn([$men]);
-
-        $product->removeCategory($men)->shouldBeCalled();
-
-        $product->addCategory($mug)->shouldBeCalled();
-        $product->addCategory($shirt)->shouldBeCalled();
+        $product->setCategories(Argument::that(function (ArrayCollection $categories) use ($mug, $shirt) {
+            return $categories->getValues() === [$mug, $shirt];
+        }))->shouldBeCalled();
 
         $this->setFieldData($product, 'categories', ['mug', 'shirt']);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/CategoryFieldSetterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/Setter/CategoryFieldSetterSpec.php
@@ -3,6 +3,9 @@
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Updater\Setter;
 
 use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownCategoryException;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\CategoryFieldSetter;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\FieldSetterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\SetterInterface;
@@ -10,10 +13,6 @@ use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownCategoryException;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Prophecy\Argument;
 
 class CategoryFieldSetterSpec extends ObjectBehavior
 {
@@ -66,10 +65,12 @@ class CategoryFieldSetterSpec extends ObjectBehavior
         $shirt = (new Category())->setCode('shirt');
         $categoryRepository->findOneByIdentifier('mug')->willReturn($mug);
         $categoryRepository->findOneByIdentifier('shirt')->willReturn($shirt);
+        $shoes = (new Category())->setCode('shoes');
 
-        $product->setCategories(Argument::that(function (ArrayCollection $categories) use ($mug, $shirt) {
-            return $categories->getValues() === [$mug, $shirt];
-        }))->shouldBeCalled();
+        $product->getCategories()->willReturn(new ArrayCollection([$mug, $shoes]));
+
+        $product->removeCategory($shoes)->shouldBeCalled();
+        $product->addCategory($shirt)->shouldBeCalled();
 
         $this->setFieldData($product, 'categories', ['mug', 'shirt']);
     }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR aims at not saving a product which was not really updated when calling the product saver. This has several benefits:
- unnecessary PRE/POST_SAVE events are not dispatched anymore
- the heavy completeness calculation and ES indexation processes are not triggered anymore when they don't need to
- unnecessary webhooks are not called anymore

**How?**

A flag (`$wasUpdated`) is added to the Product and is set to `true` whenever the product is really updated. Practically, when calling a setter, the new value is now compared with the former one. The product saver will then only save the products with their flag set to `true`

This has a big consequence: it means that, as of now, the product **must be aware of every updated that is applied to it**. It doesn't change anything for simple or one-to-one properties, but it means that we don't want a one-to-many or many-to-many collection property to be updated "from outside" (e.g `$product->getvalues()->add($myvalue))

As a consequence, every getter for such a property (`values`, `groups`, `categories` and `associations`) *now returns a copy of the collection*. You will have to explicitely call the product's setters/adders/removers to update these collections: ` $product->addValue($myValue)`

**Choices / Remarks**

- Some services need to save the product anyway, even if it was not updated (technically speaking). For instance, this is the case for the `pim:product:clean-removed-attributes` console command, which just loads a product from the DB (this filters values linked to removed attributes, but does not update the `wasUpdated` flag) and immediately saves it. In order to achieve that I added a `force_save` option in the ProductSaver; when it's true, the product is saved regardless of his `wasUpdated` state

- comparing associations is a quite tedious and complex task. I decided to set the `wasUpdated` flag to true whenever a setter is called (even if the collection is not really updated). This, unfortunately, decreases this PR's efficiency; I believe the associations need to be reworked in order to be easier to use (both from a technical and from a functional POV)

- there are 2 product methods which do not  return copies: `getAssociationByType()` and `getAssociationByTypeCode()`. I couldn't find a way to make the 2-way associations work with it (there are duplicates because of the ORM's persistence with manytomany associations)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
