### PR TITLE
RAC-339: refactor way of counting total items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,10 @@
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct` to
     - remove the `setFamilyId()` method
     - remove the `$categoryIds` public property and  the `$familyId` and `$groupIds` protected properties
+    - add `isDirty()` and `cleanup()` methods 
+- Remove the `findDatagridViewByAlias()` method in `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface`
+- Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Job\DeleteProductsAndProductModelsTasklet` to
+    - add `Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface $jobRepository`
 
 ### CLI commands
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/steps.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/steps.yml
@@ -282,6 +282,7 @@ services:
             - '@akeneo.pim.enrichment.product_model.query.count_product_models_and_children_product_models'
             - '@akeneo.pim.enrichment.product_model.query.count_variant_products'
             - '@akeneo_batch.job.job_stopper'
+            - '@akeneo_batch.job_repository'
 
     # CSV Quick Export steps ------------------------------------------------------------------------------------------
     pim_enrich.step.csv_product.quick_export:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -12,7 +12,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
@@ -66,21 +65,9 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
         $this->stepExecution = $stepExecution;
     }
 
-    public function totalItems(): int
+    public function isTrackable(): bool
     {
-        if (!$this->familyReader instanceof RewindableItemReaderInterface) {
-            return 0;
-        }
-
-        $familyCodes = $this->extractFamilyCodes();
-        $this->familyReader->rewind();
-        if (empty($familyCodes)) {
-            return 0;
-        }
-
-        $products = $this->getProductsForFamilies($familyCodes);
-
-        return $products->count();
+        return true;
     }
 
     /**
@@ -98,6 +85,8 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
         }
 
         $products = $this->getProductsForFamilies($familyCodes);
+        $this->stepExecution->setTotalItems($products->count());
+
         $productsToCompute = [];
         foreach ($products as $product) {
             Assert::isInstanceOf($product, ProductInterface::class);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/EnsureConsistentAttributeGroupOrderTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/EnsureConsistentAttributeGroupOrderTasklet.php
@@ -78,6 +78,10 @@ class EnsureConsistentAttributeGroupOrderTasklet implements TaskletInterface, Tr
      */
     public function execute()
     {
+        if ($this->attributeGroupReader instanceof TrackableItemReaderInterface) {
+            $this->stepExecution->setTotalItems($this->attributeGroupReader->totalItems());
+        }
+
         while (true) {
             try {
                 $attributeGroupItem = $this->attributeGroupReader->read();
@@ -128,15 +132,6 @@ class EnsureConsistentAttributeGroupOrderTasklet implements TaskletInterface, Tr
         }
     }
 
-    public function totalItems(): int
-    {
-        if ($this->attributeGroupReader instanceof TrackableItemReaderInterface) {
-            return $this->attributeGroupReader->totalItems();
-        }
-
-        return 0;
-    }
-
     private function updateProgressWithSkipped(): void
     {
         $this->stepExecution->incrementSummaryInfo('skip');
@@ -149,5 +144,10 @@ class EnsureConsistentAttributeGroupOrderTasklet implements TaskletInterface, Tr
         $this->stepExecution->incrementSummaryInfo('process');
         $this->stepExecution->incrementProcessedItems();
         $this->jobRepository->updateStepExecution($this->stepExecution);
+    }
+
+    public function isTrackable(): bool
+    {
+        return $this->attributeGroupReader instanceof TrackableItemReaderInterface;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
+++ b/src/Akeneo/Pim/Structure/Component/Reader/Database/MassEdit/FilteredFamilyReader.php
@@ -5,7 +5,6 @@ namespace Akeneo\Pim\Structure\Component\Reader\Database\MassEdit;
 use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
-use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
@@ -17,7 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface, InitializableInterface, RewindableItemReaderInterface, TrackableItemReaderInterface
+class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInterface, InitializableInterface, TrackableItemReaderInterface
 {
     /** @var StepExecution */
     protected $stepExecution;
@@ -37,12 +36,6 @@ class FilteredFamilyReader implements ItemReaderInterface, StepExecutionAwareInt
     public function __construct(FamilyRepositoryInterface $familyRepository)
     {
         $this->familyRepository = $familyRepository;
-    }
-
-    /** @TODO: remove this in RAC-341 */
-    public function rewind(): void
-    {
-        $this->initialize();
     }
 
     public function totalItems(): int

--- a/src/Akeneo/Tool/Component/Batch/Item/RewindableItemReaderInterface.php
+++ b/src/Akeneo/Tool/Component/Batch/Item/RewindableItemReaderInterface.php
@@ -1,9 +1,0 @@
-<?php
-declare(strict_types=1);
-
-namespace Akeneo\Tool\Component\Batch\Item;
-
-interface RewindableItemReaderInterface
-{
-    public function rewind(): void;
-}

--- a/src/Akeneo/Tool/Component/Batch/Item/TrackableTaskletInterface.php
+++ b/src/Akeneo/Tool/Component/Batch/Item/TrackableTaskletInterface.php
@@ -4,5 +4,5 @@ namespace Akeneo\Tool\Component\Batch\Item;
 
 interface TrackableTaskletInterface
 {
-    public function totalItems(): int;
+    public function isTrackable(): bool;
 }

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Csv/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Csv/Reader.php
@@ -4,7 +4,6 @@ namespace Akeneo\Tool\Component\Connector\Reader\File\Csv;
 
 use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
-use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
@@ -22,7 +21,7 @@ use Akeneo\Tool\Component\Connector\Reader\File\FileReaderInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements FileReaderInterface, TrackableItemReaderInterface, RewindableItemReaderInterface
+class Reader implements FileReaderInterface, TrackableItemReaderInterface
 {
     /** @var FileIteratorFactory */
     protected $fileIteratorFactory;
@@ -125,16 +124,6 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
     public function flush()
     {
         $this->fileIterator = null;
-    }
-
-    public function rewind(): void
-    {
-        $jobParameters = $this->stepExecution->getJobParameters();
-        $filePath = $jobParameters->get('filePath');
-        if (null === $this->fileIterator) {
-            $this->fileIterator = $this->createFileIterator($jobParameters, $filePath);
-        }
-        $this->fileIterator->rewind();
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -4,7 +4,6 @@ namespace Akeneo\Tool\Component\Connector\Reader\File\Xlsx;
 
 use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
-use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
@@ -21,7 +20,7 @@ use Akeneo\Tool\Component\Connector\Reader\File\FileReaderInterface;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements FileReaderInterface, TrackableItemReaderInterface, RewindableItemReaderInterface
+class Reader implements FileReaderInterface, TrackableItemReaderInterface
 {
     /** @var FileIteratorFactory */
     protected $fileIteratorFactory;
@@ -124,16 +123,6 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
     public function flush()
     {
         $this->fileIterator = null;
-    }
-
-    public function rewind(): void
-    {
-        $jobParameters = $this->stepExecution->getJobParameters();
-        $filePath = $jobParameters->get('filePath');
-        if (null === $this->fileIterator) {
-            $this->fileIterator = $this->fileIteratorFactory->create($filePath, $this->options);
-        }
-        $this->fileIterator->rewind();
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
@@ -4,7 +4,6 @@ namespace Akeneo\Tool\Component\Connector\Reader\File\Yaml;
 
 use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
-use Akeneo\Tool\Component\Batch\Item\RewindableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
@@ -20,7 +19,7 @@ use Symfony\Component\Yaml\Yaml;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Reader implements FileReaderInterface, TrackableItemReaderInterface, RewindableItemReaderInterface
+class Reader implements FileReaderInterface, TrackableItemReaderInterface
 {
     /** @var ArrayConverterInterface */
     protected $converter;
@@ -168,11 +167,6 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface, Rewin
     public function flush()
     {
         $this->yaml = null;
-    }
-
-    public function rewind(): void
-    {
-        $this->yaml->rewind();
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Connector/Step/TaskletStep.php
+++ b/src/Akeneo/Tool/Component/Connector/Step/TaskletStep.php
@@ -40,9 +40,6 @@ class TaskletStep extends AbstractStep implements TrackableStepInterface
     protected function doExecute(StepExecution $stepExecution)
     {
         $this->tasklet->setStepExecution($stepExecution);
-        if ($this->isTrackable()) {
-            $stepExecution->setTotalItems($this->tasklet->totalItems());
-        }
         $this->tasklet->execute();
     }
 
@@ -64,6 +61,6 @@ class TaskletStep extends AbstractStep implements TrackableStepInterface
 
     public function isTrackable(): bool
     {
-        return $this->tasklet instanceof TrackableTaskletInterface;
+        return $this->tasklet instanceof TrackableTaskletInterface && $this->tasklet->isTrackable();
     }
 }

--- a/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Csv/ReaderSpec.php
@@ -133,30 +133,6 @@ class ReaderSpec extends ObjectBehavior
         $this->shouldThrow(InvalidItemFromViolationsException::class)->during('read');
     }
 
-    function it_rewinds_the_reader(
-        $fileIteratorFactory,
-        $stepExecution,
-        FileIteratorInterface $fileIterator,
-        JobParameters $jobParameters
-    ) {
-        $filePath = $this->getPath() . DIRECTORY_SEPARATOR  . 'with_media.csv';
-
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('enclosure')->willReturn('"');
-        $jobParameters->get('delimiter')->willReturn(';');
-        $jobParameters->get('filePath')->willReturn($filePath);
-
-        $fileIteratorFactory->create($filePath, [
-            'reader_options' => [
-                'fieldDelimiter' => ';',
-                'fieldEnclosure' => '"',
-            ]
-        ])->willReturn($fileIterator);
-        $fileIterator->rewind()->shouldBeCalled();
-
-        $this->rewind();
-    }
-
     private function getPath()
     {
         return __DIR__ . DIRECTORY_SEPARATOR .

--- a/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
@@ -120,24 +120,4 @@ class ReaderSpec extends ObjectBehavior
 
         $this->shouldThrow(InvalidItemFromViolationsException::class)->during('read');
     }
-
-    function it_rewinds(
-        $fileIteratorFactory,
-        $stepExecution,
-        FileIteratorInterface $fileIterator,
-        JobParameters $jobParameters
-    ) {
-        $filePath = __DIR__ . DIRECTORY_SEPARATOR .
-            DIRECTORY_SEPARATOR . 'features' .
-            DIRECTORY_SEPARATOR . 'Context' .
-            DIRECTORY_SEPARATOR . 'fixtures' .
-            DIRECTORY_SEPARATOR . 'product_with_carriage_return.xlsx';
-
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
-        $jobParameters->get('filePath')->willReturn($filePath);
-        $fileIteratorFactory->create($filePath, [])->willReturn($fileIterator);
-        $fileIterator->rewind()->shouldBeCalled();
-
-        $this->rewind();
-    }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
@@ -14,6 +14,7 @@ use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
@@ -54,6 +55,12 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $this->beAnInstanceOf(ComputeDataRelatedToFamilyProductsTasklet::class);
     }
 
+    function it_track_processed_items()
+    {
+        $this->shouldImplement(TrackableTaskletInterface::class);
+        $this->isTrackable()->shouldReturn(true);
+    }
+
     function it_saves_the_products_belonging_to_the_family(
         $familyReader,
         $familyRepository,
@@ -86,16 +93,18 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($product1, $product2, $product3);
         $cursor->next()->shouldBeCalled();
+        $cursor->count()->shouldBeCalled()->willReturn(3);
 
         $productSaver->saveAll([$product1, $product2])->shouldBeCalled();
         $productSaver->saveAll([$product3])->shouldBeCalled();
 
+        $stepExecution->setTotalItems(3)->shouldBeCalledOnce();
         $stepExecution->incrementSummaryInfo(Argument::cetera())->shouldBeCalledTimes(2);
         $stepExecution->incrementSummaryInfo('process', 2)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('process', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
-        $stepExecution->incrementProcessedItems(2)->shouldBeCalled();
-        $stepExecution->incrementProcessedItems(1)->shouldBeCalled();
+        $stepExecution->incrementProcessedItems(2)->shouldBeCalledOnce();
+        $stepExecution->incrementProcessedItems(1)->shouldBeCalledOnce();
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
         $cacheClearer->clear()->shouldBeCalledTimes(3);
@@ -141,7 +150,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($variantProduct1, $variantProduct2, $variantProduct3);
         $cursor->next()->shouldBeCalled();
-
+        $cursor->count()->shouldBeCalled()->willReturn(3);
 
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$variantProduct1])->shouldBeCalled();
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$variantProduct2])->shouldBeCalled();
@@ -157,12 +166,13 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $productSaver->saveAll([$variantProduct1, $variantProduct2])->shouldBeCalled();
         $productSaver->saveAll([$variantProduct3])->shouldBeCalled();
 
+        $stepExecution->setTotalItems(3)->shouldBeCalledOnce();
         $stepExecution->incrementSummaryInfo(Argument::cetera())->shouldBeCalledTimes(2);
         $stepExecution->incrementSummaryInfo('process', 2)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('process', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
-        $stepExecution->incrementProcessedItems(2)->shouldBeCalled();
-        $stepExecution->incrementProcessedItems(1)->shouldBeCalled();
+        $stepExecution->incrementProcessedItems(2)->shouldBeCalledOnce();
+        $stepExecution->incrementProcessedItems(1)->shouldBeCalledOnce();
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
         $cacheClearer->clear()->shouldBeCalledTimes(3);
@@ -208,7 +218,7 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($variantProduct1, $variantProduct2, $variantProduct3);
         $cursor->next()->shouldBeCalled();
-
+        $cursor->count()->shouldBeCalled()->willReturn(3);
 
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$variantProduct1])->shouldBeCalled();
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$variantProduct2])->shouldBeCalled();
@@ -223,10 +233,10 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
 
         $productSaver->saveAll([$variantProduct3])->shouldBeCalled();
 
+        $stepExecution->setTotalItems(3)->shouldBeCalledOnce();
         $stepExecution->incrementSummaryInfo('process', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
-        $stepExecution->incrementProcessedItems(1)->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems(1)->shouldBeCalledTimes(3);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalled();
         $cacheClearer->clear()->shouldBeCalledTimes(3);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilySubProductModelsTaskletSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
@@ -77,6 +78,12 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
         $this->initialize();
     }
 
+    function it_track_processed_items()
+    {
+        $this->shouldImplement(TrackableTaskletInterface::class);
+        $this->isTrackable()->shouldReturn(true);
+    }
+
     function it_computes_no_product_models_if_there_is_nothingmore__to_read_in_the_imported_file(
         $cacheClearer,
         $familyReader
@@ -135,6 +142,7 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($productModel1, $productModel2, $productModel3);
         $cursor->next()->shouldBeCalled();
+        $cursor->count()->shouldBeCalled()->willReturn(3);
 
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$productModel1])->shouldBeCalled();
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$productModel2])->shouldBeCalled();
@@ -150,13 +158,14 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
         $productModelSaver->saveAll([$productModel1, $productModel2])->shouldBeCalled();
         $productModelSaver->saveAll([$productModel3])->shouldBeCalled();
 
+        $stepExecution->setTotalItems(3)->shouldBeCalledOnce();
         $stepExecution->incrementSummaryInfo(Argument::cetera())->shouldBeCalledTimes(2);
         $stepExecution->incrementSummaryInfo('process', 2)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('process', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldNotBeCalled();
-        $stepExecution->incrementProcessedItems(2)->shouldBeCalledTimes(1);
-        $stepExecution->incrementProcessedItems(1)->shouldBeCalledTimes(1);
 
+        $stepExecution->incrementProcessedItems(2)->shouldBeCalledOnce();
+        $stepExecution->incrementProcessedItems(1)->shouldBeCalledOnce();
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(2);
         $cacheClearer->clear()->shouldBeCalledTimes(2);
@@ -197,6 +206,7 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn($productModel1, $productModel2, $productModel3);
         $cursor->next()->shouldBeCalled();
+        $cursor->count()->shouldBeCalled()->willReturn(3);
 
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$productModel1])->shouldBeCalled();
         $keepOnlyValuesForVariation->updateEntitiesWithFamilyVariant([$productModel2])->shouldBeCalled();
@@ -211,11 +221,11 @@ class ComputeDataRelatedToFamilySubProductModelsTaskletSpec extends ObjectBehavi
 
         $productModelSaver->saveAll([$productModel3])->shouldBeCalled();
 
+        $stepExecution->setTotalItems(3)->shouldBeCalledOnce();
         $stepExecution->incrementSummaryInfo('process', 1)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalledTimes(2);
-        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(2);
-        $stepExecution->incrementProcessedItems(1)->shouldBeCalledTimes(1);
 
+        $stepExecution->incrementProcessedItems(1)->shouldBeCalledTimes(3);
 
         $jobRepository->updateStepExecution($stepExecution)->shouldBeCalledTimes(1);
         $cacheClearer->clear()->shouldBeCalledTimes(2);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/EnsureConsistentAttributeGroupOrderTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/EnsureConsistentAttributeGroupOrderTaskletSpec.php
@@ -7,6 +7,8 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 use Akeneo\Pim\Structure\Component\AttributeGroup\Query\FindAttributeGroupOrdersEqualOrSuperiorTo;
 use Akeneo\Pim\Structure\Component\Model\AttributeGroup;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableItemReaderInterface;
+use Akeneo\Tool\Component\Batch\Item\TrackableTaskletInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -41,6 +43,12 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
         $this->beAnInstanceOf(EnsureConsistentAttributeGroupOrderTasklet::class);
     }
 
+    function it_does_not_track_processed_items_when_reader_is_not_trackable()
+    {
+        $this->shouldImplement(TrackableTaskletInterface::class);
+        $this->isTrackable()->shouldReturn(false);
+    }
+
     function it_sets_consistent_sort_order_on_an_attribute_group_by_setting_next_available_sort_order(
         IdentifiableObjectRepositoryInterface $attributeGroupRepository,
         ItemReaderInterface $attributeGroupReader,
@@ -65,7 +73,7 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
 
         $attributeGroupSaver->save($attributeGroup);
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(1);
 
         $this->execute($attributeGroup);
     }
@@ -94,7 +102,7 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
 
         $attributeGroupSaver->save($attributeGroup);
         $stepExecution->incrementSummaryInfo('process')->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(1);
 
         $this->execute($attributeGroup);
     }
@@ -119,7 +127,7 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
 
         $attributeGroupSaver->save($attributeGroup)->shouldNotBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(1);
 
         $this->execute($attributeGroup);
     }
@@ -142,7 +150,7 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
 
         $attributeGroupSaver->save($attributeGroup)->shouldNotBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(1);
 
         $this->execute($attributeGroup);
     }
@@ -173,8 +181,51 @@ class EnsureConsistentAttributeGroupOrderTaskletSpec extends ObjectBehavior
 
         $attributeGroupSaver->save($attributeGroup)->shouldNotBeCalled();
         $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
-        $stepExecution->incrementProcessedItems()->shouldBeCalled();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(1);
 
         $this->execute($attributeGroup);
+    }
+
+    function it_track_processed_items_when_reader_is_trackable(
+        IdentifiableObjectRepositoryInterface $attributeGroupRepository,
+        SaverInterface $attributeGroupSaver,
+        FindAttributeGroupOrdersEqualOrSuperiorTo $findAttributeGroupOrdersEqualOrSuperiorTo,
+        StepExecution $stepExecution,
+        AttributeGroup $marketingAttributeGroup,
+        AttributeGroup $technicalAttributeGroup,
+        ValidatorInterface $validator,
+        ConstraintViolationList $emptyViolationList,
+        TrackableItemReaderInterface $attributeGroupReader
+    ) {
+        $this->isTrackable()->shouldReturn(true);
+        $this->setStepExecution($stepExecution);
+
+        $attributeGroupReader->totalItems()->willReturn(2);
+        $attributeGroupReader->read()->willReturn(['code' => 'marketing'], ['code' => 'technical'], null);
+        $attributeGroupRepository->findOneByIdentifier('marketing')->willReturn($marketingAttributeGroup);
+        $attributeGroupRepository->findOneByIdentifier('technical')->willReturn($technicalAttributeGroup);
+
+        $marketingAttributeGroup->getSortOrder()->willReturn('10');
+        $technicalAttributeGroup->getSortOrder()->willReturn('11');
+
+        $findAttributeGroupOrdersEqualOrSuperiorTo->execute($marketingAttributeGroup)->willReturn(['10', '11', '12']);
+        $findAttributeGroupOrdersEqualOrSuperiorTo->execute($technicalAttributeGroup)->willReturn(['11', '12', '13']);
+
+        $marketingAttributeGroup->setSortOrder(13)->shouldBeCalled();
+        $technicalAttributeGroup->setSortOrder(14)->shouldBeCalled();
+
+        $validator->validate($marketingAttributeGroup)->willReturn($emptyViolationList);
+        $validator->validate($technicalAttributeGroup)->willReturn($emptyViolationList);
+
+        $emptyViolationList->count()->willReturn(0);
+
+        $attributeGroupSaver->save($technicalAttributeGroup)->shouldBeCalled();
+        $attributeGroupSaver->save($marketingAttributeGroup)->shouldBeCalled();
+
+        $stepExecution->setTotalItems(2)->shouldBeCalledOnce();
+        $stepExecution->incrementProcessedItems()->shouldBeCalledTimes(2);
+        $stepExecution->incrementSummaryInfo('process')->shouldBeCalledTimes(2);
+
+        $this->execute();
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- Refactor way of set the total item in Tasklets -> before the tasklet should return the total items not the tasklet is responsible to set the total items => it's more logic and avoid double call to Elasticsearch
- DeleteProductAndProductModelTasklet progress is not updated during execution => it pass from 0 to 100 on interface 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
