### PR TITLE
PIM-9545: Update monolog config to avoid possible memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PIM-9498: Add translation for 'Mass delete products' job
 - PIM-9538: Fix sorting on rule engine list page
 - PIM-9499: Fix warning display when a job is running with warnings
+- PIM-9545: Fix possible memory leak in large import jobs
 
 ## New features
 

--- a/config/packages/behat/monolog.yml
+++ b/config/packages/behat/monolog.yml
@@ -4,6 +4,7 @@ monolog:
             type:         fingers_crossed
             action_level: warning
             handler:      nested
+            buffer_size:  1000
         nested:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'

--- a/config/packages/prod/monolog.yml
+++ b/config/packages/prod/monolog.yml
@@ -4,6 +4,7 @@ monolog:
             type:         fingers_crossed
             action_level: warning
             handler:      nested
+            buffer_size:  1000
         nested:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'

--- a/config/packages/prod_onprem_paas/monolog.yml
+++ b/config/packages/prod_onprem_paas/monolog.yml
@@ -4,6 +4,7 @@ monolog:
             type:         fingers_crossed
             action_level: warning
             handler:      nested
+            buffer_size:  1000
         nested:
             type: stream
             path: '%kernel.logs_dir%/%kernel.environment%.log'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Our monolog config used to have the default value (0 =unlimited) for the `crossed_fingers` handlers `buffer_size` param, which means it stored every log message in a buffer until one had a level high enough to be flushed. 
This has almost always no consequence, except in large jobs, where the amount of logged messages can stack up and cause an out of memory error (e.g in product imports, an INFO message is logged each time a product is updated or created)

This PR limits the buffer_size to 1000, meaning that when a message is flushed, only the 1000 previous messages will be flushed alongside.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
