### PR TITLE
PIM-9550: add integration tests on internal services used by the command "pim:product:clean-removed-attributes"

### DIFF
--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -183,6 +183,13 @@ services:
             - '@pim_catalog.updater.attribute'
             - '@validator'
 
+    akeneo_integration_tests.base.family.builder:
+        class: 'Akeneo\Test\Common\EntityBuilder'
+        arguments:
+            - '@pim_catalog.factory.family'
+            - '@pim_catalog.updater.family'
+            - '@validator'
+
     akeneo_integration_tests.catalog.product_model.builder:
         class: 'Akeneo\Test\Common\EntityWithValue\Builder\ProductModel'
         shared: false
@@ -203,3 +210,28 @@ services:
         decoration_inner_name: akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes.sql
         arguments:
             - '@akeneo.pim.structure.query.get_existing_attribute_option_codes_from_option_codes.sql'
+
+    akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute:
+        class: 'AkeneoTest\Pim\Enrichment\Integration\Fixture\ProductAndProductModelWithRemovedAttributeLoader'
+        arguments:
+            $productFactory: '@pim_catalog.builder.product'
+            $productUpdater: '@pim_catalog.updater.product'
+            $productValidator: '@pim_catalog.validator.product'
+            $productSaver: '@pim_catalog.saver.product'
+            $productModelFactory: '@pim_catalog.factory.product_model'
+            $productModelUpdater: '@pim_catalog.updater.product_model'
+            $productModelValidator: '@pim_catalog.validator.product_model'
+            $productModelSaver: '@pim_catalog.saver.product_model'
+            $familyVariantFactory: '@pim_catalog.factory.family_variant'
+            $familyVariantUpdater: '@pim_catalog.updater.family_variant'
+            $familyVariantSaver: '@pim_catalog.saver.family_variant'
+            $familyFactory: '@pim_catalog.factory.family'
+            $familyUpdater: '@pim_catalog.updater.family'
+            $familySaver: '@pim_catalog.saver.family'
+            $attributeFactory: '@pim_catalog.factory.attribute'
+            $attributeUpdater: '@pim_catalog.updater.attribute'
+            $attributeSaver: '@pim_catalog.saver.attribute'
+            $attributeRepository: '@pim_catalog.repository.attribute'
+            $attributeRemover: '@pim_catalog.remover.attribute'
+            $entityValidator: '@validator'
+            $productAndProductModelEsClient: '@akeneo_elasticsearch.client.product_and_product_model'

--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -190,6 +190,13 @@ services:
             - '@pim_catalog.updater.family'
             - '@validator'
 
+    akeneo_integration_tests.base.family_variant.builder:
+        class: 'Akeneo\Test\Common\EntityBuilder'
+        arguments:
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@validator'
+
     akeneo_integration_tests.catalog.product_model.builder:
         class: 'Akeneo\Test\Common\EntityWithValue\Builder\ProductModel'
         shared: false
@@ -214,22 +221,15 @@ services:
     akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute:
         class: 'AkeneoTest\Pim\Enrichment\Integration\Fixture\ProductAndProductModelWithRemovedAttributeLoader'
         arguments:
-            $productFactory: '@pim_catalog.builder.product'
-            $productUpdater: '@pim_catalog.updater.product'
-            $productValidator: '@pim_catalog.validator.product'
+            $productBuilder: '@akeneo_integration_tests.catalog.product.builder'
             $productSaver: '@pim_catalog.saver.product'
-            $productModelFactory: '@pim_catalog.factory.product_model'
-            $productModelUpdater: '@pim_catalog.updater.product_model'
-            $productModelValidator: '@pim_catalog.validator.product_model'
+            $productModelBuilder: '@akeneo_integration_tests.base.product_model.builder'
             $productModelSaver: '@pim_catalog.saver.product_model'
-            $familyVariantFactory: '@pim_catalog.factory.family_variant'
-            $familyVariantUpdater: '@pim_catalog.updater.family_variant'
+            $familyVariantBuilder: '@akeneo_integration_tests.base.family_variant.builder'
             $familyVariantSaver: '@pim_catalog.saver.family_variant'
-            $familyFactory: '@pim_catalog.factory.family'
-            $familyUpdater: '@pim_catalog.updater.family'
+            $familyBuilder: '@akeneo_integration_tests.base.family.builder'
             $familySaver: '@pim_catalog.saver.family'
-            $attributeFactory: '@pim_catalog.factory.attribute'
-            $attributeUpdater: '@pim_catalog.updater.attribute'
+            $attributeBuilder: '@akeneo_integration_tests.base.attribute.builder'
             $attributeSaver: '@pim_catalog.saver.attribute'
             $attributeRepository: '@pim_catalog.repository.attribute'
             $attributeRemover: '@pim_catalog.remover.attribute'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -227,7 +227,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         $progressBar = new ProgressBar($output, $countProducts + $countProductModels);
         $progressBar->start();
 
-        $updateProgressBar = function(int $count) use ($progressBar) {
+        $updateProgressBar = function (int $count) use ($progressBar) {
             $progressBar->advance($count);
         };
 

--- a/tests/back/Pim/Enrichment/Integration/Fixture/ProductAndProductModelWithRemovedAttributeLoader.php
+++ b/tests/back/Pim/Enrichment/Integration/Fixture/ProductAndProductModelWithRemovedAttributeLoader.php
@@ -298,7 +298,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         $this->removeAttribute('a_third_attribute');
     }
 
-    protected function createProduct(array $data = []): ProductInterface
+    private function createProduct(array $data = []): ProductInterface
     {
         $this->productBuilder
             ->init()
@@ -331,7 +331,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         return $product;
     }
 
-    protected function createProductModel(array $data = []): ProductModelInterface
+    private function createProductModel(array $data = []): ProductModelInterface
     {
         $productModel = $this->productModelBuilder->build($data, true);
         $this->productModelSaver->save($productModel);
@@ -340,7 +340,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         return $productModel;
     }
 
-    protected function createFamilyVariant(array $data = []): FamilyVariantInterface
+    private function createFamilyVariant(array $data = []): FamilyVariantInterface
     {
         $familyVariant = $this->familyVariantBuilder->build($data, true);
         $this->familyVariantSaver->save($familyVariant);
@@ -348,7 +348,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         return $familyVariant;
     }
 
-    protected function createFamily(array $data = []): FamilyInterface
+    private function createFamily(array $data = []): FamilyInterface
     {
         $family = $this->familyBuilder->build($data, true);
         $this->familySaver->save($family);
@@ -356,7 +356,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         return $family;
     }
 
-    protected function createAttribute(array $data = []): AttributeInterface
+    private function createAttribute(array $data = []): AttributeInterface
     {
         $attribute = $this->attributeBuilder->build($data, true);
         $this->attributeSaver->save($attribute);
@@ -364,7 +364,7 @@ class ProductAndProductModelWithRemovedAttributeLoader
         return $attribute;
     }
 
-    public function removeAttribute(string $attributeCode)
+    private function removeAttribute(string $attributeCode)
     {
         $attribute = $this->attributeRepository->findOneBy(['code' => $attributeCode]);
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
@@ -6,30 +6,14 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedA
 
 class CountProductModelsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
 {
-    public function setUp(): void
+    public function test_it_only_counts_product_models_with_a_removed_attribute()
     {
-        parent::setUp();
-        $this->loadFixtures();
-    }
+        $this->removeAttribute('an_attribute');
+        $this->removeAttribute('a_third_attribute');
 
-    public function test_it_only_count_product_models_with_a_removed_attribute()
-    {
-        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
+        $count = $this->getCountProductModelsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
-        $expectedCount = 1;
-        $count = $this->getCountProductModelsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
-
-        self::assertEquals($expectedCount, $count);
-    }
-
-    public function test_it_does_not_count_products()
-    {
-        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
-
-        $expectedCount = 0;
-        $count = $this->getCountProductModelsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
-
-        self::assertEquals($expectedCount, $count);
+        self::assertEquals(2, $count);
     }
 
     private function getCountProductModelsWithRemovedAttribute(): CountProductModelsWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
@@ -3,17 +3,28 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 
-class CountProductModelsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+class CountProductModelsWithRemovedAttributeIntegration extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->get('akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute')->load();
+    }
+
     public function test_it_only_counts_product_models_with_a_removed_attribute()
     {
-        $this->removeAttribute('an_attribute');
-        $this->removeAttribute('a_third_attribute');
-
         $count = $this->getCountProductModelsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
         self::assertEquals(2, $count);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function getCountProductModelsWithRemovedAttribute(): CountProductModelsWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
+
+class CountProductModelsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixtures();
+    }
+
+    public function test_it_only_count_product_models_with_a_removed_attribute()
+    {
+        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
+
+        $expectedCount = 1;
+        $count = $this->getCountProductModelsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
+
+        self::assertEquals($expectedCount, $count);
+    }
+
+    public function test_it_does_not_count_products()
+    {
+        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
+
+        $expectedCount = 0;
+        $count = $this->getCountProductModelsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
+
+        self::assertEquals($expectedCount, $count);
+    }
+
+    private function getCountProductModelsWithRemovedAttribute(): CountProductModelsWithRemovedAttributeInterface
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.count_product_models_with_removed_attribute');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
@@ -2,36 +2,19 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
-use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface;
 
 class CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration extends WithRemovedAttributeTestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->loadFixtures();
-    }
-
     public function test_it_only_count_products_and_product_models_with_an_inherited_removed_attribute()
     {
-        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
+        $this->removeAttribute('an_attribute');
+        $this->removeAttribute('a_third_attribute');
 
-        $expectedCount = 1;
-        $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
+        $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
-        self::assertEquals($expectedCount, $count);
+        self::assertEquals(1, $count);
     }
-
-//    public function test_it_does_not_count_products()
-//    {
-//        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
-//
-//        $expectedCount = 0;
-//        $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
-//
-//        self::assertEquals($expectedCount, $count);
-//    }
 
     private function getCountProductsAndProductModelsWithInheritedRemovedAttribute(): CountProductsAndProductModelsWithInheritedRemovedAttributeInterface
     {

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
@@ -3,17 +3,28 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 
-class CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+class CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->get('akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute')->load();
+    }
+
     public function test_it_only_count_products_and_product_models_with_an_inherited_removed_attribute()
     {
-        $this->removeAttribute('an_attribute');
-        $this->removeAttribute('a_third_attribute');
-
         $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
         self::assertEquals(1, $count);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function getCountProductsAndProductModelsWithInheritedRemovedAttribute(): CountProductsAndProductModelsWithInheritedRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface;
+
+class CountProductsAndProductModelsWithInheritedRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixtures();
+    }
+
+    public function test_it_only_count_products_and_product_models_with_an_inherited_removed_attribute()
+    {
+        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
+
+        $expectedCount = 1;
+        $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
+
+        self::assertEquals($expectedCount, $count);
+    }
+
+//    public function test_it_does_not_count_products()
+//    {
+//        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
+//
+//        $expectedCount = 0;
+//        $count = $this->getCountProductsAndProductModelsWithInheritedRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
+//
+//        self::assertEquals($expectedCount, $count);
+//    }
+
+    private function getCountProductsAndProductModelsWithInheritedRemovedAttribute(): CountProductsAndProductModelsWithInheritedRemovedAttributeInterface
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.count_products_and_product_models_with_inherited_removed_attribute');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface;
+
+class CountProductsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixtures();
+    }
+
+    public function test_it_only_count_products_with_a_removed_attribute()
+    {
+        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
+
+        $expectedCount = 1;
+        $count = $this->getCountProductsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
+
+        self::assertEquals($expectedCount, $count);
+    }
+
+    public function test_it_does_not_count_product_models()
+    {
+        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
+
+        $expectedCount = 0;
+        $count = $this->getCountProductsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
+
+        self::assertEquals($expectedCount, $count);
+    }
+
+    private function getCountProductsWithRemovedAttribute(): CountProductsWithRemovedAttributeInterface
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.count_products_with_removed_attribute');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
@@ -3,17 +3,28 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 
-class CountProductsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+class CountProductsWithRemovedAttributeIntegration extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->get('akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute')->load();
+    }
+
     public function test_it_only_count_products_with_a_removed_attribute()
     {
-        $this->removeAttribute('an_attribute');
-        $this->removeAttribute('a_third_attribute');
-
         $count = $this->getCountProductsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
         self::assertEquals(3, $count);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function getCountProductsWithRemovedAttribute(): CountProductsWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
@@ -6,30 +6,14 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttrib
 
 class CountProductsWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
 {
-    public function setUp(): void
-    {
-        parent::setUp();
-        $this->loadFixtures();
-    }
-
     public function test_it_only_count_products_with_a_removed_attribute()
     {
-        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT);
+        $this->removeAttribute('an_attribute');
+        $this->removeAttribute('a_third_attribute');
 
-        $expectedCount = 1;
-        $count = $this->getCountProductsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT]);
+        $count = $this->getCountProductsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
-        self::assertEquals($expectedCount, $count);
-    }
-
-    public function test_it_does_not_count_product_models()
-    {
-        $this->removeAttribute(self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL);
-
-        $expectedCount = 0;
-        $count = $this->getCountProductsWithRemovedAttribute()->count([self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL]);
-
-        self::assertEquals($expectedCount, $count);
+        self::assertEquals(2, $count);
     }
 
     private function getCountProductsWithRemovedAttribute(): CountProductsWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
@@ -13,7 +13,7 @@ class CountProductsWithRemovedAttributeIntegration extends WithRemovedAttributeT
 
         $count = $this->getCountProductsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
-        self::assertEquals(2, $count);
+        self::assertEquals(3, $count);
     }
 
     private function getCountProductsWithRemovedAttribute(): CountProductsWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
@@ -3,14 +3,20 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductIdentifiersWithRemovedAttributeInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 
-class GetProductIdentifiersWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+class GetProductIdentifiersWithRemovedAttributeIntegration extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->get('akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute')->load();
+    }
+
     public function test_it_retrieves_product_identifiers_with_a_removed_attribute()
     {
-        $this->removeAttribute('an_attribute');
-        $this->removeAttribute('a_third_attribute');
-
         $result = $this->getProductIdentifiersWithRemovedAttribute()->nextBatch(['an_attribute', 'a_third_attribute'], 10);
 
         $batchCount = 0;
@@ -19,6 +25,11 @@ class GetProductIdentifiersWithRemovedAttributeIntegration extends WithRemovedAt
             self::assertEquals(['product_1', 'product_2', 'product_3', 'product_4'], $batch);
         }
         self::assertEquals(1, $batchCount);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function getProductIdentifiersWithRemovedAttribute(): GetProductIdentifiersWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
@@ -16,7 +16,7 @@ class GetProductIdentifiersWithRemovedAttributeIntegration extends WithRemovedAt
         $batchCount = 0;
         foreach ($result as $batch) {
             $batchCount++;
-            self::assertEquals(['product_1', 'product_2', 'product_3'], $batch);
+            self::assertEquals(['product_1', 'product_2', 'product_3', 'product_4'], $batch);
         }
         self::assertEquals(1, $batchCount);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductIdentifiersWithRemovedAttributeInterface;
+
+class GetProductIdentifiersWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+{
+    public function test_it_retrieves_product_identifiers_with_a_removed_attribute()
+    {
+        $this->removeAttribute('an_attribute');
+        $this->removeAttribute('a_third_attribute');
+
+        $result = $this->getProductIdentifiersWithRemovedAttribute()->nextBatch(['an_attribute', 'a_third_attribute'], 10);
+
+        $batchCount = 0;
+        foreach ($result as $batch) {
+            $batchCount++;
+            self::assertEquals(['product_1', 'product_2', 'product_3'], $batch);
+        }
+        self::assertEquals(1, $batchCount);
+    }
+
+    private function getProductIdentifiersWithRemovedAttribute(): GetProductIdentifiersWithRemovedAttributeInterface
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.get_product_identifiers_with_removed_attribute');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductModelIdentifiersWithRemovedAttributeInterface;
+
+class GetProductModelIdentifiersWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+{
+    public function test_it_retrieves_product_identifiers_with_a_removed_attribute()
+    {
+        $this->removeAttribute('an_attribute');
+        $this->removeAttribute('a_third_attribute');
+
+        $result = $this->getProductModelIdentifiersWithRemovedAttribute()->nextBatch(['an_attribute', 'a_third_attribute'], 10);
+
+        $batchCount = 0;
+        foreach ($result as $batch) {
+            $batchCount++;
+            self::assertEquals(['a_product_model', 'a_sub_product_model'], $batch);
+        }
+        self::assertEquals(1, $batchCount);
+    }
+
+    private function getProductModelIdentifiersWithRemovedAttribute(): GetProductModelIdentifiersWithRemovedAttributeInterface
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.get_product_model_identifiers_with_removed_attribute');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
@@ -3,14 +3,20 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductModelIdentifiersWithRemovedAttributeInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
 
-class GetProductModelIdentifiersWithRemovedAttributeIntegration extends WithRemovedAttributeTestCase
+class GetProductModelIdentifiersWithRemovedAttributeIntegration extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->get('akeneo_integration_tests.fixture.loader.product_and_product_model_with_removed_attribute')->load();
+    }
+
     public function test_it_retrieves_product_identifiers_with_a_removed_attribute()
     {
-        $this->removeAttribute('an_attribute');
-        $this->removeAttribute('a_third_attribute');
-
         $result = $this->getProductModelIdentifiersWithRemovedAttribute()->nextBatch(['an_attribute', 'a_third_attribute'], 10);
 
         $batchCount = 0;
@@ -19,6 +25,11 @@ class GetProductModelIdentifiersWithRemovedAttributeIntegration extends WithRemo
             self::assertEquals(['a_product_model', 'a_sub_product_model'], $batch);
         }
         self::assertEquals(1, $batchCount);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
     }
 
     private function getProductModelIdentifiersWithRemovedAttribute(): GetProductModelIdentifiersWithRemovedAttributeInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
@@ -230,7 +230,9 @@ abstract class WithRemovedAttributeTestCase extends TestCase
 
     protected function createProduct(array $data = []): ProductInterface
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct('new_product_' . rand());
+        $identifier = $data['identifier'] ?? 'new_product_' . rand();
+
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
 
         /** @var ConstraintViolationList $constraintList */

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
@@ -153,6 +153,28 @@ abstract class WithRemovedAttributeTestCase extends TestCase
             ],
         ]);
 
+        // Simple product
+        $this->createProduct([
+            'identifier' => 'product_4',
+            'family' => 'a_second_family',
+            'values' => [
+                'a_second_attribute' => [
+                    [
+                        'data' => 'foo',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+                'a_third_attribute' => [
+                    [
+                        'data' => 'barfoo',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
         // Product model with only one level of variations
         $this->createProductModel([
             'code' => 'a_product_model',

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
@@ -1,0 +1,411 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+abstract class WithRemovedAttributeTestCase extends TestCase
+{
+    const ATTRIBUTE_ONLY_ON_ONE_PRODUCT = 'attribute_only_on_one_product';
+    const ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL = 'attribute_only_on_one_product_model';
+    const ATTRIBUTE_ONLY_ON_ONE_SUB_PRODUCT_MODEL = 'attribute_only_on_one_sub_product_model';
+    const ATTRIBUTE_ONLY_ON_ONE_PRODUCT_VARIANT = 'attribute_only_on_one_product_variant';
+
+    /**
+     * @inheritDoc
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function loadFixtures(): void
+    {
+        $family = $this->createFamily([
+            'code' => 'family_'.uniqid(),
+        ]);
+
+        $this->createAttribute([
+            'code' => self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT,
+            'type' => 'pim_catalog_text',
+            'group' => 'other',
+        ]);
+
+        $this->createAttribute([
+            'code' => self::ATTRIBUTE_ONLY_ON_ONE_SUB_PRODUCT_MODEL,
+            'type' => 'pim_catalog_text',
+            'group' => 'other',
+        ]);
+
+        $this->createAttribute([
+            'code' => self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_VARIANT,
+            'type' => 'pim_catalog_text',
+            'group' => 'other',
+        ]);
+
+        $this->createProduct([
+            'identifier' => 'product_'.uniqid(),
+            'family' => $family->getCode(),
+            'values' => [
+                self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT => [
+                    [
+                        'data' => 'foobar',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $attributeFirstAxis = $this->createAttribute([
+            'code' => 'attribute_axis_'.uniqid(),
+            'type' => 'pim_catalog_boolean',
+            'group' => 'other',
+        ]);
+        $attributeSecondAxis = $this->createAttribute([
+            'code' => 'attribute_axis_'.uniqid(),
+            'type' => 'pim_catalog_boolean',
+            'group' => 'other',
+        ]);
+        $attributeOnlyOnProductModels = $this->createAttribute([
+            'code' => self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL,
+            'type' => 'pim_catalog_text',
+            'group' => 'other',
+        ]);
+
+        $family->addAttribute($attributeFirstAxis);
+        $family->addAttribute($attributeSecondAxis);
+        $family->addAttribute($attributeOnlyOnProductModels);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        $familyVariantWithOneLevel = $this->createFamilyVariant([
+            'code' => 'family_variant_'.uniqid(),
+            'variant_attribute_sets' => [
+                [
+                    'axes' => [$attributeFirstAxis->getCode()],
+                    'attributes' => [self::ATTRIBUTE_ONLY_ON_ONE_SUB_PRODUCT_MODEL],
+                    'level' => 1,
+                ],
+            ],
+            'family' => $family->getCode(),
+        ]);
+
+        $familyVariantWithTwoLevels = $this->createFamilyVariant([
+            'code' => 'family_variant_'.uniqid(),
+            'variant_attribute_sets' => [
+                [
+                    'axes' => [$attributeFirstAxis->getCode()],
+                    'attributes' => [self::ATTRIBUTE_ONLY_ON_ONE_SUB_PRODUCT_MODEL],
+                    'level' => 1,
+                ],
+                [
+                    'axes' => [$attributeSecondAxis->getCode()],
+                    'attributes' => [self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_VARIANT],
+                    'level' => 2,
+                ],
+            ],
+            'family' => $family->getCode(),
+        ]);
+
+        $productModelWithoutVariants = $this->createProductModel([
+            'code' => 'product_model_'.rand(),
+            'family_variant' => $familyVariantWithOneLevel->getCode(),
+            'values' => [
+                self::ATTRIBUTE_ONLY_ON_ONE_PRODUCT_MODEL => [
+                    [
+                        'data' => 'foobar',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $productModelWithOneVariant = $this->createProductModel([
+            'code' => 'product_model_'.rand(),
+            'family_variant' => $familyVariantWithOneLevel->getCode(),
+            'values' => [],
+        ]);
+
+        $this->createVariantProduct('new_variant_product_'.rand(), [
+            'categories' => ['master'],
+            'parent' => $productModelWithOneVariant->getCode(),
+            'values' => [
+                $attributeFirstAxis->getCode() => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'true',
+                    ],
+                ],
+            ],
+        ]);
+
+        $productModelWithOneSubModel = $this->createProductModel([
+            'code' => 'product_model_'.rand(),
+            'family_variant' => $familyVariantWithOneLevel->getCode(),
+            'values' => [],
+        ]);
+
+        $subProductModel = $this->createProductModel([
+            'code' => 'product_model_'.rand(),
+            'family_variant' => $familyVariantWithTwoLevels->getCode(),
+            'parent' => $productModelWithOneSubModel->getCode(),
+            'values' => [
+                $attributeFirstAxis->getCode() => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'true',
+                    ],
+                ],
+                self::ATTRIBUTE_ONLY_ON_ONE_SUB_PRODUCT_MODEL => [
+                    [
+                        'data' => 'foobar',
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->createVariantProduct('new_variant_product_'.rand(), [
+            'parent' => $subProductModel->getCode(),
+            'values' => [
+                $attributeSecondAxis->getCode() => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'true',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function createProduct(array $data = []): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct('new_product_'.rand());
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertEquals(0, $constraintList->count());
+
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        return $product;
+    }
+
+    private function createVariantProduct(string $identifier, array $data = []): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        return $product;
+    }
+
+    protected function createRandomProductWithAttributes(array $attributesCodes): ProductInterface
+    {
+        $family = $this->createFamily([
+            'code' => 'family_'.uniqid(),
+        ]);
+
+        $values = [];
+        foreach ($attributesCodes as $attributeCode) {
+            $values[$attributeCode] = [
+                [
+                    'data' => 'some text',
+                    'locale' => null,
+                    'scope' => null,
+                ],
+            ];
+        }
+
+        return $this->createProduct([
+            'identifier' => 'new_product_'.uniqid(),
+            'family' => $family->getCode(),
+            'values' => $values,
+        ]);
+    }
+
+    private function createProductModel(array $data = []): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $constraintList = $this->get('pim_catalog.validator.product')->validate($productModel);
+        Assert::assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        return $productModel;
+    }
+
+    protected function createRandomProductModelWithAttributes(array $attributesCodes): ProductModelInterface
+    {
+        $axisAttribute = $this->createAttribute([
+            'code' => 'new_attribute_axis_'.uniqid(),
+            'type' => 'pim_catalog_boolean',
+            'group' => 'other',
+        ]);
+
+        $family = $this->createFamily([
+            'code' => 'new_family_'.uniqid(),
+        ]);
+        $family->addAttribute($axisAttribute);
+
+        $values = [];
+        foreach ($attributesCodes as $attributeCode) {
+            $values[$attributeCode] = [
+                [
+                    'data' => 'some text',
+                    'locale' => null,
+                    'scope' => null,
+                ],
+            ];
+            $attribute = $this->get('pim_catalog.repository.attribute')->findOneBy(['code' => $attributeCode]);
+            $family->addAttribute($attribute);
+        }
+
+        $errors = $this->get('validator')->validate($family);
+        Assert::assertCount(0, $errors);
+
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        $familyVariant = $this->createFamilyVariant([
+            'code' => 'new_family_variant_'.uniqid(),
+            'variant_attribute_sets' => [
+                [
+                    'axes' => [$axisAttribute->getCode()],
+                    'attributes' => [],
+                    'level' => 1,
+                ],
+            ],
+            'family' => $family->getCode(),
+        ]);
+
+        return $this->createProductModel([
+            'code' => 'new_product_model_'.rand(),
+            'family_variant' => $familyVariant->getCode(),
+            'values' => $values,
+        ]);
+    }
+
+    protected function createFamilyVariant(array $data = []): FamilyVariantInterface
+    {
+        $family = $this->get('pim_catalog.factory.family_variant')->create();
+        $this->get('pim_catalog.updater.family_variant')->update($family, $data);
+        $constraintList = $this->get('validator')->validate($family);
+        Assert::assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.family_variant')->save($family);
+
+        return $family;
+    }
+
+//    protected function createProductModelsWithAttributes(int $count, array $attributesCodes)
+//    {
+//        $axisAttribute = $this->createAttribute([
+//            'code' => 'new_attribute_'.uniqid(),
+//            'type' => 'pim_catalog_boolean',
+//            'group' => 'other',
+//        ]);
+//
+//        $family = $this->createFamily(['code' => 'new_family_'.uniqid()]);
+//        $family->addAttribute($axisAttribute);
+//
+//        $productModelValues = [];
+//        $i = 0;
+//        while ($i < $numberOfProductValues) {
+//            $attribute = $this->createAttribute([
+//                'code' => 'new_attribute_'.rand(),
+//                'type' => 'pim_catalog_text',
+//                'group' => 'other',
+//            ]);
+//
+//            $family->addAttribute($attribute);
+//            $productModelValues[$attribute->getCode()] = [
+//                ['data' => rand().' some text random', 'locale' => null, 'scope' => null],
+//            ];
+//            $i++;
+//        }
+//
+//        $errors = $this->get('validator')->validate($family);
+//        Assert::assertCount(0, $errors);
+//
+//        $this->get('pim_catalog.saver.family')->save($family);
+//
+//        $familyVariant = $this->createFamilyVariant([
+//            'code' => 'new_family_variant_'.rand(),
+//            'variant_attribute_sets' => [
+//                [
+//                    'axes' => [$axisAttribute->getCode()],
+//                    'attributes' => [],
+//                    'level' => 1,
+//                ],
+//            ],
+//            'family' => $family->getCode(),
+//        ]);
+//
+//        $this->createProductModel([
+//            'code' => 'new_product_model_'.rand(),
+//            'family_variant' => $familyVariant->getCode(),
+//            'values' => $productModelValues,
+//        ]);
+//    }
+
+    private function createFamily(array $data = []): FamilyInterface
+    {
+        $family = $this->get('pim_catalog.factory.family')->create();
+        $this->get('pim_catalog.updater.family')->update($family, $data);
+        $constraintList = $this->get('validator')->validate($family);
+        Assert::assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.family')->save($family);
+
+        return $family;
+    }
+
+    protected function createTextAttribute(string $code): AttributeInterface
+    {
+        return $this->createAttribute([
+            'code' => $code,
+            'type' => 'pim_catalog_text',
+            'group' => 'other',
+        ]);
+    }
+
+    protected function createAttribute(array $data = []): AttributeInterface
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+        $constraintList = $this->get('validator')->validate($attribute);
+        Assert::assertEquals(0, $constraintList->count());
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    protected function removeAttribute(string $attributeCode)
+    {
+        $attribute = $this->get('pim_catalog.repository.attribute')->findOneBy(['code' => $attributeCode]);
+
+        if (null == $attribute) {
+            throw new \LogicException(sprintf('Attribute %s not found', $attributeCode));
+        }
+
+        $this->get('pim_catalog.remover.attribute')->remove($attribute);
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/WithRemovedAttributeTestCase.php
@@ -10,7 +10,6 @@ use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Validator\ConstraintViolationList;
 
 abstract class WithRemovedAttributeTestCase extends TestCase
 {
@@ -234,15 +233,8 @@ abstract class WithRemovedAttributeTestCase extends TestCase
 
         $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
         $this->get('pim_catalog.updater.product')->update($product, $data);
-
-        /** @var ConstraintViolationList $constraintList */
         $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
-        foreach ($constraintList as $constraintViolation) {
-            dump($constraintViolation->getMessage(), $constraintViolation->getPropertyPath(), $constraintViolation->getInvalidValue());
-        }
         Assert::assertEquals(0, $constraintList->count(), 'Impossible to create a product');
-
-
         $this->get('pim_catalog.saver.product')->save($product);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
 
@@ -253,16 +245,9 @@ abstract class WithRemovedAttributeTestCase extends TestCase
     {
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
-
-        /** @var ConstraintViolationList $constraintList */
         $constraintList = $this->get('pim_catalog.validator.product')->validate($productModel);
-        foreach ($constraintList as $constraintViolation) {
-            dump($constraintViolation->getMessage(), $constraintViolation->getPropertyPath());
-        }
-
         Assert::assertEquals(0, $constraintList->count(), 'Impossible to create a product model');
         $this->get('pim_catalog.saver.product_model')->save($productModel);
-
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
 
         return $productModel;
@@ -272,13 +257,7 @@ abstract class WithRemovedAttributeTestCase extends TestCase
     {
         $family = $this->get('pim_catalog.factory.family_variant')->create();
         $this->get('pim_catalog.updater.family_variant')->update($family, $data);
-
-        /** @var ConstraintViolationList $constraintList */
         $constraintList = $this->get('validator')->validate($family);
-        foreach ($constraintList as $constraintViolation) {
-            dump($constraintViolation->getMessage(), $constraintViolation->getPropertyPath());
-        }
-
         Assert::assertEquals(0, $constraintList->count(), 'Impossible to create a family variant');
         $this->get('pim_catalog.saver.family_variant')->save($family);
 
@@ -289,13 +268,7 @@ abstract class WithRemovedAttributeTestCase extends TestCase
     {
         $family = $this->get('pim_catalog.factory.family')->create();
         $this->get('pim_catalog.updater.family')->update($family, $data);
-
-        /** @var ConstraintViolationList $constraintList */
         $constraintList = $this->get('validator')->validate($family);
-        foreach ($constraintList as $constraintViolation) {
-            dump($constraintViolation->getMessage(), $constraintViolation->getPropertyPath(), $constraintViolation->getInvalidValue());
-        }
-
         Assert::assertEquals(0, $constraintList->count(), 'Impossible to create a family');
         $this->get('pim_catalog.saver.family')->save($family);
 
@@ -306,13 +279,7 @@ abstract class WithRemovedAttributeTestCase extends TestCase
     {
         $attribute = $this->get('pim_catalog.factory.attribute')->create();
         $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
-
-        /** @var ConstraintViolationList $constraintList */
         $constraintList = $this->get('validator')->validate($attribute);
-        foreach ($constraintList as $constraintViolation) {
-            dump($constraintViolation->getMessage(), $constraintViolation->getPropertyPath(), $constraintViolation->getInvalidValue());
-        }
-
         Assert::assertEquals(0, $constraintList->count(), 'Impossible to create an attribute');
         $this->get('pim_catalog.saver.attribute')->save($attribute);
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Product/CleanValuesOfRemovedAttributesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Product/CleanValuesOfRemovedAttributesSpec.php
@@ -1,0 +1,210 @@
+<?php
+
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductIdentifiersWithRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductModelIdentifiersWithRemovedAttributeInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class CleanValuesOfRemovedAttributesSpec extends ObjectBehavior
+{
+    public function let(
+        CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute,
+        CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute,
+        CountProductsAndProductModelsWithInheritedRemovedAttributeInterface $countProductsAndProductModelsWithInheritedRemovedAttribute,
+        GetProductIdentifiersWithRemovedAttributeInterface $getProductIdentifiersWithRemovedAttribute,
+        GetProductModelIdentifiersWithRemovedAttributeInterface $getProductModelIdentifiersWithRemovedAttribute,
+        ProductRepositoryInterface $productRepository,
+        BulkSaverInterface $productSaver,
+        ProductModelRepositoryInterface $productModelRepository,
+        BulkSaverInterface $productModelSaver,
+        ValidatorInterface $validator,
+        GetAttributes $getAttributes,
+        UnitOfWorkAndRepositoriesClearer $clearer
+    )
+    {
+        $this->beConstructedWith(
+            $countProductsWithRemovedAttribute,
+            $countProductModelsWithRemovedAttribute,
+            $countProductsAndProductModelsWithInheritedRemovedAttribute,
+            $getProductIdentifiersWithRemovedAttribute,
+            $getProductModelIdentifiersWithRemovedAttribute,
+            $productRepository,
+            $productSaver,
+            $productModelRepository,
+            $productModelSaver,
+            $validator,
+            $getAttributes,
+            $clearer
+        );
+    }
+
+
+    public function it_counts_products_with_removed_attribute(
+        $countProductsWithRemovedAttribute
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute', 'a_third_attribute'];
+
+        $countProductsWithRemovedAttribute->count($removedAttributes)->willReturn(3);
+        $this->countProductsWithRemovedAttribute($removedAttributes)->shouldBe(3);
+    }
+
+    public function it_counts_product_models_with_removed_attribute(
+        $countProductModelsWithRemovedAttribute
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute', 'a_third_attribute'];
+
+        $countProductModelsWithRemovedAttribute->count($removedAttributes)->willReturn(2);
+        $this->countProductModelsWithRemovedAttribute($removedAttributes)->shouldBe(2);
+    }
+
+    public function it_counts_products_and_product_models_with_inherited_removed_attribute(
+        $countProductsAndProductModelsWithInheritedRemovedAttribute
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute', 'a_third_attribute'];
+
+        $countProductsAndProductModelsWithInheritedRemovedAttribute->count($removedAttributes)->willreturn(1);
+        $this->countProductsAndProductModelsWithInheritedRemovedAttribute($removedAttributes)->shouldBe(1);
+    }
+
+    public function it_cleans_product_models_with_removed_attribute(
+        $getProductModelIdentifiersWithRemovedAttribute,
+        $productModelRepository,
+        $productModelSaver,
+        $clearer,
+        ProductModelInterface $aProductModel,
+        ProductModelInterface $aSecondProductModel,
+        ProductModelInterface $aThirdProductModel
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute'];
+        $codes = [
+            ['a_product_model', 'a_second_product_model'],
+            ['a_third_product_model'],
+        ];
+        $productModelsBatch1 = [$aProductModel, $aSecondProductModel];
+        $productModelsBatch2 = [$aThirdProductModel];
+
+        $getProductModelIdentifiersWithRemovedAttribute->nextBatch($removedAttributes, Argument::type('integer'))->willReturn($codes);
+
+        $productModelRepository->findBy(['code' => $codes[0]])->willReturn($productModelsBatch1);
+        $productModelSaver->saveAll($productModelsBatch1)->shouldBeCalled();
+        $clearer->clear()->shouldBeCalled();
+
+        $productModelRepository->findBy(['code' => $codes[1]])->willReturn($productModelsBatch2);
+        $productModelSaver->saveAll($productModelsBatch2)->shouldBeCalled();
+        $clearer->clear()->shouldBeCalled();
+
+        $this->cleanProductModelsWithRemovedAttribute($removedAttributes, null);
+    }
+
+    public function it_cleans_products_with_removed_attribute(
+        $getProductIdentifiersWithRemovedAttribute,
+        $productRepository,
+        $productSaver,
+        $clearer,
+        ProductInterface $aProduct,
+        ProductInterface $aSecondProduct
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute', 'a_third_attribute'];
+        $batchOfIdentifiers = [
+            ['a_product', 'a_second_product'],
+        ];
+        $products = [$aProduct, $aSecondProduct];
+
+        $getProductIdentifiersWithRemovedAttribute->nextBatch($removedAttributes, Argument::type('integer'))->willReturn($batchOfIdentifiers);
+        $productRepository->findBy(['identifier' => ['a_product', 'a_second_product']])->willReturn($products);
+        $productSaver->saveAll($products)->shouldBeCalled();
+
+        $clearer->clear()->shouldBeCalled();
+
+        $this->cleanProductsWithRemovedAttribute($removedAttributes, null);
+    }
+
+    public function it_validates_removed_attributes_codes(
+        $validator,
+        $getAttributes
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'a_second_attribute'];
+
+        $validator->validate('an_attribute', Argument::cetera())->willReturn([]);
+        $validator->validate('a_second_attribute', Argument::cetera())->willReturn([]);
+
+        $this->validateRemovedAttributesCodes($removedAttributes);
+
+        $getAttributes->forCode('an_attribute')->shouldHaveBeenCalled();
+        $getAttributes->forCode('a_second_attribute')->shouldHaveBeenCalled();
+    }
+
+    public function it_does_not_validate_an_empty_list_of_removed_attributes_codes(): void
+    {
+        $removedAttributes = [];
+        $this->shouldThrow(\LogicException::class)->during('validateRemovedAttributesCodes', [$removedAttributes]);
+    }
+
+    public function it_does_not_validate_when_list_containing_invalid_removed_attributes_code(
+        $validator,
+        $getAttributes,
+        ConstraintViolation $anAttributeConstraintViolation
+    ): void
+    {
+        $removedAttributes = ['an_attribute', 'an_invalid_attribute'];
+
+        $validator->validate('an_attribute', Argument::cetera())->willReturn([]);
+        $validator->validate('an_invalid_attribute', Argument::cetera())->willReturn([
+            $anAttributeConstraintViolation
+        ]);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('validateRemovedAttributesCodes', [$removedAttributes]);
+
+        $getAttributes->forCode('an_attribute')->shouldHaveBeenCalled();
+        $getAttributes->forCode('an_invalid_attribute')->shouldNotHaveBeenCalled();
+    }
+
+    public function it_does_not_validate_when_list_containing_existing_attributes_code(
+        $validator,
+        $getAttributes
+    ): void
+    {
+        $anExistingAttribute = new Attribute(
+            'an_existing_attribute',
+            'an_attribute_type',
+            [],
+            false,
+            false,
+            null,
+            null,
+            'a_backend_type',
+            []
+        );
+        $removedAttributes = ['an_attribute', 'an_existing_attribute'];
+
+        $validator->validate('an_attribute', Argument::cetera())->willReturn([]);
+        $validator->validate('an_existing_attribute', Argument::cetera())->willReturn([]);
+
+        $getAttributes->forCode('an_attribute')->willReturn(null);
+        $getAttributes->forCode('an_existing_attribute')->willReturn($anExistingAttribute);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('validateRemovedAttributesCodes', [$removedAttributes]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

This pull request aims to improve the previous pull request https://github.com/akeneo/pim-community-dev/pull/13242 with specifications and integration tests

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
