### PR TITLE
CPM-54: handle multiple media files in product and product model export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@
 - Move `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\WritableDirectoryValidator` to `Akeneo\Tool\Component\StorageUtils\Validator\Constraints\WritableDirectoryValidator`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\CleanRemovedAttributesFromProductAndProductModelCommand` to
     - add `\Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
+- Change the `Oro\Bundle\PimDataGridBundle\Controller\ProductExportController` class to remove the `getRequest()` method
 - Change signature of `createInversedAssociation()` from `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface`
     - remove `AssociationInterface $association`
     - add `string $associationTypeCode` and `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface $associatedEntity`

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -387,6 +387,8 @@ pim_datagrid:
                 all_attributes: All attributes
                 with_codes: With codes
                 with_labels: With labels
+                without_media: Without media
+                with_media: With media
             flash:
                 message: "You can follow the progression of your export here."
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
@@ -375,6 +375,8 @@ pim_datagrid:
         all_attributes: Tous les attributs
         with_codes: Avec codes
         with_labels: Avec libellés
+        without_media: Sans image
+        with_media: Avec images
       flash:
         message: "Vous pouvez suivre l'avancement de votre export ici."
     mass_edit: Actions de masse

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -106,8 +106,8 @@ pim_import_export:
                         title: With header
                         help: Whether or not to print the column name
                     with_media:
-                        title: Export files and images
-                        help: Whether or not to export product files and images
+                        title: Export media
+                        help: Whether or not to export media
                     lines_per_file:
                         title: Number of lines per file
                         help: Define the limit number of lines per file

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -320,9 +320,16 @@ abstract class AbstractItemMediaWriter implements
                     if (is_dir($tmpDirectory . $exportDirectory)) {
                         $files = iterator_to_array($finder->files()->in($tmpDirectory . $exportDirectory));
                         if (!empty($files)) {
-                            $path = $exportDirectory . current($files)->getFilename();
-                            $this->writtenFiles[$tmpDirectory . $path] = $path;
-                            $item['values'][$attributeCode][$index]['data'] = $path;
+                            if (array_key_exists('paths', $value)) {
+                                foreach ($files as $file) {
+                                    $path = $exportDirectory . $file->getFilename();
+                                    $this->writtenFiles[$tmpDirectory . $path] = $path;
+                                }
+                            } else {
+                                $path = $exportDirectory . current($files)->getFilename();
+                                $this->writtenFiles[$tmpDirectory . $path] = $path;
+                                $item['values'][$attributeCode][$index]['data'] = $path;
+                            }
                         }
                     }
                 }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
@@ -142,6 +142,7 @@ define([
               launcher.action.route_parameters = {
                 ...launcher.action.route_parameters,
                 _withLabels: isProductGrid && 'with-labels' === formValue['with-labels'] ? 1 : 0,
+                _withMedia: isProductGrid && 'true' === formValue['with_media'] ? 1 : 0,
                 _fileLocale: UserContext.get('catalogLocale'),
               };
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/actions-panel.js
@@ -126,6 +126,7 @@ define([
           const isProductGrid = 'product-grid' === groupLaunchers[0]?.action.datagrid.name || false;
           const props = {
             showWithLabelsSelect: isProductGrid,
+            showWithMediaSelect: isProductGrid,
             onActionLaunch: formValue => {
               const actionName = `quick_export${'grid-context' === formValue['context'] ? `_grid_context` : ''}_${
                 formValue['type']

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -8,12 +8,14 @@ import {FileXlsxIcon, FileCsvIcon, Modal, Button, Title, SectionTitle} from 'ake
 
 type QuickExportConfiguratorProps = {
   showWithLabelsSelect: boolean;
+  showWithMediaSelect: boolean;
   onActionLaunch: (formValue: FormValue) => void;
   getProductCount: () => number;
 };
 
 const QuickExportConfigurator = ({
   showWithLabelsSelect,
+  showWithMediaSelect,
   onActionLaunch,
   getProductCount,
 }: QuickExportConfiguratorProps) => {
@@ -25,7 +27,7 @@ const QuickExportConfigurator = ({
   const readyToSubmit =
     undefined !== formValue.type &&
     undefined !== formValue.context &&
-    undefined !== formValue.with_media &&
+    (undefined !== formValue.with_media || !showWithMediaSelect) &&
     (undefined !== formValue['with-labels'] || !showWithLabelsSelect);
 
   return (
@@ -96,14 +98,19 @@ const QuickExportConfigurator = ({
               </Option>
             </Select>
           )}
-          <Select name="with_media">
-            <Option value="false" title={translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}>
-              {translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
-            </Option>
-            <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}>
-              {translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}
-            </Option>
-          </Select>
+          {showWithMediaSelect && (
+            <Select name="with_media">
+              <Option
+                value="false"
+                title={translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+              >
+                {translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+              </Option>
+              <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}>
+                {translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}
+              </Option>
+            </Select>
+          )}
         </Form>
       </Modal>
     </>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -23,8 +23,9 @@ const QuickExportConfigurator = ({
 
   const productCount = getProductCount();
   const readyToSubmit =
-    undefined !== formValue['type'] &&
-    undefined !== formValue['context'] &&
+    undefined !== formValue.type &&
+    undefined !== formValue.context &&
+    undefined !== formValue.with_media &&
     (undefined !== formValue['with-labels'] || !showWithLabelsSelect);
 
   return (
@@ -95,6 +96,14 @@ const QuickExportConfigurator = ({
               </Option>
             </Select>
           )}
+          <Select name="with_media">
+            <Option value="false" title={translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}>
+              {translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+            </Option>
+            <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}>
+              {translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}
+            </Option>
+          </Select>
         </Form>
       </Modal>
     </>

--- a/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
@@ -10,6 +10,7 @@ test('it displays a button and no modal initially', () => {
   const {getByTitle, queryByTitle} = renderWithProviders(
     <QuickExportConfigurator
       showWithLabelsSelect={true}
+      showWithMediaSelect={true}
       onActionLaunch={onActionLaunch}
       getProductCount={getProductCount}
     />
@@ -26,6 +27,7 @@ test('it does not call the action launch if an option is not set', () => {
   const {getByTitle} = renderWithProviders(
     <QuickExportConfigurator
       showWithLabelsSelect={true}
+      showWithMediaSelect={true}
       onActionLaunch={onActionLaunch}
       getProductCount={getProductCount}
     />
@@ -47,6 +49,7 @@ test('it does call the action launch if every option is set', () => {
   const {getByTitle, getByText} = renderWithProviders(
     <QuickExportConfigurator
       showWithLabelsSelect={true}
+      showWithMediaSelect={true}
       onActionLaunch={onActionLaunch}
       getProductCount={getProductCount}
     />
@@ -88,10 +91,27 @@ test('it does not display the with-labels select if specified', () => {
   const {queryByText} = renderWithProviders(
     <QuickExportConfigurator
       showWithLabelsSelect={false}
+      showWithMediaSelect={true}
       onActionLaunch={onActionLaunch}
       getProductCount={getProductCount}
     />
   );
 
   expect(queryByText('pim_datagrid.mass_action.quick_export.configurator.with_labels')).not.toBeInTheDocument();
+});
+
+test('it does not display the with-media select if specified', () => {
+  const onActionLaunch = jest.fn();
+  const getProductCount = jest.fn(() => 3);
+
+  const {queryByText} = renderWithProviders(
+    <QuickExportConfigurator
+      showWithLabelsSelect={true}
+      showWithMediaSelect={false}
+      onActionLaunch={onActionLaunch}
+      getProductCount={getProductCount}
+    />
+  );
+
+  expect(queryByText('pim_datagrid.mass_action.quick_export.configurator.with_media')).not.toBeInTheDocument();
 });

--- a/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/front/unit/QuickExportConfigurator.unit.tsx
@@ -56,17 +56,29 @@ test('it does call the action launch if every option is set', () => {
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.csv'));
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.grid_context'));
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.with_labels'));
+  fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.with_media'));
   fireEvent.click(getByTitle('pim_common.export'));
 
-  expect(onActionLaunch).toHaveBeenCalledWith({context: 'grid-context', type: 'csv', 'with-labels': 'with-labels'});
+  expect(onActionLaunch).toHaveBeenCalledWith({
+    context: 'grid-context',
+    type: 'csv',
+    'with-labels': 'with-labels',
+    'with_media': 'true',
+  });
 
   fireEvent.click(getByTitle('pim_datagrid.mass_action_group.quick_export.label'));
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.xlsx'));
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.all_attributes'));
   fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.with_codes'));
+  fireEvent.click(getByText('pim_datagrid.mass_action.quick_export.configurator.without_media'));
   fireEvent.click(getByTitle('pim_common.export'));
 
-  expect(onActionLaunch).toHaveBeenCalledWith({context: 'all-attributes', type: 'xlsx', 'with-labels': 'with-codes'});
+  expect(onActionLaunch).toHaveBeenCalledWith({
+    context: 'all-attributes',
+    type: 'xlsx',
+    'with-labels': 'with-codes',
+    'with_media': 'false',
+  });
 });
 
 test('it does not display the with-labels select if specified', () => {

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export.feature
@@ -34,6 +34,7 @@ Feature: Quick export many products from datagrid
     And I press the "CSV" button
     And I press the "All attributes" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "csv_product_quick_export" quick export to finish
     And I am on the dashboard page
@@ -61,6 +62,7 @@ Feature: Quick export many products from datagrid
     And I press the "XLSX" button
     And I press the "All attributes" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "xlsx_product_quick_export" quick export to finish
     And I am on the dashboard page

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
@@ -22,6 +22,7 @@ Feature: Quick export products according to the product grid context
     And I press the "XLSX" button
     And I press the "Grid context" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "xlsx_product_grid_context_quick_export" quick export to finish
     And I am on the dashboard page

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -17,6 +17,7 @@ Feature: Export products and product models
     And I press the "CSV" button
     And I press the "Grid context" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
@@ -32,6 +33,7 @@ Feature: Export products and product models
     And I press the "CSV" button
     And I press the "Grid context" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
@@ -49,6 +51,7 @@ Feature: Export products and product models
     And I press the "CSV" button
     And I press the "All attributes" button
     And I press the "With codes" button
+    And I press the "Without media" button
     And I press the "Export" button
     And I wait for the "csv_product_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_quick_export"

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
@@ -34,6 +34,7 @@ Feature: Quick export many products with localized attributes from datagrid
     And I press the "XLSX" button
     And I press the "Tous les attributs" button
     And I press the "Avec codes" button
+    And I press the "Avec images" button
     And I press the "Export" button
     And I wait for the "xlsx_product_quick_export" quick export to finish
     And I am on the dashboard page

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_media.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_media.feature
@@ -33,6 +33,7 @@ Feature: Quick export many products with media from datagrid
     And I press the "XLSX" button
     And I press the "All attributes" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "xlsx_product_quick_export" quick export to finish
     And I am on the dashboard page
@@ -58,6 +59,7 @@ Feature: Quick export many products with media from datagrid
     And I press the "CSV" button
     And I press the "Grid context" button
     And I press the "With codes" button
+    And I press the "With media" button
     And I press the "Export" button
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"


### PR DESCRIPTION
Change a little the behavior to handle asset files use case (https://github.com/akeneo/pim-enterprise-dev/pull/10009)
Not very proud of this but overriding this method in EE would be worse IMHO

When we export product/product model with asset files, we need to add all the files in the archive BUT we need to NOT replace the column values by the paths