### PR TITLE
PIM-9577: Remove empty 'Global settings' tab on XLSX import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - PIM-9569: Fix memory usage issue when adding a group to a product
 - PIM-9571: Fix missing items on the invalid data file when importing product models
 - PIM-9543: Print PDF content with Asian characters
+- PIM-9577: Remove empty 'Global settings' tab on following XLSX import: attribute, family, family variant, association type, attribute option, attribute group, group type
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -54,6 +54,7 @@ extensions:
         config:
             tabTitle: pim_enrich.export.product.global_settings.title
             tabCode: pim-job-instance-global
+            hideForCloudEdition: true
 
     pim-job-instance-xlsx-base-import-edit-history:
         module: pim/common/tab/history

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
@@ -12,7 +12,8 @@ define([
   'pim/template/export/common/edit/properties',
   'pim/common/tab',
   'pim/common/property',
-], function (_, __, template, BaseTab, propertyAccessor) {
+  'pim/edition',
+], function (_, __, template, BaseTab, propertyAccessor, pimEdition) {
   return BaseTab.extend({
     template: _.template(template),
     errors: {},
@@ -36,6 +37,7 @@ define([
       this.trigger('tab:register', {
         code: this.config.tabCode ? this.config.tabCode : this.code,
         label: __(this.config.tabTitle),
+        isVisible: () => !(this.config.hideForCloudEdition && pimEdition.isCloudEdition()),
       });
     },
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually, the General settings tab is empty on cloud environments on the following xlsx imports:
- attribute
- family
- family variant
- association type
- attribute option
- attribute group
- group type

This is due to the following lines :
https://github.com/akeneo/pim-community-dev/blob/97ef99631fc43e90d433acb90c8ec69e0d429c0f/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/field/allow-file-upload.ts#L6
https://github.com/akeneo/pim-community-dev/blob/97ef99631fc43e90d433acb90c8ec69e0d429c0f/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/field/file-path.ts#L6

In this PR, i added the possibility to hide an tab on cloud instance, and used it for simple xlsx import 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
