### PR TITLE
Fix InMemoryChannelRepository::getChannelCodes()

### DIFF
--- a/tests/back/Acceptance/Channel/InMemoryChannelRepository.php
+++ b/tests/back/Acceptance/Channel/InMemoryChannelRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Acceptance\Channel;
 
+use Akeneo\Channel\Component\Model\ChannelInterface;
 use Akeneo\Channel\Component\Model\CurrencyInterface;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
 use Akeneo\Test\Acceptance\Common\NotImplementedException;
@@ -83,7 +84,7 @@ final class InMemoryChannelRepository implements ChannelRepositoryInterface, Sav
     {
         return $this->channels->map(function (ChannelInterface $channel): string {
             return $channel->getCode();
-        })->toArray();
+        })->getValues();
     }
 
     /**

--- a/tests/back/Acceptance/spec/Channel/InMemoryChannelRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Channel/InMemoryChannelRepositorySpec.php
@@ -62,6 +62,17 @@ class InMemoryChannelRepositorySpec extends ObjectBehavior
         $this->findAll()->shouldReturn([$channel1, $channel2]);
     }
 
+    function it_gets_the_channel_codes()
+    {
+        $channel1 = $this->createChannel('ecommerce');
+        $this->save($channel1);
+
+        $channel2 = $this->createChannel('mobile');
+        $this->save($channel2);
+
+        $this->getChannelCodes()->shouldReturn(['ecommerce', 'mobile']);
+    }
+
     private function createChannel(string $code): ChannelInterface
     {
         $channel = new Channel();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The `ChannelInterface` was not imported. As the method is not used in any acceptance tests, the error was never noticed. 
We need this method to work in some Onboarder acceptance tests.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
