### PR TITLE
CXP-597 make event dispatching more resilient

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
@@ -10,8 +10,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -24,15 +26,21 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
     private Security $security;
     private MessageBusInterface $messageBus;
     private int $maxBulkSize;
+    private LoggerInterface $logger;
 
     /** @var array<ProductCreated|ProductUpdated> */
     private array $events = [];
 
-    public function __construct(Security $security, MessageBusInterface $messageBus, int $maxBulkSize)
-    {
+    public function __construct(
+        Security $security,
+        MessageBusInterface $messageBus,
+        int $maxBulkSize,
+        LoggerInterface $logger
+    ) {
         $this->security = $security;
         $this->messageBus = $messageBus;
         $this->maxBulkSize = $maxBulkSize;
+        $this->logger = $logger;
     }
 
     public static function getSubscribedEvents(): array
@@ -60,31 +68,31 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
             'identifier' => $product->getIdentifier(),
         ];
 
-        $event = null;
         if ($postSaveEvent->hasArgument('is_new') && true === $postSaveEvent->getArgument('is_new')) {
-            $event = new ProductCreated($author, $data);
+            $this->events[] = new ProductCreated($author, $data);
         } else {
-            $event = new ProductUpdated($author, $data);
+            $this->events[] = new ProductUpdated($author, $data);
         }
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->messageBus->dispatch(new BulkEvent([$event]));
-
-            return;
-        }
-
-        $this->events[] = $event;
-
-        if (count($this->events) >= $this->maxBulkSize) {
+            $this->dispatchBufferedProductEvents();
+        } elseif (count($this->events) >= $this->maxBulkSize) {
             $this->dispatchBufferedProductEvents();
         }
     }
 
     public function dispatchBufferedProductEvents(): void
     {
-        if (count($this->events) > 0) {
-            $this->messageBus->dispatch(new BulkEvent($this->events));
-            $this->events = [];
+        if (count($this->events) === 0) {
+            return;
         }
+
+        try {
+            $this->messageBus->dispatch(new BulkEvent($this->events));
+        } catch (TransportException $e) {
+            $this->logger->critical($e->getMessage());
+        }
+
+        $this->events = [];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
@@ -10,8 +10,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -24,15 +26,21 @@ final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements Even
     private Security $security;
     private MessageBusInterface $messageBus;
     private int $maxBulkSize;
+    private LoggerInterface $logger;
 
     /** @var array<ProductModelCreated|ProductModelUpdated> */
     private array $events = [];
 
-    public function __construct(Security $security, MessageBusInterface $messageBus, int $maxBulkSize)
-    {
+    public function __construct(
+        Security $security,
+        MessageBusInterface $messageBus,
+        int $maxBulkSize,
+        LoggerInterface $logger
+    ) {
         $this->security = $security;
         $this->messageBus = $messageBus;
         $this->maxBulkSize = $maxBulkSize;
+        $this->logger = $logger;
     }
 
     public static function getSubscribedEvents(): array
@@ -60,31 +68,31 @@ final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements Even
             'code' => $productModel->getCode()
         ];
 
-        $event = null;
         if ($postSaveEvent->hasArgument('is_new') && true === $postSaveEvent->getArgument('is_new')) {
-            $event = new ProductModelCreated($author, $data);
+            $this->events[] = new ProductModelCreated($author, $data);
         } else {
-            $event = new ProductModelUpdated($author, $data);
+            $this->events[] = new ProductModelUpdated($author, $data);
         }
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->messageBus->dispatch(new BulkEvent([$event]));
-
-            return;
-        }
-
-        $this->events[] = $event;
-
-        if (count($this->events) >= $this->maxBulkSize) {
+            $this->dispatchBufferedProductModelEvents();
+        } elseif (count($this->events) >= $this->maxBulkSize) {
             $this->dispatchBufferedProductModelEvents();
         }
     }
 
     public function dispatchBufferedProductModelEvents(): void
     {
-        if (count($this->events) > 0) {
-            $this->messageBus->dispatch(new BulkEvent($this->events));
-            $this->events = [];
+        if (count($this->events) === 0) {
+            return;
         }
+
+        try {
+            $this->messageBus->dispatch(new BulkEvent($this->events));
+        } catch (TransportException $e) {
+            $this->logger->critical($e->getMessage());
+        }
+
+        $this->events = [];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
@@ -9,8 +9,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -23,15 +25,21 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
     private Security $security;
     private MessageBusInterface $messageBus;
     private int $maxBulkSize;
+    private LoggerInterface $logger;
 
     /** @var array<ProductRemoved> */
     private array $events = [];
 
-    public function __construct(Security $security, MessageBusInterface $messageBus, int $maxBulkSize)
-    {
+    public function __construct(
+        Security $security,
+        MessageBusInterface $messageBus,
+        int $maxBulkSize,
+        LoggerInterface $logger
+    ) {
         $this->security = $security;
         $this->messageBus = $messageBus;
         $this->maxBulkSize = $maxBulkSize;
+        $this->logger = $logger;
     }
 
     public static function getSubscribedEvents(): array
@@ -60,26 +68,27 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
             'category_codes' => $product->getCategoryCodes(),
         ];
 
-        $event = new ProductRemoved($author, $data);
+        $this->events[] = new ProductRemoved($author, $data);
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->messageBus->dispatch(new BulkEvent([$event]));
-
-            return;
-        }
-
-        $this->events[] = $event;
-
-        if (count($this->events) >= $this->maxBulkSize) {
+            $this->dispatchBufferedProductEvents();
+        } elseif (count($this->events) >= $this->maxBulkSize) {
             $this->dispatchBufferedProductEvents();
         }
     }
 
     public function dispatchBufferedProductEvents(): void
     {
-        if (count($this->events) > 0) {
-            $this->messageBus->dispatch(new BulkEvent($this->events));
-            $this->events = [];
+        if (count($this->events) === 0) {
+            return;
         }
+
+        try {
+            $this->messageBus->dispatch(new BulkEvent($this->events));
+        } catch (TransportException $e) {
+            $this->logger->critical($e->getMessage());
+        }
+
+        $this->events = [];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -188,6 +188,7 @@ services:
             - '@security.helper'
             - '@Symfony\Component\Messenger\MessageBusInterface'
             - '%webhook_max_bulk_size%'
+            - '@logger'
         tags:
             - { name: kernel.event_subscriber }
 
@@ -196,6 +197,7 @@ services:
             - '@security.helper'
             - '@Symfony\Component\Messenger\MessageBusInterface'
             - '%webhook_max_bulk_size%'
+            - '@logger'
         tags:
             - { name: kernel.event_subscriber }
 
@@ -204,6 +206,7 @@ services:
             - '@security.helper'
             - '@Symfony\Component\Messenger\MessageBusInterface'
             - '%webhook_max_bulk_size%'
+            - '@logger'
         tags:
             - { name: kernel.event_subscriber }
 
@@ -212,5 +215,6 @@ services:
             - '@security.helper'
             - '@Symfony\Component\Messenger\MessageBusInterface'
             - '%webhook_max_bulk_size%'
+            - '@logger'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsSender.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsSender.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub;
 
+use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\PubSub\Topic;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -31,10 +33,14 @@ final class GpsSender implements SenderInterface
     {
         $encodedMessage = $this->serializer->encode($envelope);
 
-        $this->topic->publish([
-            'data' => $encodedMessage['body'],
-            'attributes' => $encodedMessage['headers'],
-        ]);
+        try {
+            $this->topic->publish([
+                'data' => $encodedMessage['body'],
+                'attributes' => $encodedMessage['headers'],
+            ]);
+        } catch (GoogleException $e) {
+            throw new TransportException($e->getMessage(), 0, $e);
+        }
 
         return $envelope;
     }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsReceiverSpec.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsReceiverSpec.php
@@ -6,11 +6,12 @@ namespace spec\Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub;
 
 use Akeneo\Tool\Bundle\MessengerBundle\Stamp\NativeMessageStamp;
 use Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\GpsReceiver;
+use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\PubSub\Message;
 use Google\Cloud\PubSub\Subscription;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Stamp\TransportMessageIdStamp;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
@@ -91,5 +92,52 @@ class GpsReceiverSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->reject($envelope);
+    }
+
+    public function it_throws_a_transport_exception_if_an_error_is_raised_while_fetching_a_message($subscription): void
+    {
+        $subscription->pull([
+            'maxMessages' => 1,
+            'returnImmediately' => true,
+        ])
+            ->willThrow(GoogleException::class);
+
+        $this->shouldThrow(TransportException::class)
+            ->during('get');
+    }
+
+    public function it_throws_a_transport_exception_if_an_error_is_raised_while_acknowledging_a_message(
+        $subscription
+    ): void {
+        $gpsMessage = new Message(
+            [
+                'data' => 'My message!',
+            ]
+        );
+
+        $envelope = new Envelope((object)['message' => 'My message!'], [new NativeMessageStamp($gpsMessage)]);
+
+        $subscription->acknowledge($gpsMessage)
+            ->willThrow(GoogleException::class);
+
+        $this->shouldThrow(TransportException::class)
+            ->during('ack', [$envelope]);
+    }
+
+    public function it_throws_a_transport_exception_if_an_error_is_raised_while_rejecting_a_message($subscription): void
+    {
+        $gpsMessage = new Message(
+            [
+                'data' => 'My message!',
+            ]
+        );
+
+        $envelope = new Envelope((object)['message' => 'My message!'], [new NativeMessageStamp($gpsMessage)]);
+
+        $subscription->acknowledge($gpsMessage)
+            ->willThrow(GoogleException::class);
+
+        $this->shouldThrow(TransportException::class)
+            ->during('reject', [$envelope]);
     }
 }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsSenderSpec.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsSenderSpec.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace spec\Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub;
 
 use Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\GpsSender;
+use Google\Cloud\Core\Exception\GoogleException;
 use Google\Cloud\PubSub\Topic;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 /**
@@ -43,5 +45,27 @@ class GpsSenderSpec extends ObjectBehavior
             ->shouldBeCalled();
 
         $this->send($envelope);
+    }
+
+    public function it_throws_a_transport_exception_if_an_error_is_raised_while_sending_a_message(
+        $topic,
+        $serializer
+    ): void {
+        $envelope = new Envelope((object)['message' => 'My message!']);
+
+        $serializer->encode($envelope)
+            ->willReturn([
+                'body' => 'My message!',
+                'headers' => ['my_attribute' => 'My attribute!']
+            ]);
+
+        $topic->publish([
+            'data' => 'My message!',
+            'attributes' => ['my_attribute' => 'My attribute!'],
+        ])
+            ->willThrow(GoogleException::class);
+
+        $this->shouldThrow(TransportException::class)
+            ->during('send', [$envelope]);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
@@ -15,8 +15,11 @@ use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -24,7 +27,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
 {
     function let(Security $security, MessageBusInterface $messageBus)
     {
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
     }
 
     function it_is_initializable(): void
@@ -50,7 +53,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $productModel = new ProductModel();
         $productModel->setCode('polo_col_mao');
@@ -78,7 +81,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $productModel = new ProductModel();
         $productModel->setCode('polo_col_mao');
@@ -106,7 +109,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $productModel1 = new ProductModel();
         $productModel1->setCode('product_model_code_1');
@@ -143,7 +146,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 2); // Bulk size of 2
+        $this->beConstructedWith($security, $messageBus, 2, new NullLogger()); // Bulk size of 2
 
         $productModel1 = new ProductModel();
         $productModel1->setCode('product_model_code_1');
@@ -187,9 +190,12 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
     function it_only_supports_product_model_event($security)
     {
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(new \stdClass()));
+        $this->createAndDispatchProductModelEvents(new GenericEvent(
+            new \stdClass(),
+            ['is_new' => false, 'unitary' => true]
+        ));
 
         Assert::assertCount(0, $messageBus->messages);
     }
@@ -197,16 +203,42 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
     function it_does_nothing_if_the_user_is_not_defined($security)
     {
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $productModel = new ProductModel();
         $productModel->setCode('product_model_code');
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel));
+        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel, ['is_new' => false, 'unitary' => true]));
 
         Assert::assertCount(0, $messageBus->messages);
+    }
+
+    function it_logs_an_error_if_the_event_bus_transport_raise_an_exception($security, LoggerInterface $logger)
+    {
+        $messageBus = new class () implements MessageBusInterface
+        {
+            public function dispatch($message, array $stamps = []): Envelope
+            {
+                throw new TransportException('An error occured');
+            }
+        };
+        $this->beConstructedWith($security, $messageBus, 10, $logger);
+
+        $user = new User();
+        $user->setUsername('julia');
+        $security->getUser()->willReturn($user);
+
+        $productModel = new ProductModel();
+        $productModel->setCode('product_model_code');
+
+        $this->createAndDispatchProductModelEvents(new GenericEvent(
+            $productModel,
+            ['is_new' => false, 'unitary' => true]
+        ));
+
+        $logger->critical('An error occured')->shouldBeCalled();
     }
 
     private function getMessageBus(): MessageBusInterface

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
@@ -14,8 +14,11 @@ use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Security\Core\Security;
 
@@ -25,7 +28,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         Security $security,
         MessageBusInterface $messageBus
     ) {
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
     }
 
     function it_is_initializable(): void
@@ -51,7 +54,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $product = new Product();
         $product->setIdentifier('blue_jean');
@@ -85,7 +88,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $security->getUser()->willReturn($user);
 
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $product1 = new Product();
         $product1->setIdentifier('product_identifier_1');
@@ -129,9 +132,12 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
     function it_only_supports_product_removed_event($security)
     {
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
-        $this->createAndDispatchProductEvents(new GenericEvent(new \stdClass()));
+        $this->createAndDispatchProductEvents(new GenericEvent(
+            new \stdClass(),
+            ['unitary' => true]
+        ));
 
         Assert::assertCount(0, $messageBus->messages);
     }
@@ -139,16 +145,45 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
     function it_does_nothing_if_the_user_is_not_defined($security)
     {
         $messageBus = $this->getMessageBus();
-        $this->beConstructedWith($security, $messageBus, 10);
+        $this->beConstructedWith($security, $messageBus, 10, new NullLogger());
 
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product));
+        $this->createAndDispatchProductEvents(new GenericEvent(
+            $product,
+            ['unitary' => true]
+        ));
 
         Assert::assertCount(0, $messageBus->messages);
+    }
+
+    function it_logs_an_error_if_the_event_bus_transport_raise_an_exception($security, LoggerInterface $logger)
+    {
+        $messageBus = new class () implements MessageBusInterface
+        {
+            public function dispatch($message, array $stamps = []): Envelope
+            {
+                throw new TransportException('An error occured');
+            }
+        };
+        $this->beConstructedWith($security, $messageBus, 10, $logger);
+
+        $user = new User();
+        $user->setUsername('julia');
+        $security->getUser()->willReturn($user);
+
+        $product = new Product();
+        $product->setIdentifier('product_identifier');
+
+        $this->createAndDispatchProductEvents(new GenericEvent(
+            $product,
+            ['unitary' => true]
+        ));
+
+        $logger->critical('An error occured')->shouldBeCalled();
     }
 
     private function getMessageBus()


### PR DESCRIPTION
Make event dispatching more resilient to infrastructure issues.
If there is an issue with Google PubSub (for example) then we should not necessarily break the PIM behavior and/or the UI. 
Instead the error is log as critical (still monitored by the SRE).