### PR TITLE
RAC-428: Add event and naive switch of subscriber

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
@@ -47,8 +48,8 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
     public function createAndDispatchProductEvents(GenericEvent $postSaveEvent): void
     {
         /** @var ProductInterface */
-        $product = $postSaveEvent->getSubject();
-        if (false === $product instanceof ProductInterface) {
+        $productIdentifier = $postSaveEvent->getSubject();
+        if (false === $productIdentifier instanceof SavedProductIdentifier) {
             return;
         }
 
@@ -58,7 +59,7 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
 
         $author = Author::fromUser($user);
         $data = [
-            'identifier' => $product->getIdentifier(),
+            'identifier' => $productIdentifier->getIdentifier(),
         ];
 
         $event = null;

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
@@ -45,9 +46,9 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
 
     public function createAndDispatchProductEvents(GenericEvent $postSaveEvent): void
     {
-        /** @var ProductInterface */
-        $product = $postSaveEvent->getSubject();
-        if (false === $product instanceof ProductInterface) {
+        /** @var SavedProductIdentifier */
+        $productIdentifier = $postSaveEvent->getSubject();
+        if (false === $productIdentifier instanceof SavedProductIdentifier) {
             return;
         }
 
@@ -57,8 +58,9 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
 
         $author = Author::fromUser($user);
         $data = [
-            'identifier' => $product->getIdentifier(),
-            'category_codes' => $product->getCategoryCodes(),
+            'identifier' => $productIdentifier->getIdentifier(),
+            // TODO RAC-428
+            // 'category_codes' => $productIdentifier->getCategoryCodes(),
         ];
 
         $event = new ProductRemoved($author, $data);

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnSave/ComputeProductsAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnSave/ComputeProductsAndAncestorsSubscriber.php
@@ -6,6 +6,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Product\OnSave;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifier;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifierCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -54,32 +56,12 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
 
     public function handleMultipleProducts(GenericEvent $event): void
     {
-        $products = $event->getSubject();
-        if (!is_array($products)) {
+        $productIdentifiers = $event->getSubject();
+        if (false === $productIdentifiers instanceof SavedProductIdentifierCollection) {
             return;
         }
 
-        $products = array_filter(
-            $products,
-            function ($product): bool {
-                return $product instanceof ProductInterface
-                    // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
-                    && get_class($product) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProduct';
-            }
-        );
-
-        $productIdentifiers = array_map(
-            function (ProductInterface $product): string {
-                return $product->getIdentifier();
-            },
-            $products
-        );
-
-        if (empty($productIdentifiers)) {
-            return;
-        }
-
-        $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($productIdentifiers);
-        $this->productAndAncestorsIndexer->indexFromProductIdentifiers($productIdentifiers);
+        $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($productIdentifiers->getIdentifiers());
+        $this->productAndAncestorsIndexer->indexFromProductIdentifiers($productIdentifiers->getIdentifiers());
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/RemoveValuesFromProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/RemoveValuesFromProducts.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Product;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifier;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifierCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
@@ -62,12 +64,10 @@ class RemoveValuesFromProducts
 
     private function dispatchProductSaveEvents(array $productIdentifiers): void
     {
-        $products = $this->productRepository->findBy(['identifier' => $productIdentifiers]);
-
-        foreach ($products as $product) {
+        foreach ($productIdentifiers as $productIdentifier) {
             $this->eventDispatcher->dispatch(
                 StorageEvents::POST_SAVE,
-                new GenericEvent($product, [
+                new GenericEvent(SavedProductIdentifier::fromIdentifier($productIdentifier), [
                     'unitary' => false,
                 ])
             );
@@ -75,7 +75,7 @@ class RemoveValuesFromProducts
 
         $this->eventDispatcher->dispatch(
             StorageEvents::POST_SAVE_ALL,
-            new GenericEvent($products, [
+            new GenericEvent(SavedProductIdentifierCollection::fromIdentifiers($productIdentifiers), [
                 'unitary' => false,
             ])
         );

--- a/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/EventListener/StructureVersionUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/EventListener/StructureVersionUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Enrichment\Bundle\StructureVersion\EventListener;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Event\SavedProductIdentifier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
@@ -50,7 +51,7 @@ class StructureVersionUpdater implements EventSubscriberInterface
             return;
         }
 
-        if ($subject instanceof ProductInterface || $subject instanceof ProductModelInterface) {
+        if ($subject instanceof SavedProductIdentifier || $subject instanceof ProductModelInterface) {
             return;
         }
 
@@ -67,7 +68,7 @@ class StructureVersionUpdater implements EventSubscriberInterface
             return;
         }
 
-        if ($subject instanceof ProductInterface || $subject instanceof ProductModelInterface) {
+        if ($subject instanceof SavedProductIdentifier || $subject instanceof ProductModelInterface) {
             return;
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/Event/SavedProductIdentifier.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/Event/SavedProductIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Model\Event;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+
+class SavedProductIdentifier
+{
+    private string $identifier;
+
+    private function __construct(string $identifier)
+    {
+        $this->identifier = $identifier;
+    }
+
+    public static function fromProduct(ProductInterface $product): SavedProductIdentifier
+    {
+        return new SavedProductIdentifier($product->getIdentifier());
+    }
+
+    public static function fromIdentifier(string $productIdentifier): SavedProductIdentifier
+    {
+        return new SavedProductIdentifier($productIdentifier);
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/Event/SavedProductIdentifierCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/Event/SavedProductIdentifierCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Model\Event;
+
+class SavedProductIdentifierCollection
+{
+    private array $identifiers;
+
+    private function __construct(array $identifiers)
+    {
+        $this->identifiers = $identifiers;
+    }
+
+    public static function fromProducts(array $products): SavedProductIdentifierCollection
+    {
+        return new SavedProductIdentifierCollection(array_map(fn ($product) =>  $product->getIdentifier(), $products));
+    }
+
+    public static function fromIdentifiers(array $productIdentifiers): SavedProductIdentifierCollection
+    {
+        return new SavedProductIdentifierCollection($productIdentifiers);
+    }
+
+    public function getIdentifiers(): array
+    {
+        return $this->identifiers;
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

This PR is to POC a more performant way to clean product after attribute deletion. To do so, we don't dispatch POST_SAVE_ALL events with hydrated products but only their identifiers. Here are the results:

Before: https://blackfire.io/profiles/bc994e52-ffc8-4d21-abce-4e4211b38098/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()
After: https://blackfire.io/profiles/77e68fda-235b-423d-8fba-87a0411ac7e5/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=Akeneo%5CPim%5CEnrichment%5CBundle%5CStorage%5CSql%5CElasticsearchProjection%5CGetElasticsearchProductProjection%3A%3AfromProductIdentifiers&callname=main()

With blackfire on, we have
With products: 15s
With identifiers: 10s

So the performance gain is roughly 30% which we think is not enough to justify this huge change.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
