### PR TITLE
RAC-384: Fix fatal error when an attribute is removed then re-created with the same code but another type

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - [Backport] Fix fatal error on display product model associations when they have more than 25 products associated
+- RAC-384: Fix fatal error when an attribute is removed then re-created with the same code but another type.
 
 # 3.2.76 (2020-10-22)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
@@ -26,7 +28,7 @@ final class ChainedNonExistentValuesFilter implements ChainedNonExistentValuesFi
             function (OnGoingFilteredRawValues $onGoingFilteredRawValues, NonExistentValuesFilter $obsoleteValuesFilter): OnGoingFilteredRawValues {
                 try {
                     return $obsoleteValuesFilter->filter($onGoingFilteredRawValues);
-                } catch (\TypeError $ex) {
+                } catch (\TypeError | InvalidPropertyTypeException $ex) {
                     return $onGoingFilteredRawValues;
                 }
             },

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
@@ -24,7 +24,11 @@ final class ChainedNonExistentValuesFilter implements ChainedNonExistentValuesFi
         $result = array_reduce(
             $this->iterableToArray($this->nonExistentValueFilters),
             function (OnGoingFilteredRawValues $onGoingFilteredRawValues, NonExistentValuesFilter $obsoleteValuesFilter): OnGoingFilteredRawValues {
-                return $obsoleteValuesFilter->filter($onGoingFilteredRawValues);
+                try {
+                    return $obsoleteValuesFilter->filter($onGoingFilteredRawValues);
+                } catch (\TypeError $ex) {
+                    return $onGoingFilteredRawValues;
+                }
             },
             $onGoingFilteredRawValues
         );

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -40,7 +40,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (is_array($value)) {
+                        if (\is_array($value)) {
                             $multiSelectValues[$channel][$locale] = $this->arrayIntersectCaseInsensitive($value, $optionCodes[$attributeCode] ?? []);
                         }
                     }
@@ -80,7 +80,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
             foreach ($valueCollection as $values) {
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (is_array($value)) {
+                        if (\is_array($value)) {
                             foreach ($value as $optionCode) {
                                 $optionCodes[$attributeCode][] = $optionCode;
                             }
@@ -93,7 +93,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
             foreach ($optionCodeForThisAttribute as $value) {
-                if (!is_scalar($value)) {
+                if (!\is_scalar($value)) {
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         $attributeCode,
                         sprintf('one of the "%s" values is not a scalar', $attributeCode),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -92,7 +92,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
-            foreach($optionCodeForThisAttribute as $value) {
+            foreach ($optionCodeForThisAttribute as $value) {
                 if (!is_scalar($value)) {
                     throw InvalidPropertyTypeException::validArrayStructureExpected(
                         $attributeCode,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -91,6 +92,17 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
+            foreach($optionCodeForThisAttribute as $value) {
+                if (!is_scalar($value)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        $attributeCode,
+                        sprintf('one of the "%s" values is not a scalar', $attributeCode),
+                        static::class,
+                        $optionCodeForThisAttribute
+                    );
+                }
+            }
+
             $uniqueOptionCodes[$attributeCode] = array_unique($optionCodeForThisAttribute);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
@@ -56,7 +56,7 @@ final class NonExistentPriceCollectionValueFilter implements NonExistentValuesFi
                     }
 
                     foreach ($valuesIndexedByLocale as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             throw InvalidPropertyTypeException::arrayExpected(
                                 $attributeCode,
                                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Channel\Component\Query\FindActivatedCurrenciesInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -55,6 +56,14 @@ final class NonExistentPriceCollectionValueFilter implements NonExistentValuesFi
                     }
 
                     foreach ($valuesIndexedByLocale as $locale => $value) {
+                        if (!is_array($value)) {
+                            throw InvalidPropertyTypeException::arrayExpected(
+                                $attributeCode,
+                                static::class,
+                                $value
+                            );
+                        }
+
                         $amountByCurrency = [];
                         foreach ($value as $price) {
                             if (isset($price['amount']) && isset($price['currency'])) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
@@ -40,7 +40,7 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
 
                 foreach ($productData['values'] as $channel => $valuesIndexedByLocale) {
                     foreach ($valuesIndexedByLocale as $locale => $values) {
-                        if (is_array($values)) {
+                        if (\is_array($values)) {
                             $multiSelectValues[$channel][$locale] = array_values(array_intersect($values, $existingReferenceDataCodes[$attributeCode] ?? []));
                         }
                     }
@@ -86,7 +86,7 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
                 $referenceDataName = $values['properties']['reference_data_name'];
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $values) {
-                        if (!is_array($values)) {
+                        if (!\is_array($values)) {
                             throw InvalidPropertyTypeException::arrayExpected(
                                 $attributeCode,
                                 static::class,
@@ -95,7 +95,7 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
                         }
 
                         foreach ($values as $value) {
-                            if (!is_scalar($value)) {
+                            if (!\is_scalar($value)) {
                                 throw InvalidPropertyTypeException::validArrayStructureExpected(
                                     $attributeCode,
                                     sprintf('one of the "%s" values is not a scalar', $attributeCode),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetExistingReferenceDataCodes;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Tamara Robichet <tamara.robichet@akeneo.com>
@@ -85,7 +86,24 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
                 $referenceDataName = $values['properties']['reference_data_name'];
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $values) {
+                        if (!is_array($values)) {
+                            throw InvalidPropertyTypeException::arrayExpected(
+                                $attributeCode,
+                                static::class,
+                                $values
+                            );
+                        }
+
                         foreach ($values as $value) {
+                            if (!is_scalar($value)) {
+                                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                                    $attributeCode,
+                                    sprintf('one of the "%s" values is not a scalar', $attributeCode),
+                                    static::class,
+                                    $values
+                                );
+                            }
+
                             $referenceData[$attributeCode][$referenceDataName][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataSimpleSelectValuesFilter.php
@@ -39,7 +39,7 @@ class NonExistentReferenceDataSimpleSelectValuesFilter implements NonExistentVal
 
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             if (in_array($value, $referenceDataCodes[$attributeCode])) {
                                 $simpleSelectValues[$channel][$locale] = $value;
                             } else {
@@ -88,7 +88,7 @@ class NonExistentReferenceDataSimpleSelectValuesFilter implements NonExistentVal
                 $referenceDataName = $values['properties']['reference_data_name'];
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $referenceDataCodes[$attributeCode][$referenceDataName][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
@@ -38,7 +38,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
                 $simpleSelectValues = [];
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $simpleSelectValues[$channel][$locale] = ($optionCodes[$attributeCode] ?? [])[strtolower($value ?? '')] ?? '';
                         }
                     }
@@ -79,7 +79,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
             foreach ($valueCollection as $values) {
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $optionCodes[$attributeCode][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/DateValueFactory.php
@@ -7,6 +7,8 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\DateValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -17,7 +19,25 @@ final class DateValueFactory implements ReadValueFactory
 {
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        $date = new \DateTime($data);
+        if (!is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
+        try {
+            $date = new \DateTime($data);
+        } catch (\Exception $ex) {
+            throw InvalidPropertyException::dateExpected(
+                $attribute->code(),
+                'yyyy-mm-dd',
+                static::class,
+                $data
+            );
+        }
+
         $attributeCode = $attribute->code();
 
         if ($attribute->isLocalizableAndScopable()) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/DateValueFactory.php
@@ -19,7 +19,7 @@ final class DateValueFactory implements ReadValueFactory
 {
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/FileValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/FileValueFactory.php
@@ -28,7 +28,7 @@ final class FileValueFactory implements ReadValueFactory
 
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/FileValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/FileValueFactory.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -27,6 +28,14 @@ final class FileValueFactory implements ReadValueFactory
 
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        if (!is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
         $fileInfo = $this->fileInfoRepository->findOneByIdentifier($data);
 
         if (null === $fileInfo) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ImageValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ImageValueFactory.php
@@ -28,7 +28,7 @@ final class ImageValueFactory implements ReadValueFactory
 
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ImageValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ImageValueFactory.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -27,6 +28,14 @@ final class ImageValueFactory implements ReadValueFactory
 
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        if (!is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
         $fileInfo = $this->fileInfoRepository->findOneByIdentifier($data);
 
         if (null === $fileInfo) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/MetricValueFactory.php
@@ -54,7 +54,7 @@ final class MetricValueFactory implements ReadValueFactory
 
     private function validate(Attribute $attribute, $data): void
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/MetricValueFactory.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MetricValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -26,6 +27,8 @@ final class MetricValueFactory implements ReadValueFactory
 
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        $this->validate($attribute, $data);
+
         $data = $this->metricFactory->createMetric($attribute->metricFamily(), $data['unit'], $data['amount']);
         $attributeCode = $attribute->code();
 
@@ -47,5 +50,34 @@ final class MetricValueFactory implements ReadValueFactory
     public function supportedAttributeType(): string
     {
         return AttributeTypes::METRIC;
+    }
+
+    private function validate(Attribute $attribute, $data): void
+    {
+        if (!is_array($data)) {
+            throw InvalidPropertyTypeException::arrayExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
+        if (!array_key_exists('amount', $data)) {
+            throw InvalidPropertyTypeException::arrayKeyExpected(
+                $attribute->code(),
+                'amount',
+                static::class,
+                $data
+            );
+        }
+
+        if (!array_key_exists('unit', $data)) {
+            throw InvalidPropertyTypeException::arrayKeyExpected(
+                $attribute->code(),
+                'unit',
+                static::class,
+                $data
+            );
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/PriceCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/PriceCollectionValueFactory.php
@@ -53,7 +53,7 @@ final class PriceCollectionValueFactory implements ReadValueFactory
 
     private function validate(Attribute $attribute, $data): void
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,
@@ -62,7 +62,7 @@ final class PriceCollectionValueFactory implements ReadValueFactory
         }
 
         foreach ($data as $price) {
-            if (!is_array($price)) {
+            if (!\is_array($price)) {
                 throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->code(),
                     static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/PriceCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/PriceCollectionValueFactory.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -19,6 +20,8 @@ final class PriceCollectionValueFactory implements ReadValueFactory
 {
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        $this->validate($attribute, $data);
+
         $sortedData = $this->sortByCurrency($data);
         $attributeCode = $attribute->code();
 
@@ -46,6 +49,45 @@ final class PriceCollectionValueFactory implements ReadValueFactory
     public function supportedAttributeType(): string
     {
         return AttributeTypes::PRICE_COLLECTION;
+    }
+
+    private function validate(Attribute $attribute, $data): void
+    {
+        if (!is_array($data)) {
+            throw InvalidPropertyTypeException::arrayExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
+        foreach ($data as $price) {
+            if (!is_array($price)) {
+                throw InvalidPropertyTypeException::arrayOfArraysExpected(
+                    $attribute->code(),
+                    static::class,
+                    $data
+                );
+            }
+
+            if (!array_key_exists('amount', $price)) {
+                throw InvalidPropertyTypeException::arrayKeyExpected(
+                    $attribute->code(),
+                    'amount',
+                    static::class,
+                    $data
+                );
+            }
+
+            if (!array_key_exists('currency', $price)) {
+                throw InvalidPropertyTypeException::arrayKeyExpected(
+                    $attribute->code(),
+                    'currency',
+                    static::class,
+                    $data
+                );
+            }
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ScalarValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ScalarValueFactory.php
@@ -17,7 +17,7 @@ abstract class ScalarValueFactory implements ReadValueFactory
 {
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_scalar($data)) {
+        if (!\is_scalar($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ScalarValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/Value/ScalarValueFactory.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -16,6 +17,14 @@ abstract class ScalarValueFactory implements ReadValueFactory
 {
     public function create(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        if (!is_scalar($data)) {
+            throw InvalidPropertyTypeException::arrayExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
         $attributeCode = $attribute->code();
 
         if ($attribute->isLocalizableAndScopable()) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
@@ -156,7 +156,7 @@ class ValueCollectionFactory
                         } catch (InvalidPropertyException $e) {
                             // TODO merge master/4.0: remove check
                             if (null !== $this->logger) {
-                                $this->logger->warning(
+                                $this->logger->notice(
                                     sprintf(
                                         'Tried to load a product value with the property "%s" that does not exist.',
                                         $e->getPropertyValue()
@@ -166,7 +166,7 @@ class ValueCollectionFactory
                         } catch (\TypeError | InvalidPropertyTypeException $e) {
                             // TODO merge master/4.0: remove check
                             if (null !== $this->logger) {
-                                $this->logger->warning(
+                                $this->logger->notice(
                                     sprintf(
                                         'Tried to load a product value for attribute "%s" that does not have the '.
                                         'expected type in database.',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
@@ -7,6 +7,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\Chai
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Psr\Log\LoggerInterface;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -27,16 +30,23 @@ class ValueCollectionFactory
     /** @var EmptyValuesCleaner */
     private $emptyValuesCleaner;
 
+    // TODO merge master/4.0: property $logger should be nullable
+    /** @var LoggerInterface|null */
+    private $logger;
+
+    // TODO merge master/4.0: require LoggerInterface argument
     public function __construct(
         ReadValueFactory $valueFactory,
         GetAttributes $getAttributeByCodes,
         ChainedNonExistentValuesFilterInterface $chainedNonExistentValuesFilter,
-        EmptyValuesCleaner $emptyValuesCleaner
+        EmptyValuesCleaner $emptyValuesCleaner,
+        LoggerInterface $logger = null
     ) {
         $this->valueFactory = $valueFactory;
         $this->getAttributeByCodes = $getAttributeByCodes;
         $this->chainedNonExistentValuesFilter = $chainedNonExistentValuesFilter;
         $this->emptyValuesCleaner = $emptyValuesCleaner;
+        $this->logger = $logger;
     }
 
     public function createFromStorageFormat(array $rawValues): ReadValueCollection
@@ -141,7 +151,30 @@ class ValueCollectionFactory
                             $localeCode = null;
                         }
 
-                        $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data);
+                        try {
+                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data);
+                        } catch (InvalidPropertyException $e) {
+                            // TODO merge master/4.0: remove check
+                            if (null !== $this->logger) {
+                                $this->logger->warning(
+                                    sprintf(
+                                        'Tried to load a product value with the property "%s" that does not exist.',
+                                        $e->getPropertyValue()
+                                    )
+                                );
+                            }
+                        } catch (\TypeError | InvalidPropertyTypeException $e) {
+                            // TODO merge master/4.0: remove check
+                            if (null !== $this->logger) {
+                                $this->logger->warning(
+                                    sprintf(
+                                        'Tried to load a product value for attribute "%s" that does not have the '.
+                                        'good type in database.',
+                                        $attribute->getCode()
+                                    )
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Read/ValueCollectionFactory.php
@@ -169,7 +169,7 @@ class ValueCollectionFactory
                                 $this->logger->warning(
                                     sprintf(
                                         'Tried to load a product value for attribute "%s" that does not have the '.
-                                        'good type in database.',
+                                        'expected type in database.',
                                         $attribute->getCode()
                                     )
                                 );

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -26,7 +26,7 @@ class DateValueFactory extends AbstractValueFactory
             return null;
         }
 
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,
@@ -35,12 +35,12 @@ class DateValueFactory extends AbstractValueFactory
         }
 
         $matches = [];
-        if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data, $matches)) {
+        if (!\preg_match('/^\d{4}-\d{2}-\d{2}/', $data, $matches)) {
             throw $this->buildInvalidDateException($attribute, $data);
         }
 
-        list($year, $month, $day) = explode('-', $matches[0]);
-        if (true !== checkdate($month, $day, $year)) {
+        list($year, $month, $day) = \explode('-', $matches[0]);
+        if (true !== \checkdate($month, $day, $year)) {
             throw InvalidPropertyException::validDateExpected(
                 $attribute->getCode(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MediaValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MediaValueFactory.php
@@ -40,7 +40,7 @@ class MediaValueFactory extends AbstractValueFactory
             return;
         }
 
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
@@ -42,7 +42,7 @@ class MetricValueFactory extends AbstractValueFactory
             ];
         }
 
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
@@ -50,7 +50,7 @@ class MetricValueFactory extends AbstractValueFactory
             );
         }
 
-        if (!array_key_exists('amount', $data)) {
+        if (!\array_key_exists('amount', $data)) {
             throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'amount',
@@ -59,7 +59,7 @@ class MetricValueFactory extends AbstractValueFactory
             );
         }
 
-        if (!array_key_exists('unit', $data)) {
+        if (!\array_key_exists('unit', $data)) {
             throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->getCode(),
                 'unit',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
@@ -32,7 +32,7 @@ class OptionValueFactory extends AbstractValueFactory
             return null;
         }
 
-        if (!is_string($data) && !is_numeric($data)) {
+        if (!\is_string($data) && !\is_numeric($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
@@ -34,7 +34,7 @@ class OptionsValueFactory extends AbstractValueFactory
             return [];
         }
 
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
@@ -43,7 +43,7 @@ class OptionsValueFactory extends AbstractValueFactory
         }
 
         foreach ($data as $value) {
-            if (!is_string($value)) {
+            if (!\is_string($value)) {
                 throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
                     sprintf('one of the options is not a string, "%s" given', gettype($value)),
@@ -53,7 +53,7 @@ class OptionsValueFactory extends AbstractValueFactory
             }
         }
 
-        sort($data);
+        \sort($data);
 
         return $data;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
@@ -102,7 +102,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
      */
     protected function prepareData(AttributeInterface $attribute, $data, ?string $channelCode)
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
@@ -111,7 +111,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
         }
 
         foreach ($data as $price) {
-            if (!is_array($price)) {
+            if (!\is_array($price)) {
                 throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->getCode(),
                     static::class,
@@ -119,7 +119,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
                 );
             }
 
-            if (!array_key_exists('amount', $price)) {
+            if (!\array_key_exists('amount', $price)) {
                 throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'amount',
@@ -128,7 +128,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
                 );
             }
 
-            if (!array_key_exists('currency', $price)) {
+            if (!\array_key_exists('currency', $price)) {
                 throw InvalidPropertyTypeException::arrayKeyExpected(
                     $attribute->getCode(),
                     'currency',
@@ -213,7 +213,7 @@ class PriceCollectionValueFactory implements ValueFactoryInterface
             $currencies[] = $price['currency'];
         }
 
-        $sort = array_multisort($currencies, SORT_ASC, $amounts, SORT_ASC, $arrayPrices);
+        $sort = \array_multisort($currencies, SORT_ASC, $amounts, SORT_ASC, $arrayPrices);
 
         if (false === $sort) {
             throw new \LogicException(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataCollectionValueFactory.php
@@ -40,7 +40,7 @@ class ReferenceDataCollectionValueFactory extends AbstractValueFactory
             $data = [];
         }
 
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->getCode(),
                 static::class,
@@ -49,7 +49,7 @@ class ReferenceDataCollectionValueFactory extends AbstractValueFactory
         }
 
         foreach ($data as $key => $value) {
-            if (!is_string($value)) {
+            if (!\is_string($value)) {
                 throw InvalidPropertyTypeException::validArrayStructureExpected(
                     $attribute->getCode(),
                     sprintf('array key "%s" expects a string as value, "%s" given', $key, gettype($value)),
@@ -81,9 +81,9 @@ class ReferenceDataCollectionValueFactory extends AbstractValueFactory
             }
         }
 
-        $referenceDataCodes = array_unique($referenceDataCodes);
+        $referenceDataCodes = \array_unique($referenceDataCodes);
 
-        sort($referenceDataCodes);
+        \sort($referenceDataCodes);
 
         return $referenceDataCodes;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
@@ -40,7 +40,7 @@ class ReferenceDataValueFactory extends AbstractValueFactory
             return;
         }
 
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->getCode(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ScalarValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ScalarValueFactory.php
@@ -26,7 +26,7 @@ class ScalarValueFactory extends AbstractValueFactory
             return;
         }
 
-        if (!is_scalar($data)) {
+        if (!\is_scalar($data)) {
             throw InvalidPropertyTypeException::scalarExpected(
                 $attribute->getCode(),
                 static::class,
@@ -34,14 +34,14 @@ class ScalarValueFactory extends AbstractValueFactory
             );
         }
 
-        if (is_string($data) && '' === trim($data)) {
+        if (\is_string($data) && '' === \trim($data)) {
             $data = null;
         }
 
         if (AttributeTypes::BOOLEAN === $attribute->getType() &&
             (1 === $data || '1' === $data || 0 === $data || '0' === $data)
         ) {
-            $data = boolval($data);
+            $data = \boolval($data);
         }
 
         return $data;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
@@ -151,7 +151,7 @@ class WriteValueCollectionFactory
                         try {
                             $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, $data, true);
                         } catch (InvalidAttributeException $e) {
-                            $this->logger->warning(
+                            $this->logger->notice(
                                 sprintf(
                                     'Tried to load a product value with an invalid attribute "%s". %s',
                                     $attributeCode,
@@ -159,14 +159,14 @@ class WriteValueCollectionFactory
                                 )
                             );
                         } catch (InvalidPropertyException $e) {
-                            $this->logger->warning(
+                            $this->logger->notice(
                                 sprintf(
                                     'Tried to load a product value with the property "%s" that does not exist.',
                                     $e->getPropertyValue()
                                 )
                             );
                         } catch (\TypeError | InvalidPropertyTypeException $e) {
-                            $this->logger->warning(
+                            $this->logger->notice(
                                 sprintf(
                                     'Tried to load a product value for attribute "%s" that does not have the ' .
                                     'expected type in database.',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
@@ -165,7 +165,7 @@ class WriteValueCollectionFactory
                                     $e->getPropertyValue()
                                 )
                             );
-                        } catch (InvalidPropertyTypeException $e) {
+                        } catch (\TypeError | InvalidPropertyTypeException $e) {
                             $this->logger->warning(
                                 sprintf(
                                     'Tried to load a product value for attribute "%s" that does not have the ' .
@@ -173,7 +173,6 @@ class WriteValueCollectionFactory
                                     $attribute->getCode()
                                 )
                             );
-                            $values[] = $this->valueFactory->create($attribute, $channelCode, $localeCode, null);
                         }
                     }
                 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/WriteValueCollectionFactory.php
@@ -169,7 +169,7 @@ class WriteValueCollectionFactory
                             $this->logger->warning(
                                 sprintf(
                                     'Tried to load a product value for attribute "%s" that does not have the ' .
-                                    'good type in database.',
+                                    'expected type in database.',
                                     $attribute->getCode()
                                 )
                             );

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -10,9 +10,9 @@ use Akeneo\Test\Integration\TestCase;
 class ReadValueCollectionFactoryIntegration extends TestCase
 {
     /**
-     * @dataProvider matrix
+     * @dataProvider validAttributeValue
      */
-    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $isSkipped): void
+    public function test_if_product_values_are_returned(string $attributeCode, $value): void
     {
         $product = $this->createProductWithForcedAttributeValue($attributeCode, $value);
         $rawValues = $product->getRawValues();
@@ -21,32 +21,54 @@ class ReadValueCollectionFactoryIntegration extends TestCase
         $readValueCollectionFactory = $this->get('akeneo.pim.enrichment.factory.read.value_collection');
         $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
 
-        $this->assertEquals($isSkipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+        $this->assertTrue(in_array($attributeCode, $readValueCollection->getAttributeCodes()));
     }
 
-    public function matrix(): array
+    public function validAttributeValue(): array
     {
         return [
-            ['a_text', 'some_text', false], // this attribute should not be skipped
-            ['a_price', 'some_text', true],
+            ['a_text', 'some_text'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidAttributeValue
+     */
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value): void
+    {
+        $product = $this->createProductWithForcedAttributeValue($attributeCode, $value);
+        $rawValues = $product->getRawValues();
+
+        /** @var ValueCollectionFactory $readValueCollectionFactory */
+        $readValueCollectionFactory = $this->get('akeneo.pim.enrichment.factory.read.value_collection');
+        $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
+
+        $this->assertFalse(in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+    }
+
+    public function invalidAttributeValue(): array
+    {
+        return [
+            ['a_price', 'some_text'],
             ['a_price', [
                 'unit' => 'SQUARE_METER',
                 'amount' => '10.0000',
                 'family' => 'Area',
                 'base_data' => '10',
                 'base_unit' => 'SQUARE_METER',
-            ], true],
+            ]],
             ['a_metric', [
                 ['amount' => '10.00', 'currency' => 'EUR'],
                 ['amount' => null, 'currency' => 'USB'],
-            ], true],
-            ['a_ref_data_multi_select', 'some_text', true],
-            ['a_multi_select', 'some_text', true],
-            ['a_file', 'some_text', true],
+            ]],
+            ['a_ref_data_multi_select', 'some_text'],
+            ['a_multi_select', 'some_text'],
+            ['a_file', 'some_text'],
             ['a_text', [
                 ['amount' => '10.00', 'currency' => 'EUR'],
                 ['amount' => null, 'currency' => 'USB'],
-            ], true],
+            ]],
+            ['a_date', '4/0/6/c/406ce8a9874d27ee425cc4dfeb37370df669e671_foo.txt'],
         ];
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -56,6 +56,13 @@ SQL;
         return [
             ['a_text', 'some_text', false], // this attribute should not be skipped
             ['a_price', 'some_text', true],
+            ['a_price', [
+                'unit' => 'SQUARE_METER',
+                'amount' => '10.0000',
+                'family' => 'Area',
+                'base_data' => '10',
+                'base_unit' => 'SQUARE_METER',
+            ], true],
             ['a_ref_data_multi_select', 'some_text', true],
             ['a_multi_select', 'some_text', true],
             ['a_file', 'some_text', true],

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -63,6 +63,10 @@ SQL;
                 'base_data' => '10',
                 'base_unit' => 'SQUARE_METER',
             ], true],
+            ['a_metric', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
             ['a_ref_data_multi_select', 'some_text', true],
             ['a_multi_select', 'some_text', true],
             ['a_file', 'some_text', true],

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -14,7 +14,7 @@ class ReadValueCollectionFactoryIntegration extends TestCase
     /**
      * @dataProvider matrix
      */
-    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $isSkipped): void
     {
         /** @var Product $product */
         $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
@@ -45,7 +45,7 @@ SQL;
         /** @var ReadValueCollection $readValueCollection */
         $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
 
-        Assert::eq($skipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+        Assert::eq($isSkipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
     }
 
     public function matrix(): array

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ValueCollectionFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
+
+class ReadValueCollectionFactoryIntegration extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider matrix
+     */
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void
+    {
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $rawValues = $product->getRawValues();
+        $rawValues[$attributeCode] = [
+            '<all_channels>' => [
+                '<all_locales>' => $value,
+            ],
+        ];
+
+        $sql = <<<SQL
+UPDATE pim_catalog_product SET raw_values = :raw_values
+WHERE identifier = 'my_product';
+SQL;
+        $this->get('database_connection')->executeQuery($sql, [
+            'raw_values' => json_encode($rawValues),
+        ]);
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('my_product');
+        $rawValues = $product->getRawValues();
+
+        /** @var ValueCollectionFactory $readValueCollectionFactory */
+        $readValueCollectionFactory = $this->get('akeneo.pim.enrichment.factory.read.value_collection');
+        /** @var ReadValueCollection $readValueCollection */
+        $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
+
+        Assert::eq($skipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+    }
+
+    public function matrix(): array
+    {
+        return [
+            ['a_text', 'some_text', false], // this attribute should not be skipped
+            ['a_price', 'some_text', true],
+            ['a_ref_data_multi_select', 'some_text', true],
+            ['a_multi_select', 'some_text', true],
+            ['a_file', 'some_text', true],
+            ['a_text', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -3,10 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ValueCollectionFactory;
-use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
-use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Webmozart\Assert\Assert;
@@ -14,7 +12,6 @@ use Webmozart\Assert\Assert;
 class ReadValueCollectionFactoryIntegration extends TestCase
 {
     /**
-     * @test
      * @dataProvider matrix
      */
     public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -6,7 +6,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Webmozart\Assert\Assert;
 
 class ReadValueCollectionFactoryIntegration extends TestCase
 {
@@ -22,7 +21,7 @@ class ReadValueCollectionFactoryIntegration extends TestCase
         $readValueCollectionFactory = $this->get('akeneo.pim.enrichment.factory.read.value_collection');
         $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
 
-        Assert::eq($isSkipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+        $this->assertEquals($isSkipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
     }
 
     public function matrix(): array

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Types\Type;
+use Webmozart\Assert\Assert;
+
+class WriteValueCollectionFactoryIntegration extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider matrix
+     */
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void
+    {
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $rawValues = $product->getRawValues();
+        $rawValues[$attributeCode] = [
+            '<all_channels>' => [
+                '<all_locales>' => $value,
+            ],
+        ];
+
+        $sql = <<<SQL
+UPDATE pim_catalog_product SET raw_values = :raw_values
+WHERE identifier = 'my_product';
+SQL;
+        $this->get('database_connection')->executeQuery($sql, [
+            'raw_values' => json_encode($rawValues),
+        ]);
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('my_product');
+        $rawValues = $product->getRawValues();
+
+        /** @var WriteValueCollectionFactory $writeValueCollectionFactory */
+        $writeValueCollectionFactory = $this->get('pim_catalog.factory.value_collection');
+        /** @var WriteValueCollection $writeValueCollection */
+        $writeValueCollection = $writeValueCollectionFactory->createFromStorageFormat($rawValues);
+
+        Assert::eq($skipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
+    }
+
+    public function matrix(): array
+    {
+        return [
+            ['a_text', 'some_text', false], // this attribute should not be skipped
+            ['a_price', 'some_text', true],
+            ['a_ref_data_multi_select', 'some_text', true],
+            ['a_multi_select', 'some_text', true],
+            ['a_file', 'some_text', true],
+            ['a_text', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -7,13 +7,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Doctrine\DBAL\Types\Type;
 use Webmozart\Assert\Assert;
 
 class WriteValueCollectionFactoryIntegration extends TestCase
 {
     /**
-     * @test
      * @dataProvider matrix
      */
     public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -14,7 +14,7 @@ class WriteValueCollectionFactoryIntegration extends TestCase
     /**
      * @dataProvider matrix
      */
-    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $skipped): void
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $isSkipped): void
     {
         /** @var Product $product */
         $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
@@ -45,7 +45,7 @@ SQL;
         /** @var WriteValueCollection $writeValueCollection */
         $writeValueCollection = $writeValueCollectionFactory->createFromStorageFormat($rawValues);
 
-        Assert::eq($skipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
+        Assert::eq($isSkipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
     }
 
     public function matrix(): array

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -62,6 +62,10 @@ SQL;
                 'base_data' => '10',
                 'base_unit' => 'SQUARE_METER',
             ], true],
+            ['a_metric', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
             ['a_ref_data_multi_select', 'some_text', true],
             ['a_multi_select', 'some_text', true],
             ['a_file', 'some_text', true],

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -55,6 +55,13 @@ SQL;
         return [
             ['a_text', 'some_text', false], // this attribute should not be skipped
             ['a_price', 'some_text', true],
+            ['a_price', [
+                'unit' => 'SQUARE_METER',
+                'amount' => '10.0000',
+                'family' => 'Area',
+                'base_data' => '10',
+                'base_unit' => 'SQUARE_METER',
+            ], true],
             ['a_ref_data_multi_select', 'some_text', true],
             ['a_multi_select', 'some_text', true],
             ['a_file', 'some_text', true],

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -6,7 +6,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Webmozart\Assert\Assert;
 
 class WriteValueCollectionFactoryIntegration extends TestCase
 {
@@ -22,7 +21,7 @@ class WriteValueCollectionFactoryIntegration extends TestCase
         $writeValueCollectionFactory = $this->get('pim_catalog.factory.value_collection');
         $writeValueCollection = $writeValueCollectionFactory->createFromStorageFormat($rawValues);
 
-        Assert::eq($isSkipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
+        $this->assertEquals($isSkipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
     }
 
     public function matrix(): array

--- a/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/WriteValueCollectionFactoryIntegration.php
@@ -4,7 +4,6 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
-use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Webmozart\Assert\Assert;
@@ -16,33 +15,11 @@ class WriteValueCollectionFactoryIntegration extends TestCase
      */
     public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $isSkipped): void
     {
-        /** @var Product $product */
-        $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        $rawValues = $product->getRawValues();
-        $rawValues[$attributeCode] = [
-            '<all_channels>' => [
-                '<all_locales>' => $value,
-            ],
-        ];
-
-        $sql = <<<SQL
-UPDATE pim_catalog_product SET raw_values = :raw_values
-WHERE identifier = 'my_product';
-SQL;
-        $this->get('database_connection')->executeQuery($sql, [
-            'raw_values' => json_encode($rawValues),
-        ]);
-
-        $this->get('pim_connector.doctrine.cache_clearer')->clear();
-        /** @var Product $product */
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('my_product');
+        $product = $this->createProductWithForcedAttributeValue($attributeCode, $value);
         $rawValues = $product->getRawValues();
 
         /** @var WriteValueCollectionFactory $writeValueCollectionFactory */
         $writeValueCollectionFactory = $this->get('pim_catalog.factory.value_collection');
-        /** @var WriteValueCollection $writeValueCollection */
         $writeValueCollection = $writeValueCollectionFactory->createFromStorageFormat($rawValues);
 
         Assert::eq($isSkipped, !in_array($attributeCode, $writeValueCollection->getAttributeCodes()));
@@ -72,6 +49,33 @@ SQL;
                 ['amount' => null, 'currency' => 'USB'],
             ], true],
         ];
+    }
+
+    private function createProductWithForcedAttributeValue(string $attributeCode, $value): Product
+    {
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $rawValues = $product->getRawValues();
+        $rawValues[$attributeCode] = [
+            '<all_channels>' => [
+                '<all_locales>' => $value,
+            ],
+        ];
+
+        $sql = <<<SQL
+UPDATE pim_catalog_product SET raw_values = :raw_values
+WHERE identifier = 'my_product';
+SQL;
+        $this->get('database_connection')->executeQuery($sql, [
+            'raw_values' => json_encode($rawValues),
+        ]);
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        /** @var Product $product */
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier('my_product');
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/FileValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/FileValueFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfo;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -87,6 +88,12 @@ final class FileValueFactorySpec extends ObjectBehavior
         $fileInfoRepository->findOneByIdentifier('a_file')->willReturn(null);
         $attribute = $this->getAttribute(false, false);
         $this->shouldThrow(InvalidPropertyException::class)->during('create', [$attribute, null, null, 'a_file']);
+    }
+
+    public function it_throws_an_exception_if_provided_data_is_not_a_string()
+    {
+        $attribute = $this->getAttribute(false, false);
+        $this->shouldThrow(InvalidPropertyTypeException::class)->during('create', [$attribute, null, null, ['an_array']]);
     }
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/ImageValueFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfo;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -92,7 +93,7 @@ final class ImageValueFactorySpec extends ObjectBehavior
     public function it_throws_an_exception_if_provided_data_is_not_a_string()
     {
         $attribute = $this->getAttribute(false, false);
-        $this->shouldThrow(InvalidPropertyException::class)->during('create', [$attribute, null, null, ['an_array']]);
+        $this->shouldThrow(InvalidPropertyTypeException::class)->during('create', [$attribute, null, null, ['an_array']]);
     }
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/ImageValueFactorySpec.php
@@ -89,6 +89,12 @@ final class ImageValueFactorySpec extends ObjectBehavior
         $this->shouldThrow(InvalidPropertyException::class)->during('create', [$attribute, null, null, 'a_file']);
     }
 
+    public function it_throws_an_exception_if_provided_data_is_not_a_string()
+    {
+        $attribute = $this->getAttribute(false, false);
+        $this->shouldThrow(InvalidPropertyException::class)->during('create', [$attribute, null, null, ['an_array']]);
+    }
+
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
         return new Attribute('an_attribute', AttributeTypes::IMAGE, [], $isLocalizable, $isScopable, null, false);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/MetricValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/Value/MetricValueFactorySpec.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value;
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\MetricFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\MetricValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\ReadValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Value\PriceCollectionValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Metric;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -79,6 +83,54 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->isLocalizable()->shouldBe(false);
         $value->isScopable()->shouldBe(false);
         $value->getData()->shouldBe($metric);
+    }
+
+    function it_throws_an_exception_if_data_is_not_an_array()
+    {
+        $data = 'a_string';
+        $exception = InvalidPropertyTypeException::arrayExpected(
+            'an_attribute',
+            MetricValueFactory::class,
+            $data
+        );
+
+        $this
+            ->shouldThrow($exception)
+            ->during('create', [$this->getAttribute(false, false), null, null, $data]);
+    }
+
+    function it_throws_an_exception_if_data_does_not_contains_the_amount()
+    {
+        $data = [
+            'unit' => 'SQUARE_METER',
+        ];
+        $exception = InvalidPropertyTypeException::arrayKeyExpected(
+            'an_attribute',
+            'amount',
+            MetricValueFactory::class,
+            $data
+        );
+
+        $this
+            ->shouldThrow($exception)
+            ->during('create', [$this->getAttribute(false, false), null, null, $data]);
+    }
+
+    function it_throws_an_exception_if_data_does_not_contains_the_unit()
+    {
+        $data = [
+            'amount' => '10.00',
+        ];
+        $exception = InvalidPropertyTypeException::arrayKeyExpected(
+            'an_attribute',
+            'unit',
+            MetricValueFactory::class,
+            $data
+        );
+
+        $this
+            ->shouldThrow($exception)
+            ->during('create', [$this->getAttribute(false, false), null, null, $data]);
     }
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
@@ -316,7 +316,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
             new InvalidPropertyException('attribute', 'image', static::class)
         );
 
-        $logger->warning(
+        $logger->notice(
             Argument::containingString('Tried to load a product value with the property "empty_image" that does not exist.')
         )->shouldBeCalled();
 
@@ -373,7 +373,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
             new InvalidPropertyTypeException('attribute', 'image', static::class)
         );
 
-        $logger->warning(
+        $logger->notice(
             Argument::containingString('Tried to load a product value with the property "empty_image" that does not exist.')
         )->shouldBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Read/ValueCollectionFactorySpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGo
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ReadValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\BooleanValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\IdentifierValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\ImageValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\NumberValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\OptionValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\Value\TextAreaValueFactory;
@@ -17,11 +18,17 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
+use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 
 class ValueCollectionFactorySpec extends ObjectBehavior
 {
@@ -29,7 +36,9 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         ValueFactory $writeValueFactory,
         GetAttributes $getAttributeByCodes,
         IdentifiableObjectRepositoryInterface $attributeRepository,
-        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter
+        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter,
+        LoggerInterface $logger,
+        FileInfoRepositoryInterface $fileInfoRepository
     ) {
 
         $valueFactory = new ReadValueFactory(
@@ -40,6 +49,7 @@ class ValueCollectionFactorySpec extends ObjectBehavior
                 new IdentifierValueFactory(),
                 new TextAreaValueFactory(),
                 new TextValueFactory(),
+                new ImageValueFactory($fileInfoRepository->getWrappedObject()),
             ],
             $writeValueFactory->getWrappedObject(),
             $attributeRepository->getWrappedObject()
@@ -49,7 +59,8 @@ class ValueCollectionFactorySpec extends ObjectBehavior
             $valueFactory,
             $getAttributeByCodes,
             $chainedObsoleteValueFilter,
-            new EmptyValuesCleaner()
+            new EmptyValuesCleaner(),
+            $logger
         );
     }
 
@@ -256,6 +267,120 @@ class ValueCollectionFactorySpec extends ObjectBehavior
         );
 
         $this->createFromStorageFormat($rawValues)->shouldBeLike(new ReadValueCollection([]));
+    }
+
+    function it_skips_invalid_property_when_creating_a_values_collection_from_the_storage_format(
+        GetAttributes $getAttributeByCodes,
+        ValueFactory $valueFactory,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter,
+        LoggerInterface $logger,
+        AttributeInterface $referenceData
+    ) {
+        $rawValues = [
+            'image' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'empty_image'
+                ],
+            ],
+        ];
+
+        $getAttributeByCodes->forCodes(['image'])->willReturn([
+            'image' => new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
+        ]);
+
+        $rawValueCollectionIndexedByType = [
+            AttributeTypes::IMAGE => [
+                'image' => [
+                    [
+                        'identifier' => 'not_used_identifier',
+                        'values' => [
+                            '<all_channels>' => [
+                                '<all_locales>' => 'empty_image'
+                            ],
+                        ],
+                        'properties' => [],
+                    ]
+                ]
+            ]
+        ];
+
+        $onGoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType($rawValueCollectionIndexedByType);
+
+        $chainedObsoleteValueFilter->filterAll($onGoingFilteredRawValues)->willReturn(
+            new OnGoingFilteredRawValues($rawValueCollectionIndexedByType, [])
+        );
+
+        $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
+        $valueFactory->create($referenceData, null, null, 'empty_image', true)->willThrow(
+            new InvalidPropertyException('attribute', 'image', static::class)
+        );
+
+        $logger->warning(
+            Argument::containingString('Tried to load a product value with the property "empty_image" that does not exist.')
+        )->shouldBeCalled();
+
+        $actualValues = $this->createFromStorageFormat($rawValues);
+
+        $actualValues->shouldReturnAnInstanceOf(ReadValueCollection::class);
+        $actualValues->shouldHaveCount(0);
+    }
+
+    function it_skips_invalid_property_type_when_creating_a_values_collection_from_the_storage_format(
+        GetAttributes $getAttributeByCodes,
+        ValueFactory $valueFactory,
+        IdentifiableObjectRepositoryInterface $attributeRepository,
+        ChainedNonExistentValuesFilterInterface $chainedObsoleteValueFilter,
+        LoggerInterface $logger,
+        AttributeInterface $referenceData
+    ) {
+        $rawValues = [
+            'image' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'empty_image'
+                ],
+            ],
+        ];
+
+        $getAttributeByCodes->forCodes(['image'])->willReturn([
+            'image' => new Attribute('image', AttributeTypes::IMAGE, [], false, false, null, false),
+        ]);
+
+        $rawValueCollectionIndexedByType = [
+            AttributeTypes::IMAGE => [
+                'image' => [
+                    [
+                        'identifier' => 'not_used_identifier',
+                        'values' => [
+                            '<all_channels>' => [
+                                '<all_locales>' => 'empty_image'
+                            ],
+                        ],
+                        'properties' => [],
+                    ]
+                ]
+            ]
+        ];
+
+        $onGoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType($rawValueCollectionIndexedByType);
+
+        $chainedObsoleteValueFilter->filterAll($onGoingFilteredRawValues)->willReturn(
+            new OnGoingFilteredRawValues($rawValueCollectionIndexedByType, [])
+        );
+
+        $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
+        $valueFactory->create($referenceData, null, null, 'empty_image', true)->willThrow(
+            new InvalidPropertyTypeException('attribute', 'image', static::class)
+        );
+
+        $logger->warning(
+            Argument::containingString('Tried to load a product value with the property "empty_image" that does not exist.')
+        )->shouldBeCalled();
+
+        $actualValues = $this->createFromStorageFormat($rawValues);
+
+        $actualValues->shouldReturnAnInstanceOf(ReadValueCollection::class);
+        $actualValues->shouldHaveCount(0);
     }
 
     function it_does_not_filter_falsy_values(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
@@ -345,7 +345,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
             new InvalidAttributeException('attribute', 'color', static::class)
         );
 
-        $logger->warning(Argument::containingString('Tried to load a product value with an invalid attribute "color".'));
+        $logger->notice(Argument::containingString('Tried to load a product value with an invalid attribute "color".'));
 
         $actualValues = $this->createFromStorageFormat($rawValues);
 
@@ -398,7 +398,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
             new InvalidPropertyException('attribute', 'image', static::class)
         );
 
-        $logger->warning(
+        $logger->notice(
             Argument::containingString('Tried to load a product value with the property "image" that does not exist.')
         )->shouldBeCalled();
 
@@ -463,7 +463,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
             new InvalidPropertyTypeException('attribute', 'image', static::class)
         );
 
-        $logger->warning(
+        $logger->notice(
             Argument::containingString('Tried to load a product value for attribute "reference" that does not have the expected type in database.')
         )->shouldBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
@@ -456,6 +456,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         $value1->getScopeCode()->willReturn(null);
         $value1->getAttributeCode()->willReturn('image');
         $value1->getData()->willReturn('empty_image');
+        $referenceData->getCode()->willReturn('reference');
 
         $attributeRepository->findOneByIdentifier('image')->willReturn($referenceData);
         $valueFactory->create($referenceData, null, null, 'empty_image', true)->willThrow(
@@ -463,7 +464,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         );
 
         $logger->warning(
-            Argument::containingString('Tried to load a product value for attribute "image" that does not have the good type.')
+            Argument::containingString('Tried to load a product value for attribute "reference" that does not have the good type in database.')
         )->shouldBeCalled();
 
         $actualValues = $this->createFromStorageFormat($rawValues);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
@@ -400,7 +400,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
 
         $logger->warning(
             Argument::containingString('Tried to load a product value with the property "image" that does not exist.')
-        );
+        )->shouldBeCalled();
 
         $actualValues = $this->createFromStorageFormat($rawValues);
 
@@ -408,7 +408,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         $actualValues->shouldHaveCount(0);
     }
 
-    function it_creates_empty_value_if_wrong_format_when_creating_a_values_collection_from_the_storage_format(
+    function it_skips_value_if_wrong_format_when_creating_a_values_collection_from_the_storage_format(
         ValueFactory $valueFactory,
         IdentifiableObjectRepositoryInterface $attributeRepository,
         LoggerInterface $logger,
@@ -461,16 +461,15 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         $valueFactory->create($referenceData, null, null, 'empty_image', true)->willThrow(
             new InvalidPropertyTypeException('attribute', 'image', static::class)
         );
-        $valueFactory->create($referenceData, null, null, 'empty_image', true)->willReturn($value1);
 
         $logger->warning(
             Argument::containingString('Tried to load a product value for attribute "image" that does not have the good type.')
-        );
+        )->shouldBeCalled();
 
         $actualValues = $this->createFromStorageFormat($rawValues);
 
         $actualValues->shouldReturnAnInstanceOf(WriteValueCollection::class);
-        $actualValues->shouldHaveCount(1);
+        $actualValues->shouldHaveCount(0);
     }
 
     function it_does_not_filter_falsy_values(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/WriteValueCollectionFactorySpec.php
@@ -464,7 +464,7 @@ class WriteValueCollectionFactorySpec extends ObjectBehavior
         );
 
         $logger->warning(
-            Argument::containingString('Tried to load a product value for attribute "reference" that does not have the good type in database.')
+            Argument::containingString('Tried to load a product value for attribute "reference" that does not have the expected type in database.')
         )->shouldBeCalled();
 
         $actualValues = $this->createFromStorageFormat($rawValues);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When a attribute is removed, attribute values in the products are kept.
When the attribute is re-created with the same code but a different type, the PIM tries to load the data into the new attribute structure.
When it goes from `text` to `texterea`, nothing happens.
When it goes from more complex attributes, like `price` to an incompatible one, it throws 500 errors.

The purpose of this PR is to catch those incompatible conversion errors and skip the failing attribute.
By doing so, the invalid value is not included in the responses of the API endpoints (both internal & external).

Any invalid value will be lost when the product is saved.

I've updated some specs accordingly.
I've added 2 integration tests on `ReadValueCollectionFactory` and `WriteValueCollectionFactory`.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -
