### PR TITLE
Fix css alignement of image in Table row

### DIFF
--- a/akeneo-design-system/src/components/Image/Image.tsx
+++ b/akeneo-design-system/src/components/Image/Image.tsx
@@ -9,7 +9,6 @@ const ImageContainer = styled.img<
   background: ${getColor('white')};
   border: 1px solid ${getColor('grey80')};
   object-fit: ${({fit}) => fit};
-  transform: translate(4px, -4px);
 
   ${({isStacked}) =>
     isStacked &&


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Alignment of image was wrong on Table component.

Before: 
![Capture du 2020-12-15 09-16-04](https://user-images.githubusercontent.com/7239572/102189027-55d62680-3eb6-11eb-9ea5-528ea8edff03.png)

Now:
![Capture du 2020-12-15 09-16-43](https://user-images.githubusercontent.com/7239572/102189018-5373cc80-3eb6-11eb-98d9-6e660246f1d4.png)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
