### PR TITLE
CPM-96: Set default values when creating a product or product model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,8 +232,9 @@
 - Move `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\WritableDirectory` to `Akeneo\Tool\Component\StorageUtils\Validator\Constraints\WritableDirectory`
 - Move `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\WritableDirectoryValidator` to `Akeneo\Tool\Component\StorageUtils\Validator\Constraints\WritableDirectoryValidator`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\CleanRemovedAttributesFromProductAndProductModelCommand` to
-    - add `\Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
-    
+    - add `\Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`    
+- Move `Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface` to `Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface`
+
 ### CLI commands
 
 The following CLI commands have been deleted:

--- a/src/Akeneo/Channel/Bundle/Query/Sql/SqlGetChannelCodeWithLocaleCodes.php
+++ b/src/Akeneo/Channel/Bundle/Query/Sql/SqlGetChannelCodeWithLocaleCodes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Bundle\Query\Sql;
 
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Doctrine\DBAL\Connection;
 
 /**

--- a/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Component\Query\PublicApi\Cache;
 
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>

--- a/src/Akeneo/Channel/Component/Query/PublicApi/GetChannelCodeWithLocaleCodesInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/GetChannelCodeWithLocaleCodesInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Channel\Component\Query;
+namespace Akeneo\Channel\Component\Query\PublicApi;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -14,6 +14,7 @@ $rules = [
         'Symfony\Component',
         'Symfony\Bundle',
         'Akeneo\Tool',
+        'Akeneo\Channel\Component\Query\PublicApi',
         'Akeneo\Pim\Enrichment\Component',
         'Akeneo\Pim\Structure\Component\Query\PublicApi',
         'Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent',

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues;
 
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
@@ -94,9 +94,7 @@ class AddDefaultValuesSubscriber implements EventSubscriberInterface
             fn (AttributeInterface $attribute): string => $attribute->getCode()
         )->toArray();
 
-        return empty($attributeCodesWithDefaultValues) ?
-            [] :
-            $this->getAttributes->forCodes($attributeCodesWithDefaultValues);
+        return $this->getAttributes->forCodes($attributeCodesWithDefaultValues);
     }
 
     private function addValues(EntityWithFamilyVariantInterface $entity, Attribute $attribute): void

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriber.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues;
+
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Adds default values (defined at attribute level) for products and product models
+ */
+class AddDefaultValuesSubscriber implements EventSubscriberInterface
+{
+    private GetAttributes $getAttributes;
+    private ValueFactory $valueFactory;
+    private GetChannelCodeWithLocaleCodesInterface $getChannelWithLocales;
+
+    private ?array $cachedChannelsAndLocales = null;
+
+    public function __construct(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        GetChannelCodeWithLocaleCodesInterface $getChannelWithLocales
+    ) {
+        $this->getAttributes = $getAttributes;
+        $this->valueFactory = $valueFactory;
+        $this->getChannelWithLocales = $getChannelWithLocales;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_SAVE => ['addDefaultValues', 100],
+        ];
+    }
+
+    public function addDefaultValues(GenericEvent $event)
+    {
+        $entity = $event->getSubject();
+
+        if (!$entity instanceof EntityWithFamilyInterface) {
+            return;
+        }
+        if (!$event->hasArgument('is_new') || true !== $event->getArgument('is_new')) {
+            return;
+        }
+        if ($event->hasArgument('add_default_values') && false === $event->getArgument('add_default_values')) {
+            return;
+        }
+
+        $attributesWithDefaultValue = $this->getAttributesWithDefaultValues($entity);
+        foreach ($attributesWithDefaultValue as $attribute) {
+            $this->addValues($entity, $attribute);
+        }
+    }
+
+    /**
+     * Returns all the attributes with a default_value property for a given entity:
+     * - for a simple product, the attribute must be part of the family
+     * - for a variant product or product model, the attribute must be part of the matching variant attribute set
+     *
+     * @param EntityWithFamilyVariantInterface $entity
+     *
+     * @return Attribute[]
+     */
+    private function getAttributesWithDefaultValues(EntityWithFamilyVariantInterface $entity): array
+    {
+        $attributes = new ArrayCollection();
+        if (null !== $entity->getFamilyVariant()) {
+            $level = $entity->getVariationLevel();
+            $attributes = 0 === $level ?
+                $entity->getFamilyVariant()->getCommonAttributes() :
+                $entity->getFamilyVariant()->getVariantAttributeSet($level)->getAttributes();
+        } elseif (null !== $entity->getFamily()) {
+            $attributes = $entity->getFamily()->getAttributes();
+        }
+
+        $attributeCodesWithDefaultValues = $attributes->filter(
+            fn (AttributeInterface $attribute): bool => null !== $attribute->getProperty('default_value')
+        )->map(
+            fn (AttributeInterface $attribute): string => $attribute->getCode()
+        )->toArray();
+
+        return empty($attributeCodesWithDefaultValues) ?
+            [] :
+            $this->getAttributes->forCodes($attributeCodesWithDefaultValues);
+    }
+
+    private function addValues(EntityWithFamilyVariantInterface $entity, Attribute $attribute): void
+    {
+        $defaultValue = $attribute->properties()['default_value'];
+
+        if ($attribute->isScopable() && $attribute->isLocalizable()) {
+            foreach ($this->getChannelCodesWithLocaleCodes() as $channelCode => $localeCodes) {
+                foreach ($localeCodes as $localeCode) {
+                    if ($attribute->isLocaleSpecific() && !\in_array($localeCode, $attribute->availableLocaleCodes())) {
+                        continue;
+                    }
+                    $entity->addValue(
+                        $this->valueFactory->createByCheckingData($attribute, $channelCode, $localeCode, $defaultValue)
+                    );
+                }
+            }
+        } elseif ($attribute->isScopable()) {
+            foreach ($this->getChannelCodes() as $channelCode) {
+                $entity->addValue(
+                    $this->valueFactory->createByCheckingData($attribute, $channelCode, null, $defaultValue)
+                );
+            }
+        } elseif ($attribute->isLocalizable()) {
+            foreach ($this->getAllActiveLocaleCodes() as $localeCode) {
+                if ($attribute->isLocaleSpecific() && !\in_array($localeCode, $attribute->availableLocaleCodes())) {
+                    continue;
+                }
+                $entity->addValue(
+                    $this->valueFactory->createByCheckingData($attribute, null, $localeCode, $defaultValue)
+                );
+            }
+        } else {
+            $entity->addValue($this->valueFactory->createByCheckingData($attribute, null, null, $defaultValue));
+        }
+    }
+
+    private function getChannelCodesWithLocaleCodes(): array
+    {
+        $this->initializeChannelsAndLocales();
+
+        return $this->cachedChannelsAndLocales;
+    }
+
+    private function getAllActiveLocaleCodes(): array
+    {
+        $this->initializeChannelsAndLocales();
+
+        return array_values(array_unique(array_merge(...array_values($this->cachedChannelsAndLocales))));
+    }
+
+    private function getChannelCodes(): array
+    {
+        $this->initializeChannelsAndLocales();
+
+        return array_keys($this->cachedChannelsAndLocales);
+    }
+
+    private function initializeChannelsAndLocales(): void
+    {
+        if (null === $this->cachedChannelsAndLocales) {
+            $this->cachedChannelsAndLocales = [];
+            $channelsAndLocales = $this->getChannelWithLocales->findAll();
+            foreach ($channelsAndLocales as $item) {
+                $this->cachedChannelsAndLocales[$item['channelCode']] = $item['localeCodes'];
+            }
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -214,3 +214,11 @@ services:
             - '%webhook_max_bulk_size%'
         tags:
             - { name: kernel.event_subscriber }
+
+    Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues\AddDefaultValuesSubscriber:
+        arguments:
+            - '@akeneo.pim.structure.query.get_attributes'
+            - '@akeneo.pim.enrichment.factory.value'
+            - '@pim_channel.query.sql.get_channel_code_with_locale_codes'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/tests/back/Acceptance/Channel/InMemoryGetChannelCodeWithLocaleCodes.php
+++ b/tests/back/Acceptance/Channel/InMemoryGetChannelCodeWithLocaleCodes.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Test\Acceptance\Channel;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>

--- a/tests/back/Acceptance/spec/Channel/InMemoryGetChannelCodeWithLocaleCodesSpec.php
+++ b/tests/back/Acceptance/spec/Channel/InMemoryGetChannelCodeWithLocaleCodesSpec.php
@@ -6,7 +6,7 @@ namespace spec\Akeneo\Test\Acceptance\Channel;
 
 use Akeneo\Channel\Component\Model\Channel;
 use Akeneo\Channel\Component\Model\Locale;
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Test\Acceptance\Channel\InMemoryChannelRepository;
 use Akeneo\Test\Acceptance\Channel\InMemoryGetChannelCodeWithLocaleCodes;
 use PhpSpec\ObjectBehavior;

--- a/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Channel\Component\Query\PublicApi\Cache;
 
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Channel\Component\Query\PublicApi\Cache\CachedChannelExistsWithLocale;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use PhpSpec\ObjectBehavior;

--- a/tests/back/Pim/Enrichment/Integration/Product/CreateEntityWithDefaultValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/CreateEntityWithDefaultValuesIntegration.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CreateEntityWithDefaultValuesIntegration extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_sets_the_default_boolean_values_of_a_new_simple_product()
+    {
+        $product = $this->createProduct('new_product', ['family' => 'familyA']);
+        Assert::assertNull($product->getValue('a_yes_no_with_default_value'));
+
+        $product = $this->saveProduct($product);
+
+        $value = $product->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(true, $value->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_default_values_on_a_new_root_product_model()
+    {
+        $productModel = $this->createProductModel([
+            'code' => 'root',
+            'parent' => null,
+            'family_variant' => 'familyVariantA1',
+        ]);
+        Assert::assertNull($productModel->getValue('a_yes_no_with_default_value'));
+
+        $productModel = $this->saveProductModel($productModel);
+        $value = $productModel->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(true, $value->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_default_values_on_a_new_sub_product_model()
+    {
+        // move the 'a_yes_no_with_default_value' attribute to level 1 (= sub product model level)
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('familyVariantA1');
+        $attributeSet = $familyVariant->getVariantAttributeSet(1);
+        $attributeSet->addAttribute(
+            $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_yes_no_with_default_value')
+        );
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        $root = $this->createProductModel(
+            [
+                'code' => 'root',
+                'parent' => null,
+                'family_variant' => 'familyVariantA1',
+            ]
+        );
+        Assert::assertNull($root->getValue('a_yes_no_with_default_value'));
+        $root = $this->saveProductModel($root);
+        Assert::assertNull($root->getValue('a_yes_no_with_default_value'));
+
+        $sub = $this->createProductModel([
+            'code' => 'sub',
+            'family_variant' => 'familyVariantA1',
+            'parent' => 'root',
+            'values' => [
+                'a_simple_select' => [['data' => 'optionA', 'scope' => null, 'locale' => null]],
+            ],
+        ]);
+        Assert::assertNull($sub->getValue('a_yes_no_with_default_value'));
+        $sub = $this->saveProductModel($sub);
+
+        $value = $sub->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(true, $value->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_the_default_values_on_a_new_variant_product()
+    {
+        // move the 'a_yes_no_with_default_value' attribute to level 1 (= variant product level)
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('familyVariantA2');
+        $attributeSet = $familyVariant->getVariantAttributeSet(1);
+        $attributeSet->addAttribute(
+            $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_yes_no_with_default_value')
+        );
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        $productModel = $this->createProductModel(
+            [
+                'code' => 'root',
+                'parent' => null,
+                'family_variant' => 'familyVariantA2',
+            ]
+        );
+        Assert::assertNull($productModel->getValue('a_yes_no_with_default_value'));
+        $productModel = $this->saveProductModel($productModel);
+        Assert::assertNull($productModel->getValue('a_yes_no_with_default_value'));
+
+        $variantProduct = $this->createProduct('variant', [
+            'family' => 'familyA',
+            'parent' => 'root',
+            'values' => [
+                'a_simple_select' => [['data' => 'optionA', 'locale' => null, 'scope' => null]],
+                'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]],
+            ]
+        ]);
+        Assert::assertNull($variantProduct->getValue('a_yes_no_with_default_value'));
+        $variantProduct = $this->saveProduct($variantProduct);
+
+        $value = $variantProduct->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(true, $value->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_override_already_defined_values()
+    {
+        $product = $this->createProduct('new_product', [
+            'family' => 'familyA',
+            'values' => [
+                'a_yes_no_with_default_value' => [['data' => false, 'locale' => null, 'scope' => null]],
+            ]
+        ]);
+        $value = $product->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(false, $value->getData());
+
+        $product = $this->saveProduct($product);
+        $value = $product->getValue('a_yes_no_with_default_value');
+        Assert::assertInstanceOf(ValueInterface::class, $value);
+        Assert::assertSame(false, $value->getData());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_set_default_values_on_update()
+    {
+        $product = $this->createProduct('updated', []);
+        $product = $this->saveProduct($product);
+        // no family, so the default value is not set
+        Assert::assertNull($product->getValue('a_yes_no_with_default_value'));
+
+        $this->get('pim_catalog.updater.product')->update($product, ['family' => 'familyA']);
+        $product = $this->saveProduct($product);
+        // this is an update, so the default values are not set
+        Assert::assertNull($product->getValue('a_yes_no_with_default_value'));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $attribute = $this->createAttribute([
+            'code' => 'a_yes_no_with_default_value',
+            'type' => 'pim_catalog_boolean',
+            'group' => 'attributeGroupA',
+            'default_value' => true,
+        ]);
+        $family = $this->get('pim_catalog.repository.family')->findOneByIdentifier('familyA');
+        $family->addAttribute($attribute);
+        $this->get('pim_catalog.saver.family')->save($family);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function createAttribute(array $data): AttributeInterface
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+
+        $violations = $this->get('validator')->validate($attribute);
+        Assert::assertEmpty($violations);
+
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+
+        return $attribute;
+    }
+
+    private function createProduct(string $identifier, array $data): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+
+        return $product;
+    }
+
+    private function createProductModel(array $data): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+
+        return $productModel;
+    }
+
+    private function saveProduct(ProductInterface $product): ProductInterface
+    {
+        $violations = $this->get('pim_catalog.validator.product')->validate($product);
+        Assert::assertCount(0, $violations, \sprintf('The product has validation errors: %s', $violations));
+        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        $this->get('pim_catalog.validator.unique_value_set')->reset();
+
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($product->getIdentifier());
+    }
+
+    private function saveProductModel(ProductModelInterface $productModel): ProductModelInterface
+    {
+        $violations = $this->get('pim_catalog.validator.product_model')->validate($productModel);
+        Assert::assertCount(0, $violations, \sprintf('The product model has validation errors: %s', $violations));
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        return $this->get('pim_catalog.repository.product_model')->findOneByIdentifier($productModel->getIdentifier());
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriberSpec.php
@@ -2,7 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues;
 
-use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues\AddDefaultValuesSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
@@ -91,11 +91,14 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
     }
 
     function it_does_nothing_if_the_entity_has_no_family(
+        GetAttributes $getAttributes,
         ValueFactory $valueFactory,
         EntityWithFamilyVariantInterface $entity
     ) {
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn(null);
+
+        $getAttributes->forCodes([])->shouldBeCalled()->willReturn([]);
 
         $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
         $entity->addValue(Argument::any())->shouldNotBeCalled();
@@ -106,6 +109,7 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
     }
 
     function it_does_nothing_if_the_entity_has_no_attributes_with_default_values(
+        GetAttributes $getAttributes,
         ValueFactory $valueFactory,
         EntityWithFamilyVariantInterface $entity,
         FamilyInterface $family,
@@ -119,6 +123,8 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         );
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
+
+        $getAttributes->forCodes([])->shouldBeCalled()->willReturn([]);
 
         $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
         $entity->addValue(Argument::any())->shouldNotBeCalled();
@@ -141,7 +147,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 
@@ -155,10 +160,10 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         );
     }
 
-    function it_adds_default_values_to_a_variant_product(
+    function it_adds_default_values_to_a_variant_product_or_sub_product_model(
         GetAttributes $getAttributes,
         ValueFactory $valueFactory,
-        ProductModelInterface $product,
+        EntityWithFamilyVariantInterface $entity,
         ValueInterface $value,
         VariantAttributeSetInterface $variantAttributeSet,
         FamilyVariantInterface $familyVariant,
@@ -167,18 +172,17 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $autofocus->getCode()->willReturn('autofocus');
         $autofocus->getProperty('default_value')->willReturn(true);
         $variantAttributeSet->getAttributes()->willReturn(new ArrayCollection([$autofocus->getWrappedObject()]));
-        $familyVariant->getVariantAttributeSet(2)->willReturn($variantAttributeSet);
-        $product->getFamilyVariant()->willReturn($familyVariant);
-        $product->getVariationLevel()->willReturn(2);
-        $product->getId()->willReturn(null);
+        $familyVariant->getVariantAttributeSet(1)->willReturn($variantAttributeSet);
+        $entity->getFamilyVariant()->willReturn($familyVariant);
+        $entity->getVariationLevel()->willReturn(1);
 
         $attribute = $this->createAttributeWithDefaultValue('autofocus', true);
         $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
         $valueFactory->createByCheckingData($attribute, null, null, true)->shouldBeCalled()->willReturn($value);
-        $product->addValue($value)->shouldBeCalled();
+        $entity->addValue($value)->shouldBeCalled();
 
         $this->addDefaultValues(
-            new GenericEvent($product->getWrappedObject(), ['is_new' => true])
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
         );
     }
 
@@ -197,7 +201,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         );
         $productModel->getFamilyVariant()->willReturn($familyVariant);
         $productModel->getVariationLevel()->willReturn(0);
-        $productModel->getId()->willReturn(null);
 
         $attribute = $this->createAttributeWithDefaultValue('autofocus', true);
         $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
@@ -223,7 +226,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 
@@ -257,7 +259,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 
@@ -295,7 +296,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 
@@ -336,7 +336,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 
@@ -379,7 +378,6 @@ class AddDefaultValuesSubscriberSpec extends ObjectBehavior
         $family->getAttributes()->willReturn(
             new ArrayCollection([$autofocus->getWrappedObject(), $colorScanning->getWrappedObject()])
         );
-        $entity->getId()->willReturn(null);
         $entity->getFamilyVariant()->willReturn(null);
         $entity->getFamily()->willReturn($family);
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/EntityWithValues/AddDefaultValuesSubscriberSpec.php
@@ -1,0 +1,430 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues;
+
+use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\EntityWithValues\AddDefaultValuesSubscriber;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\ValueFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyVariantInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\CommonAttributeCollection;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Pim\Structure\Component\Model\VariantAttributeSetInterface;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class AddDefaultValuesSubscriberSpec extends ObjectBehavior
+{
+    function let(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        GetChannelCodeWithLocaleCodesInterface $getChannelWithLocales
+    ) {
+        $getChannelWithLocales->findAll()->willReturn(
+            [
+                [
+                    'channelCode' => 'ecommerce',
+                    'localeCodes' => ['en_US', 'de_DE'],
+                ],
+                [
+                    'channelCode' => 'mobile',
+                    'localeCodes' => ['en_US', 'fr_FR'],
+                ],
+            ]
+        );
+        $this->beConstructedWith($getAttributes, $valueFactory, $getChannelWithLocales);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AddDefaultValuesSubscriber::class);
+    }
+
+    function it_subscribes_to_pre_save_events()
+    {
+        $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::PRE_SAVE);
+    }
+
+    function it_does_nothing_if_the_entity_is_not_an_entity_with_family_variant(ValueFactory $valueFactory)
+    {
+        $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent(new \stdClass(), ['is_new' => true])
+        );
+    }
+
+    function it_does_nothing_if_the_entity_is_not_new(ValueFactory $valueFactory, EntityWithFamilyVariantInterface $product)
+    {
+        $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+        $product->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($product->getWrappedObject())
+        );
+    }
+
+    function it_does_nothing_if_the_add_default_values_option_is_false(
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity
+    ) {
+        $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+        $entity->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true, 'add_default_values' => false])
+        );
+    }
+
+    function it_does_nothing_if_the_entity_has_no_family(
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity
+    ) {
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn(null);
+
+        $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+        $entity->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_does_nothing_if_the_entity_has_no_attributes_with_default_values(
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        FamilyInterface $family,
+        AttributeInterface $sku,
+        AttributeInterface $name
+    ) {
+        $sku->getProperty('default_value')->willReturn(null);
+        $name->getProperty('default_value')->willReturn(null);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$sku->getWrappedObject(), $name->getWrappedObject()])
+        );
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $valueFactory->createByCheckingData(Argument::cetera())->shouldNotBeCalled();
+        $entity->addValue(Argument::any())->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_to_a_simple_product(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $value,
+        FamilyInterface $family,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+        $valueFactory->createByCheckingData($attribute, null, null, true)->shouldBeCalled()->willReturn($value);
+        $entity->addValue($value)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_to_a_variant_product(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        ProductModelInterface $product,
+        ValueInterface $value,
+        VariantAttributeSetInterface $variantAttributeSet,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $variantAttributeSet->getAttributes()->willReturn(new ArrayCollection([$autofocus->getWrappedObject()]));
+        $familyVariant->getVariantAttributeSet(2)->willReturn($variantAttributeSet);
+        $product->getFamilyVariant()->willReturn($familyVariant);
+        $product->getVariationLevel()->willReturn(2);
+        $product->getId()->willReturn(null);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+        $valueFactory->createByCheckingData($attribute, null, null, true)->shouldBeCalled()->willReturn($value);
+        $product->addValue($value)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($product->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_to_a_root_product_model(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        ProductModelInterface $productModel,
+        ValueInterface $value,
+        FamilyVariantInterface $familyVariant,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $familyVariant->getCommonAttributes()->willReturn(
+            new CommonAttributeCollection([$autofocus->getWrappedObject()])
+        );
+        $productModel->getFamilyVariant()->willReturn($familyVariant);
+        $productModel->getVariationLevel()->willReturn(0);
+        $productModel->getId()->willReturn(null);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+        $valueFactory->createByCheckingData($attribute, null, null, true)->shouldBeCalled()->willReturn($value);
+        $productModel->addValue($value)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($productModel->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_for_a_scopable_attribute(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $ecommerceValue,
+        ValueInterface $mobileValue,
+        FamilyInterface $family,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true, false, true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+
+        $valueFactory->createByCheckingData($attribute, 'ecommerce', null, true)
+                     ->shouldBeCalled()->willReturn($ecommerceValue);
+        $entity->addValue($ecommerceValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'mobile', null, true)
+                     ->shouldBeCalled()->willReturn($mobileValue);
+        $entity->addValue($mobileValue)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_for_a_localizable_attribute(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $enUSValue,
+        ValueInterface $frFRValue,
+        ValueInterface $deDEValue,
+        FamilyInterface $family,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true, true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+
+        $valueFactory->createByCheckingData($attribute, null, 'en_US', true)
+                     ->shouldBeCalled()->willReturn($enUSValue);
+        $entity->addValue($enUSValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, null, 'de_DE', true)
+                     ->shouldBeCalled()->willReturn($deDEValue);
+        $entity->addValue($deDEValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, null, 'fr_FR', true)
+                     ->shouldBeCalled()->willReturn($frFRValue);
+        $entity->addValue($frFRValue)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_for_a_scopable_and_localizable_attribute(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $ecommerceEnUSValue,
+        ValueInterface $ecommerceDeDEValue,
+        ValueInterface $mobileEnUSalue,
+        ValueInterface $mobileFrFRValue,
+        FamilyInterface $family,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true, true, true);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+
+        $valueFactory->createByCheckingData($attribute, 'ecommerce', 'en_US', true)->shouldBeCalled()->willReturn(
+            $ecommerceEnUSValue
+        );
+        $entity->addValue($ecommerceEnUSValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'ecommerce', 'de_DE', true)
+                     ->shouldBeCalled()->willReturn($ecommerceDeDEValue);
+        $entity->addValue($ecommerceDeDEValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'mobile', 'en_US', true)
+                     ->shouldBeCalled()->willReturn($mobileEnUSalue);
+        $entity->addValue($mobileEnUSalue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'mobile', 'fr_FR', true)
+                     ->shouldBeCalled()->willReturn($mobileFrFRValue);
+        $entity->addValue($mobileFrFRValue)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_default_values_for_a_locale_specific_attribute(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $ecommerceEnUSValue,
+        ValueInterface $mobileEnUSalue,
+        ValueInterface $mobileFrFRValue,
+        FamilyInterface $family,
+        AttributeInterface $autofocus
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $attribute = $this->createAttributeWithDefaultValue('autofocus', true, true, true, ['en_US', 'fr_FR']);
+        $getAttributes->forCodes(['autofocus'])->shouldBeCalled()->willReturn(['autofocus' => $attribute]);
+
+        $valueFactory->createByCheckingData($attribute, 'ecommerce', 'en_US', true)
+                     ->shouldBeCalled()->willReturn($ecommerceEnUSValue);
+        $entity->addValue($ecommerceEnUSValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'mobile', 'en_US', true)
+                     ->shouldBeCalled()->willReturn($mobileEnUSalue);
+        $entity->addValue($mobileEnUSalue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($attribute, 'mobile', 'fr_FR', true)
+                     ->shouldBeCalled()->willReturn($mobileFrFRValue);
+        $entity->addValue($mobileFrFRValue)->shouldBeCalled();
+
+        $valueFactory->createByCheckingData($attribute, 'ecommerce', 'de_DE', true)->shouldNotBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    function it_adds_values_for_several_attributes_with_default_values(
+        GetAttributes $getAttributes,
+        ValueFactory $valueFactory,
+        EntityWithFamilyVariantInterface $entity,
+        ValueInterface $autoFocusValue,
+        ValueInterface $colorScanningEcommerceValue,
+        ValueInterface $colorScanningMobileValue,
+        FamilyInterface $family,
+        AttributeInterface $autofocus,
+        AttributeInterface $colorScanning
+    ) {
+        $autofocus->getCode()->willReturn('autofocus');
+        $autofocus->getProperty('default_value')->willReturn(true);
+        $colorScanning->getCode()->willReturn('color_scanning');
+        $colorScanning->getProperty('default_value')->willReturn(false);
+
+        $family->getAttributes()->willReturn(
+            new ArrayCollection([$autofocus->getWrappedObject(), $colorScanning->getWrappedObject()])
+        );
+        $entity->getId()->willReturn(null);
+        $entity->getFamilyVariant()->willReturn(null);
+        $entity->getFamily()->willReturn($family);
+
+        $readAutofocus = $this->createAttributeWithDefaultValue('autofocus', true);
+        $readColorScanning = $this->createAttributeWithDefaultValue('color_scanning', false, false, true);
+        $getAttributes->forCodes(['autofocus', 'color_scanning'])->shouldBeCalled()->willReturn(
+            [
+                'autofocus' => $readAutofocus,
+                'color_scanning' => $readColorScanning,
+            ]
+        );
+
+        $valueFactory->createByCheckingData($readAutofocus, null, null, true)
+                     ->shouldBeCalled()->willReturn($autoFocusValue);
+        $entity->addValue($autoFocusValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($readColorScanning, 'ecommerce', null, false)
+                     ->shouldBeCalled()->willReturn($colorScanningEcommerceValue);
+        $entity->addValue($colorScanningEcommerceValue)->shouldBeCalled();
+        $valueFactory->createByCheckingData($readColorScanning, 'mobile', null, false)
+                     ->shouldBeCalled()->willReturn($colorScanningMobileValue);
+        $entity->addValue($colorScanningMobileValue)->shouldBeCalled();
+
+        $this->addDefaultValues(
+            new GenericEvent($entity->getWrappedObject(), ['is_new' => true])
+        );
+    }
+
+    private function createAttributeWithDefaultValue(
+        string $code,
+        bool $defaultValue,
+        bool $isLocalizable = false,
+        bool $isScopable = false,
+        array $availableLocaleCodes = []
+    ): Attribute {
+        return new Attribute(
+            $code,
+            'pim_catalog_boolean',
+            ['default_value' => $defaultValue],
+            $isLocalizable,
+            $isScopable,
+            null,
+            null,
+            null,
+            'bool',
+            $availableLocaleCodes
+        );
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Given a boolean attribute with a `default_value`, this PR adds the default value at product / product model creation. Any existing value for this attribute will not be overridden.

I chose to implement it in a PRE_SAVE subscriber; this has pros and cons:

**pros**
- we are positive that the event is triggered when persisting a product or model, as the product(model)saver is the only mandatory service called (for instance we don't have to use the ProductUpdater, even if we do it 99% of the time)
- most entities related to the product (attributes, family...) are already loaded in the UnitOfWork at that point, so in a vast majority of the cases it should not trigger any additional SQL query

**cons**
- the product is updated after validation (and is not re-validated). I couldn't find a use case where adding a boolean value could break the validation
- the event subscriber must be executed before ComputeRawValuesEventSubscriber, therefore it must have a high priority. It might indicate that the computation of raw values should be directly executed in the saver instead of in an event subscriber.
- sometimes we don't want to add the default values. This is the case for product duplication, and for published products. I had to create an option that is passed to the subscriber in order to handle such cases (see the EE PR). I'm not very happy with that, but I wasn't able to find a cleaner way

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
