### PR TITLE
PIM-9596: Fix attribute options manual sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - PIM-9577: Remove empty 'Global settings' tab on following XLSX import: attribute, family, family variant, association type, attribute option, attribute group, group type
 - PIM-9590: Fix "Default product grid view" multiple times on user settings page
 - CPM-86: Fix undefined tab on job profile edit
+- PIM-9596: Fix attribute options manual sorting
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Component/Manager/AttributeOptionsSorter.php
+++ b/src/Akeneo/Pim/Structure/Component/Manager/AttributeOptionsSorter.php
@@ -48,6 +48,6 @@ class AttributeOptionsSorter
             $options[$key] = $option;
         }
 
-        $this->optionSaver->saveAll($$options);
+        $this->optionSaver->saveAll($options);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Manager/AttributeOptionsSorterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Manager/AttributeOptionsSorterSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Structure\Component\Manager;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOption;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use PhpSpec\ObjectBehavior;
+
+class AttributeOptionsSorterSpec extends ObjectBehavior
+{
+    public function let(BulkSaverInterface $optionSaver)
+    {
+        $this->beConstructedWith($optionSaver);
+    }
+
+    public function it_sorts_options(
+        AttributeInterface $attribute,
+        AttributeOption $size,
+        AttributeOption $width,
+        $optionSaver
+    ) {
+        $size->getId()->willReturn(45);
+        $siteValue = (new AttributeOptionValue())->setLocale('en_US')->setValue('big');
+        $size->addOptionValue($siteValue);
+
+        $width->getId()->willReturn(18);
+        $widthValue = (new AttributeOptionValue())->setLocale('en_US')->setValue('wide');
+        $width->addOptionValue($widthValue);
+
+        $attribute->getOptions()->willReturn([$size, $width]);
+
+        $size->setSortOrder(2)->shouldBeCalled();
+        $width->setSortOrder(1)->shouldBeCalled();
+
+        $optionSaver->saveAll([0 => $size, 1 => $width])->shouldBeCalled();
+
+        $this->updateSorting($attribute, [18 => 1, 45 => 2]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
A typo was introduced during a fix for PHP Stan that prevented the attribute options to be manually sorted. There was no unit test on this code so we didn't see the error. I added one in this PR.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
