### PR TITLE
RAC-376: Fix step execution migration by handling the error in the getters

### DIFF
--- a/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
@@ -25,6 +25,10 @@ class StepExecution
 {
     private const TRACKING_DATA_PROCESSED_ITEMS = 'processedItems';
     private const TRACKING_DATA_TOTAL_ITEMS = 'totalItems';
+    private const TRACKING_DATA_DEFAULT = [
+        self::TRACKING_DATA_PROCESSED_ITEMS => 0,
+        self::TRACKING_DATA_TOTAL_ITEMS => 0,
+    ];
 
     /** @var integer */
     private $id;
@@ -81,10 +85,7 @@ class StepExecution
     private $summary = [];
 
     /** @var array */
-    private $trackingData = [
-        self::TRACKING_DATA_PROCESSED_ITEMS => 0,
-        self::TRACKING_DATA_TOTAL_ITEMS => 0,
-    ];
+    private $trackingData = self::TRACKING_DATA_DEFAULT;
 
     /**
      * Constructor with mandatory properties.
@@ -557,16 +558,24 @@ class StepExecution
 
     public function setTotalItems(int $totalItems): void
     {
+        if (null === $this->trackingData) {
+            $this->trackingData = self::TRACKING_DATA_DEFAULT;
+        }
+
         $this->trackingData[self::TRACKING_DATA_TOTAL_ITEMS] = $totalItems;
     }
 
     public function getTotalItems(): int
     {
-        return $this->trackingData[self::TRACKING_DATA_TOTAL_ITEMS];
+        return $this->trackingData[self::TRACKING_DATA_TOTAL_ITEMS] ?? 0;
     }
 
     public function incrementProcessedItems(int $increment = 1): void
     {
+        if (null === $this->trackingData) {
+            $this->trackingData = self::TRACKING_DATA_DEFAULT;
+        }
+
         $this->trackingData[self::TRACKING_DATA_PROCESSED_ITEMS] += $increment;
         if ($this->trackingData[self::TRACKING_DATA_PROCESSED_ITEMS] > $this->getTotalItems()) {
             $this->setTotalItems($this->trackingData[self::TRACKING_DATA_PROCESSED_ITEMS]);
@@ -575,12 +584,12 @@ class StepExecution
 
     public function getProcessedItems(): int
     {
-        return $this->trackingData[self::TRACKING_DATA_PROCESSED_ITEMS];
+        return $this->trackingData[self::TRACKING_DATA_PROCESSED_ITEMS] ?? 0;
     }
 
     public function getTrackingData(): array
     {
-        return $this->trackingData;
+        return $this->trackingData ?? self::TRACKING_DATA_DEFAULT;
     }
 
     public function setTrackingData(array $trackingData): void


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Doctrine hydrate entities by bypassing both constructor and setters.
The migration added the column tracking data with a default value to null.
When `$this->trackingData = null;`, fatal error.
With this PR, we ensure there is no error when those getter/setter are called.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
