### PR TITLE
RAC-395: Validation error with direct link to job only on internal API

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -70,7 +70,8 @@ pim_catalog:
         family_variant_maximum_number_of_level: Family variant cannot have more than "%level%" level
         family_variant_unique_attributes_in_last_level: Unique attribute "%attribute%" must be set at the product level
         product_identifier: These identifiers "%s" don't exist.
-        blacklisted_attribute_code: The attribute code "%attribute_code%" was previously existing and is currently being cleaned up
+        blacklisted_attribute_code: Code temporarily blocked until the ongoing cleanup job is complete.
+        blacklisted_attribute_code_with_link: "Code temporarily blocked until the ongoing cleanup job is complete. To find out more, please check the <a href='{{ link }}' target='_blank'>job detail</a>."
         0: An unexpected error occurred.
         100: Non-expected value
         101: This field expects a boolean value.

--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Attribute/GetBlacklistedAttributeJobExecutionId.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Attribute/GetBlacklistedAttributeJobExecutionId.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Structure\Bundle\Query\InternalApi\Attribute;
 
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetBlacklistedAttributeJobExecutionIdInterface;
 use Doctrine\DBAL\Connection;
 
-final class GetBlacklistedAttributeJobExecutionId
+final class GetBlacklistedAttributeJobExecutionId implements GetBlacklistedAttributeJobExecutionIdInterface
 {
     private Connection $connection;
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
@@ -91,6 +91,9 @@ services:
         class: 'Akeneo\Pim\Structure\Component\Validator\Constraints\BlacklistedAttributeCodeValidator'
         arguments:
             - '@akeneo.pim.structure.query.is_attribute_code_blacklisted'
+            - '@akeneo.pim.structure.query.get_blacklisted_attribute_job_execution_id'
+            - '@translator.default'
+            - '@router'
         tags:
             - { name: validator.constraint_validator, alias: pim_blacklisted_attribute_code_validator }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetBlacklistedAttributeJobExecutionIdInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetBlacklistedAttributeJobExecutionIdInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Akeneo\Pim\Structure\Component\Query\InternalApi;
+
+interface GetBlacklistedAttributeJobExecutionIdInterface
+{
+    public function forAttributeCode(string $attributeCode): ?int;
+}

--- a/src/Akeneo/Pim/Structure/Component/Validator/Constraints/BlacklistedAttributeCode.php
+++ b/src/Akeneo/Pim/Structure/Component/Validator/Constraints/BlacklistedAttributeCode.php
@@ -10,6 +10,7 @@ class BlacklistedAttributeCode extends Constraint
      * Violation message for blacklisted attribute identifiers
      */
     public string $message = 'pim_catalog.constraint.blacklisted_attribute_code';
+    public string $internalAPIMessage = 'pim_catalog.constraint.blacklisted_attribute_code_with_link';
 
     public function validatedBy()
     {

--- a/src/Akeneo/Pim/Structure/Component/Validator/Constraints/BlacklistedAttributeCodeValidator.php
+++ b/src/Akeneo/Pim/Structure/Component/Validator/Constraints/BlacklistedAttributeCodeValidator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Structure\Component\Validator\Constraints;
 
-use Akeneo\Pim\Structure\Bundle\Query\InternalApi\Attribute\GetBlacklistedAttributeJobExecutionId;
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetBlacklistedAttributeJobExecutionIdInterface;
 use Akeneo\Pim\Structure\Component\Query\InternalApi\IsAttributeCodeBlacklistedInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Translation\Translator;
@@ -17,13 +17,13 @@ class BlacklistedAttributeCodeValidator extends ConstraintValidator
     private const JOB_TRACKER_ROUTE = 'pim_enrich_job_tracker_show';
 
     protected IsAttributeCodeBlacklistedInterface $isAttributeCodeBlacklisted;
-    private GetBlacklistedAttributeJobExecutionId $getBlacklistedAttributeJobExecutionId;
+    private GetBlacklistedAttributeJobExecutionIdInterface $getBlacklistedAttributeJobExecutionId;
     private Translator $translator;
     private RouterInterface $router;
 
     public function __construct(
         IsAttributeCodeBlacklistedInterface $isAttributeCodeBlacklisted,
-        GetBlacklistedAttributeJobExecutionId $getBlacklistedAttributeJobExecutionId,
+        GetBlacklistedAttributeJobExecutionIdInterface $getBlacklistedAttributeJobExecutionId,
         Translator $translator,
         RouterInterface $router
     ) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/common/fields/field.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/common/fields/field.html
@@ -15,7 +15,7 @@
 
     <% errors.forEach(function(error) { %>
         <span class="AknFieldContainer-validationError">
-            <span class="error-message"><%- error.message %></span>
+            <span class="error-message"><%= error.message %></span>
         </span>
     <% }) %>
     <% warnings.forEach(function(warning) { %>

--- a/tests/back/Pim/Structure/Integration/Attribute/Validation/BlacklistedAttributeCodeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Validation/BlacklistedAttributeCodeIntegration.php
@@ -26,7 +26,7 @@ class BlackListedAttributeCodeIntegration extends AbstractAttributeTestCase
 
         $this->assertCount(1, $violations);
         $this->assertSame(
-            'The attribute code "new_blacklisted_attribute" was previously existing and is currently being cleaned up',
+            'Code temporarily blocked until the ongoing cleanup job is complete.',
             $violations->get(0)->getMessage()
         );
     }

--- a/tests/back/Pim/Structure/Specification/Component/Validator/Constraints/BlacklistedAttributeCodeValidatorSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Validator/Constraints/BlacklistedAttributeCodeValidatorSpec.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Structure\Component\Validator\Constraints;
+
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetBlacklistedAttributeJobExecutionIdInterface;
+use Akeneo\Pim\Structure\Component\Query\InternalApi\IsAttributeCodeBlacklistedInterface;
+use Akeneo\Pim\Structure\Component\Validator\Constraints\BlacklistedAttributeCode;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Translation\Translator;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class BlacklistedAttributeCodeValidatorSpec extends ObjectBehavior
+{
+    function let(
+        ExecutionContextInterface $context,
+        IsAttributeCodeBlacklistedInterface $isAttributeCodeBlacklisted,
+        GetBlacklistedAttributeJobExecutionIdInterface $getBlacklistedAttributeJobExecutionId,
+        Translator $translator,
+        RouterInterface $router
+    ) {
+        $this->beConstructedWith(
+            $isAttributeCodeBlacklisted,
+            $getBlacklistedAttributeJobExecutionId,
+            $translator,
+            $router
+        );
+
+        $this->initialize($context);
+    }
+
+    function it_does_not_add_violations_if_attribute_is_not_blacklisted(
+        ExecutionContextInterface $context,
+        IsAttributeCodeBlacklistedInterface $isAttributeCodeBlacklisted,
+        BlacklistedAttributeCode $constraint
+    ) {
+        $isAttributeCodeBlacklisted->execute('my_attribute_code')->willReturn(false);
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate('my_attribute_code', $constraint);
+    }
+
+    function it_add_violation_if_attribute_is_blacklisted(
+        ExecutionContextInterface $context,
+        IsAttributeCodeBlacklistedInterface $isAttributeCodeBlacklisted,
+        BlacklistedAttributeCode $constraint,
+        ConstraintViolationBuilderInterface $violation
+    ) {
+        $isAttributeCodeBlacklisted->execute('my_attribute_code')->willReturn(true);
+        $context
+            ->buildViolation('pim_catalog.constraint.blacklisted_attribute_code')
+            ->shouldBeCalled()
+            ->willReturn($violation);
+
+        $this->validate('my_attribute_code', $constraint);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR, change the validation error to give the direct link to job only on internal API.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
