### PR TITLE
PIM-9578: Revert change on millibar conversion operation

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - [Backport] Fix fatal error on display product model associations when they have more than 25 products associated
+- PIM-9578: Revert change on millibar conversion operation
 
 # 3.2.76 (2020-10-22)
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -438,7 +438,7 @@ measures_config:
                 convert: [{'mul': '0.001'}]
                 symbol: hPa
             MILLIBAR:
-                convert: [{'mul': '1000'}]
+                convert: [{'mul': '0.001'}]
                 symbol: mBar
             ATM:
                 convert: [{'mul': '0.986923'}]


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Reverting this PR https://github.com/akeneo/pim-community-dev/pull/13064, as the doc says: `Operations are defined to convert from the unit to the standard unit`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
