### PR TITLE
Fix missing key in MessageBar

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/StopJobAction.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/StopJobAction.tsx
@@ -32,7 +32,7 @@ const StopJobAction = ({id, jobLabel, isStoppable, onStop, children, ...rest}: S
         onClose={closeConfirm}
         illustration={<ExportIllustration />}
       >
-        <SectionTitle>{translate('pim_title.pim_enrich_job_tracker_index')} /</SectionTitle>
+        <SectionTitle color="brand">{translate('pim_title.pim_enrich_job_tracker_index')} /</SectionTitle>
         <Title>{translate('pim_datagrid.action.stop.confirmation.title', {jobLabel})}</Title>
         <Helper level="info">{translate('pim_datagrid.action.stop.confirmation.content')}</Helper>
         <Modal.BottomButtons>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/widget/export-widget.js
@@ -22,7 +22,7 @@ define([
           const message = __('pim_datagrid.mass_action.quick_export.flash.message');
           const link = React.createElement(
             Link,
-            {href: `#${Routing.generate('pim_enrich_job_tracker_show', {id: data.job_id})}`},
+            {key: data.job_id, href: `#${Routing.generate('pim_enrich_job_tracker_show', {id: data.job_id})}`},
             __('pim_datagrid.mass_action.quick_export.flash.link')
           );
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The MessageBar sent by the quick export widget had a missing key error because we pass its children here as an array https://github.com/akeneo/pim-community-dev/blob/8972f7288473be719f0b39270f218552b66965fc/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/widget/export-widget.js#L29, the children elements then need a `key` prop

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
