### PR TITLE
PIM-9580: Fix conversion operation for ATM, PSI, TORR & MMHG

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 
 - [Backport] Fix fatal error on display product model associations when they have more than 25 products associated
 - PIM-9578: Revert change on millibar conversion operation
+- PIM-9580: Fix conversion operation for ATM, PSI, TORR & MMHG
 
 # 3.2.76 (2020-10-22)
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -441,16 +441,16 @@ measures_config:
                 convert: [{'mul': '0.001'}]
                 symbol: mBar
             ATM:
-                convert: [{'mul': '0.986923'}]
+                convert: [{'mul': '1.01325'}]
                 symbol: atm
             PSI:
-                convert: [{'mul': '14.50376985373022'}]
+                convert: [{'mul': '0.0689476'}]
                 symbol: PSI
             TORR:
-                convert: [{'mul': '750.06375541921'}]
+                convert: [{'mul': '0.00133322'}]
                 symbol: Torr
             MMHG:
-                convert: [{'mul': '750.06375541921'}]
+                convert: [{'mul': '0.00133322'}]
                 symbol: mmHg
     Energy:
         standard: JOULE


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The conversion was in reverse for these units

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
