### PR TITLE
PIM-9539: Fix the display of long attribute labels or codes on variant attributes page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 - AOB-277: Add an acl to allow a role member to view all job executions in last job execution grids, job tracker and last operations widget.
 - RAC-54: Add a new type of associations: Association with quantity
 - RAC-123: Add possibility to export product/product model with labels instead of code
-- RAC-271: Add possibility to declare jobs as stoppable and stop them from the UI	
+- RAC-271: Add possibility to declare jobs as stoppable and stop them from the UI
 - RAC-277: Add job progress and remaining time in the UI
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Bug fixes
 
-- PIM-9554: Discrepancy on the user dashboard due to difference between UI locale and catalog locale
 - PIM-9486: System Information sections Registered bundles and PHP extensions repeat a high number of times
 - PIM-9514: Fix check on API completness for product model
 - PIM-9408: Fix attribute group's updated_at field udpate
@@ -58,6 +57,7 @@
 - PIM-9533: Update wysiwyg editor's style in order to differentiate new paragraphs from mere line breaks
 - PIM-9548: Mitigate deadlock issues on category API
 - PIM-9540: Do not strip HTML tags on textarea content before indexing them in ES and fix newline_pattern char filter
+- PIM-9539: Fix the display of long attribute labels or codes on variant attributes page
 
 ## New features
 
@@ -66,8 +66,6 @@
 - AOB-277: Add an acl to allow a role member to view all job executions in last job execution grids, job tracker and last operations widget.
 - RAC-54: Add a new type of associations: Association with quantity
 - RAC-123: Add possibility to export product/product model with labels instead of code
-- RAC-271: Add possibility to declare jobs as stoppable and stop them from the UI
-- RAC-277: Add job progress and remaining time in the UI
 
 ## Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-9554: Discrepancy on the user dashboard due to difference between UI locale and catalog locale
 - PIM-9486: System Information sections Registered bundles and PHP extensions repeat a high number of times
 - PIM-9514: Fix check on API completness for product model
 - PIM-9408: Fix attribute group's updated_at field udpate
@@ -66,6 +67,8 @@
 - AOB-277: Add an acl to allow a role member to view all job executions in last job execution grids, job tracker and last operations widget.
 - RAC-54: Add a new type of associations: Association with quantity
 - RAC-123: Add possibility to export product/product model with labels instead of code
+- RAC-271: Add possibility to declare jobs as stoppable and stop them from the UI	
+- RAC-277: Add job progress and remaining time in the UI
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/FamilyVariant.less
@@ -15,6 +15,7 @@
         flex-basis: 30%;
         flex-grow: 1;
         margin-right: @AknFullPagePadding;
+        max-width: calc(33vw - 40px);
 
         &:nth-child(3) {
             margin-top: 65px;
@@ -123,6 +124,7 @@
             background-size: 13px;
             padding-left: 20px;
             cursor: move;
+            display: block;
         }
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
@@ -19,6 +19,9 @@
     justify-content: space-between;
     flex-shrink: 0;
     align-items: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
 
     &--selectable {
       cursor: pointer;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
@@ -27,6 +27,11 @@
       cursor: pointer;
     }
 
+    &.ui-sortable-helper {
+      background: rgba(255, 255, 255, 0.8);
+      width: auto !important;
+    }
+
     &--movable {
       cursor: move;
       background: url("/bundles/pimui/images/icon-dragcolumns.svg") no-repeat 0 center;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/family-variant/attribute-group.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/family-variant/attribute-group.html
@@ -3,6 +3,7 @@
         <li
             data-attribute-code="<%- attribute.code %>"
             class="AknVerticalList-item AknFamilyVariant-columnListItem AknFamilyVariant-attribute attribute <%- !lockedAttributes.includes(attribute.code) && movable ? 'AknFamilyVariant-attribute--movable movable' : 'AknFamilyVariant-attribute--notMovable' %> <%- !lockedAttributes.includes(attribute.code) ? 'deletable' : '' %>"
+            title="<%- i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code) %>"
         >
             <%- i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code) %>
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Long attribute labels (or codes) were displayed on 2 lines (or more) and so hover over separation lines and attributes below them on the variant attributes page of Settings > Families, making it very difficult to read and sort out.

So, I worked on the concerned css files to add an ellipsis when an attribute label/code is too long for the display to be correct.

![move_long_attribute](https://user-images.githubusercontent.com/57708349/99975978-29415a00-2da3-11eb-8a3c-3150122f062d.gif)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**


| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
