### PR TITLE
Add .env.dev to fix the standard build

### DIFF
--- a/std-build/install-required-files.sh
+++ b/std-build/install-required-files.sh
@@ -65,6 +65,7 @@ cp $DEV_DISTRIB_DIR/std-build/services.yml $STANDARD_DISTRIB_DIR/config/services
 
 # Skeleton .env file
 cp $DEV_DISTRIB_DIR/.env $STANDARD_DISTRIB_DIR/
+cp $DEV_DISTRIB_DIR/.env.dev $STANDARD_DISTRIB_DIR/
 
 # Skeleton .env file
 cp $DEV_DISTRIB_DIR/.gitignore $STANDARD_DISTRIB_DIR/


### PR DESCRIPTION
Fix https://app.circleci.com/pipelines/github/akeneo/pim-community-standard/2519/workflows/51a40b5b-0181-4592-a12a-10a53d49cd2c/jobs/3322  

Missing `.env.dev` to define the PubSub emulator in dev environment