### PR TITLE
PIM-9592: fix month to seconds conversion

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,7 @@
 
 - PIM-9513: Fix the use of an unexisting filter on the API so that it does not return an error 500
 - PIM-9586: [Backport] PIM-9571 Fix missing items on the invalid data file when importing product models
+- PIM-9592: Fix month to seconds conversion
 
 # 4.0.76 (2020-12-02)
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -318,7 +318,7 @@ measures_config:
                 convert: [{'mul': '604800'}]
                 symbol: week
             MONTH:
-                convert: [{'mul': '18748800'}]
+                convert: [{'mul': '2628000'}]
                 symbol: month
             YEAR:
                 convert: [{'mul': '31536000'}]


### PR DESCRIPTION
Fix https://akeneo.atlassian.net/browse/PIM-9592

1 day = 60 * 60 * 24 = 86400 seconds
1 year = 86400 * 365 = 31536000 seconds
1 month = 31536000 / 12 = **2628000** seconds