### PR TITLE
PIM-9598: Fix quick export when the bs_Cyrl_BA locale is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PIM-9590: Fix "Default product grid view" multiple times on user settings page
 - CPM-86: Fix undefined tab on job profile edit
 - PIM-9596: Fix attribute options manual sorting
+- PIM-9598: Fix quick export when the bs_Cyrl_BA locale is used.
 - RAC-435: Fix fatal error for user that migrate from 4.0 with product values format that doesn't correspond to expected format
 
 ## New features

--- a/src/Akeneo/Tool/Component/Localization/LanguageTranslator.php
+++ b/src/Akeneo/Tool/Component/Localization/LanguageTranslator.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Tool\Component\Localization;
 
 use Symfony\Component\Intl\Countries;
+use Symfony\Component\Intl\Exception\MissingResourceException;
 use Symfony\Component\Intl\Intl;
 
 class LanguageTranslator implements LanguageTranslatorInterface
@@ -22,7 +23,11 @@ class LanguageTranslator implements LanguageTranslatorInterface
             return $fallback;
         }
 
-        $country = Countries::getName($country, $displayLocale);
+        try {
+            $country = Countries::getName($country, $displayLocale);
+        } catch (MissingResourceException $e) {
+            return $fallback;
+        }
 
         return sprintf('%s %s', $translatedLanguage, $country);
     }

--- a/src/Akeneo/Tool/Component/Localization/spec/LanguageTranslatorSpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/LanguageTranslatorSpec.php
@@ -25,4 +25,9 @@ class LanguageTranslatorSpec extends ObjectBehavior
         $this->translate('en_GB', 'unknown', '[this is unknown]')->shouldReturn('[this is unknown]');
         $this->translate('UNKNOWN_FR', 'fr', '[unknown language]')->shouldReturn('[unknown language]');
     }
+
+    function it_returns_fallback_when_intl_can_not_translate_the_country_name_into_the_given_locale()
+    {
+        $this->translate('bs_Cyrl_BA', 'en_US', '[bs_Cyrl_BA]')->shouldReturn('[bs_Cyrl_BA]');
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When the bs_Cyrl_BA locale is active on the exported channel, the quick export with labels fails if there are localizable attributes.
When translating the locale for the header Intl is not able to find a translation.

![screenshot_221](https://user-images.githubusercontent.com/7206368/102239104-ca30ba00-3ef6-11eb-8d17-196579fff216.png)

Updating to Intl 5.2.0 does not fix the problem.

I use the given fallback when the Exception is thrown.

![Screenshot from 2020-12-15 16-59-47](https://user-images.githubusercontent.com/7206368/102239422-2267bc00-3ef7-11eb-8ec5-67cba67e52d8.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Done
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
