### PR TITLE
Test ce dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -574,6 +574,24 @@ jobs:
           - store_artifacts:
                 path: ~/project/pim/var/logs
 
+  build_and_test_ce_php_image:
+      machine:
+          image: ubuntu-1604:201903-01
+      steps:
+          - attach_workspace:
+                at: ~/
+          - run:
+              name: Change owner on project dir in order to archive the project into the workspace
+              command: sudo chown -R 1000:1000 ../project
+          - run:
+                name: build docker image
+                command: |
+                    DOCKER_BUILDKIT=1 docker build --tag akeneo/pim-php-base:master --file Dockerfile.base .
+                    DOCKER_BUILDKIT=1 docker build --tag akeneo/pim-php-dev:master --file Dockerfile.dev .
+          - run:
+                name: test dev image
+                command: docker run --rm --user www-data --volume $(pwd):/srv/pim --workdir /srv/pim akeneo/pim-php-dev:master bin/console list
+
 workflows:
   version: 2
   pull_request:
@@ -680,6 +698,19 @@ workflows:
                 is_ee_built: false
                 requires:
                     - checkout_ce
+
+          - build_and_test_ce_php_image?:
+                type: approval
+                filters:
+                    branches:
+                        ignore:
+                            - master
+                requires:
+                  - build_dev_ce
+          - build_and_test_ce_php_image:
+                requires:
+                  - build_and_test_ce_php_image?
+
           - test_back_static_and_acceptance:
                 name: test_back_static_and_acceptance_ce
                 requires:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the CE workflow, we use [the image from Dockerhub](https://hub.docker.com/r/akeneo/pim-php-dev/tags?page=1&ordering=last_updated). It means that if you update the Dockerfile or any configuration file which impacts the Docker image, you won't be able to test if it works

This PR adds an optional job to the CE workflow, which builds the `akeneo/pim-php-dev` image locally and runs a simple console command (`bin/console list`) to check if it's functional

=> see the result here: https://app.circleci.com/pipelines/github/akeneo/pim-community-dev/17854/workflows/c0814658-c548-4204-a3d4-125326e03aef/jobs/66884