### PR TITLE
RAC-343: Fix progress job errors

### DIFF
--- a/akeneo-design-system/src/components/ProgressBar/ProgressBar.tsx
+++ b/akeneo-design-system/src/components/ProgressBar/ProgressBar.tsx
@@ -3,7 +3,9 @@ import styled, {css, keyframes} from 'styled-components';
 import {AkeneoThemedProps, getColor, getColorForLevel, getFontSize, Level} from '../../theme';
 import {uuid} from '../../shared';
 
-const ProgressBarContainer = styled.div``;
+const ProgressBarContainer = styled.div`
+  overflow: hidden;
+`;
 
 const progressBarAnimation = keyframes`
   from { background-position: 0 0; }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -6,15 +6,19 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
+use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -26,7 +30,7 @@ use Webmozart\Assert\Assert;
  * TODO refactor with Akeneo\Pim\Enrichment\Component\Product\Job\ComputeCompletenessOfProductsFamilyTasklet
  *            that work only for unitary update
  */
-class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
+class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, TrackableTaskletInterface
 {
     private const BATCH_SIZE = 1000;
 
@@ -62,6 +66,23 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
         $this->stepExecution = $stepExecution;
     }
 
+    public function totalItems(): int
+    {
+        if (!$this->familyReader instanceof RewindableItemReaderInterface) {
+            return 0;
+        }
+
+        $familyCodes = $this->extractFamilyCodes();
+        $this->familyReader->rewind();
+        if (empty($familyCodes)) {
+            return 0;
+        }
+
+        $products = $this->getProductsForFamilies($familyCodes);
+
+        return $products->count();
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -71,28 +92,12 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
             $this->familyReader->initialize();
         }
 
-        $familyCodes = [];
-
-        while (true) {
-            $family = $this->familyReader->read();
-
-            if (null === $family) {
-                break;
-            }
-
-            Assert::isInstanceOf($family, FamilyInterface::class);
-
-            $familyCodes[] = $family->getCode();
-        }
-
+        $familyCodes = $this->extractFamilyCodes();
         if (empty($familyCodes)) {
             return;
         }
 
-        $productQueryBuilder = $this->productQueryBuilderFactory->create();
-        $productQueryBuilder->addFilter('family', 'IN', $familyCodes);
-        $products = $productQueryBuilder->execute();
-
+        $products = $this->getProductsForFamilies($familyCodes);
         $productsToCompute = [];
         foreach ($products as $product) {
             Assert::isInstanceOf($product, ProductInterface::class);
@@ -114,7 +119,33 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface
         $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($productIdentifiers);
         $this->saveProductCompletenesses->saveAll($completenessCollections);
 
+        $this->stepExecution->incrementProcessedItems(count($productIdentifiers));
         $this->stepExecution->incrementSummaryInfo('process', count($productIdentifiers));
         $this->jobRepository->updateStepExecution($this->stepExecution);
+    }
+
+    private function extractFamilyCodes()
+    {
+        $familyCodes = [];
+        while (true) {
+            $family = $this->familyReader->read();
+            if (null === $family) {
+                break;
+            }
+
+            Assert::isInstanceOf($family, FamilyInterface::class);
+
+            $familyCodes[] = $family->getCode();
+        }
+
+        return $familyCodes;
+    }
+
+    private function getProductsForFamilies(array $familyCodes): CursorInterface
+    {
+        $productQueryBuilder = $this->productQueryBuilderFactory->create();
+        $productQueryBuilder->addFilter('family', Operators::IN_LIST, $familyCodes);
+
+        return $productQueryBuilder->execute();
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
@@ -164,7 +164,6 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             -
-                - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.xlsx_attribute_option.export'
             - true
         tags:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/jobs.yml
@@ -151,7 +151,6 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             -
-                - '@pim_connector.step.charset_validator'
                 - '@pim_connector.step.xlsx_attribute.export'
             - true
         tags:

--- a/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
+++ b/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
@@ -5,6 +5,8 @@ namespace Akeneo\Pim\Structure\Component\Reader\Database\MassEdit;
 use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -15,7 +17,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface, InitializableInterface
+class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface, InitializableInterface, RewindableItemReaderInterface
 {
     /** @var StepExecution */
     protected $stepExecution;
@@ -35,6 +37,12 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
     public function __construct(FamilyRepositoryInterface $familyRepository)
     {
         $this->familyRepository = $familyRepository;
+    }
+
+    /** @TODO: remove this in RAC-341 */
+    public function rewind(): void
+    {
+        $this->initialize();
     }
 
     /**

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
@@ -29,7 +29,9 @@ datagrid:
                     hasError: boolean
             warning:
                 label: Warnings
-                frontendType: label
+                template: PimImportExportBundle:Property:warning.html.twig
+                type: twig
+                frontend_type: html
                 data_name: warningCount
             actions:
                 label: ~

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/templates/last-operations-widget.html
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/templates/last-operations-widget.html
@@ -42,7 +42,7 @@
                     <% } %>
                 </span>
             </td>
-            <td class="AknGrid-bodyCell"><%- counter %></td>
+            <td class="AknGrid-bodyCell"><%- (counter > 0) ? counter : '-' %></td>
             <td class="AknGrid-bodyCell AknGrid-bodyCell--right">
             <% if (operation.canSeeReport) { %>
                 <span class="AknButton AknButton--small AknButton--grey show-details-btn"

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -188,6 +188,7 @@ pim_import_export:
         in_progress: "Estimated time left: {{ duration }}"
         not_started: "Pending"
         untrackable: Untrackable step
+        estimating: "Estimating time remaining..."
 
 confirmation:
     remove:

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/Property/warning.html.twig
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/Property/warning.html.twig
@@ -1,6 +1,4 @@
-{% set status = 'success' %}
-{% set status = value is not null and value != 0 ? 'warning' : status  %}
-{% set status = 'FAILED' == record.getValue('exitStatus').exitCode ? 'important' : status %}
 {% set counter = 'FAILED' == record.getValue('exitStatus').exitCode ? 1 : value %}
+{% set counterValue = counter > 0 ? counter : '-' %}
 
-<span class="AknBadge AknBadge--{{ status }}">{{ counter }}</span>
+{{ counterValue }}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
@@ -67,7 +67,7 @@ const getStepExecutionTrackingPercent = (step: StepExecutionTracking): number | 
     }
   }
 
-  return Math.round((step.processedItems * 100) / step.totalItems);
+  return (step.processedItems * 100) / step.totalItems;
 };
 
 const getStepExecutionTrackingTitle = (step: StepExecutionTracking): string => {
@@ -84,11 +84,15 @@ const getStepExecutionTrackingProgressLabel = (step: StepExecutionTracking): str
     case 'STARTING':
       return __('pim_import_export.tracking.not_started');
     case 'STARTED':
-      if (step.totalItems === 0 || !step.isTrackable || step.processedItems === 0) {
+      if (!step.isTrackable) {
         return __('pim_import_export.tracking.untrackable');
       }
 
-      const percentProcessed = Math.round((step.processedItems * 100) / step.totalItems);
+      if (step.totalItems === 0 || step.processedItems === 0) {
+        return __('pim_import_export.tracking.estimating');
+      }
+
+      const percentProcessed = (step.processedItems * 100) / step.totalItems;
       const durationProjection = Math.round((step.duration * 100) / percentProcessed);
       const durationLeft = durationProjection - step.duration;
       return __('pim_import_export.tracking.in_progress', {duration: formatSecondsIntl(durationLeft)});

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/progress.tsx
@@ -45,11 +45,16 @@ const guessStepExecutionTrackingLevel = (step: StepExecutionTracking): Level => 
 };
 
 const getStepExecutionTrackingPercent = (step: StepExecutionTracking): number | 'indeterminate' => {
+  if (step.status === 'STARTING') {
+    return 0;
+  }
+
+  if (step.status === 'COMPLETED') {
+    return 100;
+  }
+
   if (step.totalItems === 0 || !step.isTrackable) {
     switch (step.status) {
-      case 'STARTING':
-        return 0;
-      case 'COMPLETED':
       case 'STOPPED':
       case 'FAILED':
       case 'ABANDONED':

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/status.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/status.tsx
@@ -18,6 +18,7 @@ type JobExecutionTracking = {
 
 const Label = styled.span`
   display: inline-block;
+  vertical-align: top;
   margin: 0 5px 0 0;
 `;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
@@ -344,30 +344,30 @@ test('it fallback on default job step label when missing', () => {
 });
 
 test('it render progress bar lower than 1%', () => {
-   mockGetFormData.mockImplementationOnce(() => ({
-      tracking: {
-        status: 'STARTED',
-        currentStep: 1,
-        totalSteps: 1,
-        steps: [
-          {
-            jobName: 'csv_product_export',
-            stepName: 'export',
-            status: 'STARTED',
-            isTrackable: true,
-            hasWarning: false,
-            hasError: false,
-            duration: 12,
-            processedItems: 1,
-            totalItems: 100000,
-          },
-        ],
-      },
-    }));
+  mockGetFormData.mockImplementationOnce(() => ({
+    tracking: {
+      status: 'STARTED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
+        {
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'STARTED',
+          isTrackable: true,
+          hasWarning: false,
+          hasError: false,
+          duration: 12,
+          processedItems: 1,
+          totalItems: 100000,
+        },
+      ],
+    },
+  }));
 
-    const component = new JobExecutionProgress(container);
-    component.render();
+  const component = new JobExecutionProgress(container);
+  component.render();
 
-    expect(screen.getByText('13 day(s) 21 hour(s) left')).toBeInTheDocument();
-    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0.001');
-  });
+  expect(screen.getByText('13 day(s) 21 hour(s) left')).toBeInTheDocument();
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0.001');
+});

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
@@ -253,6 +253,35 @@ test('it render the progress bar of one untrackable and started job step', () =>
   expect(screen.getByRole('progressbar')).not.toHaveAttribute('aria-valuenow');
 });
 
+test('it render the progress bar of one untrackable and failed job step', () => {
+  mockGetFormData.mockImplementationOnce(() => ({
+    tracking: {
+      status: 'FAILED',
+      currentStep: 1,
+      totalSteps: 1,
+      steps: [
+        {
+          jobName: 'csv_product_export',
+          stepName: 'export',
+          status: 'FAILED',
+          isTrackable: false,
+          hasWarning: false,
+          hasError: false,
+          duration: 10,
+          processedItems: 0,
+          totalItems: 0,
+        },
+      ],
+    },
+  }));
+
+  const component = new JobExecutionProgress(container);
+  component.render();
+
+  expect(screen.getByText('pim_import_export.tracking.completed')).toBeInTheDocument();
+  expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+});
+
 test('it render without error the progress bar of one job step with warning', () => {
   mockGetFormData.mockImplementationOnce(() => ({
     tracking: {

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/JobExecutionProgress.unit.tsx
@@ -162,7 +162,7 @@ test('it render the progress bar of one started job step without processed items
   const component = new JobExecutionProgress(container);
   component.render();
 
-  expect(screen.getByText('pim_import_export.tracking.untrackable')).toBeInTheDocument();
+  expect(screen.getByText('pim_import_export.tracking.estimating')).toBeInTheDocument();
   expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
 });
 
@@ -342,3 +342,32 @@ test('it fallback on default job step label when missing', () => {
 
   expect(screen.getByText('batch_jobs.default_steps.unknown_step')).toBeInTheDocument();
 });
+
+test('it render progress bar lower than 1%', () => {
+   mockGetFormData.mockImplementationOnce(() => ({
+      tracking: {
+        status: 'STARTED',
+        currentStep: 1,
+        totalSteps: 1,
+        steps: [
+          {
+            jobName: 'csv_product_export',
+            stepName: 'export',
+            status: 'STARTED',
+            isTrackable: true,
+            hasWarning: false,
+            hasError: false,
+            duration: 12,
+            processedItems: 1,
+            totalItems: 100000,
+          },
+        ],
+      },
+    }));
+
+    const component = new JobExecutionProgress(container);
+    component.render();
+
+    expect(screen.getByText('13 day(s) 21 hour(s) left')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0.001');
+  });

--- a/src/Akeneo/Tool/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Tool/Component/Batch/spec/Step/ItemStepSpec.php
@@ -66,6 +66,8 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
+        $execution->incrementProcessedItems(3)->shouldBeCalledOnce();
+
         $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
         $jobStopper->isStopping($execution)->willReturn(false);
 
@@ -73,12 +75,14 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r4')->shouldBeCalled()->willReturn('p4');
         $processor->process(null)->shouldNotBeCalled();
         $writer->write(['p4'])->shouldBeCalled();
+        $execution->incrementProcessedItems(1)->shouldBeCalledOnce();
+
         $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
         $jobStopper->isStopping($execution)->willReturn(false);
 
         $execution->getExitStatus()->willReturn($exitStatus);
         $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
-        $repository->updateStepExecution($execution)->shouldBeCalled();
+        $repository->updateStepExecution($execution)->shouldBeCalledTimes(5);
         $execution->isTerminateOnly()->willReturn(false);
 
         $execution->upgradeStatus(Argument::any())->shouldBeCalled();
@@ -114,6 +118,8 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r2')->shouldBeCalled()->willReturn('p2');
         $processor->process('r3')->shouldBeCalled()->willReturn('p3');
         $writer->write(['p1', 'p2', 'p3'])->shouldBeCalled();
+        $execution->incrementProcessedItems(3)->shouldBeCalledOnce();
+
         $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalled();
         $jobStopper->isStopping($execution)->willReturn(false);
 
@@ -121,6 +127,7 @@ class ItemStepSpec extends ObjectBehavior
         $processor->process('r4')->shouldBeCalled()->willThrow(
             new InvalidItemException('my msg', new FileInvalidItem(['r4'], 7))
         );
+        $execution->incrementProcessedItems(1)->shouldBeCalledOnce();
 
         $warning = new Warning($execution->getWrappedObject(), 'my msg', [], ['r4']);
         $repository
@@ -133,7 +140,55 @@ class ItemStepSpec extends ObjectBehavior
 
         $execution->getExitStatus()->willReturn($exitStatus);
         $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
-        $repository->updateStepExecution($execution)->shouldBeCalled();
+        $repository->updateStepExecution($execution)->shouldBeCalledTimes(5);
+        $execution->isTerminateOnly()->willReturn(false);
+
+        $execution->upgradeStatus(Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_SUCCEEDED, Argument::any())->shouldBeCalled();
+        $dispatcher->dispatch(EventInterface::STEP_EXECUTION_COMPLETED, Argument::any())->shouldBeCalled();
+        $execution->setEndTime(Argument::any())->shouldBeCalled();
+        $execution->setExitStatus(Argument::any())->shouldBeCalled();
+
+        $this->execute($execution);
+    }
+
+    function it_not_not_write_item_not_processed(
+        ItemReaderInterface $reader,
+        ItemProcessorInterface $processor,
+        ItemWriterInterface $writer,
+        EventDispatcherInterface $dispatcher,
+        DoctrineJobRepository $repository,
+        StepExecution $execution,
+        BatchStatus $status,
+        ExitStatus $exitStatus
+    ) {
+        $execution->getStatus()->willReturn($status);
+        $status->getValue()->willReturn(BatchStatus::STARTING);
+
+        $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
+        $execution->setStartTime(Argument::any())->shouldBeCalled();
+        $execution->setStatus(Argument::any())->shouldBeCalled();
+
+        // first batch
+        $reader->read()->willReturn('r1', 'r2', 'r3', 'r4', null);
+        $processor->process('r1')->shouldBeCalled()->willReturn('p1');
+        $processor->process('r2')->shouldBeCalled()->willReturn(null);
+        $processor->process('r3')->shouldBeCalled()->willReturn('p3');
+        $writer->write(['p1', 'p3'])->shouldBeCalled();
+        $execution->incrementProcessedItems(3)->shouldBeCalledOnce();
+
+        // second batch
+        $processor->process('r4')->shouldBeCalled()->willReturn('p4');
+        $execution->incrementProcessedItems(1)->shouldBeCalledOnce();
+
+        $dispatcher->dispatch(EventInterface::ITEM_STEP_AFTER_BATCH, Argument::any())->shouldBeCalledTimes(2);
+
+        $processor->process(null)->shouldNotBeCalled();
+        $writer->write(['p4'])->shouldBeCalled();
+
+        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
+        $execution->getExitStatus()->willReturn($exitStatus);
+        $repository->updateStepExecution($execution)->shouldBeCalledTimes(5);
         $execution->isTerminateOnly()->willReturn(false);
 
         $execution->upgradeStatus(Argument::any())->shouldBeCalled();

--- a/src/Akeneo/Tool/Component/Batch/spec/Step/ItemStepSpec.php
+++ b/src/Akeneo/Tool/Component/Batch/spec/Step/ItemStepSpec.php
@@ -160,7 +160,8 @@ class ItemStepSpec extends ObjectBehavior
         DoctrineJobRepository $repository,
         StepExecution $execution,
         BatchStatus $status,
-        ExitStatus $exitStatus
+        ExitStatus $exitStatus,
+        JobStopper $jobStopper
     ) {
         $execution->getStatus()->willReturn($status);
         $status->getValue()->willReturn(BatchStatus::STARTING);
@@ -168,6 +169,7 @@ class ItemStepSpec extends ObjectBehavior
         $dispatcher->dispatch(EventInterface::BEFORE_STEP_EXECUTION, Argument::any())->shouldBeCalled();
         $execution->setStartTime(Argument::any())->shouldBeCalled();
         $execution->setStatus(Argument::any())->shouldBeCalled();
+        $jobStopper->isStopping($execution)->willReturn(false);
 
         // first batch
         $reader->read()->willReturn('r1', 'r2', 'r3', 'r4', null);

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Csv/Reader.php
@@ -58,8 +58,7 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
     {
         $jobParameters = $this->stepExecution->getJobParameters();
         $filePath = $jobParameters->get('filePath');
-
-        $iterator = $this->fileIteratorFactory->create($filePath);
+        $iterator = $this->createFileIterator($jobParameters, $filePath);
 
         return max(iterator_count($iterator) - 1, 0);
     }
@@ -72,7 +71,7 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
         $jobParameters = $this->stepExecution->getJobParameters();
         $filePath = $jobParameters->get('filePath');
         if (null === $this->fileIterator) {
-            $this->initializeFileIterator($jobParameters, $filePath);
+            $this->fileIterator = $this->createFileIterator($jobParameters, $filePath);
             $this->fileIterator->rewind();
         }
 
@@ -133,7 +132,7 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
         $jobParameters = $this->stepExecution->getJobParameters();
         $filePath = $jobParameters->get('filePath');
         if (null === $this->fileIterator) {
-            $this->initializeFileIterator($jobParameters, $filePath);
+            $this->fileIterator = $this->createFileIterator($jobParameters, $filePath);
         }
         $this->fileIterator->rewind();
     }
@@ -203,10 +202,10 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
         }
     }
 
-    private function initializeFileIterator(
+    private function createFileIterator(
         JobParameters $jobParameters,
         string $filePath
-    ): void {
+    ): FileIteratorInterface {
         $delimiter = $jobParameters->get('delimiter');
         $enclosure = $jobParameters->get('enclosure');
         $defaultOptions = [
@@ -215,7 +214,8 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
                 'fieldEnclosure' => $enclosure,
             ],
         ];
-        $this->fileIterator = $this->fileIteratorFactory->create(
+
+        return $this->fileIteratorFactory->create(
             $filePath,
             array_merge($defaultOptions, $this->options)
         );

--- a/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
@@ -31,14 +31,21 @@ class ReaderSpec extends ObjectBehavior
         StepExecution $stepExecution
     ) {
         $filePath = $this->getPath() . DIRECTORY_SEPARATOR  . 'with_media.csv';
+        $jobParameters->get('enclosure')->willReturn('"');
+        $jobParameters->get('delimiter')->willReturn(';');
+        $jobParameters->get('filePath')->willReturn($filePath);
 
         $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('filePath')->willReturn($filePath);
         $fileIterator->valid()->willReturn(true, true, true, false);
         $fileIterator->current()->willReturn(null);
         $fileIterator->rewind()->shouldBeCalled();
         $fileIterator->next()->shouldBeCalled();
-        $fileIteratorFactory->create($filePath)->willReturn($fileIterator);
+        $readerOptions = [
+            'fieldDelimiter' => ';',
+            'fieldEnclosure' => '"',
+        ];
+
+        $fileIteratorFactory->create($filePath, ['reader_options' => $readerOptions])->willReturn($fileIterator);
 
         /** Expect 2 items, even there is 3 lines because the first one (the header) is ignored */
         $this->totalItems()->shouldReturn(2);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
@@ -11,8 +11,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Connector\Reader\File\Csv\Reader;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
@@ -45,6 +47,7 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
     function it_is_initializable()
     {
         $this->shouldHaveType(ComputeCompletenessOfFamilyProductsTasklet::class);
+        $this->shouldImplement(TrackableTaskletInterface::class);
     }
 
     function it_does_nothing_if_there_is_no_family(
@@ -101,6 +104,8 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
         $saveProductCompletenesses->saveAll(['completeness_collection'])->shouldBeCalled();
 
         $stepExecution->incrementSummaryInfo('process', 4)->shouldBeCalled();
+        $stepExecution->incrementProcessedItems(4)->shouldBeCalledOnce();
+
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
 
         $this->execute();
@@ -133,9 +138,41 @@ class ComputeCompletenessOfFamilyProductsTaskletSpec extends ObjectBehavior
 
         $stepExecution->incrementSummaryInfo('process', 1000)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('process', 6)->shouldBeCalled();
+        $stepExecution->incrementProcessedItems(1000)->shouldBeCalledOnce();
+        $stepExecution->incrementProcessedItems(6)->shouldBeCalledOnce();
+
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(2);
 
         $this->execute();
+    }
+
+    function it_does_not_count_total_item_when_reader_is_not_rewindable()
+    {
+        $this->totalItems()->shouldReturn(0);
+    }
+
+    function it_return_the_total_items_when_reader_is_rewindable(
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        ProductQueryBuilderInterface $productQueryBuilder,
+        Reader $familyReader,
+        FamilyInterface $familyShoes,
+        FamilyInterface $familyAccessories
+    ) {
+        $productQueryBuilderFactory->create()->willReturn($productQueryBuilder);
+
+        $familyReader->read()->shouldBeCalledTimes(3)->willReturn($familyShoes, $familyAccessories, null);
+        $familyReader->rewind()->shouldBeCalledOnce();
+        $familyShoes->getCode()->willReturn('Shoes');
+        $familyAccessories->getCode()->willReturn('Accessories');
+
+        $productQueryBuilder->addFilter('family', 'IN', ['Shoes', 'Accessories'])->shouldBeCalled();
+        $productQueryBuilder->execute()->shouldBeCalled()->willReturn(
+            new ProductCursor(array_map(function (int $i): ProductInterface {
+                return (new Product())->setIdentifier('product_' . $i);
+            }, range(1, 1006)))
+        );
+
+        $this->totalItems()->shouldReturn(1006);
     }
 }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR : 
**Back:**
- Remove file validation file step in XLSX attribute option export and XLSX attribute export job (user does not give the input file)
- The CSV reader do not used the defined separator in job instance, if file contain a comma and the separator is semicolon the count is false
- Make ComputeCompletenessOfFamilyProductsTasklet trackable
- Make FilteredFamilyReader trackable
- ItemStep do not update processedItem when processor return null
- ItemStep do not update jobExecution if Reader is not trackable

**Font:**
- Css problem on project calculation grid 
![Capture du 2020-11-04 16-38-28](https://user-images.githubusercontent.com/7239572/98256717-2f4fd200-1f7f-11eb-819b-7c36ed9ac5db.png)
- When status is completed the progress bar should be at 100% we don’t have to pay attention to totalItems and processedItems even if the process is trackable
- Remove warning count badge on process tracker + we should replace warning count to '-' when equal to 0
- Fix progress label is invalid when percent is lower than 0 (division by 0)

**Definition Of Done (for Core Developer only)**
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
