### PR TITLE
PIM-9575: Prepend hash to navigate actions URLs

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9575: Prepend hash to navigate actions URLs
+
 # 4.0.74 (2020-11-25)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/navigate-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/navigate-action.js
@@ -37,7 +37,7 @@ function(_, mediator, ModelAction, router) {
 
             if (this.useDirectLauncherLink) {
                 this.launcherOptions = _.extend({
-                    link: this.getLink(),
+                    link: `#${this.getLink()}`,
                     runAction: false
                 }, this.launcherOptions);
             }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PRs adds a hash at the beginning of (not unset) URLs used in datagrid actions cells so that they can be opened in a new tab with the correct URL.
The `onClick` handler intercepts the link `href` anyway so it's really only useful when "right clicking -> open in a new tab"

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
