### PR TITLE
PIM-9569: Fix memory usage issue when adding a group to a product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PIM-9548: Mitigate deadlock issues on category API
 - PIM-9540: Do not strip HTML tags on textarea content before indexing them in ES and fix newline_pattern char filter
 - PIM-9539: Fix the display of long attribute labels or codes on variant attributes page
+- PIM-9569: Fix memory usage issue when adding a group to a product
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -545,7 +545,6 @@ abstract class AbstractProduct implements ProductInterface
     {
         if (!$this->groups->contains($group)) {
             $this->groups->add($group);
-            $group->addProduct($this);
             $this->dirty = true;
         }
 


### PR DESCRIPTION
There's a circular reference with the product groups that can reach to a memory usage issue under certain circumstances.

It occurred for a client that has a group with more than 5000 products when a new product with this group is imported. The import itself already uses a lot of memory, and when the group is added to the product the memory usage explodes.

It's because the method `AbstractProduct::addGroup` adds the product to the group by calling the method `Group::addProduct` , that calls `AbstractProduct::addGroup` again. The conditions  `if (!$this->groups->contains($group))` and `if (!$this->products->contains($product))` prevents an infinite loop, but it causes all the products of the group to be automatically loaded and hydrated by the ORM.

```
abstract class AbstractProduct implements ProductInterface
...
    public function addGroup(GroupInterface $group)
    {
        if (!$this->groups->contains($group)) {
            $this->groups->add($group);
            $group->addProduct($this);
            $this->dirty = true;
        }

        return $this;
    }
```

```
class Group implements GroupInterface
...
    public function addProduct(ProductInterface $product)
    {
        if (!$this->products->contains($product)) {
            $this->products->add($product);
            $product->addGroup($this);
        }

        return $this;
    }
```

Finding a good solution for this problem is not an easy task. It would requires to break the circular reference, or to rework how the product/group relations are loaded, updated and persisted. 

Any good solution would be to heavy to be done in the context of a SLA (we have already taken a lot of time just to find the problem). So I suggest this not perfect but quick fix. As the groups are not persisted during an update or creation of a product, adding the object product to the group products collection is useless.

It's theoretically problematic to not add the product to the group, but in practice it is not. The products and groups are not independently manipulated for different use cases in the same PHP process. And there are no functional use case that needs to update products and groups in the same time.