### PR TITLE
DAPI-1397: Consolidate unique score instead of axes rates

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ComputeProductScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ComputeProductScores.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ComputeProductScores
+{
+    private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
+
+    private CriteriaEvaluationRegistry $criteriaEvaluationRegistry;
+
+    public function __construct(
+        GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
+        CriteriaEvaluationRegistry $criteriaEvaluationRegistry
+    ) {
+        $this->getLocalesByChannelQuery = $getLocalesByChannelQuery;
+        $this->criteriaEvaluationRegistry = $criteriaEvaluationRegistry;
+    }
+
+    public function fromCriteriaEvaluations(Read\CriterionEvaluationCollection $criteriaEvaluations): ChannelLocaleRateCollection
+    {
+        $scores = new ChannelLocaleRateCollection();
+
+        foreach ($this->getLocalesByChannelQuery->getChannelLocaleCollection() as $channelCode => $locales) {
+            foreach ($locales as $localeCode) {
+                $score = $this->computeChannelLocaleScore($criteriaEvaluations, $channelCode, $localeCode);
+                if (null !== $score) {
+                    $scores->addRate($channelCode, $localeCode, $score);
+                }
+            }
+        }
+
+        return $scores;
+    }
+
+    private function computeChannelLocaleScore(CriterionEvaluationCollection $criteriaEvaluations, ChannelCode $channelCode, LocaleCode $localeCode): ?Rate
+    {
+        $criteriaRates = [];
+        $totalCoefficient = 0;
+
+        foreach ($this->criteriaEvaluationRegistry->getCriterionCodes() as $criterionCode) {
+            $criterionRates = $criteriaEvaluations->getCriterionRates($criterionCode);
+            $criterionRate = null !== $criterionRates ? $criterionRates->getByChannelAndLocale($channelCode, $localeCode) : null;
+            if (null !== $criterionRate) {
+                $coefficient = $this->criteriaEvaluationRegistry->getCriterionCoefficient($criterionCode);
+                $totalCoefficient += $coefficient;
+                $criteriaRates[] = $criterionRate->toInt() * $coefficient;
+            }
+        }
+
+        if (empty($criteriaRates) || $totalCoefficient === 0) {
+            return null;
+        }
+
+        $score = round(array_sum($criteriaRates) / $totalCoefficient, 0, PHP_ROUND_HALF_DOWN);
+
+        return new Rate(intval($score));
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ConsolidateProductScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ConsolidateProductScores.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\Clock;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\ProductScoreRepositoryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ConsolidateProductScores
+{
+    private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsQuery;
+
+    private ComputeProductScores $computeProductScores;
+
+    private ProductScoreRepositoryInterface $productScoreRepository;
+
+    private Clock $clock;
+
+    public function __construct(
+        GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsQuery,
+        ComputeProductScores $computeProductScores,
+        ProductScoreRepositoryInterface $productScoreRepository,
+        Clock $clock
+    ) {
+        $this->getCriteriaEvaluationsQuery = $getCriteriaEvaluationsQuery;
+        $this->computeProductScores = $computeProductScores;
+        $this->productScoreRepository = $productScoreRepository;
+        $this->clock = $clock;
+    }
+
+    public function consolidate(array $productIds): void
+    {
+        $productsScores = [];
+        foreach ($productIds as $productId) {
+            $productId = new ProductId($productId);
+            $criteriaEvaluations = $this->getCriteriaEvaluationsQuery->execute($productId);
+            $scores = $this->computeProductScores->fromCriteriaEvaluations($criteriaEvaluations);
+            $productsScores[] = new ProductScores($productId, $this->clock->getCurrentTime(), $scores);
+        }
+
+        if (!empty($scores)) {
+            $this->productScoreRepository->saveAll($productsScores);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
@@ -2,24 +2,14 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\AxisRegistryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisEvaluation;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductEvaluationQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\AxisCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
@@ -27,99 +17,91 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
 /**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
  * Return format:
  *
  * [
- *  axis => [
- *      channel => [
- *          locale => [
- *              'rate' => [
- *                  'value' => float  // axis rate number,
- *                  'rank' => string  // axis rate letter,
- *              ],
- *              'criteria' => [
- *                  [
- *                      'code' => string  // code of the criterion,
- *                      'status' => string // status of the criterion evaluation (done, not_applicable, error)
- *                      'rate => [
- *                          'value' => float  // integer value of the criterion rate,
- *                          'rank' => string  // criterion rate letter,
- *                      ],
- *                      'improvable_attributes' => string[] // list of the code of the attributes to improve
- *                  ]
- *              ],
- *          ]
- *      ]
- *  ]
+ *    channel => [
+ *        locale => [
+ *            'score' => [
+ *                'value' => float  // score number (0-100),
+ *                'rank' => string  // score letter,
+ *            ],
+ *            'criteria' => [
+ *                [
+ *                    'code' => string  // code of the criterion,
+ *                    'status' => string // status of the criterion evaluation (done, not_applicable, error)
+ *                    'rate => [
+ *                        'value' => float  // integer value of the criterion rate,
+ *                        'rank' => string  // criterion rate letter,
+ *                    ],
+ *                    'improvable_attributes' => string[] // list of the code of the attributes to improve
+ *                ]
+ *            ],
+ *        ]
+ *    ]
  * ]
  */
 class GetProductEvaluation
 {
-    /** @var GetProductEvaluationQueryInterface */
-    private $getProductEvaluationQuery;
+    private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery;
 
-    /** @var GetLocalesByChannelQueryInterface */
-    private $getLocalesByChannelQuery;
+    private GetLatestProductScoresQueryInterface $getLatestProductScoresQuery;
 
-    /** @var AxisRegistryInterface */
-    private $axisRegistry;
+    private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
+
+    private CriteriaEvaluationRegistry $criteriaEvaluationRegistry;
 
     public function __construct(
-        GetProductEvaluationQueryInterface $getProductEvaluationQuery,
+        GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
+        GetLatestProductScoresQueryInterface $getLatestProductScoresQuery,
         GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        AxisRegistryInterface $axisRegistry
+        CriteriaEvaluationRegistry $criteriaEvaluationRegistry
     ) {
-        $this->getProductEvaluationQuery = $getProductEvaluationQuery;
+        $this->getCriteriaEvaluationsByProductIdQuery = $getCriteriaEvaluationsByProductIdQuery;
+        $this->getLatestProductScoresQuery = $getLatestProductScoresQuery;
         $this->getLocalesByChannelQuery = $getLocalesByChannelQuery;
-        $this->axisRegistry = $axisRegistry;
+        $this->criteriaEvaluationRegistry = $criteriaEvaluationRegistry;
     }
 
     public function get(ProductId $productId): array
     {
-        $productEvaluation = $this->getProductEvaluationQuery->execute($productId);
+        $productScores = $this->getLatestProductScoresQuery->byProductId($productId);
+        $criteriaEvaluations = $this->getCriteriaEvaluationsByProductIdQuery->execute($productId);
         $channelsLocales = $this->getLocalesByChannelQuery->getChannelLocaleCollection();
+
         $formattedProductEvaluation = [];
 
-        /** @var AxisEvaluation $axisEvaluation */
-        foreach ($productEvaluation->getAxesEvaluations() as $axisEvaluation) {
-            $formattedProductEvaluation[strval($axisEvaluation->getAxisCode())] = $this->formatAxisEvaluation($axisEvaluation, $channelsLocales);
+        foreach ($channelsLocales as $channelCode => $locales) {
+            foreach ($locales as $localeCode) {
+                $formattedProductEvaluation[strval($channelCode)][strval($localeCode)] = [
+                    'score' => $this->formatScore($productScores, $channelCode, $localeCode),
+                    'criteria' => $this->formatCriteriaEvaluations($criteriaEvaluations, $channelCode, $localeCode),
+                ];
+            }
         }
 
         return $formattedProductEvaluation;
     }
 
-    private function formatAxisEvaluation(AxisEvaluation $axisEvaluation, ChannelLocaleCollection $channelsLocales): array
+    private function formatScore(ChannelLocaleRateCollection $productScores, ChannelCode $channelCode, $localeCode): array
     {
-        $formattedAxisEvaluation = [];
-        foreach ($channelsLocales as $channelCode => $locales) {
-            foreach ($locales as $localeCode) {
-                $formattedAxisEvaluation[strval($channelCode)][strval($localeCode)] = [
-                    'rate' => $this->formatAxisRate($axisEvaluation, $channelCode, $localeCode),
-                    'criteria' => $this->formatAxisCriteria($axisEvaluation, $channelCode, $localeCode),
-                ];
-            }
-        }
-
-        return $formattedAxisEvaluation;
-    }
-
-    private function formatAxisRate(AxisEvaluation $axisEvaluation, ChannelCode $channelCode, $localeCode): array
-    {
-        $axisRate = $axisEvaluation->getRates()->getByChannelAndLocale($channelCode, $localeCode);
+        $score = $productScores->getByChannelAndLocale($channelCode, $localeCode);
 
         return [
-            'value' => null !== $axisRate ? $axisRate->toInt() : null,
-            'rank' => null !== $axisRate ? $axisRate->toLetter() : null,
+            'value' => null !== $score ? $score->toInt() : null,
+            'rank' => null !== $score ? $score->toLetter() : null,
         ];
     }
 
-    private function formatAxisCriteria(AxisEvaluation $axisEvaluation, ChannelCode $channelCode, LocaleCode $localeCode): array
+    private function formatCriteriaEvaluations(Read\CriterionEvaluationCollection $criteriaEvaluations, ChannelCode $channelCode, LocaleCode $localeCode): array
     {
         $criteriaRates = [];
 
-        $axis = $this->axisRegistry->get($axisEvaluation->getAxisCode());
-        foreach ($axis->getCriteriaCodes() as $criterionCode) {
-            $criterionEvaluation = $axisEvaluation->getCriteriaEvaluations()->get($criterionCode);
+        foreach ($this->criteriaEvaluationRegistry->getCriterionCodes() as $criterionCode) {
+            $criterionEvaluation = $criteriaEvaluations->get($criterionCode);
             $criteriaRates[] = $this->formatCriterionEvaluation(
                 $criterionCode,
                 $criterionEvaluation !== null ? $criterionEvaluation->getResult() : null,
@@ -128,14 +110,10 @@ class GetProductEvaluation
             );
         }
 
-        if (empty($criteriaRates)) {
-            $criteriaRates = $this->formatEmptyAxisCriteria($axisEvaluation->getAxisCode(), $channelCode, $localeCode);
-        }
-
         return $criteriaRates;
     }
 
-    private function formatCriterionEvaluation(CriterionCode $criterionCode, ?CriterionEvaluationResult $evaluationResult, ChannelCode $channelCode, LocaleCode $localeCode): array
+    private function formatCriterionEvaluation(CriterionCode $criterionCode, ?Read\CriterionEvaluationResult $evaluationResult, ChannelCode $channelCode, LocaleCode $localeCode): array
     {
         $rate = null !== $evaluationResult ? $evaluationResult->getRates()->getByChannelAndLocale($channelCode, $localeCode) : null;
         $attributes = null !== $evaluationResult ? $evaluationResult->getAttributes()->getByChannelAndLocale($channelCode, $localeCode) : [];
@@ -144,26 +122,11 @@ class GetProductEvaluation
         return [
             'code' => strval($criterionCode),
             'rate' => [
-                "value" => null !== $rate ? $rate->toInt() : null,
-                "rank" => null !== $rate ? $rate->toLetter() : null,
+                'value' => null !== $rate ? $rate->toInt() : null,
+                'rank' => null !== $rate ? $rate->toLetter() : null,
             ],
             'improvable_attributes' => $attributes ?? [],
             'status' => null !== $status ? strval($status) : CriterionEvaluationResultStatus::IN_PROGRESS,
         ];
-    }
-
-    private function formatEmptyAxisCriteria(AxisCode $axisCode, ChannelCode $channelCode, LocaleCode $localeCode): array
-    {
-        $axis = $this->axisRegistry->get($axisCode);
-        if (null === $axis) {
-            return [];
-        }
-
-        $criteriaEvaluations = [];
-        foreach ($axis->getCriteriaCodes() as $criterionCode) {
-            $criteriaEvaluations[] = $this->formatCriterionEvaluation($criterionCode, null, $channelCode, $localeCode);
-        }
-
-        return $criteriaEvaluations;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaEvaluationRegistry.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaEvaluationRegistry.php
@@ -2,23 +2,18 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Exception\CriterionNotFoundException;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class CriteriaEvaluationRegistry
 {
-    private $criterionEvaluationServices;
+    private array $criterionEvaluationServices;
 
     public function __construct(iterable $criterionEvaluationServices)
     {
@@ -44,8 +39,14 @@ class CriteriaEvaluationRegistry
      */
     public function getCriterionCodes(): array
     {
-        return array_map(function (string $code) {
-            return new CriterionCode($code);
-        }, array_keys($this->criterionEvaluationServices));
+        return array_values(array_map(
+            fn (EvaluateCriterionInterface $evaluateCriterion) => $evaluateCriterion->getCode(),
+            $this->criterionEvaluationServices
+        ));
+    }
+
+    public function getCriterionCoefficient(CriterionCode $code): int
+    {
+        return $this->get($code)->getCoefficient();
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompletenessOfNonRequiredAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompletenessOfNonRequiredAttributes.php
@@ -2,36 +2,28 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompleteness;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateCriterionInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ProductValuesCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class EvaluateCompletenessOfNonRequiredAttributes implements EvaluateCriterionInterface
 {
     public const CRITERION_CODE = 'completeness_of_non_required_attributes';
 
-    /** @var CriterionCode */
-    private $code;
+    public const CRITERION_COEFFICIENT = 1;
 
-    /** @var CalculateProductCompletenessInterface */
-    private $completenessCalculator;
+    private CriterionCode $code;
 
-    /** @var EvaluateCompleteness */
-    private $evaluateCompleteness;
+    private CalculateProductCompletenessInterface $completenessCalculator;
+
+    private EvaluateCompleteness $evaluateCompleteness;
 
     public function __construct(CalculateProductCompletenessInterface $completenessCalculator, EvaluateCompleteness $evaluateCompleteness)
     {
@@ -48,5 +40,10 @@ final class EvaluateCompletenessOfNonRequiredAttributes implements EvaluateCrite
     public function getCode(): CriterionCode
     {
         return $this->code;
+    }
+
+    public function getCoefficient(): int
+    {
+        return self::CRITERION_COEFFICIENT;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompletenessOfRequiredAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompletenessOfRequiredAttributes.php
@@ -2,15 +2,6 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateCriterionInterface;
@@ -18,18 +9,21 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ProductValuesCollecti
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class EvaluateCompletenessOfRequiredAttributes implements EvaluateCriterionInterface
 {
     public const CRITERION_CODE = 'completeness_of_required_attributes';
 
-    /** @var CriterionCode */
-    private $code;
+    public const CRITERION_COEFFICIENT = 2;
 
-    /** @var CalculateProductCompletenessInterface */
-    private $completenessCalculator;
+    private CriterionCode $code;
 
-    /** @var EvaluateCompleteness */
-    private $evaluateCompleteness;
+    private CalculateProductCompletenessInterface $completenessCalculator;
+
+    private EvaluateCompleteness $evaluateCompleteness;
 
     public function __construct(CalculateProductCompletenessInterface $completenessCalculator, EvaluateCompleteness $evaluateCompleteness)
     {
@@ -46,5 +40,10 @@ final class EvaluateCompletenessOfRequiredAttributes implements EvaluateCriterio
     public function getCode(): CriterionCode
     {
         return $this->code;
+    }
+
+    public function getCoefficient(): int
+    {
+        return self::CRITERION_COEFFICIENT;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateImageEnrichment.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateImageEnrichment.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment;
 
@@ -13,9 +14,15 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvalua
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class EvaluateImageEnrichment implements EvaluateCriterionInterface
 {
     public const CRITERION_CODE = 'enrichment_image';
+
+    public const CRITERION_COEFFICIENT = 2;
 
     private CalculateProductCompletenessInterface $completenessCalculator;
 
@@ -84,5 +91,10 @@ class EvaluateImageEnrichment implements EvaluateCriterionInterface
             ->addStatus($channelCode, $localeCode, CriterionEvaluationResultStatus::done())
             ->addRateByAttributes($channelCode, $localeCode, $attributesRates)
         ;
+    }
+
+    public function getCoefficient(): int
+    {
+        return self::CRITERION_COEFFICIENT;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/EvaluateCriterionInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/EvaluateCriterionInterface.php
@@ -22,4 +22,6 @@ interface EvaluateCriterionInterface
     public function evaluate(Write\CriterionEvaluation $criterionEvaluation, ProductValuesCollection $productValues): Write\CriterionEvaluationResult;
 
     public function getCode(): CriterionCode;
+
+    public function getCoefficient(): int;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/ProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/ProductEvaluation.php
@@ -2,31 +2,28 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class ProductEvaluation
 {
-    /** @var ProductId */
-    private $productId;
+    private ProductId $productId;
 
-    /** @var AxisEvaluationCollection */
-    private $axesEvaluations;
+    private ChannelLocaleRateCollection $scores;
 
-    public function __construct(ProductId $productId, AxisEvaluationCollection $axesEvaluations)
+    private CriterionEvaluationCollection $criteriaEvaluations;
+
+    public function __construct(ProductId $productId, ChannelLocaleRateCollection $scores, CriterionEvaluationCollection $criteriaEvaluations)
     {
         $this->productId = $productId;
-        $this->axesEvaluations = $axesEvaluations;
+        $this->scores = $scores;
+        $this->criteriaEvaluations = $criteriaEvaluations;
     }
 
     public function getProductId(): ProductId
@@ -34,24 +31,13 @@ final class ProductEvaluation
         return $this->productId;
     }
 
-    public function getAxesEvaluations(): AxisEvaluationCollection
+    public function getScores(): ChannelLocaleRateCollection
     {
-        return $this->axesEvaluations;
+        return $this->scores;
     }
 
-    // @todo: Refactor to remove axes stuff
     public function getCriteriaEvaluations(): CriterionEvaluationCollection
     {
-        $criteriaEvaluations = new CriterionEvaluationCollection();
-
-        /** @var AxisEvaluation $axesEvaluation */
-        foreach ($this->axesEvaluations as $axesEvaluation) {
-            /** @var CriterionEvaluation $criteriaEvaluation */
-            foreach ($axesEvaluation->getCriteriaEvaluations() as $criteriaEvaluation) {
-                $criteriaEvaluations->add($criteriaEvaluation);
-            }
-        }
-
-        return $criteriaEvaluations;
+        return $this->criteriaEvaluations;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/ProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/ProductEvaluation.php
@@ -38,4 +38,20 @@ final class ProductEvaluation
     {
         return $this->axesEvaluations;
     }
+
+    // @todo: Refactor to remove axes stuff
+    public function getCriteriaEvaluations(): CriterionEvaluationCollection
+    {
+        $criteriaEvaluations = new CriterionEvaluationCollection();
+
+        /** @var AxisEvaluation $axesEvaluation */
+        foreach ($this->axesEvaluations as $axesEvaluation) {
+            /** @var CriterionEvaluation $criteriaEvaluation */
+            foreach ($axesEvaluation->getCriteriaEvaluations() as $criteriaEvaluation) {
+                $criteriaEvaluations->add($criteriaEvaluation);
+            }
+        }
+
+        return $criteriaEvaluations;
+    }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Write/ProductScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Write/ProductScores.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductScores
+{
+    private ProductId $productId;
+
+    private \DateTimeImmutable $evaluatedAt;
+
+    private ChannelLocaleRateCollection $scores;
+
+    public function __construct(ProductId $productId, \DateTimeImmutable $evaluatedAt, ChannelLocaleRateCollection $scores)
+    {
+        $this->productId = $productId;
+        $this->evaluatedAt = $evaluatedAt;
+        $this->scores = $scores;
+    }
+
+    public function getProductId(): ProductId
+    {
+        return $this->productId;
+    }
+
+    public function getEvaluatedAt(): \DateTimeImmutable
+    {
+        return $this->evaluatedAt;
+    }
+
+    public function getScores(): ChannelLocaleRateCollection
+    {
+        return $this->scores;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetLatestProductScoresQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetLatestProductScoresQueryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetLatestProductScoresQueryInterface
+{
+    public function byProductId(ProductId $productId): ChannelLocaleRateCollection;
+
+    /**
+     * @param ProductId[] $productIds
+     *
+     * @return ChannelLocaleRateCollection[]
+     */
+    public function byProductIds(array $productIds): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Repository/ProductScoreRepositoryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Repository/ProductScoreRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ProductScoreRepositoryInterface
+{
+    /**
+     * @param ProductScores[] $productsScores
+     */
+    public function saveAll(array $productsScores): void;
+
+    public function purgeUntil(\DateTimeImmutable $date): void;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Install/EventSubscriber/InitDataQualityInsightsDbSchemaSubscriber.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Install/EventSubscriber/InitDataQualityInsightsDbSchemaSubscriber.php
@@ -57,22 +57,13 @@ CREATE TABLE pim_data_quality_insights_product_model_criteria_evaluation (
   INDEX status_index (status)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE TABLE pim_data_quality_insights_product_axis_rates (
+CREATE TABLE pim_data_quality_insights_product_score (
     product_id INT NOT NULL,
-    axis_code VARCHAR(40) NOT NULL,
     evaluated_at DATE NOT NULL,
-    rates JSON NOT NULL,
-    PRIMARY KEY (product_id, axis_code, evaluated_at),
-    INDEX evaluated_at_index (evaluated_at)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-CREATE TABLE pim_data_quality_insights_product_model_axis_rates (
-    product_id INT NOT NULL,
-    axis_code VARCHAR(40) NOT NULL,
-    evaluated_at DATE NOT NULL,
-    rates JSON NOT NULL,
-    PRIMARY KEY (product_id, axis_code, evaluated_at),
-    INDEX evaluated_at_index (evaluated_at)
+    scores JSON NOT NULL,
+    PRIMARY KEY (product_id, evaluated_at),
+    INDEX evaluated_at_index (evaluated_at),
+    CONSTRAINT FK_dqi_product_score FOREIGN KEY (product_id) REFERENCES pim_catalog_product (id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE pim_data_quality_insights_dashboard_rates_projection (

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEmptyScoresQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEmptyScoresQuery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductScoresQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Accommodation to handle empty scores for product models
+ */
+final class GetEmptyScoresQuery implements GetLatestProductScoresQueryInterface
+{
+    public function byProductId(ProductId $productId): ChannelLocaleRateCollection
+    {
+        return new ChannelLocaleRateCollection();
+    }
+
+    public function byProductIds(array $productIds): array
+    {
+        $productsScores = [];
+        foreach ($productIds as $productId) {
+            $productsScores[strval($productId)] = new ChannelLocaleRateCollection();
+        }
+
+        return $productsScores;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetLatestProductScoresQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetLatestProductScoresQuery.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductScoresQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetLatestProductScoresQuery implements GetLatestProductScoresQueryInterface
+{
+    private Connection $dbConnection;
+
+    public function __construct(Connection $dbConnection)
+    {
+        $this->dbConnection = $dbConnection;
+    }
+
+    public function byProductId(ProductId $productId): ChannelLocaleRateCollection
+    {
+        $productScores = $this->byProductIds([$productId]);
+
+        return $productScores[$productId->toInt()] ?? new ChannelLocaleRateCollection();
+    }
+
+    public function byProductIds(array $productIds): array
+    {
+        if (empty($productIds)) {
+            return [];
+        }
+
+        $productIds = array_map(fn (ProductId $productId) => $productId->toInt(), $productIds);
+
+        $query = <<<SQL
+SELECT latest_score.product_id, latest_score.scores
+FROM pim_data_quality_insights_product_score AS latest_score
+    LEFT JOIN pim_data_quality_insights_product_score AS younger_score
+        ON younger_score.product_id = latest_score.product_id
+        AND younger_score.evaluated_at > latest_score.evaluated_at
+WHERE latest_score.product_id IN(:product_ids)
+    AND younger_score.evaluated_at IS NULL;
+SQL;
+
+        $stmt = $this->dbConnection->executeQuery(
+            $query,
+            ['product_ids' => $productIds],
+            ['product_ids' => Connection::PARAM_INT_ARRAY]
+        );
+
+        $productsScores = [];
+        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            $productId = intval($row['product_id']);
+            $productsScores[$productId] = $this->hydrateScores($row['scores']);
+        }
+
+        return $productsScores;
+    }
+
+    private function hydrateScores(string $rawScores): ChannelLocaleRateCollection
+    {
+        $scores = json_decode($rawScores, true, 512, JSON_THROW_ON_ERROR);
+
+        return ChannelLocaleRateCollection::fromNormalizedRates($scores, fn (array $score) => $score['value']);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductScoreRepository.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Repository/ProductScoreRepository.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\ProductScoreRepositoryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use Doctrine\DBAL\Connection;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Example of JSON string stored in the column "scores":
+ * {
+ *    "mobile": {
+ *      "en_US": {
+ *        "rank": 1,
+ *        "value": 96
+ *      }
+ *    },
+ *    "ecommerce": {
+ *      "en_US": {
+ *        "rank": 2,
+ *        "value": 82
+ *      },
+ *      "fr_FR": {
+ *        "rank": 5,
+ *        "value": 32
+ *      }
+ *    }
+ *  }
+ */
+final class ProductScoreRepository implements ProductScoreRepositoryInterface
+{
+    private Connection $dbConnection;
+
+    public function __construct(Connection $dbConnection)
+    {
+        $this->dbConnection = $dbConnection;
+    }
+
+    public function saveAll(array $productsScores): void
+    {
+        if (empty($productsScores)) {
+            return;
+        }
+
+        $queries = '';
+        $queriesParameters = [];
+        $queriesParametersTypes = [];
+
+        /** @var Write\ProductScores $productScore */
+        foreach ($productsScores as $index => $productScore) {
+            Assert::isInstanceOf($productScore, Write\ProductScores::class);
+            $productId = sprintf('productId_%d', $index);
+            $evaluatedAt = sprintf('evaluatedAt_%d', $index);
+            $scores = sprintf('scores_%d', $index);
+
+            $queries .= <<<SQL
+INSERT INTO pim_data_quality_insights_product_score (product_id, evaluated_at, scores)
+VALUES (:$productId, :$evaluatedAt, :$scores)
+ON DUPLICATE KEY UPDATE evaluated_at = :$evaluatedAt, scores = :$scores;
+SQL;
+            $queriesParameters[$productId] = $productScore->getProductId()->toInt();
+            $queriesParametersTypes[$productId] = \PDO::PARAM_INT;
+            $queriesParameters[$evaluatedAt] = $productScore->getEvaluatedAt()->format('Y-m-d');
+            $queriesParameters[$scores] = $this->formatScores($productScore->getScores());
+        }
+
+        $this->dbConnection->executeQuery($queries, $queriesParameters, $queriesParametersTypes);
+    }
+
+    public function purgeUntil(\DateTimeImmutable $date): void
+    {
+        $query = <<<SQL
+DELETE old_scores
+FROM pim_data_quality_insights_product_score AS old_scores
+INNER JOIN pim_data_quality_insights_product_score AS younger_scores
+    ON younger_scores.product_id = old_scores.product_id
+    AND younger_scores.evaluated_at > old_scores.evaluated_at
+WHERE old_scores.evaluated_at < :purge_date;
+SQL;
+
+        $this->dbConnection->executeQuery(
+            $query,
+            ['purge_date' => $date->format('Y-m-d')]
+        );
+    }
+
+    private function formatScores(ChannelLocaleRateCollection $scores): string
+    {
+        $formattedScores = $scores->mapWith(function (Rate $score) {
+            return [
+                'rank' => Rank::fromRate($score)->toInt(),
+                'value' => $score->toInt(),
+            ];
+        });
+
+        return json_encode($formattedScores);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriber.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriber.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Subscriber\Product;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -14,35 +14,34 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class InitializeEvaluationOfAProductSubscriber implements EventSubscriberInterface
 {
-    /** @var FeatureFlag */
-    private $dataQualityInsightsFeature;
+    private FeatureFlag $dataQualityInsightsFeature;
 
-    /** @var CreateCriteriaEvaluations */
-    private $createProductsCriteriaEvaluations;
+    private CreateCriteriaEvaluations $createProductsCriteriaEvaluations;
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /** @var EvaluatePendingCriteria */
-    private $evaluatePendingCriteria;
+    private EvaluatePendingCriteria $evaluatePendingCriteria;
 
-    /** @var ConsolidateAxesRates */
-    private $consolidateProductAxisRates;
+    private ConsolidateProductScores $consolidateProductScores;
 
     public function __construct(
         FeatureFlag $dataQualityInsightsFeature,
         CreateCriteriaEvaluations $createProductsCriteriaEvaluations,
         LoggerInterface $logger,
         EvaluatePendingCriteria $evaluatePendingCriteria,
-        ConsolidateAxesRates $consolidateProductAxisRates
+        ConsolidateProductScores $consolidateProductScores
     ) {
         $this->dataQualityInsightsFeature = $dataQualityInsightsFeature;
         $this->createProductsCriteriaEvaluations = $createProductsCriteriaEvaluations;
         $this->logger = $logger;
         $this->evaluatePendingCriteria = $evaluatePendingCriteria;
-        $this->consolidateProductAxisRates = $consolidateProductAxisRates;
+        $this->consolidateProductScores = $consolidateProductScores;
     }
 
     public static function getSubscribedEvents()
@@ -71,7 +70,7 @@ final class InitializeEvaluationOfAProductSubscriber implements EventSubscriberI
         $productId = intval($subject->getId());
         $this->initializeCriteria($productId);
         $this->evaluatePendingCriteria->evaluateSynchronousCriteria([$productId]);
-        $this->consolidateProductAxisRates->consolidate([$productId]);
+        $this->consolidateProductScores->consolidate([$productId]);
     }
 
     private function initializeCriteria($productId)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Subscriber/ProductModel/InitializeEvaluationOfAProductModelSubscriber.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Subscriber/ProductModel/InitializeEvaluationOfAProductModelSubscriber.php
@@ -2,18 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Subscriber\ProductModel;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -24,35 +14,30 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class InitializeEvaluationOfAProductModelSubscriber implements EventSubscriberInterface
 {
-    /** @var FeatureFlag */
-    private $dataQualityInsightsFeature;
+    private FeatureFlag $dataQualityInsightsFeature;
 
-    /** @var CreateCriteriaEvaluations */
-    private $createProductModelCriteriaEvaluations;
+    private CreateCriteriaEvaluations $createProductModelCriteriaEvaluations;
 
-    /** @var LoggerInterface */
-    private $logger;
+    private LoggerInterface $logger;
 
-    /** @var EvaluatePendingCriteria */
-    private $evaluatePendingCriteria;
-
-    /** @var ConsolidateAxesRates */
-    private $consolidateAxesRates;
+    private EvaluatePendingCriteria $evaluatePendingCriteria;
 
     public function __construct(
         FeatureFlag $dataQualityInsightsFeature,
         CreateCriteriaEvaluations $createProductModelCriteriaEvaluations,
         LoggerInterface $logger,
-        EvaluatePendingCriteria $evaluatePendingCriteria,
-        ConsolidateAxesRates $consolidateAxesRates
+        EvaluatePendingCriteria $evaluatePendingCriteria
     ) {
         $this->dataQualityInsightsFeature = $dataQualityInsightsFeature;
         $this->createProductModelCriteriaEvaluations = $createProductModelCriteriaEvaluations;
         $this->logger = $logger;
         $this->evaluatePendingCriteria = $evaluatePendingCriteria;
-        $this->consolidateAxesRates = $consolidateAxesRates;
     }
 
     public static function getSubscribedEvents()
@@ -80,7 +65,6 @@ class InitializeEvaluationOfAProductModelSubscriber implements EventSubscriberIn
         $productModelId = intval($subject->getId());
         $this->initializeProductModelCriteria($productModelId);
         $this->evaluatePendingCriteria->evaluateSynchronousCriteria([$productModelId]);
-        $this->consolidateAxesRates->consolidate([$productModelId]);
     }
 
     private function initializeProductModelCriteria($productModelId)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/jobs.yml
@@ -105,11 +105,10 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\Tasklet\EvaluateProductsAndProductModelsCriteriaTasklet
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria'
-            - '@akeneo.pim.automation.data_quality_insights.consolidate_product_axes_rates'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\UpdateProductsIndex'
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_ids_to_evaluate'
             - '@akeneo.pim.automation.data_quality_insights.evaluate_product_models_pending_criteria'
-            - '@akeneo.pim.automation.data_quality_insights.consolidate_product_model_axes_rates'
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_model_ids_to_evaluate'
 
     akeneo.pim.automation.data_quality_insights.infrastructure.connector.tasklet.prepare_products_criteria_evaluation:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -124,6 +124,12 @@ services:
         arguments:
             - '@database_connection'
 
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetLatestProductScoresQuery:
+        arguments:
+            - '@database_connection'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEmptyScoresQuery: ~
+
     akeneo.pim.automation.data_quality_insights.query.get_evaluable_product_values:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetEvaluableProductValuesQuery
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/repositories.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/repositories.yml
@@ -11,6 +11,10 @@ services:
               - '@database_connection'
               - '%akeneo.pim.automation.data_quality_insights.persistence.product_axis_rate_table%'
 
+      Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductScoreRepository:
+          arguments:
+              - '@database_connection'
+
       akeneo.pim.automation.data_quality_insights.repository.product_model_axis_rate:
           class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductAxisRateRepository
           arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -19,14 +19,18 @@ services:
     akeneo.pim.automation.data_quality_insights.get_product_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
         arguments:
-            - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_latest_product_evaluations'
+            - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_criteria_evaluations'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetLatestProductScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
 
     akeneo.pim.automation.data_quality_insights.get_product_model_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
         arguments:
-            - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_latest_product_model_evaluations'
+            - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_model_criteria_evaluations'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEmptyScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateDashboardRates:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -4,41 +4,29 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock: ~
 
-    akeneo.pim.automation.data_quality_insights.consolidate_product_axes_rates:
-        class: Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates
+    Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_criteria_evaluations'
-            - '@akeneo.pim.automation.data_quality_insights.repository.product_axis_rate'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeAxisRates'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeProductScores'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductScoreRepository'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock'
-            - '@akeneo.pim.automation.data_quality_insights.axis_registry'
 
-    akeneo.pim.automation.data_quality_insights.consolidate_product_model_axes_rates:
-        class: Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates
-        arguments:
-            - '@akeneo.pim.automation.data_quality_insights.query.get_product_model_criteria_evaluations'
-            - '@akeneo.pim.automation.data_quality_insights.repository.product_model_axis_rate'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeAxisRates'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock'
-            - '@akeneo.pim.automation.data_quality_insights.axis_registry'
-
-    Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeAxisRates:
+    Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeProductScores:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
 
     akeneo.pim.automation.data_quality_insights.get_product_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_latest_product_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@akeneo.pim.automation.data_quality_insights.axis_registry'
 
     akeneo.pim.automation.data_quality_insights.get_product_model_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_latest_product_model_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@akeneo.pim.automation.data_quality_insights.axis_registry'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateDashboardRates:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/subscribers.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/subscribers.yml
@@ -7,11 +7,11 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Subscriber\Product\InitializeEvaluationOfAProductSubscriber:
         arguments:
-            $dataQualityInsightsFeature: '@akeneo.pim.automation.data_quality_insights.feature'
-            $createProductsCriteriaEvaluations: '@akeneo.pim.automation.data_quality_insights.create_products_criteria_evaluations'
-            $logger: '@logger'
-            $evaluatePendingCriteria: '@akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria'
-            $consolidateProductAxisRates: '@akeneo.pim.automation.data_quality_insights.consolidate_product_axes_rates'
+            - '@akeneo.pim.automation.data_quality_insights.feature'
+            - '@akeneo.pim.automation.data_quality_insights.create_products_criteria_evaluations'
+            - '@logger'
+            - '@akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores'
         tags:
             - { name: kernel.event_subscriber }
 
@@ -21,7 +21,6 @@ services:
             - '@akeneo.pim.automation.data_quality_insights.create_product_models_criteria_evaluations'
             - '@logger'
             - '@akeneo.pim.automation.data_quality_insights.evaluate_product_models_pending_criteria'
-            - '@akeneo.pim.automation.data_quality_insights.consolidate_product_model_axes_rates'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/DataQualityInsightsTestCase.php
@@ -305,6 +305,14 @@ SQL;
         return intval($localeId);
     }
 
+    protected function resetProductsScores(): void
+    {
+        $this->get('database_connection')->executeQuery(<<<SQL
+TRUNCATE TABLE pim_data_quality_insights_product_score;
+SQL
+        );
+    }
+
     private function formatValidationErrorMessage(string $mainMessage, ConstraintViolationListInterface $errors): string
     {
         $errorMessage = '';

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/ProductEvaluation/GetLatestProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Query/ProductEvaluation/GetLatestProductScoresQueryIntegration.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetLatestProductScoresQuery;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductScoreRepository;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetLatestProductScoresQueryIntegration extends DataQualityInsightsTestCase
+{
+    public function test_it_returns_the_latest_scores_by_product_ids()
+    {
+        $channelMobile = new ChannelCode('mobile');
+        $localeEn = new LocaleCode('en_US');
+        $localeFr = new LocaleCode('fr_FR');
+
+        $productIdA = $this->createProduct('product_A')->getId();
+        $productIdB = $this->createProduct('product_B')->getId();
+        $productIdC = $this->createProduct('product_C')->getId();
+        $productIdD = $this->createProduct('product_D')->getId();
+
+        $this->resetProductsScores();
+
+        $productsScores = [
+            'product_A_latest_scores' => new ProductScores(
+                new ProductId($productIdA),
+                new \DateTimeImmutable('2020-01-08'),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(96))
+                    ->addRate($channelMobile, $localeFr, new Rate(36))
+            ),
+            'product_A_previous_scores' => new ProductScores(
+                new ProductId($productIdA),
+                new \DateTimeImmutable('2020-01-07'),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(76))
+                    ->addRate($channelMobile, $localeFr, new Rate(67))
+            ),
+            'product_B_latest_scores' => new ProductScores(
+                new ProductId($productIdB),
+                new \DateTimeImmutable('2020-01-09'),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(100))
+                    ->addRate($channelMobile, $localeFr, new Rate(95))
+            ),
+            'product_B_previous_scores' => new ProductScores(
+                new ProductId($productIdB),
+                new \DateTimeImmutable('2020-01-08'),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(81))
+                    ->addRate($channelMobile, $localeFr, new Rate(95))
+            ),
+            'other_product_scores' => new ProductScores(
+                new ProductId($productIdC),
+                new \DateTimeImmutable('2020-01-08'),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(87))
+                    ->addRate($channelMobile, $localeFr, new Rate(95))
+            ),
+        ];
+
+        $this->get(ProductScoreRepository::class)->saveAll(array_values($productsScores));
+
+        $expectedProductsScores = [
+            $productIdA => $productsScores['product_A_latest_scores']->getScores(),
+            $productIdB => $productsScores['product_B_latest_scores']->getScores(),
+        ];
+
+        $productAxesRates = $this->get(GetLatestProductScoresQuery::class)
+            ->byProductIds([new ProductId($productIdA), new ProductId($productIdB), new ProductId($productIdD)]);
+
+        $this->assertEqualsCanonicalizing($expectedProductsScores, $productAxesRates);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Repository/ProductScoreRepositoryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Repository/ProductScoreRepositoryIntegration.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Persistence\Repository;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductScoreRepository;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductScoreRepositoryIntegration extends DataQualityInsightsTestCase
+{
+    public function test_it_save_multiple_products_scores(): void
+    {
+        $productIdA = $this->createProduct('product_A')->getId();
+        $productIdB = $this->createProduct('product_B')->getId();
+
+        $channelMobile = new ChannelCode('mobile');
+        $localeEn = new LocaleCode('en_US');
+        $localeFr = new LocaleCode('fr_FR');
+
+        $productScoreA1 = new ProductScores(
+            new ProductId($productIdA),
+            new \DateTimeImmutable('2020-11-17'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(96))
+                ->addRate($channelMobile, $localeFr, new Rate(36))
+        );
+        $productScoreA2 = new ProductScores(
+            new ProductId($productIdA),
+            new \DateTimeImmutable('2020-11-16'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(89))
+                ->addRate($channelMobile, $localeFr, new Rate(42))
+        );
+        $productScoreB = new ProductScores(
+            new ProductId($productIdB),
+            new \DateTimeImmutable('2020-11-16'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(71))
+                ->addRate($channelMobile, $localeFr, new Rate(0))
+        );
+        // To ensure that it doesn't crash when saving a unknown product
+        $unknownProductScore = new ProductScores(
+            new ProductId($productIdB),
+            new \DateTimeImmutable('2020-11-16'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(71))
+                ->addRate($channelMobile, $localeFr, new Rate(0))
+        );
+
+        $this->resetProductsScores();
+        $this->get(ProductScoreRepository::class)->saveAll([$productScoreA1, $productScoreA2, $unknownProductScore, $productScoreB]);
+
+        $this->assertCountProductsScores(3);
+        $this->assertProductScoreExists($productScoreA1);
+        $this->assertProductScoreExists($productScoreA2);
+        $this->assertProductScoreExists($productScoreB);
+    }
+
+    public function test_it_purges_scores_older_than_a_given_date(): void
+    {
+        $productIdA = $this->createProduct('product_A')->getId();
+        $productIdB = $this->createProduct('product_B')->getId();
+
+        $channelMobile = new ChannelCode('mobile');
+        $localeEn = new LocaleCode('en_US');
+        $localeFr = new LocaleCode('fr_FR');
+
+        $productScoreA1 = new ProductScores(
+            new ProductId($productIdA),
+            new \DateTimeImmutable('2020-11-18'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(96))
+                ->addRate($channelMobile, $localeFr, new Rate(36))
+        );
+        $productScoreA2 = new ProductScores(
+            new ProductId($productIdA),
+            new \DateTimeImmutable('2020-11-17'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(79))
+                ->addRate($channelMobile, $localeFr, new Rate(12))
+        );
+        $productScoreA3 = new ProductScores(
+            new ProductId($productIdA),
+            new \DateTimeImmutable('2020-11-16'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(89))
+                ->addRate($channelMobile, $localeFr, new Rate(42))
+        );
+        $productScoreB = new ProductScores(
+            new ProductId($productIdB),
+            new \DateTimeImmutable('2020-11-16'),
+            (new ChannelLocaleRateCollection())
+                ->addRate($channelMobile, $localeEn, new Rate(71))
+                ->addRate($channelMobile, $localeFr, new Rate(0))
+        );
+
+        $this->resetProductsScores();
+        $this->get(ProductScoreRepository::class)->saveAll([$productScoreA1, $productScoreA2, $productScoreA3, $productScoreB]);
+        $this->get(ProductScoreRepository::class)->purgeUntil(new \DateTimeImmutable('2020-11-17'));
+
+        $this->assertCountProductsScores(3);
+        $this->assertProductScoreExists($productScoreA1);
+        $this->assertProductScoreExists($productScoreA2);
+        $this->assertProductScoreExists($productScoreB);
+    }
+
+    private function resetProductsScores(): void
+    {
+        $this->get('database_connection')->executeQuery(<<<SQL
+TRUNCATE TABLE pim_data_quality_insights_product_score;
+SQL
+        );
+    }
+
+    private function assertCountProductsScores(int $expectedCount): void
+    {
+        $countProductsScores = $this->get('database_connection')->executeQuery(<<<SQL
+SELECT COUNT(*) FROM pim_data_quality_insights_product_score;
+SQL
+        )->fetchColumn();
+
+        $this->assertSame($expectedCount, intval($countProductsScores));
+    }
+
+    private function assertProductScoreExists(ProductScores $expectedProductScore): void
+    {
+        $productScore = $this->get('database_connection')->executeQuery(<<<SQL
+SELECT * FROM pim_data_quality_insights_product_score
+WHERE product_id = :productId AND evaluated_at = :evaluatedAt;
+SQL,
+            [
+                'productId' => $expectedProductScore->getProductId()->toInt(),
+                'evaluatedAt' => $expectedProductScore->getEvaluatedAt()->format('Y-m-d'),
+            ]
+        )->fetch(\PDO::FETCH_ASSOC);
+
+        $this->assertNotEmpty($productScore);
+
+        $expectedScore = $expectedProductScore->getScores()->mapWith(function (Rate $score) {
+            return [
+                'rank' => Rank::fromRate($score)->toInt(),
+                'value' => $score->toInt(),
+            ];
+        });
+
+        $this->assertEquals($expectedScore, json_decode($productScore['scores'], true));
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Repository/ProductScoreRepositoryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Repository/ProductScoreRepositoryIntegration.php
@@ -116,14 +116,6 @@ final class ProductScoreRepositoryIntegration extends DataQualityInsightsTestCas
         $this->assertProductScoreExists($productScoreB);
     }
 
-    private function resetProductsScores(): void
-    {
-        $this->get('database_connection')->executeQuery(<<<SQL
-TRUNCATE TABLE pim_data_quality_insights_product_score;
-SQL
-        );
-    }
-
     private function assertCountProductsScores(int $expectedCount): void
     {
         $countProductsScores = $this->get('database_connection')->executeQuery(<<<SQL

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/Consolidation/ComputeProductScoresSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/Consolidation/ComputeProductScoresSpec.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\CriterionEvaluationResultStatusCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluation;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ComputeProductScoresSpec extends ObjectBehavior
+{
+    public function let(
+        GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
+        CriteriaEvaluationRegistry $criteriaEvaluationRegistry
+    ) {
+        $this->beConstructedWith($getLocalesByChannelQuery, $criteriaEvaluationRegistry);
+    }
+
+    public function it_computes_the_product_scores_from_the_product_evaluation(
+        $getLocalesByChannelQuery,
+        $criteriaEvaluationRegistry
+    ) {
+        $getLocalesByChannelQuery->getChannelLocaleCollection()->willReturn(new ChannelLocaleCollection([
+            'mobile' => ['en_US', 'fr_FR'],
+            'print' => ['en_US', 'fr_FR'],
+        ]));
+
+        $channelMobile = new ChannelCode('mobile');
+        $channelPrint = new ChannelCode('print');
+        $localeEn = new LocaleCode('en_US');
+        $localeFr = new LocaleCode('fr_FR');
+
+        $criterionResultA = (new ChannelLocaleRateCollection)
+                ->addRate($channelMobile, $localeEn, new Rate(100))
+                ->addRate($channelMobile, $localeFr, new Rate(90))
+                ->addRate($channelPrint, $localeEn, new Rate(60));
+        $criterionResultB = (new ChannelLocaleRateCollection)
+                ->addRate($channelMobile, $localeEn, new Rate(90))
+                ->addRate($channelMobile, $localeFr, new Rate(80))
+                ->addRate($channelPrint, $localeEn, new Rate(100));
+        $criterionResultC = (new ChannelLocaleRateCollection)
+                ->addRate($channelMobile, $localeEn, new Rate(81))
+                ->addRate($channelPrint, $localeEn, new Rate(70));
+
+        $criterionA = new CriterionCode('criterion_A');
+        $criterionB = new CriterionCode('criterion_B');
+        $criterionC = new CriterionCode('criterion_C');
+
+        $criteriaEvaluations = (new CriterionEvaluationCollection())
+            ->add(new CriterionEvaluation(
+                $criterionA,
+                new ProductId(42),
+                new \DateTimeImmutable(),
+                CriterionEvaluationStatus::done(),
+                new CriterionEvaluationResult($criterionResultA, new CriterionEvaluationResultStatusCollection(), [])
+            ))
+            ->add(new CriterionEvaluation(
+                $criterionB,
+                new ProductId(42),
+                new \DateTimeImmutable(),
+                CriterionEvaluationStatus::done(),
+                new CriterionEvaluationResult($criterionResultB, new CriterionEvaluationResultStatusCollection(), [])
+            ))
+            ->add(new CriterionEvaluation(
+                $criterionC,
+                new ProductId(42),
+                new \DateTimeImmutable(),
+                CriterionEvaluationStatus::done(),
+                new CriterionEvaluationResult($criterionResultC, new CriterionEvaluationResultStatusCollection(), [])
+            ))
+        ;
+
+        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([$criterionA, $criterionB, $criterionC]);
+        $criteriaEvaluationRegistry->getCriterionCoefficient($criterionA)->willReturn(2);
+        $criteriaEvaluationRegistry->getCriterionCoefficient($criterionB)->willReturn(1);
+        $criteriaEvaluationRegistry->getCriterionCoefficient($criterionC)->willReturn(1);
+
+        $this->fromCriteriaEvaluations($criteriaEvaluations)->shouldBeLike(
+            (new ChannelLocaleRateCollection)
+                ->addRate($channelMobile, $localeEn, new Rate(93))
+                ->addRate($channelMobile, $localeFr, new Rate(87))
+                ->addRate($channelPrint, $localeEn, new Rate(72))
+        );
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductEvaluationSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductEvaluationSpec.php
@@ -2,36 +2,18 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\AxisRegistryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\AxisRegistry;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateImageEnrichment;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Axis;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Axis\Enrichment;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\CriterionEvaluationResultStatusCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisEvaluation;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\AxisEvaluationCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluation;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\ProductEvaluation;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductEvaluationQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetLatestProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\AxisCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
@@ -39,237 +21,97 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvalua
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
-use Akeneo\Pim\Automation\DataQualityInsights\tests\back\Specification\Domain\Model\Axis\Consistency;
 use PhpSpec\ObjectBehavior;
 
 /**
- * @author Olivier Pontier <olivier.pontier@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class GetProductEvaluationSpec extends ObjectBehavior
 {
-    private const CHANNELS_LOCALES = [
-        'ecommerce' => ['en_US', 'fr_FR'],
-        'mobile' => ['en_US']
-    ];
-
     public function let(
-        GetProductEvaluationQueryInterface $getProductEvaluationQuery,
+        GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
+        GetLatestProductScoresQueryInterface $getLatestProductScoresQuery,
         GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        AxisRegistryInterface $axisRegistry,
-        Axis $consistencyAxis
+        CriteriaEvaluationRegistry $criteriaEvaluationRegistry
     ) {
-        $consistencyAxis->getCriteriaCodes()->willReturn([
-            new CriterionCode('consistency_spelling'),
-            new CriterionCode('consistency_textarea_lowercase_words'),
-            new CriterionCode('consistency_textarea_uppercase_words'),
-            new CriterionCode('consistency_attribute_spelling'),
-            new CriterionCode('consistency_attribute_option_spelling'),
-        ]);
-        $axisRegistry->get(new AxisCode(Enrichment::AXIS_CODE))->willReturn(new Enrichment());
-        $axisRegistry->get(new AxisCode('consistency'))->willReturn($consistencyAxis);
-        $this->beConstructedWith($getProductEvaluationQuery, $getLocalesByChannelQuery, $axisRegistry);
-
-        $getLocalesByChannelQuery->getChannelLocaleCollection()->willReturn(new ChannelLocaleCollection(self::CHANNELS_LOCALES));
+        $this->beConstructedWith($getCriteriaEvaluationsByProductIdQuery, $getLatestProductScoresQuery, $getLocalesByChannelQuery, $criteriaEvaluationRegistry);
     }
 
-    public function it_gets_the_evaluations_of_a_product(
-        GetProductEvaluationQueryInterface $getProductEvaluationQuery
+    public function it_gives_the_evaluation_of_a_product(
+        $getCriteriaEvaluationsByProductIdQuery,
+        $getLatestProductScoresQuery,
+        $criteriaEvaluationRegistry,
+        $getLocalesByChannelQuery
     ) {
         $productId = new ProductId(2000);
 
-        $productEvaluationReadModel = $this->givenAProductEvaluation($productId);
-        $expectedEvaluation = $this->getExpectedProductEvaluation();
+        $getLocalesByChannelQuery->getChannelLocaleCollection()->willReturn(new ChannelLocaleCollection([
+            'ecommerce' => ['en_US', 'fr_FR'],
+            'mobile' => ['en_US']
+        ]));
 
-        $getProductEvaluationQuery->execute($productId)->willReturn($productEvaluationReadModel);
+        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([
+            new CriterionCode('completeness_of_required_attributes'),
+            new CriterionCode('completeness_of_non_required_attributes'),
+            new CriterionCode('consistency_spelling'),
+        ]);
 
-        $this->get($productId)->shouldBeLike($expectedEvaluation);
-    }
+        $getCriteriaEvaluationsByProductIdQuery->execute($productId)->willReturn($this->givenProductCriteriaEvaluations($productId));
+        $getLatestProductScoresQuery->byProductId($productId)->willReturn($this->givenProductScores());
 
-    public function it_returns_default_values_if_the_product_has_no_evaluation(
-        GetProductEvaluationQueryInterface $getProductEvaluationQuery
-    ) {
-        $productId = new ProductId(42);
-        $productEvaluation = $this->givenAnEmptyProductEvaluation($productId);
-        $getProductEvaluationQuery->execute($productId)->willReturn($productEvaluation);
-
-        $expectedEvaluation = $this->getExpectedEmptyProductEvaluation();
-
-        $this->get($productId)->shouldBeLike($expectedEvaluation);
+        $this->get($productId)->shouldBeLike($this->getExpectedProductEvaluation());
     }
 
     public function it_handle_deprecated_improvable_attribute_structure(
-        GetProductEvaluationQueryInterface $getProductEvaluationQuery
+        $getCriteriaEvaluationsByProductIdQuery,
+        $getLatestProductScoresQuery,
+        $criteriaEvaluationRegistry,
+        $getLocalesByChannelQuery
     ) {
+        $getLocalesByChannelQuery->getChannelLocaleCollection()->willReturn(new ChannelLocaleCollection([
+            'ecommerce' => ['en_US'],
+        ]));
+
+        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([
+            new CriterionCode('consistency_spelling'),
+            new CriterionCode('consistency_textarea_lowercase_words'),
+        ]);
+
         $productId = new ProductId(39);
-        $productEvaluation = $this->givenADeprecatedProductEvaluation($productId);
-        $getProductEvaluationQuery->execute($productId)->willReturn($productEvaluation);
+        $getCriteriaEvaluationsByProductIdQuery->execute($productId)->willReturn($this->givenDeprecatedCriteriaEvaluations($productId));
+        $getLatestProductScoresQuery->byProductId($productId)->willReturn((new ChannelLocaleRateCollection())
+            ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(50)));
 
         $expectedEvaluation = [
-            "consistency" => [
-                "ecommerce" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => 50,
-                            "rank" => "E",
-                        ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" => "consistency_textarea_lowercase_words",
-                                "rate" => [
-                                    "value" => 50,
-                                    "rank" => "E",
-                                ],
-                                "improvable_attributes" => ["short_description", "long_description"],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                        ],
+            "ecommerce" => [
+                "en_US" => [
+                    "score" => [
+                        "value" => 50,
+                        "rank" => "E",
                     ],
-                    "fr_FR" => [
-                        "rate" => [
-                            "value" => null,
-                            "rank" => null,
+                    "criteria" => [
+                        [
+                            "code" =>"consistency_spelling",
+                            "rate" => [
+                                "value" => null,
+                                "rank" => null,
+                            ],
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
                         ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                        [
+                            "code" => "consistency_textarea_lowercase_words",
+                            "rate" => [
+                                "value" => 50,
+                                "rank" => "E",
                             ],
-                            [
-                                "code" => "consistency_textarea_lowercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
+                            "improvable_attributes" => ["short_description", "long_description"],
+                            "status" => CriterionEvaluationResultStatus::DONE,
                         ],
                     ],
                 ],
-                "mobile" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => null,
-                            "rank" => null,
-                        ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" => "consistency_textarea_lowercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                        ],
-                    ],
-                ]
-            ]
+            ],
         ];
 
         $this->get($productId)->shouldBeLike($expectedEvaluation);
@@ -286,27 +128,29 @@ class GetProductEvaluationSpec extends ObjectBehavior
         );
     }
 
-    private function givenAProductEvaluation(ProductId $productId): ProductEvaluation
+    private function givenProductCriteriaEvaluations(ProductId $productId): CriterionEvaluationCollection
     {
-        $axesEvaluations = (new AxisEvaluationCollection())
-            ->add($this->givenAnEnrichmentEvaluation($productId))
-            ->add($this->givenAConsistencyEvaluation($productId))
-        ;
-
-        return new ProductEvaluation($productId, $axesEvaluations);
-    }
-
-    private function givenAnEnrichmentEvaluation(ProductId $productId): AxisEvaluation
-    {
-        $enrichment = new Enrichment();
         $channelCodeEcommerce = new ChannelCode('ecommerce');
+        $channelCodeMobile = new ChannelCode('mobile');
         $localeCodeEn = new LocaleCode('en_US');
 
-        $enrichmentRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(75));
+        $completenessOfRequiredAttributesRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(95))
+            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(70));
+
+        $completenessOfRequiredAttributesStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
+            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done());
+
+        $completenessOfRequiredAttributesData = [
+            "attributes_with_rates" => [
+                "ecommerce" => ["en_US" => ["long_description" => 0]],
+                "mobile" => ["en_US" => ["title" => 0, "name" => 0]],
+            ]
+        ];
 
         $completenessOfNonRequiredAttributesRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(50));
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(70));
 
         $completenessOfNonRequiredAttributesStatus = (new CriterionEvaluationResultStatusCollection())
             ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done());
@@ -314,47 +158,34 @@ class GetProductEvaluationSpec extends ObjectBehavior
         $completenessOfNonRequiredAttributesData = [
             "attributes_with_rates" => [
                 "ecommerce" => [
-                    "en_US" => ["title" => 50, "meta_title" => 50]
+                    "en_US" => ["title" => 0, "meta_title" => 0]
                 ]
             ]
         ];
 
-        $completenessOfRequiredAttributesRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(100));
-
-        $completenessOfRequiredAttributesStatus = (new CriterionEvaluationResultStatusCollection())
-            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done());
-
-        $completenessOfRequiredAttributesData = [
+        $evaluateSpellingRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(88))
+            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(100))
+        ;
+        $evaluateSpellingStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
+            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done())
+        ;
+        $evaluateSpellingData = [
             "attributes_with_rates" => [
-                "ecommerce" => ["long_description" => 100]
+                "ecommerce" => [
+                    "en_US" => ["description" => 86],
+                ],
+                "mobile" => [
+                    "en_US" => [],
+                ]
             ]
         ];
 
-        $imageEnrichmentRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(100));
-
-        $imageEnrichmentStatus = (new CriterionEvaluationResultStatusCollection())
-            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done());
-
-        $imageEnrichmentAttributesData = [
-            "attributes_with_rates" => [
-                "ecommerce" => ["picture" => 100]
-            ]
-        ];
-
-        $enrichmentCriteriaEvaluations = (new CriterionEvaluationCollection())
+        return (new CriterionEvaluationCollection())
             ->add($this->generateCriterionEvaluation(
                 $productId,
-                EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
-                CriterionEvaluationStatus::DONE,
-                $completenessOfNonRequiredAttributesRates,
-                $completenessOfNonRequiredAttributesStatus,
-                $completenessOfNonRequiredAttributesData
-            ))
-            ->add($this->generateCriterionEvaluation(
-                $productId,
-                EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+                'completeness_of_required_attributes',
                 CriterionEvaluationStatus::DONE,
                 $completenessOfRequiredAttributesRates,
                 $completenessOfRequiredAttributesStatus,
@@ -362,72 +193,12 @@ class GetProductEvaluationSpec extends ObjectBehavior
             ))
             ->add($this->generateCriterionEvaluation(
                 $productId,
-                EvaluateImageEnrichment::CRITERION_CODE,
+                'completeness_of_non_required_attributes',
                 CriterionEvaluationStatus::DONE,
-                $imageEnrichmentRates,
-                $imageEnrichmentStatus,
-                $imageEnrichmentAttributesData
+                $completenessOfNonRequiredAttributesRates,
+                $completenessOfNonRequiredAttributesStatus,
+                $completenessOfNonRequiredAttributesData
             ))
-        ;
-
-        return new AxisEvaluation($enrichment->getCode(), $enrichmentRates, $enrichmentCriteriaEvaluations);
-    }
-
-    public function givenAConsistencyEvaluation(ProductId $productId): AxisEvaluation
-    {
-        $consistency = new Consistency();
-        $channelCodeEcommerce = new ChannelCode('ecommerce');
-        $channelCodeMobile = new ChannelCode('mobile');
-        $localeCodeEn = new LocaleCode('en_US');
-        $localeCodeFr = new LocaleCode('fr_FR');
-
-
-        $consistencyRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(86))
-            ->addRate($channelCodeEcommerce, $localeCodeFr, new Rate(68))
-            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(38))
-        ;
-
-        $evaluateSpellingRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(88))
-            ->addRate($channelCodeEcommerce, $localeCodeFr, new Rate(68))
-            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(76))
-        ;
-        $evaluateSpellingStatus = (new CriterionEvaluationResultStatusCollection())
-            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
-            ->add($channelCodeEcommerce, $localeCodeFr, CriterionEvaluationResultStatus::done())
-            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done())
-        ;
-        $evaluateSpellingData = [
-            "attributes_with_rates" => [
-                "ecommerce" => [
-                    "en_US" => ["description" => 86],
-                    "fr_FR" => ["description" => 68, "short_description" => 68],
-                ]
-            ]
-        ];
-
-        $evaluateLowercaseRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(84))
-            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(0))
-        ;
-        $evaluateLowercaseStatus = (new CriterionEvaluationResultStatusCollection())
-            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
-            ->add($channelCodeEcommerce, $localeCodeFr, CriterionEvaluationResultStatus::notApplicable())
-            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done())
-        ;
-        $evaluateLowercaseData = [
-            "attributes_with_rates" => [
-                "ecommerce" => [
-                    "en_US" => ["title" => 84],
-                ],
-                "mobile" => [
-                    "en_US" => ["title" => 0, "meta_title" => 0]
-                ]
-            ]
-        ];
-
-        $consistencyCriteriaEvaluations = (new CriterionEvaluationCollection())
             ->add($this->generateCriterionEvaluation(
                 $productId,
                 'consistency_spelling',
@@ -435,304 +206,131 @@ class GetProductEvaluationSpec extends ObjectBehavior
                 $evaluateSpellingRates,
                 $evaluateSpellingStatus,
                 $evaluateSpellingData
-            ))
-            ->add($this->generateCriterionEvaluation(
-                $productId,
-                'consistency_textarea_lowercase_words',
-                CriterionEvaluationStatus::DONE,
-                $evaluateLowercaseRates,
-                $evaluateLowercaseStatus,
-                $evaluateLowercaseData
-            ))
-        ;
+            ));
+    }
 
-        return new AxisEvaluation($consistency->getCode(), $consistencyRates, $consistencyCriteriaEvaluations);
+    private function givenProductScores(): ChannelLocaleRateCollection
+    {
+        $channelEcommerce = new ChannelCode('ecommerce');
+        $channelMobile = new ChannelCode('mobile');
+        $localeEn = new LocaleCode('en_US');
+
+        return (new ChannelLocaleRateCollection())
+            ->addRate($channelEcommerce, $localeEn, new Rate(87))
+            ->addRate($channelMobile, $localeEn, new Rate(90))
+        ;
     }
 
     private function getExpectedProductEvaluation(): array
     {
         return [
-            "enrichment" => [
-                "ecommerce" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => 75,
-                            "rank" => "C",
-                        ],
-                        "criteria" => [
-                            [
-                                "code" => "completeness_of_required_attributes",
-                                "rate" => [
-                                    "value" => 100,
-                                    "rank" => "A",
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" => "completeness_of_non_required_attributes",
-                                "rate" => [
-                                    "value" => 50,
-                                    "rank" => "E",
-                                ],
-                                "improvable_attributes" => ["title", "meta_title"],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" => "enrichment_image",
-                                "rate" => [
-                                    "value" => 100,
-                                    "rank" => "A",
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                        ],
+            "ecommerce" => [
+                "en_US" => [
+                    "score" => [
+                        "value" => 87,
+                        "rank" => "B",
                     ],
-                    "fr_FR" => [
-                        "rate" => [
-                            "value" => null,
-                            "rank" => null,
+                    "criteria" => [
+                        [
+                            "code" => "completeness_of_required_attributes",
+                            "rate" => [
+                                "value" => 95,
+                                "rank" => "A",
+                            ],
+                            "improvable_attributes" => ["long_description"],
+                            "status" => CriterionEvaluationResultStatus::DONE,
                         ],
-                        "criteria" => [
-                            [
-                                "code" => "completeness_of_required_attributes",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                        [
+                            "code" => "completeness_of_non_required_attributes",
+                            "rate" => [
+                                "value" => 70,
+                                "rank" => "C",
                             ],
-                            [
-                                "code" => "completeness_of_non_required_attributes",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                            "improvable_attributes" => ["title", "meta_title"],
+                            "status" => CriterionEvaluationResultStatus::DONE,
+                        ],
+                        [
+                            "code" =>"consistency_spelling",
+                            "rate" => [
+                                "value" => 88,
+                                "rank" => "B",
                             ],
-                            [
-                                "code" => "enrichment_image",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                            "improvable_attributes" => [
+                                "description",
                             ],
+                            "status" => CriterionEvaluationResultStatus::DONE,
                         ],
                     ],
                 ],
-                "mobile" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => null,
-                            "rank" => null,
+                "fr_FR" => [
+                    "score" => [
+                        "value" => null,
+                        "rank" => null,
+                    ],
+                    "criteria" => [
+                        [
+                            "code" => "completeness_of_required_attributes",
+                            "rate" => [
+                                "value" => null,
+                                "rank" => null,
+                            ],
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
                         ],
-                        "criteria" => [
-                            [
-                                "code" =>"completeness_of_required_attributes",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                        [
+                            "code" => "completeness_of_non_required_attributes",
+                            "rate" => [
+                                "value" => null,
+                                "rank" => null,
                             ],
-                            [
-                                "code" => "completeness_of_non_required_attributes",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
+                        ],
+                        [
+                            "code" =>"consistency_spelling",
+                            "rate" => [
+                                "value" => null,
+                                "rank" => null,
                             ],
-                            [
-                                "code" => "enrichment_image",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
                         ],
                     ],
                 ],
             ],
-            "consistency" => [
-                "ecommerce" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => 86,
-                            "rank" => "B",
-                        ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => 88,
-                                    "rank" => "B",
-                                ],
-                                "improvable_attributes" => [
-                                    "description",
-                                ],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" => 'consistency_textarea_lowercase_words',
-                                "rate" => [
-                                    "value" => 84,
-                                    "rank" => "B",
-                                ],
-                                "improvable_attributes" => [
-                                    "title",
-                                ],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                        ],
+            "mobile" => [
+                "en_US" => [
+                    "score" => [
+                        "value" => 90,
+                        "rank" => "A",
                     ],
-                    "fr_FR" => [
-                        "rate" => [
-                            "value" => 68,
-                            "rank" => "D",
+                    "criteria" => [
+                        [
+                            "code" =>"completeness_of_required_attributes",
+                            "rate" => [
+                                "value" => 70,
+                                "rank" => "C",
+                            ],
+                            "improvable_attributes" => ["title", "name"],
+                            "status" => CriterionEvaluationResultStatus::DONE,
                         ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => 68,
-                                    "rank" => "D",
-                                ],
-                                "improvable_attributes" => [
-                                    "description",
-                                    "short_description",
-                                ],
-                                "status" => CriterionEvaluationResultStatus::DONE,
+                        [
+                            "code" => "completeness_of_non_required_attributes",
+                            "rate" => [
+                                "value" => null,
+                                "rank" => null,
                             ],
-                            [
-                                "code" => 'consistency_textarea_lowercase_words',
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::NOT_APPLICABLE,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
                         ],
-                    ],
-                ],
-                "mobile" => [
-                    "en_US" => [
-                        "rate" => [
-                            "value" => 38,
-                            "rank" => "E",
-                        ],
-                        "criteria" => [
-                            [
-                                "code" =>"consistency_spelling",
-                                "rate" => [
-                                    "value" => 76,
-                                    "rank" => "C",
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::DONE,
+                        [
+                            "code" =>"consistency_spelling",
+                            "rate" => [
+                                "value" => 100,
+                                "rank" => "A",
                             ],
-                            [
-                                "code" => 'consistency_textarea_lowercase_words',
-                                "rate" => [
-                                    "value" => 0,
-                                    "rank" => "E",
-                                ],
-                                "improvable_attributes" => [
-                                   "title", "meta_title",
-                                ],
-                                "status" => CriterionEvaluationResultStatus::DONE,
-                            ],
-                            [
-                                "code" =>"consistency_textarea_uppercase_words",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
-                            [
-                                "code" =>"consistency_attribute_option_spelling",
-                                "rate" => [
-                                    "value" => null,
-                                    "rank" => null,
-                                ],
-                                "improvable_attributes" => [],
-                                "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                            ],
+                            "improvable_attributes" => [],
+                            "status" => CriterionEvaluationResultStatus::DONE,
                         ],
                     ],
                 ],
@@ -740,72 +338,10 @@ class GetProductEvaluationSpec extends ObjectBehavior
         ];
     }
 
-    private function givenAnEmptyProductEvaluation(ProductId $productId)
+    private function givenDeprecatedCriteriaEvaluations(ProductId $productId): CriterionEvaluationCollection
     {
-        $axesRegistry = new AxisRegistry();
-        $axesEvaluations = new AxisEvaluationCollection();
-
-        foreach ($axesRegistry->all() as $axis) {
-            $axesEvaluations->add(new AxisEvaluation(
-                $axis->getCode(),
-                new ChannelLocaleRateCollection(),
-                new CriterionEvaluationCollection()
-            ));
-        }
-
-        return new ProductEvaluation($productId, $axesEvaluations);
-    }
-
-    private function getExpectedEmptyProductEvaluation(): array
-    {
-        $productEvaluations = [];
-        $axesRegistry = new AxisRegistry();
-
-        foreach ($axesRegistry->all() as $axis) {
-            $axisCode = strval($axis->getCode());
-            $productEvaluations[$axisCode] = [];
-            foreach (self::CHANNELS_LOCALES as $channel => $locales) {
-                foreach ($locales as $locale) {
-                    $productEvaluations[$axisCode][$channel][$locale]['rate'] = [
-                        "value" => null,
-                        "rank" => null,
-                    ];
-                    foreach ($axis->getCriteriaCodes() as $criterionCode) {
-                        $productEvaluations[$axisCode][$channel][$locale]['criteria'][] = [
-                            "code" => strval($criterionCode),
-                            "rate" => [
-                                "value" => null,
-                                "rank" => null,
-                            ],
-                            "improvable_attributes" => [],
-                            "status" => CriterionEvaluationResultStatus::IN_PROGRESS,
-                        ];
-                    }
-                }
-            }
-        }
-
-        return $productEvaluations;
-    }
-
-    private function givenADeprecatedProductEvaluation(ProductId $productId): ProductEvaluation
-    {
-        $axesEvaluations = (new AxisEvaluationCollection())
-            ->add($this->givenADeprecatedConsistencyEvaluation($productId))
-        ;
-
-        return new ProductEvaluation($productId, $axesEvaluations);
-    }
-
-    private function givenADeprecatedConsistencyEvaluation(ProductId $productId): AxisEvaluation
-    {
-        $consistency = new Consistency();
         $channelCodeEcommerce = new ChannelCode('ecommerce');
         $localeCodeEn = new LocaleCode('en_US');
-
-
-        $consistencyRates = (new ChannelLocaleRateCollection())
-            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(50));
 
         $lowercaseWordsRates = (new ChannelLocaleRateCollection())
             ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(50));
@@ -821,7 +357,7 @@ class GetProductEvaluationSpec extends ObjectBehavior
         $lowercaseWordsStatus = (new CriterionEvaluationResultStatusCollection())
             ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done());
 
-        $consistencyCriteriaEvaluations = (new CriterionEvaluationCollection())
+        return (new CriterionEvaluationCollection())
             ->add($this->generateCriterionEvaluation(
                 $productId,
                 'consistency_textarea_lowercase_words',
@@ -829,9 +365,6 @@ class GetProductEvaluationSpec extends ObjectBehavior
                 $lowercaseWordsRates,
                 $lowercaseWordsStatus,
                 $lowercaseWordsAttributesDataDeprecatedFormat
-            ))
-        ;
-
-        return new AxisEvaluation($consistency->getCode(), $consistencyRates, $consistencyCriteriaEvaluations);
+            ));
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaEvaluationRegistrySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaEvaluationRegistrySpec.php
@@ -39,4 +39,18 @@ class CriteriaEvaluationRegistrySpec extends ObjectBehavior
         $this->getCriterionCodes()->shouldBeLike([new CriterionCode('my_code')]);
         $this->get(new CriterionCode('my_code'))->shouldReturn($evaluateCriterion->getWrappedObject());
     }
+
+    public function it_gives_the_coefficient_of_a_given_criterion(
+        EvaluateCriterionInterface $evaluateCriterionA,
+        EvaluateCriterionInterface $evaluateCriterionB
+    ) {
+        $this->beConstructedWith([$evaluateCriterionA->getWrappedObject(), $evaluateCriterionB->getWrappedObject()]);
+
+        $evaluateCriterionA->getCode()->willReturn(new CriterionCode('criterion_A'));
+        $evaluateCriterionB->getCode()->willReturn(new CriterionCode('criterion_B'));
+
+        $evaluateCriterionA->getCoefficient()->willReturn(1);
+
+        $this->getCriterionCoefficient(new CriterionCode('criterion_A'))->shouldReturn(1);
+    }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriberSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/Product/InitializeEvaluationOfAProductSubscriberSpec.php
@@ -2,18 +2,9 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2019 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Subscriber\Product;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -33,14 +24,14 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
         CreateCriteriaEvaluations $createProductsCriteriaEvaluations,
         LoggerInterface $logger,
         EvaluatePendingCriteria $evaluatePendingCriteria,
-        ConsolidateAxesRates $consolidateProductAxisRates
+        ConsolidateProductScores $consolidateProductScores
     ) {
         $this->beConstructedWith(
             $dataQualityInsightsFeature,
             $createProductsCriteriaEvaluations,
             $logger,
             $evaluatePendingCriteria,
-            $consolidateProductAxisRates
+            $consolidateProductScores
         );
     }
 
@@ -88,7 +79,7 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
         $dataQualityInsightsFeature,
         $createProductsCriteriaEvaluations,
         $evaluatePendingCriteria,
-        $consolidateProductAxisRates,
+        $consolidateProductScores,
         ProductInterface $product
     ) {
         $product->getId()->willReturn(12345);
@@ -96,7 +87,7 @@ class InitializeEvaluationOfAProductSubscriberSpec extends ObjectBehavior
         $createProductsCriteriaEvaluations->createAll([new ProductId(12345)])->shouldBeCalled();
 
         $evaluatePendingCriteria->evaluateSynchronousCriteria([12345])->shouldBeCalled();
-        $consolidateProductAxisRates->consolidate([12345])->shouldBeCalled();
+        $consolidateProductScores->consolidate([12345])->shouldBeCalled();
 
         $this->onPostSave(new GenericEvent($product->getWrappedObject(), ['unitary' => true]));
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/ProductModel/InitializeEvaluationOfAProductModelSubscriberSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Subscriber/ProductModel/InitializeEvaluationOfAProductModelSubscriberSpec.php
@@ -2,18 +2,8 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2020 Akeneo SAS (http://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Subscriber\ProductModel;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateAxesRates;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetDescendantVariantProductIdsQueryInterface;
@@ -35,7 +25,6 @@ class InitializeEvaluationOfAProductModelSubscriberSpec extends ObjectBehavior
         CreateCriteriaEvaluations $createCriteriaEvaluations,
         LoggerInterface $logger,
         EvaluatePendingCriteria $evaluatePendingCriteria,
-        ConsolidateAxesRates $consolidateAxesRates,
         GetDescendantVariantProductIdsQueryInterface $getDescendantVariantProductIdsQuery,
         DescendantProductModelIdsQueryInterface $getDescendantProductModelIdsQuery,
         CreateCriteriaEvaluations $createProductsCriteriaEvaluations
@@ -45,7 +34,6 @@ class InitializeEvaluationOfAProductModelSubscriberSpec extends ObjectBehavior
             $createCriteriaEvaluations,
             $logger,
             $evaluatePendingCriteria,
-            $consolidateAxesRates,
             $getDescendantVariantProductIdsQuery,
             $getDescendantProductModelIdsQuery,
             $createProductsCriteriaEvaluations
@@ -96,7 +84,6 @@ class InitializeEvaluationOfAProductModelSubscriberSpec extends ObjectBehavior
         $dataQualityInsightsFeature,
         $createCriteriaEvaluations,
         $evaluatePendingCriteria,
-        $consolidateAxesRates,
         ProductModelInterface $productModel
     ) {
         $productModel->getId()->willReturn(12345);
@@ -104,7 +91,6 @@ class InitializeEvaluationOfAProductModelSubscriberSpec extends ObjectBehavior
         $createCriteriaEvaluations->createAll([new ProductId(12345)])->shouldBeCalled();
 
         $evaluatePendingCriteria->evaluateSynchronousCriteria([12345])->shouldBeCalled();
-        $consolidateAxesRates->consolidate([12345])->shouldBeCalled();
 
         $this->onPostSave(new GenericEvent($productModel->getWrappedObject(), ['unitary' => true]));
     }


### PR DESCRIPTION
This PR concerns only the writing part of the consolidation of the unique score.

The adaptations to remove axes and to read the unique score will follow in dedicated PRs

I moved the coefficients constants into each criterion evaluation service. It's not perfect but consistent because it's already them that handle the criterion code.