### PR TITLE
PIM-9595: Avoid 403 error when launching import with no view rights on import details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Bug fixes
 
+- PIM-9595: Avoid 403 error when launching import with no view rights on import details
+
 ## New features
 
 ## Improvements

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -24,6 +24,7 @@ use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -126,7 +127,6 @@ class JobInstanceController
      * @param EventDispatcherInterface              $eventDispatcher
      * @param CollectionFilterInterface             $inputFilter
      * @param string                                $uploadTmpDir
-     * @param FilesystemInterface                   $filesystem
      * @param SecurityFacade                        $securityFacade
      */
     public function __construct(

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -21,6 +21,7 @@ use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use League\Flysystem\FilesystemInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -32,7 +33,6 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -103,8 +103,8 @@ class JobInstanceController
     /** @var FilesystemInterface */
     protected $filesystem;
 
-    /** @var AuthorizationCheckerInterface */
-    protected $authorizationChecker;
+    /** @var SecurityFacade */
+    protected $securityFacade;
 
     /**
      * @param IdentifiableObjectRepositoryInterface $repository
@@ -127,7 +127,7 @@ class JobInstanceController
      * @param CollectionFilterInterface             $inputFilter
      * @param string                                $uploadTmpDir
      * @param FilesystemInterface                   $filesystem
-     * @param AuthorizationCheckerInterface             $authorizationChecker
+     * @param SecurityFacade                        $securityFacade
      */
     public function __construct(
         IdentifiableObjectRepositoryInterface $repository,
@@ -149,7 +149,7 @@ class JobInstanceController
         EventDispatcherInterface $eventDispatcher,
         CollectionFilterInterface $inputFilter,
         FilesystemInterface $filesystem,
-        AuthorizationCheckerInterface $authorizationChecker
+        SecurityFacade $securityFacade
     ) {
         $this->repository            = $repository;
         $this->jobRegistry           = $jobRegistry;
@@ -170,7 +170,7 @@ class JobInstanceController
         $this->eventDispatcher       = $eventDispatcher;
         $this->inputFilter           = $inputFilter;
         $this->filesystem            = $filesystem;
-        $this->authorizationChecker  = $authorizationChecker;
+        $this->securityFacade        = $securityFacade;
     }
 
     /**
@@ -471,7 +471,7 @@ class JobInstanceController
 
         $jobExecution = $this->launchJob($jobInstance);
 
-        if (!$this->authorizationChecker->isGranted('pim_importexport_import_execution_show')) {
+        if (!$this->securityFacade->isGranted('pim_importexport_import_execution_show')) {
             return new JsonResponse('', 200);
         }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -127,7 +127,7 @@ class JobInstanceController
      * @param CollectionFilterInterface             $inputFilter
      * @param string                                $uploadTmpDir
      * @param FilesystemInterface                   $filesystem
- * @param AuthorizationCheckerInterface             $authorizationChecker
+     * @param AuthorizationCheckerInterface             $authorizationChecker
      */
     public function __construct(
         IdentifiableObjectRepositoryInterface $repository,
@@ -477,9 +477,9 @@ class JobInstanceController
 
         return new JsonResponse([
             'redirectUrl' => '#' . $this->router->generate(
-                    sprintf('pim_importexport_%s_execution_show', $jobInstance->getType()),
-                    ['id' => $jobExecution->getId()]
-                )
+                sprintf('pim_importexport_%s_execution_show', $jobInstance->getType()),
+                ['id' => $jobExecution->getId()]
+            )
         ], 200);
     }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -471,7 +471,7 @@ class JobInstanceController
 
         $jobExecution = $this->launchJob($jobInstance);
 
-        if (!$this->securityFacade->isGranted('pim_importexport_import_execution_show')) {
+        if (!$this->securityFacade->isGranted(sprintf('pim_importexport_%s_execution_show', $jobInstance->getType()))) {
             return new JsonResponse('', 200);
         }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Repository/InternalApi/JobExecutionRepository.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Repository/InternalApi/JobExecutionRepository.php
@@ -33,6 +33,7 @@ class JobExecutionRepository extends EntityRepository implements DatagridReposit
         $qb = $this->createQueryBuilder('e');
         $qb
             ->addSelect('e.id')
+            ->addSelect('j.type AS type')
             ->addSelect('e.status AS status')
             ->addSelect(
                 "CONCAT('pim_import_export.batch_status.', e.status) as statusLabel"

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -44,6 +44,7 @@ services:
             - '@event_dispatcher'
             - '@pim_catalog.filter.chained'
             - '@oneup_flysystem.jobs_storage_filesystem'
+            - '@security.authorization_checker'
 
     pim_enrich.controller.rest.job_execution:
         public: true

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -44,7 +44,7 @@ services:
             - '@event_dispatcher'
             - '@pim_catalog.filter.chained'
             - '@oneup_flysystem.jobs_storage_filesystem'
-            - '@security.authorization_checker'
+            - '@oro_security.security_facade'
 
     pim_enrich.controller.rest.job_execution:
         public: true

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
@@ -40,6 +40,7 @@ datagrid:
                 component: pimimportexport/js/datagrid/Actions
                 props:
                     id: string
+                    type: string
                     jobLabel: string
                     isStoppable: boolean
                     showLink: string
@@ -51,6 +52,7 @@ datagrid:
                 rowAction: true
         properties:
             id: ~
+            type: ~
             jobLabel: ~
             isStoppable: ~
             currentStep: ~

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_export_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_export_executions.yml
@@ -5,6 +5,9 @@ datagrid:
             acl_resource: pim_importexport_export_execution_index
         options:
             entityHint: export report
+        actions:
+            view:
+                acl_resource: pim_importexport_export_execution_show
         properties:
             showLink:
                 route: pim_importexport_export_execution_show

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_import_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_import_executions.yml
@@ -5,6 +5,9 @@ datagrid:
             acl_resource: pim_importexport_import_execution_index
         options:
             entityHint: import report
+        actions:
+            view:
+                acl_resource: pim_importexport_import_execution_show
         properties:
             showLink:
                 route: pim_importexport_import_execution_show

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 import {Button} from 'akeneo-design-system';
-import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
+import {useSecurity, useTranslate} from '@akeneo-pim-community/legacy-bridge';
 import {StopJobAction} from 'pimui/js/job/execution/StopJobAction';
-
-const securityContext = require('pim/security-context');
 
 const ActionsContainer = styled.div`
   display: flex;
@@ -21,17 +19,19 @@ type ActionsProps = {
   isVisible: boolean;
 };
 
-const checkAuthorization = () => {
-    return securityContext.isGranted('pim_importexport_import_execution_show');
-};
-
-const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection, isVisible}: ActionsProps) => {
+const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection}: ActionsProps) => {
   const translate = useTranslate();
-  return (
+  const security = useSecurity();
+
+  const isAllowedToViewJobDetails = security.isGranted('pim_importexport_import_execution_show');
+
+    return (
     <ActionsContainer className="AknGrid-onHoverElement">
-      <Button size="small" ghost={true} level="tertiary" href={`#${showLink}`} isVisible={checkAuthorization} >
-        {translate('pim_datagrid.action.show.title')}
-      </Button>
+      {isAllowedToViewJobDetails &&
+        <Button size="small" ghost={true} level="tertiary" href={`#${showLink}`}>
+          {translate('pim_datagrid.action.show.title')}
+        </Button>
+      }
       <StopJobAction
         id={id}
         jobLabel={jobLabel}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
@@ -4,6 +4,8 @@ import {Button} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
 import {StopJobAction} from 'pimui/js/job/execution/StopJobAction';
 
+const securityContext = require('pim/security-context');
+
 const ActionsContainer = styled.div`
   display: flex;
   gap: 10px;
@@ -16,13 +18,18 @@ type ActionsProps = {
   isStoppable: boolean;
   showLink: string;
   refreshCollection: () => void;
+  isVisible: boolean;
 };
 
-const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection}: ActionsProps) => {
+const checkAuthorization = () => {
+    return securityContext.isGranted('pim_importexport_import_execution_show');
+};
+
+const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection, isVisible}: ActionsProps) => {
   const translate = useTranslate();
   return (
     <ActionsContainer className="AknGrid-onHoverElement">
-      <Button size="small" ghost={true} level="tertiary" href={`#${showLink}`}>
+      <Button size="small" ghost={true} level="tertiary" href={`#${showLink}`} isVisible={checkAuthorization} >
         {translate('pim_datagrid.action.show.title')}
       </Button>
       <StopJobAction

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
@@ -17,13 +17,14 @@ type ActionsProps = {
   showLink: string;
   refreshCollection: () => void;
   isVisible: boolean;
+  type: string;
 };
 
-const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection}: ActionsProps) => {
+const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection, type}: ActionsProps) => {
   const translate = useTranslate();
   const security = useSecurity();
 
-  const isAllowedToViewJobDetails = security.isGranted('pim_importexport_import_execution_show');
+  const isAllowedToViewJobDetails = security.isGranted('pim_importexport_' + type + '_execution_show');
 
     return (
     <ActionsContainer className="AknGrid-onHoverElement">

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/datagrid/Actions.tsx
@@ -26,13 +26,13 @@ const Actions = ({id, jobLabel, isStoppable, showLink, refreshCollection, type}:
 
   const isAllowedToViewJobDetails = security.isGranted('pim_importexport_' + type + '_execution_show');
 
-    return (
+  return (
     <ActionsContainer className="AknGrid-onHoverElement">
-      {isAllowedToViewJobDetails &&
+      {isAllowedToViewJobDetails && (
         <Button size="small" ghost={true} level="tertiary" href={`#${showLink}`}>
           {translate('pim_datagrid.action.show.title')}
         </Button>
-      }
+      )}
       <StopJobAction
         id={id}
         jobLabel={jobLabel}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/launch.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/launch.js
@@ -65,7 +65,11 @@ define([
       loadingMask.render().$el.appendTo(this.getRoot().$el).show();
       $.post(this.getUrl())
         .then(function (response) {
-          router.redirect(response.redirectUrl);
+          if (response.redirectUrl) {
+            router.redirect(response.redirectUrl);
+          } else {
+            router.reloadPage();
+          }
         })
         .fail(function () {
           messenger.notify('error', __('pim_import_export.form.job_instance.fail.launch'));

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -45,7 +45,9 @@ define([
           processData: false,
         })
           .then(response => {
-            router.redirect(response.redirectUrl);
+            if (response.redirectUrl){
+              router.redirect(response.redirectUrl);
+            }
           })
           .fail(response => {
             if (undefined !== response.responseJSON.message) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/upload-launch.js
@@ -45,8 +45,10 @@ define([
           processData: false,
         })
           .then(response => {
-            if (response.redirectUrl){
+            if (response.redirectUrl) {
               router.redirect(response.redirectUrl);
+            } else {
+              router.reloadPage();
             }
           })
           .fail(response => {

--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddJobCodeToGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddJobCodeToGridListener.php
@@ -42,6 +42,6 @@ class AddJobCodeToGridListener
 
         $qb = $dataSource->getQueryBuilder();
         $qb->andWhere($qb->expr()->eq('j.code', ':jobCode'));
-        $qb->orderBy('e.startTime', OrmSorterExtension::DIRECTION_DESC);
+        $qb->orderBy('e.createTime', OrmSorterExtension::DIRECTION_DESC);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A 403 error was served after dropping a valid product import file and clicking "Upload and import now" in the case the user has no permission to "View import report details".

Validating by Benjamin and Stéphane:
If no permission to view the import report details, we need to remove the action button "view" to avoid 403 errors
and we need to stay on the import profile page after launching an import.

So, when the user does not have the rights to view the import details:
- I made sure that we stay on the import profile page after launching the job execution by returning an empty URL to the upload-launch.js file
- I made the view button invisible using useSecurity ()
- I added a reload of the import profile page to see the last executions after clicking on the "upload and import now" button.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
