### PR TITLE
PIM-9513: Fix the use of an unexisting filter on the API so that it does not return an error 500

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9513: Fix the use of an unexisting filter on the API so that it does not return an error 500
+
 # 4.0.76 (2020-12-02)
 
 # 4.0.75 (2020-11-27)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -82,8 +82,7 @@ final class ApplyProductSearchQueryParametersToPQB
                         $value = $values;
                     } elseif (!in_array($filter['operator'], [Operators::SINCE_LAST_N_DAYS, Operators::SINCE_LAST_JOB])) {
                         //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
-                        $value = strval($value);
-                        $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
+                        $value = \DateTime::createFromFormat('Y-m-d H:i:s', strval($value));
                     }
                 }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -82,6 +82,7 @@ final class ApplyProductSearchQueryParametersToPQB
                         $value = $values;
                     } elseif (!in_array($filter['operator'], [Operators::SINCE_LAST_N_DAYS, Operators::SINCE_LAST_JOB])) {
                         //PIM-7541 Create the date with the server timezone configuration. Do not force it to UTC timezone.
+                        $value = strval($value);
                         $value = \DateTime::createFromFormat('Y-m-d H:i:s', $value);
                     }
                 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

If I used this filter, I got a 500 (the "2" isn't in quote) :
`{{url}}/api/rest/v1/products?search={"updated": [{"operator": "SINCE LAST N HOURS","value": 2}]`

When I used this filter, I got a 422, that is expected (the "2" is in quote) :
({{url}}/api/rest/v1/products?search={"updated": [{"operator": "SINCE LAST N HOURS","value": "2"}]}

_NOTE: using "SINCE LAST N DAYS" filter works both with an int or a string (2 or "2")_

**Solution:**
The 500 error was raised because the function createFromFormat() expects a parameter to be string, int was given.
So, I converted $value to string.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
