### PR TITLE
CXP-503: Add the number of activated WH in the tracker

### DIFF
--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/DataCollector/DBDataCollector.php
@@ -4,6 +4,7 @@ namespace Akeneo\Platform\Bundle\AnalyticsBundle\DataCollector;
 
 use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Query\AverageMaxQuery;
 use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Query\CountQuery;
+use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;
 use Akeneo\Tool\Component\Analytics\ApiConnectionCountQuery;
 use Akeneo\Tool\Component\Analytics\DataCollectorInterface;
 use Akeneo\Tool\Component\Analytics\EmailDomainsQuery;
@@ -57,6 +58,8 @@ class DBDataCollector implements DataCollectorInterface
 
     private IsDemoCatalogQuery $isDemoCatalogQuery;
 
+    private ActiveEventSubscriptionCountQuery $activeEventSubscriptionCountQuery;
+
     public function __construct(
         CountQuery $channelCountQuery,
         CountQuery $productCountQuery,
@@ -76,7 +79,8 @@ class DBDataCollector implements DataCollectorInterface
         EmailDomainsQuery $emailDomains,
         ApiConnectionCountQuery $apiConnectionCountQuery,
         MediaCountQuery $mediaCountQuery,
-        IsDemoCatalogQuery $isDemoCatalogQuery
+        IsDemoCatalogQuery $isDemoCatalogQuery,
+        ActiveEventSubscriptionCountQuery $activeEventSubscriptionCountQuery
     ) {
         $this->channelCountQuery = $channelCountQuery;
         $this->productCountQuery = $productCountQuery;
@@ -97,6 +101,7 @@ class DBDataCollector implements DataCollectorInterface
         $this->apiConnectionCountQuery = $apiConnectionCountQuery;
         $this->mediaCountQuery = $mediaCountQuery;
         $this->isDemoCatalogQuery = $isDemoCatalogQuery;
+        $this->activeEventSubscriptionCountQuery = $activeEventSubscriptionCountQuery;
     }
 
     /**
@@ -126,6 +131,7 @@ class DBDataCollector implements DataCollectorInterface
             'nb_media_files_in_products' => $this->mediaCountQuery->countFiles(),
             'nb_media_images_in_products' => $this->mediaCountQuery->countImages(),
             'is_demo_catalog' => $this->isDemoCatalogQuery->fetch(),
+            'nb_active_event_subscription' => $this->activeEventSubscriptionCountQuery->fetch(),
         ];
     }
 }

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Query/Sql/ActiveEventSubscriptionCount.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Query/Sql/ActiveEventSubscriptionCount.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Bundle\AnalyticsBundle\Query\Sql;
+
+use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ActiveEventSubscriptionCount implements ActiveEventSubscriptionCountQuery
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function fetch(): int
+    {
+        $query = <<<SQL
+SELECT count(*)
+FROM akeneo_connectivity_connection
+WHERE webhook_enabled=1
+SQL;
+
+        return (int)$this->connection->query($query)->fetchColumn(0);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/data_collectors.yml
@@ -60,6 +60,7 @@ services:
             - '@pim_analytics.query.api_connection_count'
             - '@pim_analytics.query.media_count'
             - '@pim_analytics.query.is_demo_catalog'
+            - '@pim_analytics.query.active_event_subscription_count'
         tags:
             - { name: pim_analytics.data_collector, type: update_checker }
             - { name: pim_analytics.data_collector, type: system_info_report }

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/queries.yml
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/queries.yml
@@ -9,6 +9,11 @@ services:
         arguments:
             - '@database_connection'
 
+    pim_analytics.query.active_event_subscription_count:
+        class: Akeneo\Platform\Bundle\AnalyticsBundle\Query\Sql\ActiveEventSubscriptionCount
+        arguments:
+            - '@database_connection'
+
     pim_analytics.query.media_count:
         class: Akeneo\Platform\Bundle\AnalyticsBundle\Query\ElasticsearchAndSql\MediaCount
         arguments:

--- a/src/Akeneo/Tool/Component/Analytics/ActiveEventSubscriptionCountQuery.php
+++ b/src/Akeneo/Tool/Component/Analytics/ActiveEventSubscriptionCountQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Analytics;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ActiveEventSubscriptionCountQuery
+{
+    public function fetch(): int;
+}

--- a/tests/back/Platform/Acceptance/Analytics/Query/InMemory/ActiveEventSubscriptionCountInMemory.php
+++ b/tests/back/Platform/Acceptance/Analytics/Query/InMemory/ActiveEventSubscriptionCountInMemory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Platform\Acceptance\Analytics\Query\InMemory;
+
+use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ActiveEventSubscriptionCountInMemory implements ActiveEventSubscriptionCountQuery
+{
+    public function fetch(): int
+    {
+        return 666;
+    }
+}

--- a/tests/back/Platform/Acceptance/Analytics/Resources/config/queries.yml
+++ b/tests/back/Platform/Acceptance/Analytics/Resources/config/queries.yml
@@ -5,6 +5,9 @@ services:
     pim_analytics.query.api_connection_count:
         class: AkeneoTest\Platform\Acceptance\Analytics\Query\InMemory\ApiConnectionCountInMemory
 
+    pim_analytics.query.active_event_subscription_count:
+        class: AkeneoTest\Platform\Acceptance\Analytics\Query\InMemory\ActiveEventSubscriptionCountInMemory
+
     pim_analytics.query.media_count:
         class: AkeneoTest\Platform\Acceptance\Analytics\Query\InMemory\MediaCountInMemory
 

--- a/tests/back/Platform/Integration/Analytics/Query/ActiveEventSubscriptionCountIntegration.php
+++ b/tests/back/Platform/Integration/Analytics/Query/ActiveEventSubscriptionCountIntegration.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Platform\Integration\Analytics\Query;
+
+use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;
+use Doctrine\DBAL\Connection as DbalConnection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ActiveEventSubscriptionCountIntegration extends TestCase
+{
+    private ConnectionLoader $connectionLoader;
+    private ActiveEventSubscriptionCountQuery $activeEventSubscriptionCount;
+
+    /** @var DbalConnection */
+    private $dbalConnection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+        $this->activeEventSubscriptionCount = $this->get('pim_analytics.query.active_event_subscription_count');
+        $this->dbalConnection = $this->get('database_connection');
+    }
+
+    public function test_it_fetches_active_event_subscription_count()
+    {
+        $this->createConnectionWithWebhookData(
+            'erp',
+            'ERP',
+            FlowType::DATA_SOURCE,
+            true,
+            'secret_erp',
+            'http://localhost/webhook_erp',
+            true
+        );
+
+        $this->createConnectionWithWebhookData(
+            'csv',
+            'CSV',
+            FlowType::DATA_SOURCE,
+            true,
+            'secret_csv',
+            'http://localhost/webhook_csv',
+            false
+        );
+
+        $this->createConnectionWithWebhookData(
+            'magento',
+            'MAGENTO',
+            FlowType::DATA_DESTINATION,
+            true,
+            'secret_magento',
+            'http://localhost/webhook_magento',
+            true
+        );
+
+        $this->createConnectionWithWebhookData(
+            'print',
+            'PRINT',
+            FlowType::DATA_DESTINATION,
+            true,
+            'secret_print',
+            'http://localhost/webhook_print',
+            false
+        );
+
+        $this->createConnectionWithWebhookData(
+            'translations',
+            'TRANSLATIONS',
+            FlowType::OTHER,
+            true,
+            'secret_translations',
+            'http://localhost/webhook_translations',
+            true
+        );
+
+        $result = $this->activeEventSubscriptionCount->fetch();
+        $expectedResult = 3;
+
+        Assert::assertEquals($expectedResult, $result);
+
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    private function createConnectionWithWebhookData(
+        string $code,
+        string $label,
+        string $flowType,
+        bool $auditable,
+        string $secret,
+        ?string $url,
+        bool $enabled
+    ): void {
+
+        $this->connectionLoader->createConnection($code, $label, $flowType, $auditable);
+
+        $this->dbalConnection->update(
+            'akeneo_connectivity_connection',
+            [
+                'webhook_url' => $url,
+                'webhook_secret' => $secret,
+                'webhook_enabled' => (int)$enabled,
+            ],
+            ['code' => $code]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/DBDataCollectorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/DBDataCollectorSpec.php
@@ -5,6 +5,7 @@ namespace Specification\Akeneo\Platform\Bundle\AnalyticsBundle\DataCollector;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Platform\Bundle\AnalyticsBundle\Query\ElasticsearchAndSql\MediaCount;
 use Akeneo\Platform\Bundle\AnalyticsBundle\Query\Sql\ApiConnectionCount;
+use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;
 use Akeneo\Tool\Component\Analytics\DataCollectorInterface;
 use Akeneo\Tool\Component\Analytics\EmailDomainsQuery;
 use Akeneo\Tool\Component\Analytics\IsDemoCatalogQuery;
@@ -36,7 +37,8 @@ class DBDataCollectorSpec extends ObjectBehavior
         EmailDomainsQuery $emailDomains,
         ApiConnectionCount $apiConnectionCount,
         MediaCount $mediaCount,
-        IsDemoCatalogQuery $isDemoCatalogQuery
+        IsDemoCatalogQuery $isDemoCatalogQuery,
+        ActiveEventSubscriptionCountQuery $activeEventSubscriptionCountQuery
     ) {
         $this->beConstructedWith(
             $channelCountQuery,
@@ -57,7 +59,8 @@ class DBDataCollectorSpec extends ObjectBehavior
             $emailDomains,
             $apiConnectionCount,
             $mediaCount,
-            $isDemoCatalogQuery
+            $isDemoCatalogQuery,
+            $activeEventSubscriptionCountQuery
         );
     }
 
@@ -86,7 +89,8 @@ class DBDataCollectorSpec extends ObjectBehavior
         $emailDomains,
         ApiConnectionCount $apiConnectionCount,
         MediaCount $mediaCount,
-        IsDemoCatalogQuery $isDemoCatalogQuery
+        IsDemoCatalogQuery $isDemoCatalogQuery,
+        ActiveEventSubscriptionCountQuery $activeEventSubscriptionCountQuery
     ) {
         $channelCountQuery->fetch()->willReturn(new CountVolume(3, -1, 'count_channels'));
         $productCountQuery->fetch()->willReturn(new CountVolume(1121, -1, 'count_products'));
@@ -112,6 +116,7 @@ class DBDataCollectorSpec extends ObjectBehavior
         $mediaCount->countFiles()->willReturn(2);
         $mediaCount->countImages()->willReturn(1);
         $isDemoCatalogQuery->fetch()->willreturn(true);
+        $activeEventSubscriptionCountQuery->fetch()->willReturn(42);
 
         $this->collect()->shouldReturn(
             [
@@ -139,7 +144,8 @@ class DBDataCollectorSpec extends ObjectBehavior
                 ],
                 'nb_media_files_in_products' => 2,
                 'nb_media_images_in_products' => 1,
-                'is_demo_catalog' => true
+                'is_demo_catalog' => true,
+                'nb_active_event_subscription' => 42,
             ]
         );
     }


### PR DESCRIPTION
In order to follow-up the Events API activation, we add the number of activated event subscriptions into the PIM tracker. 

`nb_active_event_subscription : integer
`