### PR TITLE
PIM-9533: Update wysiwyg editor's style in order to differentiate new…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PIM-9538: Fix sorting on rule engine list page
 - PIM-9499: Fix warning display when a job is running with warnings
 - PIM-9545: Fix possible memory leak in large import jobs
+- PIM-9533: Update wysiwyg editor's style in order to differentiate new paragraphs from mere line breaks
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -8,6 +8,10 @@
   margin-bottom: 4px;
 
   .note-editable {
+    p {
+      margin-bottom: 10px;
+    }
+
     ol {
       list-style-type: decimal;
       margin-left: 1em;


### PR DESCRIPTION
… paragraphs from mere line breaks

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Adds margin at the bottom of <p> tags in the wysiwyg editor, in order to differentiate the from a mere line break.
Given the following html:
```html
<p>This is a paragraph</p>
<p>This is a new paragraph with<br>a line break</p>
<p>This is a new paragraph</p>
```

before:
![before](https://user-images.githubusercontent.com/5301298/98961292-b2d06c80-2505-11eb-84ba-6cc9f844a063.png)

after:
![after](https://user-images.githubusercontent.com/5301298/98961489-e6ab9200-2505-11eb-8d3d-6948db4ecf57.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
