### PR TITLE
CPM-74: rework datagrid view repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,7 +217,7 @@
 - Change the `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface` to:
     - remove the `findDatagridViewByAlias()` method
     - rename the `getDatagridViewTypeByUser()` method to `getDatagridViewAliasesByUser()` and add type hint on the return (array)
-    - add type hint on the return of the `findDatagridViewBySearch()` method (array)
+    - add type hint on the return of the `findDatagridViewBySearch()` method (`Doctrine\Common\Collections\Collection`)
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Job\DeleteProductsAndProductModelsTasklet` to
     - add `Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface $jobRepository`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,10 @@
     - remove the `setFamilyId()` method
     - remove the `$categoryIds` public property and  the `$familyId` and `$groupIds` protected properties
     - add `isDirty()` and `cleanup()` methods 
-- Remove the `findDatagridViewByAlias()` method in `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface`
+- Change the `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface` to:
+    - remove the `findDatagridViewByAlias()` method
+    - rename the `getDatagridViewTypeByUser()` method to `getDatagridViewAliasesByUser()` and add type hint on the return (array)
+    - add type hint on the return of the `findDatagridViewBySearch()` method (array)
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Job\DeleteProductsAndProductModelsTasklet` to
     - add `Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface $jobRepository`
 

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -116,11 +116,11 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
             ]
         ];
 
-        $types = $this->datagridViewRepo->getDatagridViewTypeByUser($user);
-        foreach ($types as $type) {
-            $defaultView = $user->getDefaultGridView($type['datagridAlias']);
+        $aliases = $this->datagridViewRepo->getDatagridViewAliasesByUser($user);
+        foreach ($aliases as $alias) {
+            $defaultView = $user->getDefaultGridView($alias);
             // Set default_product_grid_view, default_published_product_grid_view, etc.
-            $result[sprintf('default_%s_view', str_replace('-', '_', $type['datagridAlias']))]
+            $result[sprintf('default_%s_view', str_replace('-', '_', $alias))]
                 = $defaultView === null ? null : $defaultView->getId();
         }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
@@ -21,6 +21,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * REST Controller for Datagrid Views.
@@ -99,21 +100,12 @@ class DatagridViewController
         ]);
     }
 
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    public function typesAction(Request $request): JsonResponse
+    public function typesAction(): JsonResponse
     {
-        $result = [];
         $user = $this->tokenStorage->getToken()->getUser();
-        $types = $this->datagridViewRepo->getDatagridViewTypeByUser($user);
-        foreach ($types as $type) {
-            $result[] = $type['datagridAlias'];
-        }
+        Assert::isInstanceOf($user, UserInterface::class);
 
-        return new JsonResponse($result);
+        return new JsonResponse($this->datagridViewRepo->getDatagridViewAliasesByUser($user));
     }
 
     /**

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
@@ -74,13 +74,8 @@ class DatagridViewController
     /**
      * Return the list of all Datagrid Views that belong to the current user for the given $alias grid.
      * Response data is in Json format and is paginated.
-     *
-     * @param Request $request
-     * @param string  $alias
-     *
-     * @return JsonResponse
      */
-    public function indexAction(Request $request, $alias)
+    public function indexAction(Request $request, string $alias): JsonResponse
     {
         $user = $this->tokenStorage->getToken()->getUser();
 
@@ -111,12 +106,8 @@ class DatagridViewController
     /**
      * Return the Datagrid View that belongs to the current user, with the given view $identifier.
      * Response data is in Json format, 404 is sent if there is no result.
-     *
-     * @param string $identifier
-     *
-     * @return JsonResponse|NotFoundHttpException
      */
-    public function getAction($identifier)
+    public function getAction(string $identifier): JsonResponse
     {
         $view = $this->datagridViewRepo->find($identifier);
         if (null === $view) {
@@ -204,13 +195,8 @@ class DatagridViewController
      *
      * If any errors occur during the process, a Json response is sent with {'errors' => 'Error message'}.
      * If success, return an empty Json response with code 204 (No content).
-     *
-     * @param Request $request
-     * @param string  $identifier
-     *
-     * @return Response
      */
-    public function removeAction(Request $request, $identifier)
+    public function removeAction(Request $request, string $identifier): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return new RedirectResponse('/');
@@ -235,12 +221,8 @@ class DatagridViewController
      * Response data is in Json format.
      *
      * Eg.: ['sku', 'name', 'brand']
-     *
-     * @param string $alias
-     *
-     * @return JsonResponse
      */
-    public function defaultViewColumnsAction($alias)
+    public function defaultViewColumnsAction(string $alias): JsonResponse
     {
         $columns = $this->datagridViewManager->getDefaultColumns($alias);
 
@@ -250,12 +232,8 @@ class DatagridViewController
     /**
      * Return the current user default Datagrid View object for the grid with the given $alias.
      * Response data is in Json format.
-     *
-     * @param string $alias
-     *
-     * @return JsonResponse
      */
-    public function getUserDefaultDatagridViewAction($alias)
+    public function getUserDefaultDatagridViewAction(string $alias): JsonResponse
     {
         $user = $this->tokenStorage->getToken()->getUser();
         $view = $user->getDefaultGridView($alias);
@@ -269,12 +247,8 @@ class DatagridViewController
 
     /**
      * List available datagrid columns
-     *
-     * @param string $alias
-     *
-     * @return JsonResponse
      */
-    public function listColumnsAction($alias)
+    public function listColumnsAction(string $alias): JsonResponse
     {
         return new JsonResponse($this->datagridViewManager->getColumnChoices($alias));
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
@@ -75,8 +75,12 @@ class DatagridViewController
      * Return the list of all Datagrid Views that belong to the current user for the given $alias grid.
      * Response data is in Json format and is paginated.
      */
-    public function indexAction(Request $request, string $alias): JsonResponse
+    public function indexAction(Request $request, string $alias): Response
     {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
         $user = $this->tokenStorage->getToken()->getUser();
 
         $options = $request->query->get('options', []);

--- a/src/Oro/Bundle/PimDataGridBundle/DataTransformer/DefaultViewDataTransformer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/DataTransformer/DefaultViewDataTransformer.php
@@ -34,10 +34,10 @@ class DefaultViewDataTransformer implements DataTransformerInterface
             return;
         }
 
-        $types = $this->datagridViewRepo->getDatagridViewTypeByUser($value);
-        foreach ($types as $type) {
-            $field = 'default_' . str_replace('-', '_', $type['datagridAlias']) . '_view';
-            $value->$field = $value->getDefaultGridView($type['datagridAlias']);
+        $aliases = $this->datagridViewRepo->getDatagridViewAliasesByUser($value);
+        foreach ($aliases as $alias) {
+            $field = 'default_' . str_replace('-', '_', $alias) . '_view';
+            $value->$field = $value->getDefaultGridView($alias);
         }
 
         return $value;
@@ -52,13 +52,13 @@ class DefaultViewDataTransformer implements DataTransformerInterface
             return null;
         }
 
-        $types = $this->datagridViewRepo->getDatagridViewTypeByUser($value);
-        foreach ($types as $type) {
-            $field = 'default_' . str_replace('-', '_', $type['datagridAlias']) . '_view';
+        $aliases = $this->datagridViewRepo->getDatagridViewAliasesByUser($value);
+        foreach ($aliases as $alias) {
+            $field = 'default_' . str_replace('-', '_', $alias) . '_view';
 
             if (property_exists($value, $field)) {
-                if ($value->getDefaultGridView($type['datagridAlias']) !== $value->$field) {
-                    $value->setDefaultGridView($type['datagridAlias'], $value->$field);
+                if ($value->getDefaultGridView($alias) !== $value->$field) {
+                    $value->setDefaultGridView($alias, $value->$field);
                 }
             }
         }

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
@@ -3,6 +3,8 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
 use Doctrine\ORM\EntityRepository;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
 
@@ -18,24 +20,32 @@ class DatagridViewRepository extends EntityRepository implements DatagridViewRep
     /**
      * {@inheritdoc}
      */
-    public function getDatagridViewTypeByUser(UserInterface $user)
+    public function getDatagridViewAliasesByUser(UserInterface $user): array
     {
-        return $this->createQueryBuilder('v')
-            ->select('v.datagridAlias')
-            ->distinct(true)
-            ->where('v.type = :public_type OR (v.type = :private_type AND v.owner = :owner)')
-                ->setParameter('public_type', DatagridView::TYPE_PUBLIC)
-                ->setParameter('private_type', DatagridView::TYPE_PRIVATE)
-                ->setParameter('owner', $user)
-            ->getQuery()
-            ->execute();
+        $sql = <<<SQL
+SELECT datagrid_alias
+FROM pim_datagrid_view
+WHERE type = :public_type OR (type = :private_type AND owner_id = :owner_id)
+SQL;
+
+        $statement = $this->getConnection()->executeQuery($sql, [
+            'public_type' => DatagridView::TYPE_PUBLIC,
+            'private_type' => DatagridView::TYPE_PRIVATE,
+            'owner_id' => $user->getId(),
+        ]);
+
+        return $statement->fetchAll(FetchMode::COLUMN);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function findDatagridViewBySearch(UserInterface $user, $alias, $term = '', array $options = [])
-    {
+    public function findDatagridViewBySearch(
+        UserInterface $user,
+        string $alias,
+        string $term = '',
+        array $options = []
+    ): array {
         $options += ['limit' => 20, 'page' => 1];
         $offset = (int) $options['limit'] * ((int) $options['page'] - 1);
 
@@ -62,5 +72,10 @@ class DatagridViewRepository extends EntityRepository implements DatagridViewRep
         }
 
         return $qb->getQuery()->execute();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->getEntityManager()->getConnection();
     }
 }

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
@@ -3,8 +3,9 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\ORM\EntityRepository;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
 
@@ -34,7 +35,7 @@ SQL;
             'owner_id' => $user->getId(),
         ]);
 
-        return $statement->fetchAll(FetchMode::COLUMN);
+        return $statement->fetchAll(\PDO::FETCH_COLUMN);
     }
 
     /**
@@ -45,7 +46,7 @@ SQL;
         string $alias,
         string $term = '',
         array $options = []
-    ): array {
+    ): Collection {
         $options += ['limit' => 20, 'page' => 1];
         $offset = (int) $options['limit'] * ((int) $options['page'] - 1);
 
@@ -71,7 +72,7 @@ SQL;
             $qb->setParameter('ids', $identifiers);
         }
 
-        return $qb->getQuery()->execute();
+        return new ArrayCollection($qb->getQuery()->execute());
     }
 
     private function getConnection(): Connection

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepository.php
@@ -3,8 +3,6 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityRepository;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
@@ -46,7 +44,7 @@ SQL;
         string $alias,
         string $term = '',
         array $options = []
-    ): Collection {
+    ): array {
         $options += ['limit' => 20, 'page' => 1];
         $offset = (int) $options['limit'] * ((int) $options['page'] - 1);
 
@@ -72,7 +70,7 @@ SQL;
             $qb->setParameter('ids', $identifiers);
         }
 
-        return new ArrayCollection($qb->getQuery()->execute());
+        return $qb->getQuery()->execute();
     }
 
     private function getConnection(): Connection

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * Datagrid view repository interface
@@ -25,12 +25,12 @@ interface DatagridViewRepositoryInterface
      * The search is applied on label with the given $term.
      * You can pass $options to add limit or page info.
      *
-     * @return DatagridView[]
+     * Returns a collection of DatagridView objects
      */
     public function findDatagridViewBySearch(
         UserInterface $user,
         string $alias,
         string $term = '',
         array $options = []
-    ): array;
+    ): Collection;
 }

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Doctrine\Common\Collections\ArrayCollection;
+use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
 
 /**
  * Datagrid view repository interface
@@ -15,25 +15,22 @@ use Doctrine\Common\Collections\ArrayCollection;
 interface DatagridViewRepositoryInterface
 {
     /**
-     * Get all datagrid view type for a given user
-     *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
-     *
-     * @return ArrayCollection
+     * Get all datagrid view aliases for a given user.
+     * Returns a list of aliases.
      */
-    public function getDatagridViewTypeByUser(UserInterface $user);
+    public function getDatagridViewAliasesByUser(UserInterface $user): array;
 
     /**
      * Search datagrid views for the given $user and grid $alias.
      * The search is applied on label with the given $term.
      * You can pass $options to add limit or page info.
      *
-     * @param UserInterface $user
-     * @param string        $alias
-     * @param string        $term
-     * @param array         $options
-     *
-     * @return ArrayCollection
+     * @return DatagridView[]
      */
-    public function findDatagridViewBySearch(UserInterface $user, $alias, $term = '', array $options = []);
+    public function findDatagridViewBySearch(
+        UserInterface $user,
+        string $alias,
+        string $term = '',
+        array $options = []
+    ): array;
 }

--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
@@ -3,7 +3,6 @@
 namespace Oro\Bundle\PimDataGridBundle\Repository;
 
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Doctrine\Common\Collections\Collection;
 
 /**
  * Datagrid view repository interface
@@ -32,5 +31,5 @@ interface DatagridViewRepositoryInterface
         string $alias,
         string $term = '',
         array $options = []
-    ): Collection;
+    ): array;
 }

--- a/src/Oro/Bundle/PimDataGridBundle/spec/DataTransformer/DefaultViewDataTransformerSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/DataTransformer/DefaultViewDataTransformerSpec.php
@@ -16,7 +16,7 @@ class DefaultViewDataTransformerSpec extends ObjectBehavior
 
     function it_transforms_the_given_user($datagridViewRepo, UserInterface $julia, DatagridView $productView)
     {
-        $datagridViewRepo->getDatagridViewTypeByUser($julia)->willReturn([['datagridAlias' => 'product-grid'], ['datagridAlias' => 'category']]);
+        $datagridViewRepo->getDatagridViewAliasesByUser($julia)->willReturn(['product-grid', 'category']);
 
         $julia->getDefaultGridView('product-grid')->willReturn($productView);
         $julia->getDefaultGridView('category')->willReturn(null);

--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
@@ -7,6 +7,7 @@ namespace Oro\Bundle\PimDataGridBundle\tests\Integration\Repository;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
+use Doctrine\Common\Collections\Collection;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
 use Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface;
 use Webmozart\Assert\Assert;
@@ -46,12 +47,11 @@ class DatagridViewRepositoryIntegration extends TestCase
         $view6Id = $this->createDatagridView('view 6', 'product-grid', DatagridView::TYPE_PUBLIC, $juliaUser)->getId();
 
         $result = $this->datagridViewRepository->findDatagridViewBySearch($adminUser, 'product-grid');
-        Assert::isArray($result);
-        Assert::notEmpty($result);
+        Assert::notSame($result->count(), 0);
         Assert::isInstanceOf($result[0], DatagridView::class);
         Assert::same(array_map(function ($view) {
             return $view->getId();
-        }, $result), [$view1Id, $view2Id, $view3Id, $view4Id, $view6Id]);
+        }, $result->toArray()), [$view1Id, $view2Id, $view3Id, $view4Id, $view6Id]);
     }
 
     public function test_that_it_filters_by_ids(): void
@@ -66,7 +66,7 @@ class DatagridViewRepositoryIntegration extends TestCase
         ]);
         Assert::same(array_map(function ($view) {
             return $view->getId();
-        }, $result), [$view1Id, $view2Id]);
+        }, $result->toArray()), [$view1Id, $view2Id]);
     }
 
     public function test_it_returns_view_aliases_for_a_given_user(): void

--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
@@ -46,6 +46,9 @@ class DatagridViewRepositoryIntegration extends TestCase
         $view6Id = $this->createDatagridView('view 6', 'product-grid', DatagridView::TYPE_PUBLIC, $juliaUser)->getId();
 
         $result = $this->datagridViewRepository->findDatagridViewBySearch($adminUser, 'product-grid');
+        Assert::isArray($result);
+        Assert::notEmpty($result);
+        Assert::isInstanceOf($result[0], DatagridView::class);
         Assert::same(array_map(function ($view) {
             return $view->getId();
         }, $result), [$view1Id, $view2Id, $view3Id, $view4Id, $view6Id]);
@@ -72,15 +75,17 @@ class DatagridViewRepositoryIntegration extends TestCase
         $juliaUser = $this->userRepository->findOneBy(['username' => 'julia']);
 
         $this->createDatagridView('view 1', 'product-grid', DatagridView::TYPE_PRIVATE, $adminUser)->getId();
-        $aliases = $this->datagridViewRepository->getDatagridViewTypeByUser($adminUser);
-        Assert::same($aliases, [['datagridAlias' => 'product-grid']]);
+        $this->createDatagridView('view 3', 'other-grid', DatagridView::TYPE_PRIVATE, $adminUser)->getId();
+        $aliases = $this->datagridViewRepository->getDatagridViewAliasesByUser($adminUser);
+        Assert::same($aliases, ['product-grid', 'other-grid']);
 
-        $aliases = $this->datagridViewRepository->getDatagridViewTypeByUser($juliaUser);
+        $aliases = $this->datagridViewRepository->getDatagridViewAliasesByUser($juliaUser);
         Assert::same($aliases, []);
 
         $this->createDatagridView('view 2', 'product-grid', DatagridView::TYPE_PUBLIC, $adminUser)->getId();
-        $aliases = $this->datagridViewRepository->getDatagridViewTypeByUser($juliaUser);
-        Assert::same($aliases, [['datagridAlias' => 'product-grid']]);
+        $this->createDatagridView('view 4', 'another-grid', DatagridView::TYPE_PUBLIC, $adminUser)->getId();
+        $aliases = $this->datagridViewRepository->getDatagridViewAliasesByUser($juliaUser);
+        Assert::same($aliases, ['product-grid', 'another-grid']);
     }
 
     private function createDatagridView(

--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Repository/DatagridViewRepositoryIntegration.php
@@ -47,11 +47,12 @@ class DatagridViewRepositoryIntegration extends TestCase
         $view6Id = $this->createDatagridView('view 6', 'product-grid', DatagridView::TYPE_PUBLIC, $juliaUser)->getId();
 
         $result = $this->datagridViewRepository->findDatagridViewBySearch($adminUser, 'product-grid');
-        Assert::notSame($result->count(), 0);
+        Assert::isArray($result);
+        Assert::notEmpty($result);
         Assert::isInstanceOf($result[0], DatagridView::class);
         Assert::same(array_map(function ($view) {
             return $view->getId();
-        }, $result->toArray()), [$view1Id, $view2Id, $view3Id, $view4Id, $view6Id]);
+        }, $result), [$view1Id, $view2Id, $view3Id, $view4Id, $view6Id]);
     }
 
     public function test_that_it_filters_by_ids(): void
@@ -66,7 +67,7 @@ class DatagridViewRepositoryIntegration extends TestCase
         ]);
         Assert::same(array_map(function ($view) {
             return $view->getId();
-        }, $result->toArray()), [$view1Id, $view2Id]);
+        }, $result), [$view1Id, $view2Id]);
     }
 
     public function test_it_returns_view_aliases_for_a_given_user(): void

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -54,7 +54,7 @@ class UserNormalizerSpec extends ObjectBehavior
         $user->setDefaultTree(new Category());
         $user->addProperty('property_name', 'value');
 
-        $datagridViewRepo->getDatagridViewTypeByUser($user)->willReturn([]);
+        $datagridViewRepo->getDatagridViewAliasesByUser($user)->willReturn([]);
 
         $result = [
             'code'                      => null,
@@ -122,7 +122,7 @@ class UserNormalizerSpec extends ObjectBehavior
         $normalizerOne->normalize($user, Argument::cetera())->willReturn(['properties' => []]);
         $normalizerTwo->normalize($user, Argument::cetera())->willReturn([]);
 
-        $datagridViewRepo->getDatagridViewTypeByUser($user)->willReturn([]);
+        $datagridViewRepo->getDatagridViewAliasesByUser($user)->willReturn([]);
 
         $securityFacade->isGranted('pim_user_user_edit')->willReturn(true);
 
@@ -151,7 +151,7 @@ class UserNormalizerSpec extends ObjectBehavior
         $normalizerOne->normalize($user, Argument::cetera())->willReturn(['properties' => []]);
         $normalizerTwo->normalize($user, Argument::cetera())->willReturn([]);
 
-        $datagridViewRepo->getDatagridViewTypeByUser($user)->willReturn([]);
+        $datagridViewRepo->getDatagridViewAliasesByUser($user)->willReturn([]);
 
         $securityFacade->isGranted('pim_user_user_edit')->willReturn(false);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

There was some issues between the `DatagridViewRepositoryInterface` and its implementation: `getDatagridViewTypeByUser` and `findDatagridViewBySearch` was defined to return ArrayCollection in interface but returned array in implementation.  

Some rework is done to fix that (and more):

- `getDatagridViewTypeByUser` is renamed as `getDatagridViewAliasesByUser`. Datagrid views has an alias and a type. To have a method `getDatagridViewTypeByUser` that return aliases is very confusing. Now the method return a flat array instead of unnecessary complex array

Before:
```
[["datagridAlias" => "alias1"], ["datagridAlias" => "alias2"], ...]
```

After:
```
["alias1", "alias2", ...]
```

- `findDatagridViewBySearch` now returns a Collection in the implementation  

