### PR TITLE
RAC-449: search after does not work when identifier is in uppercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PIM-9596: Fix attribute options manual sorting
 - PIM-9598: Fix quick export when the bs_Cyrl_BA locale is used.
 - RAC-435: Fix fatal error for user that migrate from 4.0 with product values format that doesn't correspond to expected format
+- RAC-449: Fix invalid processed item when remove attribute
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttribute.php
@@ -57,7 +57,7 @@ final class GetProductIdentifiersWithRemovedAttribute implements GetProductIdent
                 return $product['_source']['identifier'];
             }, $rows['hits']['hits']);
             yield $identifiers;
-            $body['search_after'] = [end($identifiers)];
+            $body['search_after'] = end($rows['hits']['hits'])['sort'];
             $rows = $this->elasticsearchClient->search($body);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttribute.php
@@ -62,7 +62,7 @@ final class GetProductModelIdentifiersWithRemovedAttribute implements GetProduct
                 return $product['_source']['identifier'];
             }, $rows['hits']['hits']);
             yield $identifiers;
-            $body['search_after'] = [end($identifiers)];
+            $body['search_after'] = end($rows['hits']['hits'])['sort'];
             $rows = $this->elasticsearchClient->search($body);
         }
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Summary:** 
The number of processed items in product clean is invalid when we remove an attribute from the PIM. On the icecat catalog when we remove the attribute name the number of processed item is invalid.

![Capture du 2020-12-18 17-07-54](https://user-images.githubusercontent.com/7239572/102780527-5f6bfc80-4396-11eb-930b-48b8f84ea1fc.png)

**Explanation**
Why this happened ? The last product on the last batch is "AKNSTK". To know if it's the last batch we use "AKNSTK" 
 on search after field. In the pim the identifier are indexed by lowercase identifier. Elasticsearch loop randomly several time with the query `search_after: ["AKNSTK"]` (here 10 times). 
 
I think that this result, is returned while the product is really deleted on elasticsearch but I find nothing on documentation.

**Now**
Now search_after is filled with "aknstk" and we didn't have the problem now.
This is the same solution than https://github.com/akeneo/pim-community-dev/blob/6c6811521935ea6c5b57c08d09ad87d57d15942e/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php#L112

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
