### PR TITLE
CXP-582: Clear cache after sending events to webhooks

### DIFF
--- a/src/Akeneo/Channel/Bundle/Doctrine/Query/FindActivatedCurrencies.php
+++ b/src/Akeneo/Channel/Bundle/Doctrine/Query/FindActivatedCurrencies.php
@@ -15,15 +15,9 @@ use Doctrine\ORM\EntityManagerInterface;
  */
 class FindActivatedCurrencies implements FindActivatedCurrenciesInterface
 {
-    /** @var array */
-    private $activatedCurrenciesForChannels = [];
+    private array $activatedCurrenciesForChannels = [];
+    private EntityManagerInterface $entityManager;
 
-    /** @var EntityManagerInterface */
-    private $entityManager;
-
-    /**
-     * @param EntityManagerInterface $entityManager
-     */
     public function __construct(EntityManagerInterface $entityManager)
     {
         $this->entityManager = $entityManager;
@@ -59,6 +53,11 @@ class FindActivatedCurrencies implements FindActivatedCurrenciesInterface
         }
 
         return array_unique(array_merge(...array_values($this->activatedCurrenciesForChannels)));
+    }
+
+    public function clearCache(): void
+    {
+        $this->activatedCurrenciesForChannels = [];
     }
 
     /**

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -74,3 +74,8 @@ services:
 
     akeneo_connectivity.connection.webhook.cache_clearer:
         class: Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer
+        arguments:
+            - '@pim_channel.query.cache.channel_exists_with_locale'
+            - '@pim_catalog.query.find_activated_currencies'
+            - '@pim_connector.doctrine.cache_clearer'
+            - '@akeneo.pim.structure.query.get_attributes'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
@@ -3,7 +3,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
 
+use Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies;
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
+use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
 
 /**
  * @author    Willy Mesnage <willy.mesnage@akeneo.com>
@@ -12,7 +16,28 @@ use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInter
  */
 class CacheClearer implements CacheClearerInterface
 {
+    private ChannelExistsWithLocaleInterface $channelExistsWithLocale;
+    private FindActivatedCurrencies $findActivatedCurrencies;
+    private UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer;
+    private LRUCachedGetAttributes $LRUCachedGetAttributes;
+
+    public function __construct(
+        ChannelExistsWithLocaleInterface $channelExistsWithLocale,
+        FindActivatedCurrencies $findActivatedCurrencies,
+        UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
+        LRUCachedGetAttributes $LRUCachedGetAttributes
+    ) {
+        $this->channelExistsWithLocale = $channelExistsWithLocale;
+        $this->findActivatedCurrencies = $findActivatedCurrencies;
+        $this->unitOfWorkAndRepositoriesClearer = $unitOfWorkAndRepositoriesClearer;
+        $this->LRUCachedGetAttributes = $LRUCachedGetAttributes;
+    }
+
     public function clear(): void
     {
+        $this->channelExistsWithLocale->clearCache();
+        $this->findActivatedCurrencies->clearCache();
+        $this->unitOfWorkAndRepositoriesClearer->clear();
+        $this->LRUCachedGetAttributes->clearCache();
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
@@ -3,15 +3,47 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
 
+use Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies;
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer;
+use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
 use PhpSpec\ObjectBehavior;
 
 class CacheClearerSpec extends ObjectBehavior
 {
+    public function let(
+        ChannelExistsWithLocaleInterface $channelExistsWithLocale,
+        FindActivatedCurrencies $findActivatedCurrencies,
+        UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
+        GetAttributes $getAttributes
+    ): void {
+        $LRUCachedGetAttributes = new LRUCachedGetAttributes($getAttributes->getWrappedObject());
+        $this->beConstructedWith(
+            $channelExistsWithLocale,
+            $findActivatedCurrencies,
+            $unitOfWorkAndRepositoriesClearer,
+            $LRUCachedGetAttributes
+        );
+    }
+
     public function it_is_a_cache_clearer(): void
     {
         $this->shouldHaveType(CacheClearer::class);
         $this->shouldImplement(CacheClearerInterface::class);
+    }
+
+    public function it_clears_the_cache(
+        $channelExistsWithLocale,
+        $findActivatedCurrencies,
+        $unitOfWorkAndRepositoriesClearer
+    ): void {
+        $channelExistsWithLocale->clearCache()->shouldBeCalled();
+        $findActivatedCurrencies->clearCache()->shouldBeCalled();
+        $unitOfWorkAndRepositoriesClearer->clear()->shouldBeCalled();
+
+        $this->clear();
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
@@ -55,4 +55,9 @@ final class LRUCachedGetAttributes implements GetAttributes
 
         return $this->cache->getForKey($attributeCode, $fetchNonFoundAttributeCodes);
     }
+
+    public function clearCache(): void
+    {
+        $this->cache = new LRUCache(1000);
+    }
 }

--- a/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributesSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributesSpec.php
@@ -61,4 +61,14 @@ final class LRUCachedGetAttributesSpec extends ObjectBehavior
         $getAttributes->forCodes(array_keys($attributes))->willReturn(array_values($attributes));
         $this->forCodes(array_keys($attributes))->shouldReturn(array_values($attributes));
     }
+
+    public function it_clears_the_cache(GetAttributes $getAttributes) {
+        $aText = new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []);
+        $getAttributes->forCodes(['a_text'])->willReturn(['a_text' => $aText]);
+        $getAttributes->forCodes(['a_text'])->shouldBeCalledTimes(2);
+
+        $this->forCodes(['a_text'])->shouldReturn(['a_text' => $aText]);
+        $this->clearCache();
+        $this->forCodes(['a_text'])->shouldReturn(['a_text' => $aText]);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Currently the consumer daemon is restarted regularly to invalidate any cache on permissions or structure. This PR aims to clear cache from services that are used during the process of sending events to webhooks.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | y
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
