### PR TITLE
RAC-436: Add cache to FindQuantifiedAssociationTypeCodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,7 +215,6 @@
 - Change constructor of `Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeGroupController` to replace `Doctrine\ORM\EntityRepository $attributeGroupRepo` by `Akeneo\Pim\Structure\Component\Repository\AttributeGroupRepositoryInterface $attributeGroupRepo`
 - Change `Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface` interface to add `getWithVariants()`
 - Change constructor of `Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup` to replace `Doctrine\DBAL\Driver\Connection $connection` by `Doctrine\DBAL\Connection $connection`
-- Add `clearCache` method in `Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface`
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface` to
     - remove the `setFamilyId()` method
     - extend the new `Akeneo\Tool\Component\StorageUtils\Model\StateUpdatedAware` interface (with `isDirty()` and `cleanup()` methods)

--- a/src/Akeneo/Channel/Bundle/Doctrine/Query/FindActivatedCurrencies.php
+++ b/src/Akeneo/Channel/Bundle/Doctrine/Query/FindActivatedCurrencies.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Channel\Bundle\Doctrine\Query;
 
 use Akeneo\Channel\Component\Query\FindActivatedCurrenciesInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -13,7 +14,7 @@ use Doctrine\ORM\EntityManagerInterface;
  * @copyright 2018 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FindActivatedCurrencies implements FindActivatedCurrenciesInterface
+class FindActivatedCurrencies implements FindActivatedCurrenciesInterface, CachedQueryInterface
 {
     private array $activatedCurrenciesForChannels = [];
     private EntityManagerInterface $entityManager;

--- a/src/Akeneo/Channel/Bundle/EventListener/ClearCacheSubscriber.php
+++ b/src/Akeneo/Channel/Bundle/EventListener/ClearCacheSubscriber.php
@@ -6,6 +6,7 @@ namespace Akeneo\Channel\Bundle\EventListener;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -19,9 +20,9 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class ClearCacheSubscriber implements EventSubscriberInterface
 {
-    private ChannelExistsWithLocaleInterface $cachedChannelExistsWithLocale;
+    private CachedQueryInterface $cachedChannelExistsWithLocale;
 
-    public function __construct(ChannelExistsWithLocaleInterface $cachedChannelExistsWithLocale)
+    public function __construct(CachedQueryInterface $cachedChannelExistsWithLocale)
     {
         $this->cachedChannelExistsWithLocale = $cachedChannelExistsWithLocale;
     }

--- a/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
@@ -8,3 +8,4 @@ services:
         class: 'Akeneo\Channel\Component\Query\PublicApi\Cache\CachedChannelExistsWithLocale'
         arguments:
             - '@pim_channel.query.sql.get_channel_code_with_locale_codes'
+        tags: ['akeneo.pim.cached_query']

--- a/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -6,13 +6,14 @@ namespace Akeneo\Channel\Component\Query\PublicApi\Cache;
 
 use Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface
+final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface
 {
     private GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes;
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -76,5 +76,4 @@ services:
         class: Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer
         arguments:
             - '@pim_connector.doctrine.cache_clearer'
-            - '@akeneo.pim.structure.query.get_attributes'
             - '@akeneo.pim.storage_utils.cache.cached_queries_clearer'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -79,3 +79,4 @@ services:
             - '@pim_catalog.query.find_activated_currencies'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo.pim.structure.query.get_attributes'
+            - '@akeneo.pim.storage_utils.cache.cached_queries_clearer'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -75,8 +75,6 @@ services:
     akeneo_connectivity.connection.webhook.cache_clearer:
         class: Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer
         arguments:
-            - '@pim_channel.query.cache.channel_exists_with_locale'
-            - '@pim_catalog.query.find_activated_currencies'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo.pim.structure.query.get_attributes'
             - '@akeneo.pim.storage_utils.cache.cached_queries_clearer'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
@@ -3,8 +3,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
 
-use Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies;
-use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
 use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
@@ -17,21 +15,15 @@ use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface;
  */
 class CacheClearer implements CacheClearerInterface
 {
-    private ChannelExistsWithLocaleInterface $channelExistsWithLocale;
-    private FindActivatedCurrencies $findActivatedCurrencies;
     private UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer;
     private LRUCachedGetAttributes $LRUCachedGetAttributes;
     private CachedQueriesClearerInterface $cachedQueriesClearer;
 
     public function __construct(
-        ChannelExistsWithLocaleInterface $channelExistsWithLocale,
-        FindActivatedCurrencies $findActivatedCurrencies,
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
         LRUCachedGetAttributes $LRUCachedGetAttributes,
         CachedQueriesClearerInterface $cachedQueriesClearer
     ) {
-        $this->channelExistsWithLocale = $channelExistsWithLocale;
-        $this->findActivatedCurrencies = $findActivatedCurrencies;
         $this->unitOfWorkAndRepositoriesClearer = $unitOfWorkAndRepositoriesClearer;
         $this->LRUCachedGetAttributes = $LRUCachedGetAttributes;
         $this->cachedQueriesClearer = $cachedQueriesClearer;
@@ -39,8 +31,6 @@ class CacheClearer implements CacheClearerInterface
 
     public function clear(): void
     {
-        $this->channelExistsWithLocale->clearCache();
-        $this->findActivatedCurrencies->clearCache();
         $this->unitOfWorkAndRepositoriesClearer->clear();
         $this->LRUCachedGetAttributes->clearCache();
         $this->cachedQueriesClearer->clear();

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
@@ -16,23 +16,19 @@ use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface;
 class CacheClearer implements CacheClearerInterface
 {
     private UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer;
-    private LRUCachedGetAttributes $LRUCachedGetAttributes;
     private CachedQueriesClearerInterface $cachedQueriesClearer;
 
     public function __construct(
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
-        LRUCachedGetAttributes $LRUCachedGetAttributes,
         CachedQueriesClearerInterface $cachedQueriesClearer
     ) {
         $this->unitOfWorkAndRepositoriesClearer = $unitOfWorkAndRepositoriesClearer;
-        $this->LRUCachedGetAttributes = $LRUCachedGetAttributes;
         $this->cachedQueriesClearer = $cachedQueriesClearer;
     }
 
     public function clear(): void
     {
         $this->unitOfWorkAndRepositoriesClearer->clear();
-        $this->LRUCachedGetAttributes->clearCache();
         $this->cachedQueriesClearer->clear();
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/CacheClearer.php
@@ -8,6 +8,7 @@ use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
 use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface;
 
 /**
  * @author    Willy Mesnage <willy.mesnage@akeneo.com>
@@ -20,17 +21,20 @@ class CacheClearer implements CacheClearerInterface
     private FindActivatedCurrencies $findActivatedCurrencies;
     private UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer;
     private LRUCachedGetAttributes $LRUCachedGetAttributes;
+    private CachedQueriesClearerInterface $cachedQueriesClearer;
 
     public function __construct(
         ChannelExistsWithLocaleInterface $channelExistsWithLocale,
         FindActivatedCurrencies $findActivatedCurrencies,
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
-        LRUCachedGetAttributes $LRUCachedGetAttributes
+        LRUCachedGetAttributes $LRUCachedGetAttributes,
+        CachedQueriesClearerInterface $cachedQueriesClearer
     ) {
         $this->channelExistsWithLocale = $channelExistsWithLocale;
         $this->findActivatedCurrencies = $findActivatedCurrencies;
         $this->unitOfWorkAndRepositoriesClearer = $unitOfWorkAndRepositoriesClearer;
         $this->LRUCachedGetAttributes = $LRUCachedGetAttributes;
+        $this->cachedQueriesClearer = $cachedQueriesClearer;
     }
 
     public function clear(): void
@@ -39,5 +43,6 @@ class CacheClearer implements CacheClearerInterface
         $this->findActivatedCurrencies->clearCache();
         $this->unitOfWorkAndRepositoriesClearer->clear();
         $this->LRUCachedGetAttributes->clearCache();
+        $this->cachedQueriesClearer->clear();
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
@@ -10,6 +10,8 @@ use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer;
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearer;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface;
 use PhpSpec\ObjectBehavior;
 
 class CacheClearerSpec extends ObjectBehavior
@@ -18,14 +20,16 @@ class CacheClearerSpec extends ObjectBehavior
         ChannelExistsWithLocaleInterface $channelExistsWithLocale,
         FindActivatedCurrencies $findActivatedCurrencies,
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
-        GetAttributes $getAttributes
+        GetAttributes $getAttributes,
+        CachedQueriesClearerInterface $cachedQueriesClearer
     ): void {
         $LRUCachedGetAttributes = new LRUCachedGetAttributes($getAttributes->getWrappedObject());
         $this->beConstructedWith(
             $channelExistsWithLocale,
             $findActivatedCurrencies,
             $unitOfWorkAndRepositoriesClearer,
-            $LRUCachedGetAttributes
+            $LRUCachedGetAttributes,
+            $cachedQueriesClearer
         );
     }
 
@@ -38,11 +42,13 @@ class CacheClearerSpec extends ObjectBehavior
     public function it_clears_the_cache(
         $channelExistsWithLocale,
         $findActivatedCurrencies,
-        $unitOfWorkAndRepositoriesClearer
+        $unitOfWorkAndRepositoriesClearer,
+        CachedQueriesClearerInterface $cachedQueriesClearer
     ): void {
         $channelExistsWithLocale->clearCache()->shouldBeCalled();
         $findActivatedCurrencies->clearCache()->shouldBeCalled();
         $unitOfWorkAndRepositoriesClearer->clear()->shouldBeCalled();
+        $cachedQueriesClearer->clear()->shouldBeCalled();
 
         $this->clear();
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
@@ -3,30 +3,23 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
 
-use Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies;
-use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer;
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
-use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearer;
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface;
 use PhpSpec\ObjectBehavior;
 
 class CacheClearerSpec extends ObjectBehavior
 {
     public function let(
-        ChannelExistsWithLocaleInterface $channelExistsWithLocale,
-        FindActivatedCurrencies $findActivatedCurrencies,
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
         GetAttributes $getAttributes,
         CachedQueriesClearerInterface $cachedQueriesClearer
     ): void {
         $LRUCachedGetAttributes = new LRUCachedGetAttributes($getAttributes->getWrappedObject());
         $this->beConstructedWith(
-            $channelExistsWithLocale,
-            $findActivatedCurrencies,
             $unitOfWorkAndRepositoriesClearer,
             $LRUCachedGetAttributes,
             $cachedQueriesClearer
@@ -40,13 +33,9 @@ class CacheClearerSpec extends ObjectBehavior
     }
 
     public function it_clears_the_cache(
-        $channelExistsWithLocale,
-        $findActivatedCurrencies,
         $unitOfWorkAndRepositoriesClearer,
         CachedQueriesClearerInterface $cachedQueriesClearer
     ): void {
-        $channelExistsWithLocale->clearCache()->shouldBeCalled();
-        $findActivatedCurrencies->clearCache()->shouldBeCalled();
         $unitOfWorkAndRepositoriesClearer->clear()->shouldBeCalled();
         $cachedQueriesClearer->clear()->shouldBeCalled();
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/CacheClearerSpec.php
@@ -15,15 +15,9 @@ class CacheClearerSpec extends ObjectBehavior
 {
     public function let(
         UnitOfWorkAndRepositoriesClearer $unitOfWorkAndRepositoriesClearer,
-        GetAttributes $getAttributes,
         CachedQueriesClearerInterface $cachedQueriesClearer
     ): void {
-        $LRUCachedGetAttributes = new LRUCachedGetAttributes($getAttributes->getWrappedObject());
-        $this->beConstructedWith(
-            $unitOfWorkAndRepositoriesClearer,
-            $LRUCachedGetAttributes,
-            $cachedQueriesClearer
-        );
+        $this->beConstructedWith($unitOfWorkAndRepositoriesClearer, $cachedQueriesClearer);
     }
 
     public function it_is_a_cache_clearer(): void

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/FindQuantifiedAssociationTypeCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/FindQuantifiedAssociationTypeCodes.php
@@ -27,7 +27,7 @@ class FindQuantifiedAssociationTypeCodes implements FindQuantifiedAssociationTyp
         return $this->cachedResult;
     }
 
-    public function clear(): void
+    public function clearCache(): void
     {
         $this->cachedResult = null;
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -341,6 +341,7 @@ services:
         class: Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\FindQuantifiedAssociationTypeCodes
         arguments:
             - '@database_connection'
+        tags: ['akeneo.pim.cached_query']
 
     akeneo.pim.enrichment.product.query.quantified_association.get_id_mapping_from_product_identifiers_query:
         class: 'Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\QuantifiedAssociation\GetIdMappingFromProductIdentifiersQuery'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -39,6 +39,7 @@ services:
         class: Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies
         arguments:
             - '@doctrine.orm.entity_manager'
+        tags: ['akeneo.pim.cached_query']
 
     akeneo.pim.enrichment.product.grid.query.fetch_product_and_product_model_rows:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductGrid\FetchProductAndProductModelRows'

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
@@ -5,6 +5,7 @@ namespace Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache;
 
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
 
 /**
@@ -12,7 +13,7 @@ use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class LRUCachedGetAttributes implements GetAttributes
+final class LRUCachedGetAttributes implements GetAttributes, CachedQueryInterface
 {
     /** @var GetAttributes */
     private $getAttributes;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -35,6 +35,7 @@ services:
         class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes'
         arguments:
             $getAttributes: '@akeneo.pim.structure.query.sql_get_attributes'
+        tags: ['akeneo.pim.cached_query']
 
     akeneo.pim.structure.query.sql_get_required_attributes_masks:
         class: 'Akeneo\Pim\Structure\Bundle\Query\PublicApi\Family\Sql\SqlGetRequiredAttributesMasks'

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/AkeneoStorageUtilsExtension.php
@@ -26,6 +26,7 @@ class AkeneoStorageUtilsExtension extends Extension
         $container->setParameter($this->getAlias() . '.mapping_overrides', $config['mapping_overrides']);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('cache.yml');
         $loader->load('doctrine.yml');
         $loader->load('factories.yml');
         $loader->load('removers.yml');

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/cache.yml
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Resources/config/cache.yml
@@ -1,0 +1,5 @@
+services:
+  akeneo.pim.storage_utils.cache.cached_queries_clearer:
+    class: Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearer
+    arguments:
+      - !tagged_iterator akeneo.pim.cached_query

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearer.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearer.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\StorageUtils\Cache;
+
+use Webmozart\Assert\Assert;
+
+final class CachedQueriesClearer implements CachedQueriesClearerInterface
+{
+    /** @var CachedQueryInterface[] */
+    private iterable $cachedQueries;
+
+    public function __construct(iterable $cachedQueries)
+    {
+        Assert::allIsInstanceOf($cachedQueries, CachedQueryInterface::class);
+
+        $this->cachedQueries = $cachedQueries;
+    }
+
+    public function clear(): void
+    {
+        foreach ($this->cachedQueries as $cachedQuery) {
+            $cachedQuery->clear();
+        }
+    }
+}

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearer.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearer.php
@@ -21,7 +21,7 @@ final class CachedQueriesClearer implements CachedQueriesClearerInterface
     public function clear(): void
     {
         foreach ($this->cachedQueries as $cachedQuery) {
-            $cachedQuery->clear();
+            $cachedQuery->clearCache();
         }
     }
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearerInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueriesClearerInterface.php
@@ -1,9 +1,10 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Tool\Component\StorageUtils\Cache;
 
-interface CachedQueryInterface
+interface CachedQueriesClearerInterface
 {
     public function clear(): void;
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueryInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueryInterface.php
@@ -5,5 +5,5 @@ namespace Akeneo\Tool\Component\StorageUtils\Cache;
 
 interface CachedQueryInterface
 {
-    public function clear(): void;
+    public function clearCache(): void;
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueryInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Cache/CachedQueryInterface.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\StorageUtils\Cache;
+
+interface CachedQueryInterface
+{
+    public function clear():void;
+}

--- a/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/CachedQueriesClearerSpec.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/CachedQueriesClearerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\Akeneo\Tool\Component\StorageUtils\Cache;
 
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
-use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
 use PhpSpec\ObjectBehavior;
 
 class CachedQueriesClearerSpec extends ObjectBehavior
@@ -17,8 +16,8 @@ class CachedQueriesClearerSpec extends ObjectBehavior
             $cachedQuery2
         ]);
 
-        $cachedQuery1->clear()->shouldBeCalledOnce();
-        $cachedQuery2->clear()->shouldBeCalledOnce();
+        $cachedQuery1->clearCache()->shouldBeCalledOnce();
+        $cachedQuery2->clearCache()->shouldBeCalledOnce();
 
         $this->clear();
     }

--- a/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/CachedQueriesClearerSpec.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/spec/Cache/CachedQueriesClearerSpec.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace spec\Akeneo\Tool\Component\StorageUtils\Cache;
+
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
+use PhpSpec\ObjectBehavior;
+
+class CachedQueriesClearerSpec extends ObjectBehavior
+{
+    function it_clear_all_cached_queries(
+        CachedQueryInterface $cachedQuery1,
+        CachedQueryInterface $cachedQuery2
+    ) {
+        $this->beConstructedWith([
+            $cachedQuery1,
+            $cachedQuery2
+        ]);
+
+        $cachedQuery1->clear()->shouldBeCalledOnce();
+        $cachedQuery2->clear()->shouldBeCalledOnce();
+
+        $this->clear();
+    }
+
+    function it_throws_an_exception_when_query_is_not_a_cached_query(
+        CachedQueryInterface $cachedQuery1,
+        \stdClass $LRUCache
+    ) {
+        $this->beConstructedWith([$cachedQuery1, $LRUCache]);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/tests/back/Channel/Specification/Bundle/EventListener/ClearCacheSubscriberSpec.php
+++ b/tests/back/Channel/Specification/Bundle/EventListener/ClearCacheSubscriberSpec.php
@@ -5,13 +5,14 @@ namespace Specification\Akeneo\Channel\Bundle\EventListener;
 use Akeneo\Channel\Bundle\EventListener\ClearCacheSubscriber;
 use Akeneo\Channel\Component\Model\ChannelInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 class ClearCacheSubscriberSpec extends ObjectBehavior
 {
-    function let(ChannelExistsWithLocaleInterface $cachedChannelExistsWithLocale)
+    function let(CachedQueryInterface $cachedChannelExistsWithLocale)
     {
         $this->beConstructedWith($cachedChannelExistsWithLocale);
     }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindQuantifiedAssociationTypeCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindQuantifiedAssociationTypeCodesIntegration.php
@@ -70,7 +70,7 @@ class FindQuantifiedAssociationTypeCodesIntegration extends TestCase
         $actualQuantifiedAssociationTypeCodes = $this->findQuantifiedAssociationCodes->execute(); // result is still the cache
         self::assertEquals($actualQuantifiedAssociationTypeCodes, ['association_type_1']);
 
-        $this->findQuantifiedAssociationCodes->clear();
+        $this->findQuantifiedAssociationCodes->clearCache();
         $actualQuantifiedAssociationTypeCodes = $this->findQuantifiedAssociationCodes->execute(); // Cache is reinitialized
         self::assertEquals($actualQuantifiedAssociationTypeCodes, ['association_type_1', 'association_type_2']);
     }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindQuantifiedAssociationTypeCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindQuantifiedAssociationTypeCodesIntegration.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\FindQuantifiedAssociationTyp
 use Akeneo\Test\Integration\TestCase;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 
-class FindQuantifiedAssociationTypeCodesQueryIntegration extends TestCase
+class FindQuantifiedAssociationTypeCodesIntegration extends TestCase
 {
     use QuantifiedAssociationsTestCaseTrait;
 
@@ -57,5 +57,21 @@ class FindQuantifiedAssociationTypeCodesQueryIntegration extends TestCase
             $actualQuantifiedAssociationTypeCodes,
             $quantifiedAssociationTypes
         );
+    }
+
+    /** @test */
+    public function it_caches_the_results()
+    {
+        $this->createQuantifiedAssociationType('association_type_1');
+        $actualQuantifiedAssociationTypeCodes = $this->findQuantifiedAssociationCodes->execute(); // Cache is initialized
+        self::assertEquals($actualQuantifiedAssociationTypeCodes, ['association_type_1']);
+
+        $this->createQuantifiedAssociationType('association_type_2');
+        $actualQuantifiedAssociationTypeCodes = $this->findQuantifiedAssociationCodes->execute(); // result is still the cache
+        self::assertEquals($actualQuantifiedAssociationTypeCodes, ['association_type_1']);
+
+        $this->findQuantifiedAssociationCodes->clear();
+        $actualQuantifiedAssociationTypeCodes = $this->findQuantifiedAssociationCodes->execute(); // Cache is reinitialized
+        self::assertEquals($actualQuantifiedAssociationTypeCodes, ['association_type_1', 'association_type_2']);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR we introduce:
- a dedicated interface for cachedQuery called CachedQueryInterface
- a tag for those queries that are automagically injected into a the "Connectivity/CacheClearer" class
- some queries directly injected in the "Connectivity/CacheClearer" were tagged with the new tag and removed from the CacheClearer constructor injection
    - pim_channel.query.cache.channel_exists_with_locale
    - pim_catalog.query.find_activated_currencies
    - Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Ok
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Ok
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
