### PR TITLE
Make ProductModel::setCode() respect fluent interface

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -110,12 +110,14 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode(string $code): void
+    public function setCode(string $code): ProductModelInterface
     {
         if ($code !== $this->code) {
             $this->code = $code;
             $this->dirty = true;
         }
+        
+        return $this;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
@@ -44,7 +44,7 @@ interface ProductModelInterface extends
      *
      * @param string $code
      */
-    public function setCode(string $code): void;
+    public function setCode(string $code): ProductModelInterface;
 
     /**
      * Gets the products of the product model.


### PR DESCRIPTION
... like other setters. Because it's annoying.