### PR TITLE
CXP-546: Clear cache after sending event to webhooks

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -1,11 +1,11 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Application\Webhook\Command;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionEventBuildLog;
 use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionSkipOwnEventLog;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookEventBuilder;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookUserAuthenticator;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookClient;
@@ -39,6 +39,7 @@ final class SendBusinessEventToWebhooksHandler
     private GetConnectionUserForFakeSubscription $connectionUserForFakeSubscription;
     private string $pimSource;
     private ?\Closure $getTimeCallable;
+    private CacheClearerInterface $cacheClearer;
 
     public function __construct(
         SelectActiveWebhooksQuery $selectActiveWebhooksQuery,
@@ -47,6 +48,7 @@ final class SendBusinessEventToWebhooksHandler
         WebhookEventBuilder $builder,
         LoggerInterface $logger,
         GetConnectionUserForFakeSubscription $connectionUserForFakeSubscription,
+        CacheClearerInterface $cacheClearer,
         string $pimSource,
         ?callable $getTimeCallable = null
     ) {
@@ -58,6 +60,7 @@ final class SendBusinessEventToWebhooksHandler
         $this->connectionUserForFakeSubscription = $connectionUserForFakeSubscription;
         $this->pimSource = $pimSource;
         $this->getTimeCallable = null !== $getTimeCallable ? \Closure::fromCallable($getTimeCallable) : null;
+        $this->cacheClearer = $cacheClearer;
     }
 
     public function handle(SendBusinessEventToWebhooksCommand $command): void
@@ -132,6 +135,8 @@ final class SendBusinessEventToWebhooksHandler
         } else {
             $this->client->bulkSend($requests());
         }
+
+        $this->cacheClearer->clear();
     }
 
     /**

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/CacheClearerInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/CacheClearerInterface.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CacheClearerInterface
+{
+    public function clear(): void;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -100,6 +100,7 @@ services:
             - '@akeneo_connectivity.connection.webhook.webhook_event_builder'
             - '@monolog.logger.event_api'
             - '@akeneo_connectivity.connection.persistence.query.get_connection_user_for_fake_subscription'
+            - '@akeneo_connectivity.connection.webhook.cache_clearer'
             - '%env(AKENEO_PIM_URL)%'
 
     akeneo_connectivity.connection.application.webhook.handler.update_connection_webhook:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -72,3 +72,5 @@ services:
     akeneo_connectivity.connection.webhook.generate_secret:
         class: Akeneo\Connectivity\Connection\Infrastructure\Webhook\GenerateSecret
 
+    akeneo_connectivity.connection.webhook.cache_clearer:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CacheClearer implements CacheClearerInterface
+{
+    public function clear(): void
+    {
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -7,6 +7,7 @@ namespace spec\Akeneo\Connectivity\Connection\Application\Webhook\Command;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler;
 use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionEventBuildLog;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookEventBuilder;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookUserAuthenticator;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookClient;
@@ -38,7 +39,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         WebhookUserAuthenticator $webhookUserAuthenticator,
         WebhookClient $client,
         WebhookEventBuilder $builder,
-        GetConnectionUserForFakeSubscription $connectionUserForFakeSubscription
+        GetConnectionUserForFakeSubscription $connectionUserForFakeSubscription,
+        CacheClearerInterface $cacheClearer
     ): void {
         $this->beConstructedWith(
             $selectActiveWebhooksQuery,
@@ -47,7 +49,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $builder,
             new NullLogger(),
             $connectionUserForFakeSubscription,
-            'staging.akeneo.com',
+            $cacheClearer,
+            'staging.akeneo.com'
         );
     }
 
@@ -60,7 +63,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder
+        $builder,
+        $cacheClearer
     ): void {
         $juliaUser = new User();
         $juliaUser->setId(0);
@@ -128,6 +132,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 }),
             )
             ->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->handle($command);
     }
@@ -137,7 +142,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $webhookUserAuthenticator,
         $client,
         $builder,
-        $connectionUserForFakeSubscription
+        $connectionUserForFakeSubscription,
+        $cacheClearer
     ): void {
         $julia = new User();
         $julia->setId(1234);
@@ -239,6 +245,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 }),
             )
             ->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->handle($command);
     }
@@ -247,7 +254,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder
+        $builder,
+        $cacheClearer
     ): void {
         $erpUser = new User();
         $erpUser->setId(42);
@@ -319,6 +327,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 }),
             )
             ->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->handle($command);
     }
@@ -327,7 +336,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder
+        $builder,
+        $cacheClearer
     ): void {
         $user = new User();
         $user->setId(0);
@@ -362,6 +372,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 }),
             )
             ->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $this->handle($command);
     }
@@ -372,6 +383,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $client,
         $builder,
         $connectionUserForFakeSubscription,
+        $cacheClearer,
         LoggerInterface $logger
     ): void {
         $getTimeIterable = (function () {
@@ -396,8 +408,9 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $builder,
             $logger,
             $connectionUserForFakeSubscription,
+            $cacheClearer,
             'staging.akeneo.com',
-            $getTimeCallable,
+            $getTimeCallable
         );
 
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
@@ -430,6 +443,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             iterator_to_array($iterable); // Call the iterator to run the code.
             return true;
         }))->shouldBeCalled();
+        $cacheClearer->clear()->shouldBeCalled();
 
         $command = new SendBusinessEventToWebhooksCommand($bulkEvent);
         $this->handle($command);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
+use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer;
+use PhpSpec\ObjectBehavior;
+
+class CacheClearerSpec extends ObjectBehavior
+{
+    public function it_is_a_cache_clearer(): void
+    {
+        $this->shouldHaveType(CacheClearer::class);
+        $this->shouldImplement(CacheClearerInterface::class);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Currently the consumer daemon is restarted regularly to invalidate any cache on permissions or structure. This PR aims to clear cache from services that are used during the process of sending events to webhooks.
<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
