### PR TITLE
DAPI-1367: update family attribute grid filter to use code instead of ids

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/Criterion.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/Criterion.tsx
@@ -95,9 +95,9 @@ const Criterion: FunctionComponent<CriterionProps> = ({criterionEvaluation, axis
         })
       );
       if (criterion === ATTRIBUTE_OPTION_SPELLING_CRITERION_CODE) {
-        redirectToAttributeGridFilteredByFamilyAndQualityAndSelectAttributeTypes(family.meta.id);
+        redirectToAttributeGridFilteredByFamilyAndQualityAndSelectAttributeTypes(family.code);
       } else {
-        redirectToAttributeGridFilteredByFamilyAndQuality(family.meta.id);
+        redirectToAttributeGridFilteredByFamilyAndQuality(family.code);
       }
     }
   };

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/AttributeGridRouter.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/AttributeGridRouter.ts
@@ -1,17 +1,17 @@
 const Router = require('pim/router');
 const DatagridState = require('pim/datagrid/state');
 
-export const redirectToAttributeGridFilteredByFamilyAndQuality = (familyId: number) => {
-  const gridFilters = `i=1&p=25&s[label]=-1&f[family][value][]=${familyId}&f[quality][value]=to_improve&t=attribute-grid`;
-  DatagridState.set('attribute-grid', {
-    filters: gridFilters,
-  });
-
-  window.location.href = '#' + Router.generate('pim_enrich_attribute_index');
+export const redirectToAttributeGridFilteredByFamilyAndQuality = (familyCode: string) => {
+  const gridFilters = `i=1&p=25&s[label]=-1&f[family][value][]=${familyCode}&f[quality][value]=to_improve&t=attribute-grid`;
+  redirectToFilteredAttributeGrid(gridFilters);
 };
 
-export const redirectToAttributeGridFilteredByFamilyAndQualityAndSelectAttributeTypes = (familyId: number) => {
-  const gridFilters = `i=1&p=25&s[label]=-1&f[family][value][]=${familyId}&f[quality][value]=to_improve&t=attribute-grid&f[type][value][]=pim_catalog_multiselect&f[type][value][]=pim_catalog_simpleselect`;
+export const redirectToAttributeGridFilteredByFamilyAndQualityAndSelectAttributeTypes = (familyCode: string) => {
+  const gridFilters = `i=1&p=25&s[label]=-1&f[family][value][]=${familyCode}&f[quality][value]=to_improve&t=attribute-grid&f[type][value][]=pim_catalog_multiselect&f[type][value][]=pim_catalog_simpleselect`;
+  redirectToFilteredAttributeGrid(gridFilters);
+};
+
+export const redirectToFilteredAttributeGrid = (gridFilters: string) => {
   DatagridState.set('attribute-grid', {
     filters: gridFilters,
   });

--- a/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/FamilyFilter.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/FamilyFilter.php
@@ -24,7 +24,7 @@ class FamilyFilter extends ChoiceFilter
         $rootAlias = current($qb->getRootAliases());
 
         $qb
-            ->innerJoin($rootAlias . '.families', 'f', 'WITH', 'f.id IN(:families)')
+            ->innerJoin($rootAlias . '.families', 'f', 'WITH', 'f.code IN(:families)')
             ->setParameter(':families', $data['value']);
 
         return true;

--- a/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/RegisterFamilyFilter.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/RegisterFamilyFilter.php
@@ -4,18 +4,22 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Structure\Bundle\Datagrid\Attribute;
 
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetAllFamiliesLabelByLocaleQueryInterface;
 use Akeneo\Platform\Bundle\UIBundle\Provider\TranslatedLabelsProviderInterface;
+use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Oro\Bundle\DataGridBundle\Event\BuildBefore;
 use Oro\Bundle\FilterBundle\Grid\Extension\Configuration as FilterConfiguration;
 
 class RegisterFamilyFilter
 {
-    /** @var TranslatedLabelsProviderInterface */
-    private $familyRepository;
+    private GetAllFamiliesLabelByLocaleQueryInterface $familyRepository;
 
-    public function __construct(TranslatedLabelsProviderInterface $familyRepository)
+    private UserContext $userContext;
+
+    public function __construct(GetAllFamiliesLabelByLocaleQueryInterface $familiesLabelByLocaleQuery, UserContext $userContext)
     {
-        $this->familyRepository = $familyRepository;
+        $this->familyRepository = $familiesLabelByLocaleQuery;
+        $this->userContext = $userContext;
     }
 
     public function buildBefore(BuildBefore $event): void
@@ -29,7 +33,7 @@ class RegisterFamilyFilter
                 'options' => [
                     'field_options' => [
                         'multiple' => true,
-                        'choices' => $this->familyRepository->findTranslatedLabels(),
+                        'choices' => array_flip($this->familyRepository->execute($this->userContext->getCurrentLocaleCode())),
                     ],
                 ],
             ]

--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Family/GetAllFamiliesLabelByLocaleQuery.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Family/GetAllFamiliesLabelByLocaleQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\InternalApi\Family;
+
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetAllFamiliesLabelByLocaleQueryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetAllFamiliesLabelByLocaleQuery implements GetAllFamiliesLabelByLocaleQueryInterface
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $localeCode): array
+    {
+        $query = <<<SQL
+SELECT 
+   family.code,
+   COALESCE(NULLIF(ft.label, ''), CONCAT('[', family.code, ']')) as label
+FROM pim_catalog_family family
+LEFT JOIN pim_catalog_family_translation ft ON family.id = ft.foreign_key AND ft.locale = :locale
+ORDER BY label
+SQL;
+
+        $families = $this->connection->executeQuery($query, ['locale' => $localeCode])->fetchAll(\PDO::FETCH_ASSOC);
+
+        $result = [];
+        foreach ($families as $family) {
+            $result[$family['code']] = $family['label'];
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -100,3 +100,8 @@ services:
         class: Akeneo\Pim\Structure\Bundle\Query\PublicApi\Group\Sql\SqlGetGroupTranslations
         arguments:
             - '@database_connection'
+
+    akeneo.pim.structure.query.get_all_families_label_by_locale:
+        class: Akeneo\Pim\Structure\Bundle\Query\InternalApi\Family\GetAllFamiliesLabelByLocaleQuery
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/services.yml
@@ -72,7 +72,8 @@ services:
 
     Akeneo\Pim\Structure\Bundle\Datagrid\Attribute\RegisterFamilyFilter:
         arguments:
-            - '@pim_enrich.repository.family'
+            - '@akeneo.pim.structure.query.get_all_families_label_by_locale'
+            - '@pim_user.context.user'
         tags:
             - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.attribute-grid, method: buildBefore }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetAllFamiliesLabelByLocaleQueryInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetAllFamiliesLabelByLocaleQueryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Component\Query\InternalApi;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetAllFamiliesLabelByLocaleQueryInterface
+{
+    public function execute(string $localeCode): array;
+}

--- a/tests/back/Pim/Structure/Integration/Family/GetAllFamiliesLabelByLocaleQueryIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/GetAllFamiliesLabelByLocaleQueryIntegration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\Family;
+
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Family\Sql\SqlGetFamilyTranslations;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
+
+final class GetAllFamiliesLabelByLocaleQueryIntegration extends TestCase
+{
+    public function test_it_gets_family_translations_by_giving_family_codes_and_locale_code(): void
+    {
+        $query = $this->get('akeneo.pim.structure.query.get_all_families_label_by_locale');
+        $results = $query->execute('en_US');
+
+        $this->assertSame([
+            'familyA2' => '[familyA2]',
+            'familyA3' => '[familyA3]',
+            'familyA' => 'A family A',
+            'familyA1' => 'A family A1',
+        ], $results);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
