### PR TITLE
PIM-9586: [Backport PIM-9571] Fix missing items on the invalid data file when importing product models

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,7 @@
 # 4.0.x
 
+- PIM-9586: [Backport] PIM-9571 Fix missing items on the invalid data file when importing product models
+
 # 4.0.76 (2020-12-02)
 
 # 4.0.75 (2020-11-27)

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/InvalidItemsCollector.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/InvalidItemsCollector.php
@@ -4,6 +4,7 @@ namespace Akeneo\Tool\Bundle\ConnectorBundle\EventListener;
 
 use Akeneo\Tool\Component\Batch\Event\EventInterface;
 use Akeneo\Tool\Component\Batch\Event\InvalidItemEvent;
+use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -35,7 +36,9 @@ class InvalidItemsCollector implements EventSubscriberInterface
      */
     public function collect(InvalidItemEvent $event)
     {
-        $this->invalidItems[$this->getHashKey($event->getItem()->getInvalidData())] = $event->getItem();
+        $invalidItem = $event->getItem();
+        $itemData = $invalidItem instanceof FileInvalidItem ? ['position' => $invalidItem->getItemPosition()] : $invalidItem->getInvalidData();
+        $this->invalidItems[$this->getHashKey($itemData)] = $event->getItem();
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/InvalidItemsCollectorSpec.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/InvalidItemsCollectorSpec.php
@@ -4,6 +4,7 @@ namespace spec\Akeneo\Tool\Bundle\ConnectorBundle\EventListener;
 
 use Akeneo\Tool\Component\Batch\Event\EventInterface;
 use Akeneo\Tool\Component\Batch\Event\InvalidItemEvent;
+use Akeneo\Tool\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\FileInvalidItem;
 use PhpSpec\ObjectBehavior;
 
@@ -23,7 +24,7 @@ class InvalidItemsCollectorSpec extends ObjectBehavior
         );
     }
 
-    function it_collects_invalid_items_from_event(InvalidItemEvent $event, FileInvalidItem $invalidItem)
+    function it_collects_invalid_items_from_event(InvalidItemEvent $event, DataInvalidItem $invalidItem)
     {
         $item = [
             'sku'        => 'sku-001',
@@ -45,9 +46,9 @@ class InvalidItemsCollectorSpec extends ObjectBehavior
         InvalidItemEvent $event1,
         InvalidItemEvent $event2,
         InvalidItemEvent $event3,
-        FileInvalidItem $invalidItem1,
-        FileInvalidItem $invalidItem2,
-        FileInvalidItem $invalidItem3
+        DataInvalidItem $invalidItem1,
+        DataInvalidItem $invalidItem2,
+        DataInvalidItem $invalidItem3
     ) {
         $item1 = [
             'sku'        => 'sku-001',
@@ -91,16 +92,10 @@ class InvalidItemsCollectorSpec extends ObjectBehavior
         InvalidItemEvent $event,
         FileInvalidItem $invalidItem
     ) {
-        $item = [
-            'sku'        => 'sku-001',
-            'name_en-us' => 'Black shoes',
-            'name_fr-fr' => 'Chaussures noires',
-        ];
 
         $event->getItem()->willReturn($invalidItem);
-        $invalidItem->getInvalidData()->willReturn($item);
-
-        $hashKeyItem = md5(serialize($item));
+        $invalidItem->getItemPosition()->willReturn(3);
+        $hashKeyItem = md5(serialize(['position' => 3]));
 
         $this->collect($event);
         $this->getInvalidItems()->shouldReturn([$hashKeyItem => $invalidItem]);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

PR master => https://github.com/akeneo/pim-community-dev/pull/13377

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
