### PR TITLE
PIM-9559: Dispatch event when clean removed attributes command is over

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,7 +3,7 @@
 ## Bug fixes
 
 - PIM-9575: Prepend hash to navigate actions URLs
-- PIM-9559: Override clean removed attributes command in EE to also clean proposals
+- PIM-9559: Dispatch event when clean removed attributes command is over
 
 # 4.0.74 (2020-11-25)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9559: Override clean removed attributes command in EE to also clean proposals
+
 # 4.0.74 (2020-11-25)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -92,6 +92,7 @@ $rules = [
 
         // TIP-1017: Do not use public constants of AttributeTypes
         'Akeneo\Pim\Structure\Component\AttributeTypes',
+        'Akeneo\Pim\Structure\Bundle\Event\AttributeEvents',
 
         // TODO: : EASY PICK! API PaginatorInterface should catch ServerErrorResponseException and throw its own exception,
         'Elasticsearch\Common\Exceptions\BadRequest400Exception',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Command;
 
-use Akeneo\Pim\Enrichment\Bundle\Product\RemoveAttributesValuesFromProductAndProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\ValuesRemover\CleanValuesOfRemovedAttributesInterface;
@@ -31,19 +30,19 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     protected static $defaultName = 'pim:product:clean-removed-attributes';
 
     /** @var EntityManagerClearerInterface */
-    private $entityManagerClearer;
+    protected $entityManagerClearer;
 
     /** @var ProductQueryBuilderFactoryInterface */
-    private $productQueryBuilderFactory;
+    protected $productQueryBuilderFactory;
 
     /** @var string */
-    private $kernelRootDir;
+    protected $kernelRootDir;
 
     /** @var int */
-    private $productBatchSize;
+    protected $productBatchSize;
 
     /** @var CleanValuesOfRemovedAttributesInterface|null */
-    private $cleanValuesOfRemovedAttributes;
+    protected $cleanValuesOfRemovedAttributes;
 
     public function __construct(
         EntityManagerClearerInterface $entityManagerClearer,
@@ -82,6 +81,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
             if (!empty($attributesCodes)) {
                 $this->cleanValues($attributesCodes, $input, $output);
+
                 return;
             }
         }
@@ -91,8 +91,10 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
         $io->title('Clean removed attributes values');
         $answer = $io->confirm(
-            'This command with removes all values of deleted attributes on all products and product models' . "\n" .
-            'Do you want to proceed?', true);
+            'This command will remove all values of deleted attributes on all products and product models' . "\n" .
+                'Do you want to proceed?',
+            true
+        );
 
         if (!$answer) {
             $io->text('That\'s ok, see you!');
@@ -118,12 +120,8 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
     /**
      * Get products
-     *
-     * @param ProductQueryBuilderFactoryInterface $pqbFactory
-     *
-     * @return CursorInterface
      */
-    private function getProducts(ProductQueryBuilderFactoryInterface $pqbFactory): CursorInterface
+    protected function getProducts(ProductQueryBuilderFactoryInterface $pqbFactory): CursorInterface
     {
         $pqb = $pqbFactory->create();
 
@@ -132,15 +130,8 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
     /**
      * Iterate over given products to launch clean commands
-     *
-     * @param  CursorInterface               $products
-     * @param  ProgressBar                   $progressBar
-     * @param  int                           $productBatchSize
-     * @param  EntityManagerClearerInterface $cacheClearer
-     * @param  string                        $env
-     * @param  string                        $rootDir
      */
-    private function cleanProducts(
+    protected function cleanProducts(
         CursorInterface $products,
         ProgressBar $progressBar,
         int $productBatchSize,
@@ -172,10 +163,6 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
     /**
      * Lanches the clean command on given ids
-     *
-     * @param array  $productIds
-     * @param string $env
-     * @param string $rootDir
      */
     private function launchCleanTask(array $productIds, string $env, string $rootDir)
     {
@@ -184,7 +171,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         $process->run();
     }
 
-    private function cleanValues(
+    protected function cleanValues(
         array $attributesCodes,
         InputInterface $input,
         OutputInterface $output
@@ -204,12 +191,12 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         $io->title('Clean removed attributes values');
 
         $confirmMessage = sprintf(
-            "This command will remove the values of the attributes: \n ".
-            "%s".
-            "This will update: \n".
-            " - %d product model(s) (and %d product variant(s)) \n".
-            " - %d product(s) \n".
-            "Do you want to proceed?",
+            "This command will remove the values of the attributes: \n " .
+                "%s" .
+                "This will update: \n" .
+                " - %d product model(s) (and %d product variant(s)) \n" .
+                " - %d product(s) \n" .
+                "Do you want to proceed?",
             implode(array_map(function (string $attributeCode) {
                 return sprintf(" - %s \n ", $attributeCode);
             }, $attributesCodes)),

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
@@ -12,6 +12,7 @@ services:
             - '%kernel.root_dir%'
             - '%pim_job_product_batch_size%'
             - '@pim_catalog.product_values.clean_values_of_removed_attributes'
+            - '@event_dispatcher'
         tags:
             - { name: console.command }
 

--- a/src/Akeneo/Pim/Structure/Bundle/Event/AttributeEvents.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Event/AttributeEvents.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Event;
+
+final class AttributeEvents
+{
+    /**
+     * This event is dispatched after attribute values are cleaned up from products & product models.
+     */
+    const POST_CLEAN = 'pim_enrich.attribute.post_clean';
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Setting methods as protected to be able to extend this command in EE

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
