### PR TITLE
PIM-9568: Fix performance issue when saving a big product group

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 
 - PIM-9565: Fix StandardToFlat boolean value converter
 - PIM-9550: Add attribute codes as an argument to the command "pim:product:clean-removed-attributes"
+- PIM-9568: Fix performance issue when saving a big product group
 
 # 4.0.72 (2020-11-16)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,12 +1,15 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9568: Fix performance issue when saving a big product group
+
 # 4.0.73 (2020-11-23)
 
 ## Bug fixes
 
 - PIM-9565: Fix StandardToFlat boolean value converter
 - PIM-9550: Add attribute codes as an argument to the command "pim:product:clean-removed-attributes"
-- PIM-9568: Fix performance issue when saving a big product group
 
 # 4.0.72 (2020-11-16)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/GroupUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/GroupUpdater.php
@@ -145,21 +145,29 @@ class GroupUpdater implements ObjectUpdaterInterface
     }
 
     /**
-     * @param GroupInterface $group
-     * @param array          $productIdentifiers
+     * @todo Find a better solution than a database query to determine what are the products that have been added.
+     *       (it will certainly cause a BC-break)
      */
     protected function setProducts(GroupInterface $group, array $productIdentifiers)
     {
+        $oldProductIdentifiers = [];
         foreach ($group->getProducts() as $product) {
-            $group->removeProduct($product);
+            $oldProductIdentifiers[] = $product->getIdentifier();
+            // Remove products that are no longer in the group
+            if (!in_array($product->getIdentifier(), $productIdentifiers)) {
+                $group->removeProduct($product);
+            }
         }
 
-        if (empty($productIdentifiers)) {
+        // Extract the products that are not already in the group to add them to it
+        $productIdentifiersToAdd = array_values(array_diff($productIdentifiers, $oldProductIdentifiers));
+
+        if (empty($productIdentifiersToAdd)) {
             return;
         }
 
         $pqb = $this->productQueryBuilderFactory->create();
-        $pqb->addFilter('identifier', Operators::IN_LIST, $productIdentifiers);
+        $pqb->addFilter('identifier', Operators::IN_LIST, $productIdentifiersToAdd);
 
         $products = $pqb->execute();
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/GroupSaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/GroupSaverSpec.php
@@ -13,7 +13,7 @@ use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Component\Model\GroupType;
 use Akeneo\Tool\Bundle\VersioningBundle\Manager\VersionContext;
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Prophecy\Argument;
@@ -74,15 +74,17 @@ class GroupSaverSpec extends ObjectBehavior
         $this->save($group);
     }
 
-    function it_saves_a_group_and_added_products(
+    function it_saves_a_new_group_with_products(
         $optionsResolver,
         $objectManager,
         $productSaver,
         $eventDispatcher,
         GroupInterface $group,
-        GroupType $type,
-        ProductInterface $addedProduct
+        GroupType $type
     ) {
+        $addedProduct = new Product();
+        $addedProduct->setId(42);
+
         $optionsResolver->resolveSaveOptions(['add_products' => [$addedProduct]])->willReturn(
             [
                 'flush'                   => true,
@@ -106,7 +108,7 @@ class GroupSaverSpec extends ObjectBehavior
         $this->save($group, ['add_products' => [$addedProduct]]);
     }
 
-    function it_saves_a_group_and_removed_products(
+    function it_saves_an_updated_group_with_removed_and_added_products(
         $optionsResolver,
         $objectManager,
         $productSaver,
@@ -114,9 +116,12 @@ class GroupSaverSpec extends ObjectBehavior
         $pqbFactory,
         GroupInterface $group,
         GroupType $type,
-        ProductInterface $removedProduct,
         ProductQueryBuilderInterface $pqb
     ) {
+        $productAlreadyInGroup = (new Product())->setId(42);
+        $addedProduct = (new Product())->setId(123);
+        $removedProduct = (new Product())->setId(456);
+
         $optionsResolver->resolveSaveOptions(['remove_products' => [$removedProduct]])->willReturn(
             [
                 'flush'                   => true,
@@ -126,9 +131,9 @@ class GroupSaverSpec extends ObjectBehavior
 
         $pqbFactory->create()->willReturn($pqb);
         $pqb->addFilter('groups', 'IN', ['foo'])->shouldBeCalled();
-        $pqb->execute()->willReturn([$removedProduct]);
+        $pqb->execute()->willReturn([$removedProduct, $productAlreadyInGroup]);
 
-        $group->getProducts()->willReturn(new ArrayCollection([]));
+        $group->getProducts()->willReturn(new ArrayCollection([$productAlreadyInGroup, $addedProduct]));
         $group->getType()->willReturn($type);
         $group->getCode()->willReturn('my_code');
         $group->getId()->willReturn(42);
@@ -137,7 +142,7 @@ class GroupSaverSpec extends ObjectBehavior
         $objectManager->persist($group)->shouldBeCalled();
         $objectManager->flush()->shouldBeCalled();
 
-        $productSaver->saveAll([$removedProduct])->shouldBeCalled();
+        $productSaver->saveAll([$addedProduct, $removedProduct])->shouldBeCalled();
 
         $eventDispatcher->dispatch(StorageEvents::PRE_SAVE, Argument::cetera())->shouldBeCalled();
         $eventDispatcher->dispatch(StorageEvents::POST_SAVE, Argument::cetera())->shouldBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/GroupUpdaterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Updater/GroupUpdaterSpec.php
@@ -10,7 +10,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\GroupTranslation;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Akeneo\Pim\Structure\Component\Model\GroupTypeInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
@@ -59,13 +59,15 @@ class GroupUpdaterSpec extends ObjectBehavior
         GroupTranslation $translatable,
         AttributeInterface $attributeColor,
         AttributeInterface $attributeSize,
-        ProductInterface $removedProduct,
-        ProductInterface $addedProduct,
         ProductQueryBuilderInterface $pqb
     ) {
         $groupTypeRepository->findOneByIdentifier('RELATED')->willReturn($type);
         $attributeRepository->findOneByIdentifier('color')->willReturn($attributeColor);
         $attributeRepository->findOneByIdentifier('size')->willReturn($attributeSize);
+
+        $addedProduct = (new Product())->setIdentifier('foo');
+        $productAlreadyInGroup = (new Product())->setIdentifier('bar');
+        $removedProduct = (new Product())->setIdentifier('ziggy');
 
         $pqbFactory->create()->willReturn($pqb);
         $pqb->addFilter('identifier', 'IN', ['foo'])->shouldBeCalled();
@@ -80,7 +82,7 @@ class GroupUpdaterSpec extends ObjectBehavior
 
         $group->removeProduct($removedProduct)->shouldBeCalled();
         $group->addProduct($addedProduct)->shouldBeCalled();
-        $group->getProducts()->willReturn([$removedProduct]);
+        $group->getProducts()->willReturn([$removedProduct, $productAlreadyInGroup]);
 
         $values = [
             'code'     => 'mycode',
@@ -88,7 +90,7 @@ class GroupUpdaterSpec extends ObjectBehavior
             'labels'   => [
                 'fr_FR' => 'T-shirt super beau',
             ],
-            'products' => ['foo']
+            'products' => ['foo', 'bar']
         ];
 
         $this->update($group, $values, []);


### PR DESCRIPTION
This fix a performance issue when saving a group with a lot of products (whatever the change)

The group updater was removing all the products before re-adding them all, and the group saver was saving all the products for the versioning.

Now, it will only add, remove and save the products that need it.

It's not an ideal solution, and the problem will remain if too many products are added/removed in the same request. But better solutions will cause BC-breaks.

