### PR TITLE
PIM-9540: replace use of strip_tags before storing textarea values in Elasticsearch

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizer.php
@@ -41,9 +41,18 @@ class TextAreaNormalizer extends AbstractProductValueNormalizer implements Norma
         if (null === $textAreaValue) {
             return null;
         }
+        return $this->clean($textAreaValue);
+    }
 
-        $cleanedData = str_replace(["\r", "\n"], "", $textAreaValue);
-        $cleanedData = strip_tags(html_entity_decode($cleanedData));
+    private function clean(string $value): string
+    {
+        $cleanedData = $value;
+        $cleanedData = html_entity_decode($cleanedData);
+
+        $cleanedData = preg_replace('/<!--.+-->/i', '', $cleanedData);
+        $cleanedData = preg_replace('/<.+?>/i', '', $cleanedData);
+
+        $cleanedData = str_replace(["\r", "\n"], "", $cleanedData);
 
         return $cleanedData;
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Indexing/Value/TextAreaNormalizerSpec.php
@@ -320,4 +320,40 @@ description\r\n");
             ]
         ]);
     }
+
+    function it_normalizes_a_text_area_product_value_with_html_tags_and_invalid_tags(
+        ValueInterface $textAreaValue,
+        GetAttributes $getAttributes
+    ) {
+            $textAreaValue->getAttributeCode()->willReturn('description');
+            $textAreaValue->getLocaleCode()->willReturn(null);
+            $textAreaValue->getScopeCode()->willReturn(null);
+            $textAreaValue->getData()->willReturn("my <a href=\"www.foo.bar\">link</a> 
+<br>hello<!--comment--> 
+hello<script><!-- f('<!--internal--></script>'); --></script> 
+if a<b then print a; 
+hello <td height=22 nowrap align=\"left\">
+a<b &#65 Alpha&Omega Ω");
+
+            $getAttributes->forCode('description')->willReturn(new Attribute(
+                'description',
+                'pim_catalog_textarea',
+                [],
+                false,
+                false,
+                null,
+                null,
+                true,
+                'textarea',
+                []
+            ));
+
+            $this->normalize($textAreaValue, ValueCollectionNormalizer::INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX)->shouldReturn([
+                'description-textarea' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'my link hello hello if a<b then print a; hello a<b &#65 Alpha&Omega Ω'
+                    ]
+                ]
+            ]);
+    }
 }


### PR DESCRIPTION


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
