### PR TITLE
PIM-9551: Add service for purging logs from job executions

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9551: Purge logs when calling the command akeneo:batch:purge-job-execution
+
 # 4.0.78 (2020-12-08)
 
 # 4.0.77 (2020-12-07)

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
@@ -24,6 +24,7 @@ final class PurgeJobExecution
     /** @var DeleteOrphanJobExecutionDirectories */
     private $deleteOrphansJobExecutionDirectories;
 
+    // @todo merge master: remove null
     /** @var DeleteJobExecutionLogs|null */
     private $deleteJobExecutionLogs;
 
@@ -31,7 +32,7 @@ final class PurgeJobExecution
         DeleteJobExecution $deleteJobExecution,
         DeleteJobExecutionMessageOrphansQueryInterface $deleteOrphanJobExecutionMessages,
         DeleteOrphanJobExecutionDirectories $deleteOrphansJobExecutionDirectories,
-        DeleteJobExecutionLogs $deleteJobExecutionLogs = null
+        DeleteJobExecutionLogs $deleteJobExecutionLogs = null // @todo merge master: remove null
     ) {
         $this->deleteJobExecution = $deleteJobExecution;
         $this->deleteOrphanJobExecutionMessages = $deleteOrphanJobExecutionMessages;
@@ -41,6 +42,7 @@ final class PurgeJobExecution
 
     public function olderThanDays(int $days): int
     {
+        // @todo merge master: remove null check
         if (null !== $this->deleteJobExecutionLogs) {
             $this->deleteJobExecutionLogs->olderThanDays($days);
         }
@@ -53,6 +55,7 @@ final class PurgeJobExecution
 
     public function all(): void
     {
+        // @todo merge master: remove null check
         if (null !== $this->deleteJobExecutionLogs) {
             $this->deleteJobExecutionLogs->all();
         }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
@@ -6,6 +6,7 @@ namespace Akeneo\Platform\Bundle\ImportExportBundle\Purge;
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Persistence\Filesystem\DeleteOrphanJobExecutionDirectories;
 use Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\DeleteJobExecution;
+use Akeneo\Tool\Bundle\BatchBundle\Storage\DeleteJobExecutionLogs;
 use Akeneo\Tool\Component\BatchQueue\Query\DeleteJobExecutionMessageOrphansQueryInterface;
 
 /**
@@ -23,18 +24,26 @@ final class PurgeJobExecution
     /** @var DeleteOrphanJobExecutionDirectories */
     private $deleteOrphansJobExecutionDirectories;
 
+    /** @var DeleteJobExecutionLogs|null */
+    private $deleteJobExecutionLogs;
+
     public function __construct(
         DeleteJobExecution $deleteJobExecution,
         DeleteJobExecutionMessageOrphansQueryInterface $deleteOrphanJobExecutionMessages,
-        DeleteOrphanJobExecutionDirectories $deleteOrphansJobExecutionDirectories
+        DeleteOrphanJobExecutionDirectories $deleteOrphansJobExecutionDirectories,
+        DeleteJobExecutionLogs $deleteJobExecutionLogs = null
     ) {
         $this->deleteJobExecution = $deleteJobExecution;
         $this->deleteOrphanJobExecutionMessages = $deleteOrphanJobExecutionMessages;
         $this->deleteOrphansJobExecutionDirectories = $deleteOrphansJobExecutionDirectories;
+        $this->deleteJobExecutionLogs = $deleteJobExecutionLogs;
     }
 
     public function olderThanDays(int $days): int
     {
+        if (null !== $this->deleteJobExecutionLogs) {
+            $this->deleteJobExecutionLogs->olderThanDays($days);
+        }
         $numberOfDeletedJobExecutions = $this->deleteJobExecution->olderThanDays($days);
         $this->deleteOrphanJobExecutionMessages->execute();
         $this->deleteOrphansJobExecutionDirectories->execute();
@@ -44,6 +53,9 @@ final class PurgeJobExecution
 
     public function all(): void
     {
+        if (null !== $this->deleteJobExecutionLogs) {
+            $this->deleteJobExecutionLogs->all();
+        }
         $this->deleteJobExecution->all();
         $this->deleteOrphanJobExecutionMessages->execute();
         $this->deleteOrphansJobExecutionDirectories->execute();

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
@@ -13,6 +13,7 @@ services:
             - '@akeneo_batch.delete_job_execution'
             - '@akeneo_batch_queue.query.delete_job_execution_message_orphans'
             - '@akeneo.platform.import_export.filesystem.delete_orphans_job_execution_directories'
+            - '@Akeneo\Tool\Bundle\BatchBundle\Storage\DeleteJobExecutionLogs'
 
     Akeneo\Platform\Bundle\ImportExportBundle\Command\PurgeJobExecutionCommand:
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/GetJobExecutionIds.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/GetJobExecutionIds.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql;
+
+use Akeneo\Tool\Component\Batch\Job\BatchStatus;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\PDOStatement;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetJobExecutionIds
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function olderThanDays(int $days): PDOStatement
+    {
+        if ($days < 1) {
+            throw new \InvalidArgumentException(sprintf('Number of days should be strictly superior to 0, "%s% given', $days));
+        }
+
+        $endTime = new \DateTime();
+        $endTime->modify(sprintf('- %d days', $days));
+
+        $query = <<<SQL
+            SELECT id
+            FROM akeneo_batch_job_execution
+            WHERE akeneo_batch_job_execution.create_time < :create_time AND akeneo_batch_job_execution.id NOT IN (
+                SELECT MAX(last_job_execution.id) 
+                FROM akeneo_batch_job_execution last_job_execution 
+                WHERE last_job_execution.status = :status 
+                GROUP BY last_job_execution.job_instance_id
+            )
+SQL;
+
+        return $this->connection->executeQuery(
+            $query,
+            ['create_time' => $endTime, 'status' => BatchStatus::COMPLETED],
+            ['create_time' => Type::DATETIME]
+        );
+    }
+
+    public function all(): PDOStatement
+    {
+        $query = <<<SQL
+            SELECT id
+            FROM akeneo_batch_job_execution
+        SQL;
+
+        return $this->connection->executeQuery($query);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/removers.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/removers.yml
@@ -15,3 +15,7 @@ services:
         class: 'Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\SqlCreateJobInstance'
         arguments:
             - '@database_connection'
+
+    Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\GetJobExecutionIds:
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -86,3 +86,9 @@ services:
         class: '%akeneo_batch.entity_manager.persisted_connection_entity_manager.class%'
         arguments:
             - '@doctrine.orm.entity_manager'
+
+    Akeneo\Tool\Bundle\BatchBundle\Storage\DeleteJobExecutionLogs:
+        arguments:
+            - '@Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\GetJobExecutionIds'
+            - '@filesystem'
+            - '%kernel.logs_dir%/batch'

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Storage/DeleteJobExecutionLogs.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Storage/DeleteJobExecutionLogs.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\Storage;
+
+use Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\GetJobExecutionIds;
+use Doctrine\DBAL\FetchMode;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class DeleteJobExecutionLogs
+{
+    /** @var GetJobExecutionIds */
+    private $getJobExecutionIds;
+
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var string */
+    private $logDir;
+
+    public function __construct(
+        GetJobExecutionIds $getJobExecutionIds,
+        Filesystem $filesystem,
+        string $logDir
+    ) {
+        $this->getJobExecutionIds = $getJobExecutionIds;
+        $this->filesystem = $filesystem;
+        $this->logDir = $logDir;
+    }
+
+    public function olderThanDays(int $days): void
+    {
+        $statement = $this->getJobExecutionIds->olderThanDays($days);
+        while ($id = $statement->fetch(FetchMode::COLUMN)) {
+            $this->filesystem->remove($this->getJobExecutionLogDirectory($id));
+        }
+    }
+
+    public function all(): void
+    {
+        $statement = $this->getJobExecutionIds->all();
+        while ($id = $statement->fetch(FetchMode::COLUMN)) {
+            $this->filesystem->remove($this->getJobExecutionLogDirectory($id));
+        }
+    }
+
+    private function getJobExecutionLogDirectory(string $jobExecutionId): string
+    {
+        return sprintf('%s/%s', $this->logDir, $jobExecutionId);
+    }
+}

--- a/tests/back/Tool/Integration/Batch/Persistence/Sql/GetJobExecutionIdsIntegration.php
+++ b/tests/back/Tool/Integration/Batch/Persistence/Sql/GetJobExecutionIdsIntegration.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Tool\Integration\Batch\Persistence\Sql;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql\GetJobExecutionIds;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
+
+class GetJobExecutionIdsIntegration extends TestCase {
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    public function tests_that_it_returns_the_older_than_days_ids() {
+
+        $this->loadFixtures();
+
+        /** @var GetJobExecutionIds $getJobExecutionIds */
+        $getJobExecutionIds = $this->get(GetJobExecutionIds::class);
+        $result = $getJobExecutionIds->olderThanDays(5);
+        $ids = $result->fetchAll(FetchMode::COLUMN);
+        $expectedIds = [1, 2];
+        $this->assertEquals($expectedIds, $ids);
+    }
+
+    public function tests_that_it_returns_all_ids () {
+
+        $this->loadFixtures();
+
+        /** @var GetJobExecutionIds $getJobExecutionIds */
+        $getJobExecutionIds = $this->get(GetJobExecutionIds::class);
+        $result = $getJobExecutionIds->all();
+        $ids = $result->fetchAll(FetchMode::COLUMN);
+        $expectedIds = [1, 2, 3];
+        $this->assertEquals($expectedIds, $ids);
+    }
+
+    private function loadFixtures() {
+
+        $insertJobInstanceQuery = <<<SQL
+            INSERT INTO akeneo_batch_job_instance (id, code, job_name, status, connector, raw_parameters, type)
+            VALUES 
+            (1, 'test', '', 0, '', '', '')
+SQL;
+
+        $this->getConnection()->executeQuery($insertJobInstanceQuery);
+
+        $insertJobExecutionQuery = <<<SQL
+            INSERT INTO akeneo_batch_job_execution (id, job_instance_id, create_time, status, raw_parameters) 
+            VALUES 
+            (1, 1, DATE_SUB(NOW(), INTERVAL 10 day), 1, '{}'), 
+            (2, 1, DATE_SUB(NOW(), INTERVAL 10 day), 1, '{}'), 
+            (3, 1, DATE_SUB(NOW(), INTERVAL 3 day), 1, '{}')
+SQL;
+
+        $this->getConnection()->executeQuery($insertJobExecutionQuery);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When calling the command `akeneo:batch:purge-job-execution`, we should also remove the logs of those deleted jobs.

Batch logs are logged like this:
```
batch/
  24/
    batch_5dfd97dbb66807705ce1bcf5c38c69c1cede36dc.log
```
In that case, the directory `24` is always the job execution id.

So the solution is a query to find the ids of the soon-to-be removed jobs, then removing this directories in the logs.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | yes
| Changelog updated                 | yes
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

