### PR TITLE
RAC-397: Add confirm attribute code field in delete modal

### DIFF
--- a/akeneo-design-system/src/components/Input/TextInput/TextInput.tsx
+++ b/akeneo-design-system/src/components/Input/TextInput/TextInput.tsx
@@ -48,7 +48,7 @@ const CharacterLeftLabel = styled.div`
 `;
 
 type TextInputProps = Override<
-  React.InputHTMLAttributes<HTMLInputElement> & InputProps,
+  Override<React.InputHTMLAttributes<HTMLInputElement>, InputProps>,
   (
     | {
         readOnly?: true;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -224,6 +224,7 @@ pim_enrich.entity.attribute:
             helper:
                 content: If you need to change your attribute type, to make it localizable or scopable, while keeping access to your existing attribute values,
                 link: we walk you through the different steps here.
+            type: Please type "{{ attributeCode }}"
             confirm_from_family: Are you sure you want to delete this attribute from the family?
             confirm_from_group: Are you sure you want to remove the attribute {{ attribute }} from this attribute group?
             confirm_from_product: Are you sure you want to delete this attribute from the product?

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -1,11 +1,22 @@
 import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
-import {Button, DeleteIllustration, getColor, Helper, Link, Modal, SectionTitle, Title} from 'akeneo-design-system';
+import {
+  Button,
+  DeleteIllustration,
+  Field,
+  getColor,
+  Helper,
+  Link,
+  Modal,
+  SectionTitle,
+  TextInput,
+  Title,
+} from 'akeneo-design-system';
 import {NotificationLevel, useNotify, useTranslate, useRoute} from '@akeneo-pim-community/legacy-bridge';
 import {useIsMounted} from '@akeneo-pim-community/shared';
 
-const Content = styled.div`
-  margin-bottom: 10px;
+const SpacedHelper = styled(Helper)`
+  margin: 10px 0 20px;
 `;
 
 const Highlight = styled.span`
@@ -47,6 +58,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
   const notify = useNotify();
   const removeRoute = useRoute('pim_enrich_attribute_rest_remove', {code: attributeCode});
   const [productCount, productModelCount] = useImpactedItemCount(attributeCode);
+  const [attributeCodeConfirm, setAttributeCodeConfirm] = useState<string>('');
 
   const handleConfirm = () => {
     fetch(removeRoute, {
@@ -100,27 +112,28 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
     >
       <SectionTitle color="brand">{translate('pim_enrich.entity.attribute.plural_label')}</SectionTitle>
       <Title>{translate('pim_common.confirm_deletion')}</Title>
-      <Content>
-        {translate('pim_enrich.entity.attribute.module.delete.confirm')}
-        {(0 < productCount || 0 < productModelCount) && (
-          <p>
-            <Highlight>{impactedItemsText}</Highlight>
-            &nbsp;
-            {translate('pim_enrich.entity.attribute.module.delete.used')}
-          </p>
-        )}
-      </Content>
-      <Helper>
+      {translate('pim_enrich.entity.attribute.module.delete.confirm')}
+      {(0 < productCount || 0 < productModelCount) && (
+        <p>
+          <Highlight>{impactedItemsText}</Highlight>
+          &nbsp;
+          {translate('pim_enrich.entity.attribute.module.delete.used')}
+        </p>
+      )}
+      <SpacedHelper>
         {translate('pim_enrich.entity.attribute.module.delete.helper.content')}
         <Link href="https://help.akeneo.com/pim/serenity/articles/manage-your-attributes.html#delete-an-attribute-and-keep-the-related-data">
           {translate('pim_enrich.entity.attribute.module.delete.helper.link')}
         </Link>
-      </Helper>
+      </SpacedHelper>
+      <Field label={translate('pim_enrich.entity.attribute.module.delete.type', {attributeCode})}>
+        <TextInput name="attribute_confirm" value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
+      </Field>
       <Modal.BottomButtons>
         <Button level="tertiary" onClick={onCancel}>
           {translate('pim_common.cancel')}
         </Button>
-        <Button level="danger" onClick={handleConfirm}>
+        <Button disabled={attributeCodeConfirm !== attributeCode} level="danger" onClick={handleConfirm}>
           {translate('pim_common.delete')}
         </Button>
       </Modal.BottomButtons>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -128,7 +128,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
         </Link>
       </SpacedHelper>
       <Field label={translate('pim_enrich.entity.attribute.module.delete.type', {attributeCode})}>
-        <TextInput name="attribute_confirm" value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
+        <TextInput value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
       </Field>
       <Modal.BottomButtons>
         <Button level="tertiary" onClick={onCancel}>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -59,6 +59,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
   const removeRoute = useRoute('pim_enrich_attribute_rest_remove', {code: attributeCode});
   const [productCount, productModelCount] = useImpactedItemCount(attributeCode);
   const [attributeCodeConfirm, setAttributeCodeConfirm] = useState<string>('');
+  const isValid = attributeCodeConfirm === attributeCode;
 
   const handleConfirm = () => {
     fetch(removeRoute, {
@@ -133,7 +134,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
         <Button level="tertiary" onClick={onCancel}>
           {translate('pim_common.cancel')}
         </Button>
-        <Button disabled={attributeCodeConfirm !== attributeCode} level="danger" onClick={handleConfirm}>
+        <Button disabled={!isValid} level="danger" onClick={handleConfirm}>
           {translate('pim_common.delete')}
         </Button>
       </Modal.BottomButtons>

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteAction.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteAction.unit.tsx
@@ -46,11 +46,14 @@ test('it opens the confirm modal on click', async () => {
 });
 
 test('it redirects to the list after attribute is deleted', async () => {
-  renderWithProviders(<DeleteAction attributeCode="foo" />);
+  renderWithProviders(<DeleteAction attributeCode="nice_attribute" />);
 
   await act(async () => {
     fireEvent.click(screen.getByText('pim_common.delete'));
   });
+
+  const input = screen.getByLabelText('pim_enrich.entity.attribute.module.delete.type') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: 'nice_attribute'}});
 
   const modal = screen.getByRole('dialog');
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteModal.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteModal.unit.tsx
@@ -47,10 +47,20 @@ test('it renders a confirm modal delete', async () => {
   expect(screen.getByText('pim_common.confirm_deletion')).toBeInTheDocument();
 });
 
-test('it calls the attribute remover when confirm is clicked', async () => {
+test('it does not allow confirmation until the attributeCodeConfirm field is valid', async () => {
   const onSuccess = jest.fn();
 
-  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={onSuccess} attributeCode="foo" />);
+  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={onSuccess} attributeCode="nice_attribute" />);
+
+  await act(async () => {
+    fireEvent.click(screen.getByText('pim_common.delete'));
+  });
+
+  expect(screen.getByText('pim_common.delete')).toHaveAttribute('disabled');
+  expect(onSuccess).not.toHaveBeenCalled();
+
+  const input = screen.getByLabelText('pim_enrich.entity.attribute.module.delete.type') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: 'nice_attribute'}});
 
   await act(async () => {
     fireEvent.click(screen.getByText('pim_common.delete'));
@@ -75,7 +85,10 @@ test('it displays an error when the delete failed', async () => {
     }
   });
 
-  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={jest.fn()} attributeCode="foo" />);
+  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={jest.fn()} attributeCode="nice_attribute" />);
+
+  const input = screen.getByLabelText('pim_enrich.entity.attribute.module.delete.type') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: 'nice_attribute'}});
 
   await act(async () => {
     fireEvent.click(screen.getByText('pim_common.delete'));
@@ -99,7 +112,10 @@ test('it displays an error when the delete was rejected', async () => {
     }
   });
 
-  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={jest.fn()} attributeCode="foo" />);
+  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={jest.fn()} attributeCode="nice_attribute" />);
+
+  const input = screen.getByLabelText('pim_enrich.entity.attribute.module.delete.type') as HTMLInputElement;
+  fireEvent.change(input, {target: {value: 'nice_attribute'}});
 
   await act(async () => {
     fireEvent.click(screen.getByText('pim_common.delete'));

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -1767,6 +1767,22 @@ class WebUser extends PimContext
     }
 
     /**
+     * @param string $inputName
+     * @param string $value
+     *
+     * @When /^I fill the "([^"]*)" input with "([^"]*)"$/
+     */
+    public function iFillTheInput($inputName, $value)
+    {
+        $page = $this->getCurrentPage();
+        $element = $this->spin(function () use ($page, $inputName) {
+            return $page->find('css', sprintf('input[name="%s"]', $inputName));
+        }, sprintf("Can not find any '%s' element", $inputName));
+
+        $element->setValue($value);
+    }
+
+    /**
      * @param string $button
      *
      * @Given /^I should see the "([^"]*)" button$/

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -1767,19 +1767,21 @@ class WebUser extends PimContext
     }
 
     /**
-     * @param string $inputName
+     * @param string $label
      * @param string $value
      *
-     * @When /^I fill the "([^"]*)" input with "([^"]*)"$/
+     * @When /^I fill the input labelled '(.*)' with '(.*)'$/
      */
-    public function iFillTheInput($inputName, $value)
+    public function iFillTheInputLabelledWith($label, $value)
     {
         $page = $this->getCurrentPage();
-        $element = $this->spin(function () use ($page, $inputName) {
-            return $page->find('css', sprintf('input[name="%s"]', $inputName));
-        }, sprintf("Can not find any '%s' element", $inputName));
 
-        $element->setValue($value);
+        $label = $this->spin(function () use ($page, $label) {
+            return $page->find('css', sprintf('label:contains(%s)', $label));
+        }, sprintf("Can not find any label with content '%s'", $label));
+
+        $input = $page->findByID($label->getAttribute('for'));
+        $input->setValue($value);
     }
 
     /**

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
@@ -29,10 +29,12 @@ Feature: Display the product history
     When I am on the attributes page
     And I search "Weather conditions"
     And I click on the "delete" action of the row which contains "Weather conditions"
+    And I fill the "attribute_confirm" input with "weather_conditions"
     And I press the "Delete" button
     And I am on the attributes page
     And I search "Name"
     And I click on the "delete" action of the row which contains "Name"
+    And I fill the "attribute_confirm" input with "name"
     And I press the "Delete" button
     And I edit the "boots" product
     And the history of the product "boots" has been built

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
@@ -29,12 +29,12 @@ Feature: Display the product history
     When I am on the attributes page
     And I search "Weather conditions"
     And I click on the "delete" action of the row which contains "Weather conditions"
-    And I fill the "attribute_confirm" input with "weather_conditions"
+    And I fill the input labelled 'Please type "weather_conditions"' with 'weather_conditions'
     And I press the "Delete" button
     And I am on the attributes page
     And I search "Name"
     And I click on the "delete" action of the row which contains "Name"
-    And I fill the "attribute_confirm" input with "name"
+    And I fill the input labelled 'Please type "name"' with 'name'
     And I press the "Delete" button
     And I edit the "boots" product
     And the history of the product "boots" has been built

--- a/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
+++ b/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
@@ -11,6 +11,7 @@ Feature: Delete an attribute
     And I am logged in as "Julia"
     When I am on the attributes page
     And I click on the "delete" action of the row which contains "SKU"
+    And I fill the "attribute_confirm" input with "sku"
     And I press the "Delete" button
     Then I should see the text "Identifier attribute can not be removed"
     And there should be a "SKU" attribute

--- a/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
+++ b/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
@@ -11,7 +11,7 @@ Feature: Delete an attribute
     And I am logged in as "Julia"
     When I am on the attributes page
     And I click on the "delete" action of the row which contains "SKU"
-    And I fill the "attribute_confirm" input with "sku"
+    And I fill the input labelled 'Please type "sku"' with 'sku'
     And I press the "Delete" button
     Then I should see the text "Identifier attribute can not be removed"
     And there should be a "SKU" attribute

--- a/tests/legacy/features/pim/structure/attribute/option/delete_attribute_options.feature
+++ b/tests/legacy/features/pim/structure/attribute/option/delete_attribute_options.feature
@@ -33,7 +33,7 @@ Feature: Delete attribute options
     And I am on the "color" attribute page
     And I visit the "Options" tab
     When I remove the "red" option
-    And I press the "Delete" button
+    And I confirm the deletion
     Then I should not see the text "Error during deletion of the attribute option"
     Then I should not see the text "red"
 
@@ -42,6 +42,6 @@ Feature: Delete attribute options
     And I am on the "color" attribute page
     And I visit the "Options" tab
     When I remove the "white" option
-    And I press the "Delete" button
+    And I confirm the deletion
     And I should see the text "Attribute option \"white\" could not be removed as it is used as variant axis value."
     Then I should see the text "white"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
<img width="700" alt="image" src="https://user-images.githubusercontent.com/3492179/102345555-de7bc200-3f9d-11eb-95be-14c31de43624.png">


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
