### PR TITLE
Do not update products or models when quantified associations were not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,11 +93,11 @@
 - PIM-9485: Change ACL name “Remove a product model” to “Remove a product model (including children)”
 - BH-138: clear Locale cache on save
 - CXP-493: Do not save products when they were not actually updated. In order to do so, the product now returns copies of
-  its collections (values, categories, groups and associations). Practically, this means that such a collection cannot be directly
+  its collections (values, categories, groups, associations and quantified associations). Practically, this means that such a collection cannot be directly
   updated "from outside" anymore (e.g: `$product->getCategories()->add($category)` **won't update the product anymore**,
   you should now use `$product->addCategory($category)` to achieve it)  
 - CXP-544: Do not save product models when they were not actually updated. As for products, the product model
-  will now return copies of its collections (values, categories and associations)
+  will now return copies of its collections (values, categories, associations and quantified associations)
 
 # Technical Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -832,16 +832,27 @@ abstract class AbstractProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
+    public function getQuantifiedAssociations(): QuantifiedAssociationCollection
+    {
+        return clone $this->quantifiedAssociationCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
     {
         if (null === $this->quantifiedAssociationCollection) {
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection
             ->filterProductIdentifiers($productIdentifiersToKeep)
             ->filterProductModelCodes($productModelCodesToKeep);
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -852,8 +863,12 @@ abstract class AbstractProduct implements ProductInterface
         if ($this->quantifiedAssociationCollection === null) {
             return;
         }
+
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->merge($quantifiedAssociations);
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -865,10 +880,13 @@ abstract class AbstractProduct implements ProductInterface
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->patchQuantifiedAssociations(
             $submittedQuantifiedAssociations
         );
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -880,8 +898,11 @@ abstract class AbstractProduct implements ProductInterface
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->clearQuantifiedAssociations();
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -616,16 +616,27 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritdoc}
      */
+    public function getQuantifiedAssociations(): QuantifiedAssociationCollection
+    {
+        return clone $this->quantifiedAssociationCollection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function filterQuantifiedAssociations(array $productIdentifiersToKeep, array $productModelCodesToKeep): void
     {
         if (null === $this->quantifiedAssociationCollection) {
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection
             ->filterProductIdentifiers($productIdentifiersToKeep)
             ->filterProductModelCodes($productModelCodesToKeep);
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -636,8 +647,12 @@ class ProductModel implements ProductModelInterface
         if ($this->quantifiedAssociationCollection === null) {
             return;
         }
+
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->merge($quantifiedAssociations);
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -649,10 +664,13 @@ class ProductModel implements ProductModelInterface
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->patchQuantifiedAssociations(
             $submittedQuantifiedAssociations
         );
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**
@@ -664,8 +682,11 @@ class ProductModel implements ProductModelInterface
             return;
         }
 
+        $initialCollection = $this->getQuantifiedAssociations();
         $this->quantifiedAssociationCollection = $this->quantifiedAssociationCollection->clearQuantifiedAssociations();
-        $this->dirty = true;
+        if (!$this->quantifiedAssociationCollection->equals($initialCollection)) {
+            $this->dirty = true;
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollection.php
@@ -258,6 +258,30 @@ class QuantifiedAssociationCollection
         return new self($filteredQuantifiedAssociations);
     }
 
+    public function equals(QuantifiedAssociationCollection $otherCollection): bool
+    {
+        $sortByIdentifiers = fn (
+            array $quantifiedLinkA,
+            array $quantifiedLinkB
+        ): int => $quantifiedLinkA['identifier'] <=> $quantifiedLinkB['identifier'];
+
+        $normalized = $this->normalize();
+        ksort($normalized);
+        foreach ($normalized as $associationType => $associations) {
+            usort($normalized[$associationType][self::PRODUCTS_QUANTIFIED_LINKS_KEY], $sortByIdentifiers);
+            usort($normalized[$associationType][self::PRODUCT_MODELS_QUANTIFIED_LINKS_KEY], $sortByIdentifiers);
+        }
+
+        $otherNormalized = $otherCollection->normalize();
+        ksort($otherNormalized);
+        foreach ($otherNormalized as $associationType => $associations) {
+            usort($otherNormalized[$associationType][self::PRODUCTS_QUANTIFIED_LINKS_KEY], $sortByIdentifiers);
+            usort($otherNormalized[$associationType][self::PRODUCT_MODELS_QUANTIFIED_LINKS_KEY], $sortByIdentifiers);
+        }
+
+        return $normalized === $otherNormalized;
+    }
+
     private function getAssociationTypeCodes()
     {
         return array_keys($this->quantifiedAssociations);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -23,7 +23,6 @@ use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 class ProductSpec extends ObjectBehavior
 {
@@ -650,42 +649,6 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    function it_is_updated_when_filtering_quantified_associations()
-    {
-        $this->filterQuantifiedAssociations(['foo', 'bar'], ['baz']);
-        $this->isDirty()->shouldBe(true);
-    }
-
-    function it_is_updated_when_patching_quantified_associations(
-        QuantifiedAssociationCollection $quantifiedAssociations
-    ) {
-        $quantifiedAssociations->normalize()->willReturn([
-            'type' => [
-                'products' => [
-                    [
-                        'identifier' => 'foo',
-                        'quantity' => 2,
-                    ]
-                ],
-                'product_models' => [
-                    [
-                        'identifier' => 'bar',
-                        'quantity' => 1
-                    ],
-                ],
-            ],
-        ]);
-        $this->mergeQuantifiedAssociations($quantifiedAssociations);
-        $this->isDirty()->shouldBe(true);
-    }
-
-    function it_is_updated_when_clearing_quantified_associations()
-    {
-        $this->isDirty()->shouldBe(false);
-        $this->clearQuantifiedAssociations();
-        $this->isDirty()->shouldBe(true);
-    }
-
     function it_is_updated_when_adding_a_non_empty_association(
         AssociationInterface $association,
         AssociationTypeInterface $associationType
@@ -711,7 +674,6 @@ class ProductSpec extends ObjectBehavior
         $association->getProductModels()->willReturn(new ArrayCollection());
         $association->getGroups()->willReturn(new ArrayCollection());
         $this->cleanup();
-
 
         $association->setOwner($this)->shouldBeCalled();
 
@@ -830,7 +792,8 @@ class ProductSpec extends ObjectBehavior
         $this->addAssociatedProduct($product, 'x_sell');
     }
 
-    public function it_is_updated_if_a_product_is_added_to_an_association(): void {
+    public function it_is_updated_if_a_product_is_added_to_an_association(): void
+    {
         $product = new Product();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -844,7 +807,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_product_to_add_to_an_association_already_exists(): void {
+    public function it_is_not_updated_if_a_product_to_add_to_an_association_already_exists(): void
+    {
         $product = new Product();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -878,7 +842,8 @@ class ProductSpec extends ObjectBehavior
         $this->removeAssociatedProduct($product, 'x_sell');
     }
 
-    public function it_is_updated_if_a_product_is_removed_from_an_association(): void {
+    public function it_is_updated_if_a_product_is_removed_from_an_association(): void
+    {
         $product = new Product();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -893,7 +858,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_product_to_remove_from_an_association_does_not_exist(): void {
+    public function it_is_not_updated_if_a_product_to_remove_from_an_association_does_not_exist(): void
+    {
         $product = new Product();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -944,7 +910,8 @@ class ProductSpec extends ObjectBehavior
         $this->addAssociatedProductModel($productModel, 'x_sell');
     }
 
-    public function it_is_updated_if_a_product_model_is_added_to_an_association(): void {
+    public function it_is_updated_if_a_product_model_is_added_to_an_association(): void
+    {
         $productModel = new ProductModel();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -958,7 +925,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_product_model_to_add_to_an_association_already_exists(): void {
+    public function it_is_not_updated_if_a_product_model_to_add_to_an_association_already_exists(): void
+    {
         $productModel = new ProductModel();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -992,7 +960,8 @@ class ProductSpec extends ObjectBehavior
         $this->removeAssociatedProductModel($productModel, 'x_sell');
     }
 
-    public function it_is_updated_if_a_product_model_is_removed_from_an_association(): void {
+    public function it_is_updated_if_a_product_model_is_removed_from_an_association(): void
+    {
         $productModel = new ProductModel();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1007,7 +976,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_product_model_to_remove_from_an_association_does_not_exist(): void {
+    public function it_is_not_updated_if_a_product_model_to_remove_from_an_association_does_not_exist(): void
+    {
         $productModel = new ProductModel();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1058,7 +1028,8 @@ class ProductSpec extends ObjectBehavior
         $this->addAssociatedGroup($group, 'x_sell');
     }
 
-    public function it_is_updated_if_a_group_is_added_to_an_association(): void {
+    public function it_is_updated_if_a_group_is_added_to_an_association(): void
+    {
         $group = new Group();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1072,7 +1043,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_group_to_add_to_an_association_already_exists(): void {
+    public function it_is_not_updated_if_a_group_to_add_to_an_association_already_exists(): void
+    {
         $group = new Group();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1105,7 +1077,8 @@ class ProductSpec extends ObjectBehavior
         $this->removeAssociatedGroup($group, 'x_sell');
     }
 
-    public function it_is_updated_if_a_group_is_removed_from_an_association(): void {
+    public function it_is_updated_if_a_group_is_removed_from_an_association(): void
+    {
         $group = new Group();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1120,7 +1093,8 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_if_a_group_to_remove_from_an_association_does_not_exist(): void {
+    public function it_is_not_updated_if_a_group_to_remove_from_an_association_does_not_exist(): void
+    {
         $group = new Group();
         $xsellAssociation = new ProductAssociation();
         $xsellType = new AssociationType();
@@ -1150,5 +1124,298 @@ class ProductSpec extends ObjectBehavior
 
         $this->getAssociatedGroups('x_sell')->shouldBeLike(new ArrayCollection([$plate, $spoon]));
         $this->getAssociatedGroups('another_association_type')->shouldReturn(null);
+    }
+
+    public function it_is_updated_when_quantified_associations_are_updated(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                        ['identifier' => 'my_other_product', 'quantity' => 10],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt', 'quantity' => 1],
+                        ['identifier' => 'model_jeans', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 5],
+                        ['identifier' => 'yet_another_product', 'quantity' => 2],
+                    ],
+                ],
+            ]
+        );
+        $this->isDirty()->shouldBe(true);
+    }
+
+    public function it_is_not_updated_when_quantified_associations_are_not_updated(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                        ['identifier' => 'my_other_product', 'quantity' => 10],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt', 'quantity' => 1],
+                        ['identifier' => 'model_jeans', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'product_models' => [
+                        ['identifier' => 'model_jeans', 'quantity' => 1],
+                        ['identifier' => 'model_tshirt', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->isDirty()->shouldBe(false);
+    }
+
+    public function it_is_updated_when_clearing_non_empty_quantified_associations(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                        ['identifier' => 'my_other_product', 'quantity' => 10],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt', 'quantity' => 1],
+                        ['identifier' => 'model_jeans', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->clearQuantifiedAssociations();
+        $this->isDirty()->shouldBe(true);
+    }
+
+    public function it_is_not_updated_when_clearing_empty_quantified_associations(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'product_set' => [
+                    'products' => [],
+                    'product_models' => [],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->clearQuantifiedAssociations();
+        $this->isDirty()->shouldBe(false);
+    }
+
+    public function it_is_updated_when_merging_new_quantified_associations(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'associationB' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 4],
+                    ],
+                ],
+                'associationA' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 4],
+                        ['identifier' => 'my_other_product', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->mergeQuantifiedAssociations(
+            QuantifiedAssociationCollection::createFromNormalized(
+                [
+                    'associationB' => [
+                        'products' => [
+                            ['identifier' => 'another_product', 'quantity' => 4],
+                        ],
+                    ],
+                ]
+            )
+        );
+        $this->isDirty()->shouldBe(true);
+    }
+
+    public function it_is_updated_when_merging_quantified_associations_with_an_updated_quantity(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'associationB' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 4],
+                    ],
+                ],
+                'associationA' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 4],
+                        ['identifier' => 'my_other_product', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->mergeQuantifiedAssociations(
+            QuantifiedAssociationCollection::createFromNormalized(
+                [
+                    'associationB' => [
+                        'products' => [
+                            ['identifier' => 'my_product', 'quantity' => 20],
+                        ],
+                    ],
+                ]
+            )
+        );
+        $this->isDirty()->shouldBe(true);
+    }
+
+    public function it_is_not_updated_when_merging_identical_quantified_associations(): void
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'associationB' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 4],
+                    ],
+                ],
+                'associationA' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 4],
+                        ['identifier' => 'my_other_product', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->mergeQuantifiedAssociations(
+            QuantifiedAssociationCollection::createFromNormalized(
+                [
+                    'associationA' => [
+                        'products' => [
+                            ['identifier' => 'my_product', 'quantity' => 4],
+                        ],
+                    ],
+                    'associationB' => [
+                        'product_models' => [
+                            ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ],
+                    ],
+                ]
+            )
+        );
+        $this->isDirty()->shouldBe(false);
+    }
+
+    public function it_is_updated_when_filtering_associated_products_or_product_models_from_quantified_associations()
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'associationB' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 4],
+                    ],
+                ],
+                'associationsA' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 4],
+                        ['identifier' => 'my_other_product', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->filterQuantifiedAssociations(['my_product'], ['model_tshirt_2']);
+        $this->isDirty()->shouldBe(true);
+    }
+
+    public function it_is_not_updated_when_keeping_all_associated_products_or_models()
+    {
+        $this->patchQuantifiedAssociations(
+            [
+                'associationB' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 1],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 4],
+                    ],
+                ],
+                'associationsA' => [
+                    'products' => [
+                        ['identifier' => 'my_product', 'quantity' => 4],
+                        ['identifier' => 'my_other_product', 'quantity' => 2],
+                    ],
+                    'product_models' => [
+                        ['identifier' => 'model_tshirt_1', 'quantity' => 3],
+                        ['identifier' => 'model_tshirt_2', 'quantity' => 1],
+                    ],
+                ],
+            ]
+        );
+        $this->cleanup();
+
+        $this->filterQuantifiedAssociations(
+            ['my_product', 'my_other_product'],
+            ['model_tshirt_1', 'model_tshirt_2']
+        );
+        $this->isDirty()->shouldBe(false);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductSpec.php
@@ -1354,7 +1354,7 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(false);
     }
 
-    public function it_is_updated_when_filtering_associated_products_or_product_models_from_quantified_associations()
+    public function it_is_updated_when_filtering_associated_products_or_product_models_from_quantified_associations(): void
     {
         $this->patchQuantifiedAssociations(
             [
@@ -1385,7 +1385,7 @@ class ProductSpec extends ObjectBehavior
         $this->isDirty()->shouldBe(true);
     }
 
-    public function it_is_not_updated_when_keeping_all_associated_products_or_models()
+    public function it_is_not_updated_when_keeping_all_associated_products_or_models(): void
     {
         $this->patchQuantifiedAssociations(
             [

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollectionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/QuantifiedAssociation/QuantifiedAssociationCollectionSpec.php
@@ -569,6 +569,72 @@ class QuantifiedAssociationCollectionSpec extends ObjectBehavior
         ]));
     }
 
+    public function it_can_compare_itself_to_another_collection()
+    {
+        $this->beConstructedThrough(
+            'createFromNormalized',
+            [
+                [
+                    'type1' => [
+                        'products' => [
+                            ['identifier' => 'foo', 'quantity' => 2],
+                            ['identifier' => 'bar', 'quantity' => 5],
+                        ],
+                        'product_models' => [
+                            ['identifier' => 'baz', 'quantity' => 3],
+                        ],
+                    ],
+                    'type2' => [
+                        'products' => [
+                            ['identifier' => 'foo', 'quantity' => 10],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $identicalCollection = QuantifiedAssociationCollection::createFromNormalized(
+            [
+                'type2' => [
+                    'product_models' => [],
+                    'products' => [
+                        ['quantity' => 10, 'identifier' => 'foo'],
+                    ],
+                ],
+                'type1' => [
+                    'product_models' => [
+                        ['identifier' => 'baz', 'quantity' => 3],
+                    ],
+                    'products' => [
+                        ['identifier' => 'bar', 'quantity' => 5],
+                        ['identifier' => 'foo', 'quantity' => 2],
+                    ],
+                ],
+            ]
+        );
+        $this->equals($identicalCollection)->shouldBe(true);
+
+        $differentCollection = $identicalCollection = QuantifiedAssociationCollection::createFromNormalized(
+            [
+                'type2' => [
+                    'product_models' => [],
+                    'products' => [
+                        ['quantity' => 0, 'identifier' => 'foo'],
+                    ],
+                ],
+                'type1' => [
+                    'product_models' => [
+                        ['identifier' => 'other_sku', 'quantity' => 1],
+                    ],
+                    'products' => [
+                        ['identifier' => 'foo', 'quantity' => 2],
+                    ],
+                ],
+            ]
+        );
+        $this->equals($differentCollection)->shouldBe(false);
+    }
+
     private function anIdMapping(): IdMapping
     {
         return IdMapping::createFromMapping(


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Last PR in the series of _**Do not save a product or product model if it was not actually updated**_ :slightly_smiling_face: 

Here we compare the quantified association collection before and after calling methods which potentially update it to compute the state of the product / model (aka `isDirty()`). In order to do so, I added the `QuantifiedAssociationCollection::equals()` public method


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
