### PR TITLE
Fix "in memory" channel repository

### DIFF
--- a/tests/back/Acceptance/Channel/InMemoryChannelRepository.php
+++ b/tests/back/Acceptance/Channel/InMemoryChannelRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Acceptance\Channel;
 
+use Akeneo\Channel\Component\Model\ChannelInterface;
 use Akeneo\Channel\Component\Model\CurrencyInterface;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
 use Akeneo\Test\Acceptance\Common\NotImplementedException;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Without this missing `use`, there is no way `InMemoryChannelRepository::getChannelCodes()` can work.
I already did this fix 2 months ago, but on the 4.0 branch ><.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | TODO
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
