### PR TITLE
DAPI-1425: Add helper methods to key indicator model

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
@@ -46,4 +46,18 @@ final class KeyIndicator
 
         return $total === 0 ? 0 : intval(round($this->totalGood / $total * 100));
     }
+
+    public function isEmpty(): bool
+    {
+        return $this->totalToImprove === 0 && $this->totalGood === 0;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'ratioGood' => $this->getRatioGood(),
+            'totalGood' => $this->totalGood,
+            'totalToImprove' => $this->totalToImprove,
+        ];
+    }
 }


### PR DESCRIPTION
These two new methods are indirectly tested by the spec of the service `GetKeyIndicators` 