### PR TITLE
DAPI-1377: Adaptations for key-indicators calculation

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetCriteriaEvaluationsByProductIdQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetCriteriaEvaluationsByProductIdQuery.php
@@ -36,7 +36,6 @@ final class GetCriteriaEvaluationsByProductIdQuery implements GetCriteriaEvaluat
         TransformCriterionEvaluationResultIds $transformCriterionEvaluationResultIds,
         string $tableName
     ) {
-
         $this->db = $db;
         $this->clock = $clock;
         $this->transformCriterionEvaluationResultIds = $transformCriterionEvaluationResultIds;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels.php
@@ -16,16 +16,21 @@ class Channels
 
     private array $channelCodesByIds;
 
+    private bool $channelsLoaded;
+
     private Connection $dbConnection;
 
     public function __construct(Connection $dbConnection)
     {
         $this->dbConnection = $dbConnection;
+        $this->channelCodesByIds = [];
+        $this->channelIdsByCodes = [];
+        $this->channelsLoaded = false;
     }
 
     public function getIdByCode(string $code): ?int
     {
-        if (null === $this->channelIdsByCodes) {
+        if (false === $this->channelsLoaded) {
             $this->loadChannels();
         }
 
@@ -34,7 +39,7 @@ class Channels
 
     public function getCodeById(int $id): ?string
     {
-        if (null === $this->channelCodesByIds) {
+        if (false === $this->channelsLoaded) {
             $this->loadChannels();
         }
 
@@ -43,9 +48,6 @@ class Channels
 
     private function loadChannels(): void
     {
-        $this->channelIdsByCodes = [];
-        $this->channelCodesByIds = [];
-
         $channels = $this->dbConnection->executeQuery(
             'SELECT JSON_OBJECTAGG(id, code) FROM pim_catalog_channel;'
         )->fetchColumn();
@@ -54,5 +56,7 @@ class Channels
             $this->channelCodesByIds = json_decode($channels, true);
             $this->channelIdsByCodes = array_flip($this->channelCodesByIds);
         }
+
+        $this->channelsLoaded = true;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales.php
@@ -16,16 +16,21 @@ class Locales
 
     private array $localeCodesByIds;
 
+    private bool $localesLoaded;
+
     private Connection $dbConnection;
 
     public function __construct(Connection $dbConnection)
     {
         $this->dbConnection = $dbConnection;
+        $this->localeIdsByCodes = [];
+        $this->localeCodesByIds = [];
+        $this->localesLoaded = false;
     }
 
     public function getIdByCode(string $code): ?int
     {
-        if (null === $this->localeIdsByCodes) {
+        if (false === $this->localesLoaded) {
             $this->loadLocales();
         }
 
@@ -34,7 +39,7 @@ class Locales
 
     public function getCodeById(int $id): ?string
     {
-        if (null === $this->localeCodesByIds) {
+        if (false === $this->localesLoaded) {
             $this->loadLocales();
         }
 
@@ -43,9 +48,6 @@ class Locales
 
     private function loadLocales(): void
     {
-        $this->localeIdsByCodes = [];
-        $this->localeCodesByIds = [];
-
         $locales = $this->dbConnection->executeQuery(
             'SELECT JSON_OBJECTAGG(id, code) FROM pim_catalog_locale WHERE is_activated = 1;'
         )->fetchColumn();
@@ -54,5 +56,7 @@ class Locales
             $this->localeCodesByIds = json_decode($locales, true);
             $this->localeIdsByCodes = array_flip($this->localeCodesByIds);
         }
+
+        $this->localesLoaded = true;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIds.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIds.php
@@ -32,8 +32,7 @@ final class TransformCriterionEvaluationResultIds
         foreach ($evaluationResult as $propertyId => $propertyData) {
             switch ($propertyId) {
                 case $propertiesIds['data']:
-
-                    $propertyDataByCodes = $this->transformResultAttributeRatesIdsToCodes($propertyData);
+                    $propertyDataByCodes = $this->transformResultDataIdsToCodes($propertyData);
                     break;
                 case $propertiesIds['rates']:
                     $propertyDataByCodes = $this->transformRatesIdsToCodes($propertyData);
@@ -49,6 +48,26 @@ final class TransformCriterionEvaluationResultIds
         }
 
         return $resultByCodes;
+    }
+
+    private function transformResultDataIdsToCodes(array $resultDataByIds): array
+    {
+        $dataByCodes = [];
+        foreach ($resultDataByIds as $dataType => $dataByIds) {
+            switch ($dataType) {
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates']:
+                    $dataByCodes['attributes_with_rates'] = $this->transformResultAttributeRatesIdsToCodes($dataByIds);
+                    break;
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes']:
+                    $dataByCodes['total_number_of_attributes'] =
+                        $this->transformChannelLocaleDataFromIdsToCodes($dataByIds, fn ($number) => $number);
+                    break;
+                default:
+                    throw new CriterionEvaluationResultTransformationFailedException(sprintf('Unknown data type id "%s"', $dataType));
+            }
+        }
+
+        return $dataByCodes;
     }
 
     private function transformChannelLocaleDataFromIdsToCodes(array $channelLocaleData, \Closure $transformData): array
@@ -76,7 +95,7 @@ final class TransformCriterionEvaluationResultIds
 
     private function transformResultAttributeRatesIdsToCodes(array $resultAttributeIdsRates): array
     {
-        $attributesRates = $this->transformChannelLocaleDataFromIdsToCodes($resultAttributeIdsRates, function (array $attributeRates) {
+        return $this->transformChannelLocaleDataFromIdsToCodes($resultAttributeIdsRates, function (array $attributeRates) {
             $attributeCodesRates = [];
             $attributesCodes = $this->attributes->getCodesByIds(array_keys($attributeRates));
 
@@ -89,8 +108,6 @@ final class TransformCriterionEvaluationResultIds
 
             return $attributeCodesRates;
         });
-
-        return empty($attributesRates) ? [] : ['attributes_with_rates' => $attributesRates];
     }
 
     private function transformRatesIdsToCodes(array $ratesIds): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -171,11 +171,13 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQuery:
         arguments:
             - '@database_connection'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery:
         arguments:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'
         tags:
             - { name:  akeneo.pim.automation.data_quality_insights.compute_key_indicator_query}
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Transformation/TransformCriterionEvaluationResultCodesIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Transformation/TransformCriterionEvaluationResultCodesIntegration.php
@@ -41,6 +41,16 @@ final class TransformCriterionEvaluationResultCodesIntegration extends DataQuali
                         'de_DE' => [],
                     ],
                 ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 4,
+                    ],
+                    'mobile' => [
+                        'en_US' => 6,
+                        'de_DE' => 0,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -66,18 +76,30 @@ final class TransformCriterionEvaluationResultCodesIntegration extends DataQuali
 
         $expectedEvaluationResult = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
-                $ecommerceId => [
-                    $enUsId => [
-                        $nameId => 50,
-                        $descriptionId => 0,
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                    $ecommerceId => [
+                        $enUsId => [
+                            $nameId => 50,
+                            $descriptionId => 0,
+                        ],
+                        $frFrId => [
+                            $descriptionId => 20,
+                        ],
                     ],
-                    $frFrId => [
-                        $descriptionId => 20,
+                    $mobileId => [
+                        $enUsId => [$nameId => 0],
+                        $deDeId => [],
                     ],
                 ],
-                $mobileId => [
-                    $enUsId => [$nameId => 0],
-                    $deDeId => [],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                    $ecommerceId => [
+                        $enUsId => 4,
+                        $frFrId => 4,
+                    ],
+                    $mobileId => [
+                        $enUsId => 6,
+                        $deDeId => 0,
+                    ],
                 ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
@@ -27,18 +27,30 @@ final class TransformCriterionEvaluationResultIdsIntegration extends DataQuality
 
         $evaluationResult = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
-                $ecommerceId => [
-                    $enUsId => [
-                        $nameId => 50,
-                        $descriptionId => 0,
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                    $ecommerceId => [
+                        $enUsId => [
+                            $nameId => 50,
+                            $descriptionId => 0,
+                        ],
+                        $frFrId => [
+                            $descriptionId => 20,
+                        ],
                     ],
-                    $frFrId => [
-                        $descriptionId => 20,
+                    $mobileId => [
+                        $enUsId => [$nameId => 0],
+                        $deDeId => [],
                     ],
                 ],
-                $mobileId => [
-                    $enUsId => [$nameId => 0],
-                    $deDeId => [],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                    $ecommerceId => [
+                        $enUsId => 4,
+                        $frFrId => 4,
+                    ],
+                    $mobileId => [
+                        $enUsId => 6,
+                        $deDeId => 0,
+                    ],
                 ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
@@ -78,6 +90,16 @@ final class TransformCriterionEvaluationResultIdsIntegration extends DataQuality
                     'mobile' => [
                         'en_US' => ['name' => 0],
                         'de_DE' => [],
+                    ],
+                ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 4,
+                    ],
+                    'mobile' => [
+                        'en_US' => 6,
+                        'de_DE' => 0,
                     ],
                 ],
             ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
@@ -45,6 +45,12 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 5,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -113,6 +119,32 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
         $this->shouldThrow(CriterionEvaluationResultTransformationFailedException::class)->during('transformToIds', [$invalidEvaluationResult]);
     }
 
+    public function it_throws_an_exception_if_the_evaluation_result_has_an_unknown_data_type()
+    {
+        $invalidEvaluationResult = [
+            'data' => [
+                'attributes_with_rates' => [
+                    'ecommerce' => [
+                        'en_US' => [
+                            'name' => 50,
+                            'description' => 0,
+                        ],
+                    ],
+                ],
+                'foo' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 5,
+                    ],
+                ],
+            ],
+            'rates' => [],
+            'status' => [],
+        ];
+
+        $this->shouldThrow(CriterionEvaluationResultTransformationFailedException::class)->during('transformToIds', [$invalidEvaluationResult]);
+    }
+
     public function it_removes_unknown_channels($channels)
     {
         $channels->getIdByCode('foo')->willReturn(null);
@@ -133,6 +165,15 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         'en_US' => [
                             'name' => 50,
                         ],
+                    ],
+                ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 5,
+                    ],
+                    'foo' => [
+                        'en_US' => 3,
                     ],
                 ],
             ],
@@ -179,6 +220,13 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         ],
                     ],
                 ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 5,
+                        'fo_FO' => 3,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -204,12 +252,20 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
         return [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
                     ],
-                    90 => [
-                        34 => 20,
+                ],
+                2 => [
+                    1 => [
+                        58 => 4,
+                        90 => 5,
                     ],
                 ],
             ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsSpec.php
@@ -35,12 +35,20 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $criterionEvaluationResultIds = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
                     ],
-                    90 => [
-                        34 => 20,
+                ],
+                2 => [
+                    1 => [
+                        58 => 4,
+                        90 => 5,
                     ],
                 ],
             ],
@@ -66,9 +74,11 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $invalidEvaluationResult = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
                     ],
                 ],
             ],
@@ -88,14 +98,16 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $invalidEvaluationResult = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
                     ],
-                    90 => [
-                        34 => 20,
-                    ],
-                ],
+                ]
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 1 => [
@@ -114,6 +126,40 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $this->shouldThrow(CriterionEvaluationResultTransformationFailedException::class)->during('transformToCodes', [$invalidEvaluationResult]);
     }
 
+    public function it_throws_an_exception_if_the_evaluation_result_has_an_unknown_data_type()
+    {
+        $invalidEvaluationResult = [
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
+                1 => [
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
+                    ],
+                ],
+                42 => [
+                    1 => [
+                        58 => 4,
+                        90 => 5,
+                    ],
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
+                1 => [
+                    58 => 25,
+                    90 => 75,
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['status'] => []
+        ];
+
+        $this->shouldThrow(CriterionEvaluationResultTransformationFailedException::class)->during('transformToCodes', [$invalidEvaluationResult]);
+    }
+
     public function it_removes_unknown_channels($channels)
     {
         $channels->getCodeById(42)->willReturn(null);
@@ -121,19 +167,30 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $criterionEvaluationResultIds = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
                     ],
-                    90 => [
-                        34 => 20,
+                    42 => [
+                        58 => [
+                            12 => 100,
+                        ],
                     ],
                 ],
-                42 => [
-                    58 => [
-                        12 => 100,
+                2 => [
+                    1 => [
+                        58 => 4,
+                        90 => 5,
                     ],
-                ],
+                    42 => [
+                        58 => 6,
+                    ],
+                ]
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 1 => [
@@ -167,16 +224,25 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
         $criterionEvaluationResultIds = [
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
                 1 => [
-                    58 => [
-                        12 => 50,
-                        34 => 0,
+                    1 => [
+                        58 => [
+                            12 => 50,
+                            34 => 0,
+                        ],
+                        90 => [
+                            34 => 20,
+                        ],
+                        987 => [
+                            12 => 56,
+                        ]
                     ],
-                    90 => [
-                        34 => 20,
+                ],
+                2 => [
+                    1 => [
+                        58 => 4,
+                        90 => 5,
+                        987 => 6
                     ],
-                    987 => [
-                        12 => 56,
-                    ]
                 ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
@@ -211,6 +277,12 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
                         'fr_FR' => [
                             'description' => 20,
                         ],
+                    ],
+                ],
+                'total_number_of_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 4,
+                        'fr_FR' => 5,
                     ],
                 ],
             ],


### PR DESCRIPTION
The key-indicators calculation added MySQL queries on the table `pim_data_quality_insights_product_criteria_evaluation` that need adaptation to transform ids to codes.