### PR TITLE
PIM-9585: Display the product models codes on the warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@
   you should now use `$product->addCategory($category)` to achieve it)  
 - CXP-544: Do not save product models when they were not actually updated. As for products, the product model
   will now return copies of its collections (values, categories and associations)
+- PIM-9585: Display the product models codes on the warnings
 
 # Technical Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -102,7 +102,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
             return null;
         }
 
-        if (!isset($standardProductModel['code'])) {
+        if (empty($code)) {
             $this->skipItemWithMessage($standardProductModel, 'The code must be filled');
         }
 
@@ -127,14 +127,15 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
             }
         }
 
+        if (null !== $code) {
+            $standardProductModel['code'] = $code;
+        }
+
         if (isset($standardProductModel['values'])) {
             try {
                 $standardProductModel['values'] = $this->mediaStorer->store($standardProductModel['values']);
             } catch (InvalidPropertyException $e) {
                 $this->objectDetacher->detach($productModel);
-                if (null !== $code) {
-                    $standardProductModel['code'] = $code;
-                }
                 $this->skipItemWithMessage($standardProductModel, $e->getMessage(), $e);
             }
         }
@@ -144,9 +145,6 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         } catch (PropertyException $exception) {
             $this->objectDetacher->detach($productModel);
             $message = sprintf('%s: %s', $exception->getPropertyName(), $exception->getMessage());
-            if (null !== $code) {
-                $standardProductModel['code'] = $code;
-            }
             $this->skipItemWithMessage($standardProductModel, $message, $exception);
         }
 
@@ -154,9 +152,6 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
 
         if ($violations->count() > 0) {
             $this->objectDetacher->detach($productModel);
-            if (null !== $code) {
-                $standardProductModel['code'] = $code;
-            }
             $this->skipItemWithConstraintViolations($standardProductModel, $violations);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -102,7 +102,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
             return null;
         }
 
-        if (empty($code)) {
+        if (!isset($standardProductModel['code'])) {
             $this->skipItemWithMessage($standardProductModel, 'The code must be filled');
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -132,6 +132,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
                 $standardProductModel['values'] = $this->mediaStorer->store($standardProductModel['values']);
             } catch (InvalidPropertyException $e) {
                 $this->objectDetacher->detach($productModel);
+                $standardProductModel['code'] = $code;
                 $this->skipItemWithMessage($standardProductModel, $e->getMessage(), $e);
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -141,6 +141,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         } catch (PropertyException $exception) {
             $this->objectDetacher->detach($productModel);
             $message = sprintf('%s: %s', $exception->getPropertyName(), $exception->getMessage());
+            $standardProductModel['code'] = $code;
             $this->skipItemWithMessage($standardProductModel, $message, $exception);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -125,9 +125,8 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
 
                 return null;
             }
-        }
 
-        if (null !== $code) {
+            // The code was removed by productModelFilter, we need to be sure it's still there for the next checks
             $standardProductModel['code'] = $code;
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -93,6 +93,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
     public function process($standardProductModel): ?ProductModelInterface
     {
         $code = $standardProductModel['code'] ?? null;
+        $values = $standardProductModel['values'] ?? null;
         $parent = $standardProductModel['parent'] ?? '';
         if ($this->importType === self::ROOT_PRODUCT_MODEL && !empty($parent) ||
             $this->importType === self::SUB_PRODUCT_MODEL && empty($parent)
@@ -126,8 +127,9 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
                 return null;
             }
 
-            // The code was removed by productModelFilter, we need to be sure it's still there for the next checks
+            // The code and the values were removed by productModelFilter, we need to be sure it's still there for the next checks
             $standardProductModel['code'] = $code;
+            $standardProductModel['values'] = $values;
         }
 
         if (isset($standardProductModel['values'])) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -168,7 +168,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      *
      * @return ProductModelInterface
      */
-    public function findOrCreateProductModel(string $code): ProductModelInterface
+    private function findOrCreateProductModel(string $code): ProductModelInterface
     {
         $productModel = $this->productModelRepository->findOneByIdentifier($code);
         if (null === $productModel) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -92,7 +92,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      */
     public function process($standardProductModel): ?ProductModelInterface
     {
-        $code = $standardProductModel['code'];
+        $code = $standardProductModel['code'] ?? null;
         $parent = $standardProductModel['parent'] ?? '';
         if ($this->importType === self::ROOT_PRODUCT_MODEL && !empty($parent) ||
             $this->importType === self::SUB_PRODUCT_MODEL && empty($parent)
@@ -132,7 +132,9 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
                 $standardProductModel['values'] = $this->mediaStorer->store($standardProductModel['values']);
             } catch (InvalidPropertyException $e) {
                 $this->objectDetacher->detach($productModel);
-                $standardProductModel['code'] = $code;
+                if (null !== $code) {
+                    $standardProductModel['code'] = $code;
+                }
                 $this->skipItemWithMessage($standardProductModel, $e->getMessage(), $e);
             }
         }
@@ -142,7 +144,9 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
         } catch (PropertyException $exception) {
             $this->objectDetacher->detach($productModel);
             $message = sprintf('%s: %s', $exception->getPropertyName(), $exception->getMessage());
-            $standardProductModel['code'] = $code;
+            if (null !== $code) {
+                $standardProductModel['code'] = $code;
+            }
             $this->skipItemWithMessage($standardProductModel, $message, $exception);
         }
 
@@ -150,7 +154,9 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
 
         if ($violations->count() > 0) {
             $this->objectDetacher->detach($productModel);
-            $standardProductModel['code'] = $code;
+            if (null !== $code) {
+                $standardProductModel['code'] = $code;
+            }
             $this->skipItemWithConstraintViolations($standardProductModel, $violations);
         }
 
@@ -162,7 +168,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      *
      * @return ProductModelInterface
      */
-    private function findOrCreateProductModel(string $code): ProductModelInterface
+    public function findOrCreateProductModel(string $code): ProductModelInterface
     {
         $productModel = $this->productModelRepository->findOneByIdentifier($code);
         if (null === $productModel) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php
@@ -92,6 +92,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
      */
     public function process($standardProductModel): ?ProductModelInterface
     {
+        $code = $standardProductModel['code'];
         $parent = $standardProductModel['parent'] ?? '';
         if ($this->importType === self::ROOT_PRODUCT_MODEL && !empty($parent) ||
             $this->importType === self::SUB_PRODUCT_MODEL && empty($parent)
@@ -147,6 +148,7 @@ class ProductModelProcessor extends AbstractProcessor implements ItemProcessorIn
 
         if ($violations->count() > 0) {
             $this->objectDetacher->detach($productModel);
+            $standardProductModel['code'] = $code;
             $this->skipItemWithConstraintViolations($standardProductModel, $violations);
         }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Connector/Processor/Denormalizer/ProductModelProcessorIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Connector/Processor/Denormalizer/ProductModelProcessorIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Connector\Processor\Denormalizer;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer\ProductModelProcessor;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
@@ -13,25 +14,30 @@ class ProductModelProcessorIntegration extends TestCase
 {
     public function testWarningOnImportContainsProductModelCode(): void
     {
-        $jobParameters = new JobParameters([
-            'enabledComparison' => false,
+        $this->createProductModel([
+            'code' => 'a_product_model_code',
+            'family_variant' => 'familyVariantA2',
         ]);
-        $jobExecution = new JobExecution();
-        $jobExecution->setJobParameters($jobParameters);
-        $stepExecution = new StepExecution('test', $jobExecution);
+        $stepExecution = $this->createStepExecution();
+
         /** @var ProductModelProcessor $processor */
         $processor = $this->get('pim_connector.processor.denormalization.root_product_model');
         $processor->setStepExecution($stepExecution);
 
         $standardProductModel = [
             'code' => 'a_product_model_code',
-            'brand' => 'foo',
+            'family_variant' => 'foo',
+        ];
+
+        $expectedWarningItem = [
+            'code' => 'a_product_model_code',
+            'family_variant' => 'foo',
         ];
 
         try {
             $processor->process($standardProductModel);
-        } catch (InvalidItemException $exception){
-            $this->assertEquals($standardProductModel, $exception->getItem()->getInvalidData());
+        } catch (InvalidItemException $exception) {
+            $this->assertEquals($expectedWarningItem, $exception->getItem()->getInvalidData());
 
             return;
         }
@@ -39,11 +45,31 @@ class ProductModelProcessorIntegration extends TestCase
         throw new \RuntimeException('An exception should have been thrown');
     }
 
+    private function createStepExecution(): StepExecution
+    {
+        $jobParameters = new JobParameters([
+            'enabledComparison' => true,
+        ]);
+        $jobExecution = new JobExecution();
+        $jobExecution->setJobParameters($jobParameters);
+
+        return new StepExecution('test', $jobExecution);
+    }
+
+    private function createProductModel(array $data): ProductModelInterface
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+
+        return $productModel;
+    }
+
     /**
      * {@inheritdoc}
      */
     protected function getConfiguration()
     {
-        return $this->catalog->useMinimalCatalog();
+        return $this->catalog->useTechnicalCatalog();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/Connector/Processor/Denormalizer/ProductModelProcessorIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Connector/Processor/Denormalizer/ProductModelProcessorIntegration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Product\Connector\Processor\Denormalizer;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer\ProductModelProcessor;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+
+class ProductModelProcessorIntegration extends TestCase
+{
+    public function testWarningOnImportContainsProductModelCode(): void
+    {
+        $jobParameters = new JobParameters([
+            'enabledComparison' => false,
+        ]);
+        $jobExecution = new JobExecution();
+        $jobExecution->setJobParameters($jobParameters);
+        $stepExecution = new StepExecution('test', $jobExecution);
+        /** @var ProductModelProcessor $processor */
+        $processor = $this->get('pim_connector.processor.denormalization.root_product_model');
+        $processor->setStepExecution($stepExecution);
+
+        $standardProductModel = [
+            'code' => 'a_product_model_code',
+            'brand' => 'foo',
+        ];
+
+        try {
+            $processor->process($standardProductModel);
+        } catch (InvalidItemException $exception){
+            $this->assertEquals($standardProductModel, $exception->getItem()->getInvalidData());
+
+            return;
+        }
+
+        throw new \RuntimeException('An exception should have been thrown');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When importing a file, if warnings are raised with products, the identifier of each problematic product is given on the warnings 
With product models, the warning didn't display the code of the PM.

So, we added the product model code as a value to display in the process function of the ProductModelProcessor class.

**Explanation**

When `$jobParameters->get('enabledComparison') && null !== $productModel->getId()` is true, meaning that `enabledComparison` is enabled and a product model with this code already exists, the following line is executed:
https://github.com/akeneo/pim-community-dev/blob/07faafa9934bdc43c29f0cf49a9e983a772c03ae/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductModelProcessor.php#L119

Removing the code from `$standardProductModel`.
When a validation error happens, the warning cannot display the code since it's not there anymore.
The solution is to restore the code after this filter.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
