### PR TITLE
RAC-388: Fix fatal error when an attribute is removed then re-created with the same code but another type

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9568: Fix performance issue when saving a big product group
+- RAC-388: Fix fatal error when an attribute is removed then re-created with the same code but another type.
 
 # 4.0.73 (2020-11-23)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_value_factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/product_value_factories.yml
@@ -72,6 +72,7 @@ services:
             - '@akeneo.pim.enrichment.factory.value'
             - '@akeneo.pim.structure.query.get_attributes'
             - '@akeneo.pim.enrichment.factory.non_existent_values_filter.chained'
+            - '@logger'
 
     akeneo.pim.enrichment.factory.write_value_collection:
         class: Akeneo\Pim\Enrichment\Component\Product\Factory\WriteValueCollectionFactory

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
@@ -6,8 +6,8 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\TransformRawValuesCollections;
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 
 /**
  * The implementation of this non existent filter uses a pivot format internally.

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\TransformRawValuesCollections;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * The implementation of this non existent filter uses a pivot format internally.
@@ -59,7 +60,11 @@ class ChainedNonExistentValuesFilter implements ChainedNonExistentValuesFilterIn
         $result = array_reduce(
             $this->iterableToArray($this->nonExistentValueFilters),
             function (OnGoingFilteredRawValues $onGoingFilteredRawValues, NonExistentValuesFilter $obsoleteValuesFilter): OnGoingFilteredRawValues {
-                return $obsoleteValuesFilter->filter($onGoingFilteredRawValues);
+                try {
+                    return $obsoleteValuesFilter->filter($onGoingFilteredRawValues);
+                } catch (\TypeError | InvalidPropertyTypeException $ex) {
+                    return $onGoingFilteredRawValues;
+                }
             },
             $onGoingFilteredRawValues
         );

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentFileValueFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentFileValueFilter.php
@@ -55,7 +55,7 @@ final class NonExistentFileValueFilter implements NonExistentValuesFilter
                 $fileValues = [];
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $fileValues[$channel][$locale] = $existingEntities[$value] ?? null;
                         }
                     }
@@ -79,7 +79,7 @@ final class NonExistentFileValueFilter implements NonExistentValuesFilter
             foreach ($valueCollection as $values) {
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $fileKeys[] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -39,7 +40,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (is_array($value)) {
+                        if (\is_array($value)) {
                             $multiSelectValues[$channel][$locale] = $this->arrayIntersectCaseInsensitive($value, $optionCodes[$attributeCode] ?? []);
                         }
                     }
@@ -79,7 +80,7 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
             foreach ($valueCollection as $values) {
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (is_array($value)) {
+                        if (\is_array($value)) {
                             foreach ($value as $optionCode) {
                                 $optionCodes[$attributeCode][] = $optionCode;
                             }
@@ -91,6 +92,17 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
+            foreach ($optionCodeForThisAttribute as $value) {
+                if (!\is_scalar($value)) {
+                    throw InvalidPropertyTypeException::validArrayStructureExpected(
+                        $attributeCode,
+                        sprintf('one of the "%s" values is not a scalar', $attributeCode),
+                        static::class,
+                        $optionCodeForThisAttribute
+                    );
+                }
+            }
+
             $uniqueOptionCodes[$attributeCode] = array_unique($optionCodeForThisAttribute);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentPriceCollectionValueFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Channel\Component\Query\FindActivatedCurrenciesInterface;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -55,6 +56,14 @@ final class NonExistentPriceCollectionValueFilter implements NonExistentValuesFi
                     }
 
                     foreach ($valuesIndexedByLocale as $locale => $value) {
+                        if (!\is_array($value)) {
+                            throw InvalidPropertyTypeException::arrayExpected(
+                                $attributeCode,
+                                static::class,
+                                $value
+                            );
+                        }
+
                         $amountByCurrency = [];
                         foreach ($value as $price) {
                             if (isset($price['amount']) && isset($price['currency'])) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataMultiSelectValuesFilter.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetExistingReferenceDataCodes;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * As assets are reference data also, we handle it in this filter.
@@ -48,7 +49,7 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
 
                 foreach ($productData['values'] as $channel => $valuesIndexedByLocale) {
                     foreach ($valuesIndexedByLocale as $locale => $values) {
-                        if (is_array($values)) {
+                        if (\is_array($values)) {
                             $multiSelectValues[$channel][$locale] = array_values(
                                 array_uintersect(
                                     $existingReferenceDataCodes[$attributeCode] ?? [],
@@ -100,7 +101,24 @@ class NonExistentReferenceDataMultiSelectValuesFilter implements NonExistentValu
                 $referenceDataName = $values['properties']['reference_data_name'];
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $values) {
+                        if (!\is_array($values)) {
+                            throw InvalidPropertyTypeException::arrayExpected(
+                                $attributeCode,
+                                static::class,
+                                $values
+                            );
+                        }
+
                         foreach ($values as $value) {
+                            if (!\is_scalar($value)) {
+                                throw InvalidPropertyTypeException::validArrayStructureExpected(
+                                    $attributeCode,
+                                    sprintf('one of the "%s" values is not a scalar', $attributeCode),
+                                    static::class,
+                                    $values
+                                );
+                            }
+
                             $referenceData[$attributeCode][$referenceDataName][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentReferenceDataSimpleSelectValuesFilter.php
@@ -39,7 +39,7 @@ class NonExistentReferenceDataSimpleSelectValuesFilter implements NonExistentVal
 
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $simpleSelectValues[$channel][$locale] = $referenceDataCodes[$attributeCode][strtolower($value)] ?? '';
                         }
                     }
@@ -87,7 +87,7 @@ class NonExistentReferenceDataSimpleSelectValuesFilter implements NonExistentVal
                 $referenceDataName = $values['properties']['reference_data_name'];
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $referenceDataCodes[$attributeCode][$referenceDataName][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
@@ -38,7 +38,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
                 $simpleSelectValues = [];
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $simpleSelectValues[$channel][$locale] = ($optionCodes[$attributeCode] ?? [])[strtolower($value ?? '')] ?? '';
                         }
                     }
@@ -79,7 +79,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
             foreach ($valueCollection as $values) {
                 foreach ($values['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
-                        if (!is_array($value)) {
+                        if (!\is_array($value)) {
                             $optionCodes[$attributeCode][] = $value;
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -25,11 +25,11 @@ class ReadValueCollectionFactory
     /** @var ChainedNonExistentValuesFilterInterface */
     private $chainedNonExistentValuesFilter;
 
-    // TODO merge master: property $logger should be nullable
+    // TODO merge master: remove the logger
     /** @var LoggerInterface|null */
     private $logger;
 
-    // TODO merge master: require LoggerInterface argument
+    // TODO merge master: remove the logger
     public function __construct(
         ValueFactory $valueFactory,
         GetAttributes $getAttributeByCodes,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -103,7 +103,7 @@ class ReadValueCollectionFactory
                             );
                         } catch (\TypeError | InvalidPropertyTypeException | InvalidPropertyException $ex) {
                             if (null !== $this->logger) {
-                                $this->logger->warning(
+                                $this->logger->notice(
                                     sprintf(
                                         'Tried to load a product value for attribute "%s" that does not have the '.
                                         'expected type in database.',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\ChainedNonExistentValuesFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Psr\Log\LoggerInterface;
 
@@ -100,7 +101,7 @@ class ReadValueCollectionFactory
                                 $localeCode,
                                 $data
                             );
-                        } catch (\TypeError | InvalidPropertyTypeException $ex) {
+                        } catch (\TypeError | InvalidPropertyTypeException | InvalidPropertyException $ex) {
                             if (null !== $this->logger) {
                                 $this->logger->warning(
                                     sprintf(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -62,12 +62,12 @@ class ReadValueCollectionFactory
         $attributeCodes = [];
 
         foreach ($rawValueCollections as $productIdentifier => $rawValues) {
-            foreach (array_keys($rawValues) as $attributeCode) {
+            foreach (\array_keys($rawValues) as $attributeCode) {
                 $attributeCodes[] = (string) $attributeCode;
             }
         }
 
-        $attributes = $this->getAttributeByCodes->forCodes(array_unique($attributeCodes));
+        $attributes = $this->getAttributeByCodes->forCodes(\array_unique($attributeCodes));
 
         return $attributes;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
@@ -22,7 +22,7 @@ final class BooleanValueFactory extends ScalarValueFactory implements ValueFacto
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_bool($data)) {
+        if (!\is_bool($data)) {
             throw InvalidPropertyTypeException::booleanExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/DateValueFactory.php
@@ -39,7 +39,7 @@ final class DateValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,
@@ -50,7 +50,7 @@ final class DateValueFactory implements ValueFactory
         try {
             $date = new \DateTime($data);
 
-            if (!preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
+            if (!\preg_match('/^\d{4}-\d{2}-\d{2}/', $data)) {
                 throw InvalidPropertyException::dateExpected(
                     $attribute->code(),
                     'yyyy-mm-dd',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/FileValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/FileValueFactory.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -51,6 +52,14 @@ final class FileValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data) : ValueInterface
     {
+        if (!\is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
         $file = $data instanceof FileInfoInterface ? $data : $this->getFile($data);
 
         if ($file === null) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/FileValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/FileValueFactory.php
@@ -52,7 +52,7 @@ final class FileValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data) : ValueInterface
     {
-        if (!\is_string($data)) {
+        if (!\is_string($data) && !$data instanceof FileInfoInterface) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/IdentifierValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/IdentifierValueFactory.php
@@ -17,7 +17,7 @@ final class IdentifierValueFactory extends ScalarValueFactory implements ValueFa
 {
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_scalar($data) || (is_string($data) && trim($data) === '')) {
+        if (!\is_scalar($data) || (\is_string($data) && \trim($data) === '')) {
             throw InvalidPropertyTypeException::scalarExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ImageValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ImageValueFactory.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -51,6 +52,14 @@ final class ImageValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
+        if (!\is_string($data)) {
+            throw InvalidPropertyTypeException::stringExpected(
+                $attribute->code(),
+                static::class,
+                $data
+            );
+        }
+
         $file = $data instanceof FileInfoInterface ? $data : $this->getFile($data);
 
         if ($file === null) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ImageValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ImageValueFactory.php
@@ -52,7 +52,7 @@ final class ImageValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!\is_string($data)) {
+        if (!\is_string($data) && !$data instanceof FileInfoInterface) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
@@ -47,7 +47,7 @@ final class MetricValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/NumberValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/NumberValueFactory.php
@@ -17,7 +17,7 @@ final class NumberValueFactory extends ScalarValueFactory implements ValueFactor
 {
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_scalar($data) || (is_string($data) && '' === trim($data))) {
+        if (!\is_scalar($data) || (\is_string($data) && '' === \trim($data))) {
             throw InvalidPropertyTypeException::numericExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionValueFactory.php
@@ -37,7 +37,7 @@ final class OptionValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
@@ -19,7 +19,7 @@ final class OptionsValueFactory implements ValueFactory
 {
     public function createWithoutCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        sort($data);
+        \sort($data);
         $attributeCode = $attribute->code();
 
         if ($attribute->isLocalizableAndScopable()) {
@@ -39,14 +39,14 @@ final class OptionsValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,
                 $data
             );
         }
-        
+
         try {
             Assert::allString($data);
         } catch (\Exception $exception) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/PriceCollectionValueFactory.php
@@ -46,7 +46,7 @@ final class PriceCollectionValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,
@@ -55,7 +55,7 @@ final class PriceCollectionValueFactory implements ValueFactory
         }
 
         foreach ($data as $price) {
-            if (!is_array($price)) {
+            if (!\is_array($price)) {
                 throw InvalidPropertyTypeException::arrayOfArraysExpected(
                     $attribute->code(),
                     static::class,
@@ -133,7 +133,7 @@ final class PriceCollectionValueFactory implements ValueFactory
             $currencies[] = $price['currency'];
         }
 
-        $sort = array_multisort($currencies, SORT_ASC, $amounts, SORT_ASC, $arrayPrices);
+        $sort = \array_multisort($currencies, SORT_ASC, $amounts, SORT_ASC, $arrayPrices);
 
         if (false === $sort) {
             throw new \LogicException(

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataCollectionValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataCollectionValueFactory.php
@@ -19,7 +19,7 @@ final class ReferenceDataCollectionValueFactory implements ValueFactory
 {
     public function createWithoutCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        $data = array_unique($data);
+        $data = \array_unique($data);
         $attributeCode = $attribute->code();
 
         if ($attribute->isLocalizableAndScopable()) {
@@ -39,7 +39,7 @@ final class ReferenceDataCollectionValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_array($data)) {
+        if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
                 static::class,
@@ -58,8 +58,8 @@ final class ReferenceDataCollectionValueFactory implements ValueFactory
             );
         }
 
-        $data = array_unique($data);
-        sort($data);
+        $data = \array_unique($data);
+        \sort($data);
 
         return $this->createWithoutCheckingData($attribute, $channelCode, $localeCode, $data);
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/ReferenceDataValueFactory.php
@@ -37,7 +37,7 @@ final class ReferenceDataValueFactory implements ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_string($data)) {
+        if (!\is_string($data)) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/TextAreaValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/TextAreaValueFactory.php
@@ -17,7 +17,7 @@ final class TextAreaValueFactory extends ScalarValueFactory implements ValueFact
 {
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_scalar($data) || (is_string($data) && '' === trim($data))) {
+        if (!\is_scalar($data) || (\is_string($data) && '' === \trim($data))) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/TextValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/TextValueFactory.php
@@ -17,7 +17,7 @@ final class TextValueFactory extends ScalarValueFactory implements ValueFactory
 {
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!is_scalar($data) || (is_string($data) && '' === trim($data))) {
+        if (!\is_scalar($data) || (\is_string($data) && '' === \trim($data))) {
             throw InvalidPropertyTypeException::stringExpected(
                 $attribute->code(),
                 static::class,

--- a/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ReadValueCollectionFactoryIntegration.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Factory\Read\ValueCollectionFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+class ReadValueCollectionFactoryIntegration extends TestCase
+{
+    /**
+     * @dataProvider matrix
+     */
+    public function test_if_product_values_with_wrong_attribute_type_are_skipped(string $attributeCode, $value, bool $isSkipped): void
+    {
+        $product = $this->createProductWithForcedAttributeValue($attributeCode, $value);
+        $rawValues = $product->getRawValues();
+
+        /** @var ValueCollectionFactory $readValueCollectionFactory */
+        $readValueCollectionFactory = $this->get('akeneo.pim.enrichment.factory.read_value_collection');
+        $readValueCollection = $readValueCollectionFactory->createFromStorageFormat($rawValues);
+
+        $this->assertEquals($isSkipped, !in_array($attributeCode, $readValueCollection->getAttributeCodes()));
+    }
+
+    public function matrix(): array
+    {
+        return [
+            ['a_text', 'some_text', false], // this attribute should not be skipped
+            ['a_price', 'some_text', true],
+            ['a_price', [
+                'unit' => 'SQUARE_METER',
+                'amount' => '10.0000',
+                'family' => 'Area',
+                'base_data' => '10',
+                'base_unit' => 'SQUARE_METER',
+            ], true],
+            ['a_metric', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
+            ['a_ref_data_multi_select', 'some_text', true],
+            ['a_multi_select', 'some_text', true],
+            ['a_file', 'some_text', true],
+            ['a_text', [
+                ['amount' => '10.00', 'currency' => 'EUR'],
+                ['amount' => null, 'currency' => 'USB'],
+            ], true],
+            ['a_date', '4/0/6/c/406ce8a9874d27ee425cc4dfeb37370df669e671_foo.txt', true],
+        ];
+    }
+
+    private function createProductWithForcedAttributeValue(string $attributeCode, $value): Product
+    {
+        /** @var Product $product */
+        $product = $this->get('pim_catalog.builder.product')->createProduct('my_product', 'familyA');
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $rawValues = $product->getRawValues();
+        $rawValues[$attributeCode] = [
+            '<all_channels>' => [
+                '<all_locales>' => $value,
+            ],
+        ];
+
+        $sql = <<<SQL
+UPDATE pim_catalog_product SET raw_values = :raw_values
+WHERE identifier = 'my_product';
+SQL;
+        $this->get('database_connection')->executeQuery($sql, [
+            'raw_values' => json_encode($rawValues),
+        ]);
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        /** @var Product $product */
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier('my_product');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfo;
+use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -35,13 +36,14 @@ final class FileValueFactorySpec extends ObjectBehavior
         $this->supportedAttributeType()->shouldReturn(AttributeTypes::FILE);
     }
 
-    public function it_does_not_support_null()
+    public function it_does_not_support_null(FileInfoRepositoryInterface $fileInfoRepository)
     {
+        $fileInfoRepository->findOneByIdentifier('foo')->willReturn(null);
         $this->shouldThrow(InvalidPropertyException::class)->during('createByCheckingData', [
             $this->getAttribute(true, true),
             'ecommerce',
             'fr_FR',
-            null
+            'foo'
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/FileValueFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfo;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -89,6 +90,12 @@ final class FileValueFactorySpec extends ObjectBehavior
         $attribute = $this->getAttribute(false, false);
         $value = $this->createWithoutCheckingData($attribute, null, null, 'a_file');
         $value->shouldBeLike(MediaValue::value('an_attribute', $fileInfo));
+    }
+
+    public function it_throws_an_exception_if_provided_data_is_not_a_string()
+    {
+        $attribute = $this->getAttribute(false, false);
+        $this->shouldThrow(InvalidPropertyTypeException::class)->during('createByCheckingData', [$attribute, null, null, ['an_array']]);
     }
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
@@ -90,6 +90,12 @@ final class ImageValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MediaValue::value('an_attribute', $fileInfo));
     }
 
+    public function it_throws_an_exception_if_provided_data_is_not_a_string()
+    {
+        $attribute = $this->getAttribute(false, false);
+        $this->shouldThrow(InvalidPropertyTypeException::class)->during('createByCheckingData', [$attribute, null, null, ['an_array']]);
+    }
+
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
         return new Attribute('an_attribute', AttributeTypes::IMAGE, [], $isLocalizable, $isScopable, null, false, 'file', []);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfo;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use PhpSpec\ObjectBehavior;
 
 /**

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/ImageValueFactorySpec.php
@@ -35,13 +35,14 @@ final class ImageValueFactorySpec extends ObjectBehavior
         $this->supportedAttributeType()->shouldReturn(AttributeTypes::IMAGE);
     }
 
-    public function it_does_not_support_null()
+    public function it_does_not_support_null(FileInfoRepositoryInterface $fileInfoRepository)
     {
+        $fileInfoRepository->findOneByIdentifier('foo')->willReturn(null);
         $this->shouldThrow(InvalidPropertyException::class)->during('createByCheckingData', [
             $this->getAttribute(true, true),
             'ecommerce',
             'fr_FR',
-            null
+            'foo'
         ]);
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

see https://github.com/akeneo/pim-community-dev/pull/13330 for the 3.2 version

Between 3.2 and 4.0, in `ReadValueCollectionFactory`, the implem of `createWithoutCheckingData` was added to improve the performances of the API.
Sadly, this allows fatal errors when an attribute is removed then re-created with the same code but another type.

After the benchmarks done by Steven and I, on a reference catalog (100 products with 120 attributes each), we found out that using `createByCheckingData` instead of `createWithoutCheckingData` effectively increase ReadValueCollectionFactory time by **+20%**.
This result in a time increase of **+8%** on the product API endpoint, when fetching 100 products.

Since most of those checks are done by calling a lot of php functions, like `is_string`, we also found out that prefixing those function by `\` slightly increase the perfs, and limit the overhead cost to **+5.5%**.

This is, in our opinion, an acceptable trade-off to resolve this critical error.
Also, **this fix will not be pulled on master**. On master, a proper fix, cleaning the data directly in the database, is currently developed.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
