### PR TITLE
RAC-394: Remove job insert from subscriber and add it in fixtures

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/InitDeletedAttributeSchemaSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/InitDeletedAttributeSchemaSubscriber.php
@@ -9,9 +9,9 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * The table used to store blacklisted attributes to avoid recreation before the cleanup job is finished
+ * The table used to store blacklisted attributes to avoid recreation before the cleanup job is finished.
  *
- * We need to manually create the table and insert the new job instance.
+ * We need to manually create the table.
  */
 class InitDeletedAttributeSchemaSubscriber implements EventSubscriberInterface
 {
@@ -26,7 +26,6 @@ class InitDeletedAttributeSchemaSubscriber implements EventSubscriberInterface
     {
         return [
             InstallerEvents::POST_DB_CREATE => 'createBlacklistTable',
-            InstallerEvents::POST_LOAD_FIXTURES => 'addJobInstance'
         ];
     }
 
@@ -42,23 +41,5 @@ CREATE TABLE IF NOT EXISTS pim_catalog_attribute_blacklist (
 SQL;
 
         $this->connection->exec($createTableSql);
-    }
-
-    public function addJobInstance(): void
-    {
-        $insertSql = <<<SQL
-INSERT INTO akeneo_batch_job_instance (code, label, job_name, status, connector, raw_parameters, type)
-VALUES (:code, :label, :job_name, :status, :connector, :raw_parameters, :type);
-SQL;
-
-        $this->connection->executeUpdate($insertSql, [
-            'code'           => 'clean_removed_attribute_job',
-            'label'          => 'Clean the removed attribute values in products and product models',
-            'job_name'       => 'clean_removed_attribute_job',
-            'status'         => 0,
-            'connector'      => 'internal',
-            'raw_parameters' => 'a:0:{}',
-            'type'           => 'clean_removed_attribute_job',
-        ]);
     }
 }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -716,3 +716,8 @@ jobs:
         alias:     remove_non_existing_product_values
         label:     Remove non existing product values
         type:      remove_non_existing_product_values
+    clean_removed_attribute_job:
+        connector: internal
+        alias:     clean_removed_attribute_job
+        label:     Clean removed attribute job
+        type:      clean_removed_attribute_job

--- a/tests/legacy/features/Context/catalog/apparel/jobs.yml
+++ b/tests/legacy/features/Context/catalog/apparel/jobs.yml
@@ -346,3 +346,8 @@ jobs:
         alias:     remove_non_existing_product_values
         label:     Remove non existing product values
         type:      remove_non_existing_product_values
+    clean_removed_attribute_job:
+        connector: internal
+        alias:     clean_removed_attribute_job
+        label:     Clean removed attribute job
+        type:      clean_removed_attribute_job

--- a/tests/legacy/features/Context/catalog/default/jobs.yml
+++ b/tests/legacy/features/Context/catalog/default/jobs.yml
@@ -131,3 +131,8 @@ jobs:
         alias:     remove_non_existing_product_values
         label:     Remove non existing product values
         type:      remove_non_existing_product_values
+    clean_removed_attribute_job:
+        connector: internal
+        alias:     clean_removed_attribute_job
+        label:     Clean removed attribute job
+        type:      clean_removed_attribute_job

--- a/tests/legacy/features/Context/catalog/footwear/jobs.yml
+++ b/tests/legacy/features/Context/catalog/footwear/jobs.yml
@@ -578,3 +578,8 @@ jobs:
         alias:     remove_non_existing_product_values
         label:     Remove non existing product values
         type:      remove_non_existing_product_values
+    clean_removed_attribute_job:
+        connector: internal
+        alias:     clean_removed_attribute_job
+        label:     Clean removed attribute job
+        type:      clean_removed_attribute_job


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Removing the job db insert on the POST_LOAD_FIXTURES event and adding it instead in each catalog fixtures

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
