### PR TITLE
PIM-9601: Fix completeness mask memory usage

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -14,7 +14,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
  */
 class ComputeAndPersistProductCompletenesses
 {
-    private const CHUNK_SIZE = 20000;
+    private const CHUNK_SIZE = 10000;
 
     /** @var CompletenessCalculator */
     private $completenessCalculator;
@@ -44,7 +44,7 @@ class ComputeAndPersistProductCompletenesses
     public function fromProductIdentifiers(array $productIdentifiers): void
     {
         foreach (array_chunk($productIdentifiers, self::CHUNK_SIZE) as $identifiersChunk) {
-            $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($productIdentifiers);
+            $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($identifiersChunk);
             $this->saveProductCompletenesses->saveAll($completenessCollections);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -14,6 +14,8 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
  */
 class ComputeAndPersistProductCompletenesses
 {
+    private const CHUNK_SIZE = 20000;
+
     /** @var CompletenessCalculator */
     private $completenessCalculator;
 
@@ -41,8 +43,9 @@ class ComputeAndPersistProductCompletenesses
      */
     public function fromProductIdentifiers(array $productIdentifiers): void
     {
-        $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($productIdentifiers);
-
-        $this->saveProductCompletenesses->saveAll($completenessCollections);
+        foreach (array_chunk($productIdentifiers, self::CHUNK_SIZE) as $identifiersChunk) {
+            $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($productIdentifiers);
+            $this->saveProductCompletenesses->saveAll($completenessCollections);
+        }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\MaskItemGenerator\MaskItemGenerator;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\CompletenessProductMask;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetCompletenessProductMasks;
-use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;


### PR DESCRIPTION
Completeness can takes a lots of space in memory due to masks, locales, etc.
This PR is a first step to reduce the required memory by processing the completeness by chunks.

Next step will be to use iterable generators which should not need any arbitrary chunk size.