### PR TITLE
CXP-598: store count of events api request per minute

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/InstallSubscriber.php
@@ -6,6 +6,7 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Install;
 
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionAuditErrorTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionAuditTableQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionEventsApiRequestCountTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateWrongCredentialsCombinationQuery;
 use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
@@ -21,8 +22,8 @@ class InstallSubscriber implements EventSubscriberInterface
 {
     const ICECAT_DEMO_DEV = 'icecat_demo_dev';
 
-    private $dbalConnection;
-    private $fixturesLoader;
+    private DbalConnection $dbalConnection;
+    private FixturesLoader $fixturesLoader;
 
     public function __construct(DbalConnection $dbalConnection, FixturesLoader $fixturesLoader)
     {
@@ -44,6 +45,7 @@ class InstallSubscriber implements EventSubscriberInterface
         $this->dbalConnection->exec(CreateConnectionAuditTableQuery::QUERY);
         $this->dbalConnection->exec(CreateWrongCredentialsCombinationQuery::QUERY);
         $this->dbalConnection->exec(CreateConnectionAuditErrorTableQuery::QUERY);
+        $this->dbalConnection->exec(CreateConnectionEventsApiRequestCountTableQuery::QUERY);
     }
 
     public function loadFixtures(InstallerEvent $installerEvent): void

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateConnectionEventsApiRequestCountTableQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateConnectionEventsApiRequestCountTableQuery.php
@@ -13,10 +13,10 @@ final class CreateConnectionEventsApiRequestCountTableQuery
 {
     const QUERY = <<<SQL
 CREATE TABLE IF NOT EXISTS akeneo_connectivity_connection_events_api_request_count(
-    minute INT NOT NULL,
-    count INT NOT NULL,
+    event_minute INT NOT NULL,
+    event_count INT NOT NULL,
     updated DATETIME NOT NULL,
-    PRIMARY KEY (minute)
+    PRIMARY KEY (event_minute)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
 SQL;
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateConnectionEventsApiRequestCountTableQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateConnectionEventsApiRequestCountTableQuery.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Install\Query;
+
+/**
+ * @author Pierre Jolly <pierre.jolly@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class CreateConnectionEventsApiRequestCountTableQuery
+{
+    const QUERY = <<<SQL
+CREATE TABLE IF NOT EXISTS akeneo_connectivity_connection_events_api_request_count(
+    minute INT NOT NULL,
+    count INT NOT NULL,
+    updated DATETIME NOT NULL,
+    PRIMARY KEY (minute)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+SQL;
+}

--- a/upgrades/schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table.php
+++ b/upgrades/schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @author Pierre Jolly <pierre.jolly@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class Version_5_0_20201207171120_create_connection_events_api_request_count_table extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS akeneo_connectivity_connection_events_api_request_count(
+    minute INT NOT NULL,
+    count INT NOT NULL,
+    updated DATETIME NOT NULL,
+    PRIMARY KEY (minute)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+SQL;
+
+        $this->addSql($sql);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table.php
+++ b/upgrades/schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table.php
@@ -18,10 +18,10 @@ final class Version_5_0_20201207171120_create_connection_events_api_request_coun
     {
         $sql = <<<SQL
 CREATE TABLE IF NOT EXISTS akeneo_connectivity_connection_events_api_request_count(
-    minute INT NOT NULL,
-    count INT NOT NULL,
+    event_minute INT NOT NULL,
+    event_count INT NOT NULL,
     updated DATETIME NOT NULL,
-    PRIMARY KEY (minute)
+    PRIMARY KEY (event_minute)
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
 SQL;
 

--- a/upgrades/test_schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table_Integration.php
@@ -29,8 +29,8 @@ class Version_5_0_20201207171120_create_connection_events_api_request_count_tabl
 
         Assert::assertTrue($this->schemaManager->tablesExist('akeneo_connectivity_connection_events_api_request_count'));
         $expectedColumnsAndTypes = [
-            'minute' => 'integer',
-            'count' => 'integer',
+            'event_minute' => 'integer',
+            'event_count' => 'integer',
             'updated' => 'datetime',
         ];
 

--- a/upgrades/test_schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20201207171120_create_connection_events_api_request_count_table_Integration.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_5_0_20201207171120_create_connection_events_api_request_count_table_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private Connection $dbalConnection;
+    private AbstractSchemaManager $schemaManager;
+
+    private const MIGRATION_LABEL = '_5_0_20201207171120_create_connection_events_api_request_count_table';
+
+    public function test_it_creates_the_audit_error_table(): void
+    {
+        $this->dbalConnection->executeQuery('DROP TABLE IF EXISTS akeneo_connectivity_connection_events_api_request_count');
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->schemaManager->tablesExist('akeneo_connectivity_connection_events_api_request_count'));
+        $expectedColumnsAndTypes = [
+            'minute' => 'integer',
+            'count' => 'integer',
+            'updated' => 'datetime',
+        ];
+
+        $tableColumns = $this->schemaManager->listTableColumns('akeneo_connectivity_connection_events_api_request_count');
+        $this->assertCount(count($expectedColumnsAndTypes), $tableColumns);
+
+        $actualColumnsAndTypes = [];
+        foreach ($tableColumns as $actualColumn) {
+            $actualColumnsAndTypes[$actualColumn->getName()] =  $actualColumn->getType()->getName();
+        }
+        Assert::assertEquals($expectedColumnsAndTypes, $actualColumnsAndTypes);
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbalConnection = $this->get('database_connection');
+        $this->schemaManager  = $this->dbalConnection->getSchemaManager();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

We want to be able to implement a “rate limiting” on the Events API.
Rate limiting would be “per hour”.

- dbtable
    - akeneo_connectivity_connection_events_api_request_count
        - minute (int)
        - count (int)
        - updated (datetime)

- migration (+ migration test) + installer

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
