### PR TITLE
RAC-453: Remove isOpen prop from the DSM modal

### DIFF
--- a/akeneo-design-system/src/components/Modal/Modal.stories.mdx
+++ b/akeneo-design-system/src/components/Modal/Modal.stories.mdx
@@ -39,7 +39,7 @@ It can be used with or without an Illustration and adapts its content accordingl
       const close = () => setOpen(false);
       return (
         <>
-          {isOpen ? (
+          {isOpen && (
             <Modal
               {...args}
               onClose={close}

--- a/akeneo-design-system/src/components/Modal/Modal.stories.mdx
+++ b/akeneo-design-system/src/components/Modal/Modal.stories.mdx
@@ -54,7 +54,6 @@ It can be used with or without an Illustration and adapts its content accordingl
         </>
       );
     }}
-
   </Story>
 </Canvas>
 

--- a/akeneo-design-system/src/components/Modal/Modal.stories.mdx
+++ b/akeneo-design-system/src/components/Modal/Modal.stories.mdx
@@ -34,9 +34,9 @@ It can be used with or without an Illustration and adapts its content accordingl
 <Canvas>
   <Story name="Standard">
     {args => {
-      const [{isOpen}, updateArgs] = useArgs();
-      const open = () => updateArgs({isOpen: true});
-      const close = () => updateArgs({isOpen: false});
+      const [isOpen, setOpen] = useState(false);
+      const open = () => setOpen(true);
+      const close = () => setOpen(false);
       return (
         <>
           {isOpen ? (
@@ -71,7 +71,11 @@ It can be used with or without an Illustration and adapts its content accordingl
       return (
         <>
           {isOpen && (
-            <Modal {...args} isOpen={isOpen} onClose={close} illustration={<Illustrations.ChannelsIllustration />}>
+            <Modal
+              {...args}
+              onClose={close}
+              illustration={<Illustrations.ChannelsIllustration />}
+            >
               Such nice Illustration
               <Modal.BottomButtons>
                 <Button onClick={close}>Close</Button>

--- a/akeneo-design-system/src/components/Modal/Modal.stories.mdx
+++ b/akeneo-design-system/src/components/Modal/Modal.stories.mdx
@@ -16,7 +16,6 @@ import * as Illustrations from '../../illustrations';
     },
   }}
   args={{
-    isOpen: false,
     children: 'Modal text',
     illustration: undefined,
     closeTitle: 'Close',
@@ -40,19 +39,22 @@ It can be used with or without an Illustration and adapts its content accordingl
       const close = () => updateArgs({isOpen: false});
       return (
         <>
-          <Modal
-            {...args}
-            onClose={close}
-            illustration={
-              undefined === Illustrations[args.illustration]
-                ? undefined
-                : React.createElement(Illustrations[args.illustration])
-            }
-          />
+          {isOpen ? (
+            <Modal
+              {...args}
+              onClose={close}
+              illustration={
+                undefined === Illustrations[args.illustration]
+                  ? undefined
+                  : React.createElement(Illustrations[args.illustration])
+              }
+            />
+          )}
           <Button onClick={open}>Open Modal</Button>
         </>
       );
     }}
+
   </Story>
 </Canvas>
 
@@ -68,12 +70,14 @@ It can be used with or without an Illustration and adapts its content accordingl
       const close = () => setOpen(false);
       return (
         <>
-          <Modal {...args} isOpen={isOpen} onClose={close} illustration={<Illustrations.ChannelsIllustration />}>
-            Such nice Illustration
-            <Modal.BottomButtons>
-              <Button onClick={close}>Close</Button>
-            </Modal.BottomButtons>
-          </Modal>
+          {isOpen && (
+            <Modal {...args} isOpen={isOpen} onClose={close} illustration={<Illustrations.ChannelsIllustration />}>
+              Such nice Illustration
+              <Modal.BottomButtons>
+                <Button onClick={close}>Close</Button>
+              </Modal.BottomButtons>
+            </Modal>
+          )}
           <Button onClick={open}>Open Modal with Illustration</Button>
         </>
       );

--- a/akeneo-design-system/src/components/Modal/Modal.tsx
+++ b/akeneo-design-system/src/components/Modal/Modal.tsx
@@ -5,7 +5,8 @@ import {AkeneoThemedProps, CommonStyle, getColor, getFontSize} from '../../theme
 import {IconButton} from '../../components';
 import {CloseIcon} from '../../icons';
 import {IllustrationProps} from '../../illustrations/IllustrationProps';
-import {Override} from '../../shared';
+import {useShortcut} from '../../hooks';
+import {Key, Override} from '../../shared';
 
 const ModalContainer = styled.div`
   ${CommonStyle}
@@ -117,6 +118,8 @@ const Modal: React.FC<ModalProps> & {
   const portalNode = document.createElement('div');
   portalNode.setAttribute('id', 'modal-root');
   const containerRef = useRef(portalNode);
+
+  useShortcut(Key.Escape, onClose);
 
   useEffect(() => {
     document.body.appendChild(containerRef.current);

--- a/akeneo-design-system/src/components/Modal/Modal.tsx
+++ b/akeneo-design-system/src/components/Modal/Modal.tsx
@@ -5,8 +5,7 @@ import {AkeneoThemedProps, CommonStyle, getColor, getFontSize} from '../../theme
 import {IconButton} from '../../components';
 import {CloseIcon} from '../../icons';
 import {IllustrationProps} from '../../illustrations/IllustrationProps';
-import {useShortcut} from '../../hooks';
-import {Key, Override} from '../../shared';
+import {Override} from '../../shared';
 
 const ModalContainer = styled.div`
   ${CommonStyle}
@@ -87,11 +86,6 @@ type ModalProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
     /**
-     * Prop to display or hide the Modal.
-     */
-    isOpen: boolean;
-
-    /**
      * Illustration to display.
      */
     illustration?: ReactElement<IllustrationProps>;
@@ -119,9 +113,7 @@ type ModalProps = Override<
 const Modal: React.FC<ModalProps> & {
   BottomButtons: typeof BottomButtons;
   TopRightButtons: typeof TopRightButtons;
-} = ({isOpen, onClose, illustration, closeTitle, children, ...rest}: ModalProps) => {
-  useShortcut(Key.Escape, onClose);
-
+} = ({onClose, illustration, closeTitle, children, ...rest}: ModalProps) => {
   const portalNode = document.createElement('div');
   portalNode.setAttribute('id', 'modal-root');
   const containerRef = useRef(portalNode);
@@ -133,8 +125,6 @@ const Modal: React.FC<ModalProps> & {
       document.body.removeChild(containerRef.current);
     };
   }, []);
-
-  if (!isOpen) return null;
 
   return createPortal(
     <ModalContainer role="dialog" {...rest}>

--- a/akeneo-design-system/src/components/Modal/Modal.unit.tsx
+++ b/akeneo-design-system/src/components/Modal/Modal.unit.tsx
@@ -4,7 +4,7 @@ import {fireEvent, render, screen} from '../../storybook/test-util';
 
 test('it renders its children properly', () => {
   render(
-    <Modal closeTitle="Close" isOpen={true} onClose={jest.fn()}>
+    <Modal closeTitle="Close" onClose={jest.fn()}>
       Modal content
     </Modal>
   );
@@ -14,7 +14,7 @@ test('it renders its children properly', () => {
 
 test('it renders its exposed subcomponent `BottomButtons` properly', () => {
   render(
-    <Modal closeTitle="Close" isOpen={true} onClose={jest.fn()}>
+    <Modal closeTitle="Close" onClose={jest.fn()}>
       <Modal.BottomButtons>Buttons</Modal.BottomButtons>
     </Modal>
   );
@@ -22,21 +22,11 @@ test('it renders its exposed subcomponent `BottomButtons` properly', () => {
   expect(screen.getByText('Buttons')).toBeInTheDocument();
 });
 
-test('it does not display its children if it is closed', () => {
-  render(
-    <Modal closeTitle="Close" isOpen={false} onClose={jest.fn()}>
-      Modal content
-    </Modal>
-  );
-
-  expect(screen.queryByText('Modal content')).not.toBeInTheDocument();
-});
-
 test('it calls the onClose handler when clicking on the close button', () => {
   const onClose = jest.fn();
 
   render(
-    <Modal closeTitle="Close" isOpen={true} onClose={onClose}>
+    <Modal closeTitle="Close" onClose={onClose}>
       Modal content
     </Modal>
   );
@@ -50,7 +40,7 @@ test('it calls the onClose handler when hitting the Escape key', () => {
   const onClose = jest.fn();
 
   render(
-    <Modal closeTitle="Close" isOpen={true} onClose={onClose}>
+    <Modal closeTitle="Close" onClose={onClose}>
       <SectionTitle>With a section Title</SectionTitle>
       Modal content
     </Modal>

--- a/akeneo-design-system/src/patterns/Overlays.stories.mdx
+++ b/akeneo-design-system/src/patterns/Overlays.stories.mdx
@@ -24,19 +24,21 @@ Overlays interrupt the user workflow by design. They are the most effective when
       const close = () => setOpen(false);
       return (
         <>
-          <Modal closeTitle="Close" isOpen={isOpen} onClose={close} illustration={<DeleteIllustration />}>
-            <SectionTitle color="brand">Products</SectionTitle>
-            <Title>Confirm deletion</Title>
-            Are you sure you want to delete this product?
-            <Modal.BottomButtons>
-              <Button level="tertiary" onClick={close}>
-                Cancel
-              </Button>
-              <Button level="danger" onClick={close}>
-                Delete
-              </Button>
-            </Modal.BottomButtons>
-          </Modal>
+          {isOpen && (
+            <Modal closeTitle="Close" onClose={close} illustration={<DeleteIllustration />}>
+              <SectionTitle color="brand">Products</SectionTitle>
+              <Title>Confirm deletion</Title>
+              Are you sure you want to delete this product?
+              <Modal.BottomButtons>
+                <Button level="tertiary" onClick={close}>
+                  Cancel
+                </Button>
+                <Button level="danger" onClick={close}>
+                  Delete
+                </Button>
+              </Modal.BottomButtons>
+            </Modal>
+          )}
           <Button onClick={open}>Open Confirm Modal</Button>
         </>
       );
@@ -66,23 +68,25 @@ Overlays are composed of distinct areas: a header, the body, and sometimes an il
       const close = () => setOpen(false);
       return (
         <>
-          <Modal closeTitle="Close" isOpen={isOpen} onClose={close}>
-            <SectionTitle color="brand">Entity type</SectionTitle>
-            <Title>Title of Overlay</Title>
-            Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices
-            diam.
-            <Content width={900} height={400}>
-              CONTENT
-            </Content>
-            <Modal.BottomButtons>
-              <Button level="tertiary" onClick={close}>
-                Cancel
-              </Button>
-              <Button level="primary" onClick={close}>
-                Confirm
-              </Button>
-            </Modal.BottomButtons>
-          </Modal>
+          {isOpen && (
+            <Modal closeTitle="Close" onClose={close}>
+              <SectionTitle color="brand">Entity type</SectionTitle>
+              <Title>Title of Overlay</Title>
+              Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum
+              ultrices diam.
+              <Content width={900} height={400}>
+                CONTENT
+              </Content>
+              <Modal.BottomButtons>
+                <Button level="tertiary" onClick={close}>
+                  Cancel
+                </Button>
+                <Button level="primary" onClick={close}>
+                  Confirm
+                </Button>
+              </Modal.BottomButtons>
+            </Modal>
+          )}
           <Button onClick={open}>Open Fullscreen Overlay</Button>
         </>
       );
@@ -100,23 +104,25 @@ Overlays are composed of distinct areas: a header, the body, and sometimes an il
       const close = () => setOpen(false);
       return (
         <>
-          <Modal closeTitle="Close" isOpen={isOpen} onClose={close} illustration={<AddingValueIllustration />}>
-            <SectionTitle color="brand">Entity type</SectionTitle>
-            <Title>Title of Overlay</Title>
-            Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum ultrices
-            diam.
-            <Content width={600} height={300}>
-              CONTENT
-            </Content>
-            <Modal.BottomButtons>
-              <Button level="tertiary" onClick={close}>
-                Cancel
-              </Button>
-              <Button level="primary" onClick={close}>
-                Confirm
-              </Button>
-            </Modal.BottomButtons>
-          </Modal>
+          {isOpen && (
+            <Modal closeTitle="Close" onClose={close} illustration={<AddingValueIllustration />}>
+              <SectionTitle color="brand">Entity type</SectionTitle>
+              <Title>Title of Overlay</Title>
+              Suspendisse lectus tortor, dignissim sit amet, adipiscing nec, ultricies sed, dolor. Cras elementum
+              ultrices diam.
+              <Content width={600} height={300}>
+                CONTENT
+              </Content>
+              <Modal.BottomButtons>
+                <Button level="tertiary" onClick={close}>
+                  Cancel
+                </Button>
+                <Button level="primary" onClick={close}>
+                  Confirm
+                </Button>
+              </Modal.BottomButtons>
+            </Modal>
+          )}
           <Button onClick={open}>Open Split screen Overlay</Button>
         </>
       );

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -105,12 +105,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
   }${productModelText}`;
 
   return (
-    <Modal
-      isOpen={true}
-      onClose={onCancel}
-      closeTitle={translate('pim_common.close')}
-      illustration={<DeleteIllustration />}
-    >
+    <Modal onClose={onCancel} closeTitle={translate('pim_common.close')} illustration={<DeleteIllustration />}>
       <SectionTitle color="brand">{translate('pim_enrich.entity.attribute.plural_label')}</SectionTitle>
       <Title>{translate('pim_common.confirm_deletion')}</Title>
       {translate('pim_enrich.entity.attribute.module.delete.confirm')}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/StopJobAction.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/StopJobAction.tsx
@@ -32,32 +32,29 @@ const StopJobAction = ({id, jobLabel, isStoppable, onStop, children, ...rest}: S
 
   return (
     <>
-      <Modal
-        closeTitle={translate('pim_common.close')}
-        isOpen={isConfirmOpen}
-        onClose={closeConfirm}
-        illustration={<ExportIllustration />}
-      >
-        <SectionTitle color="brand">{translate('pim_title.pim_enrich_job_tracker_index')} /</SectionTitle>
-        <Title>{translate('pim_datagrid.action.stop.confirmation.title', {jobLabel})}</Title>
-        <Helper level="info">
-          {translate('pim_datagrid.action.stop.confirmation.content')}
-          <Link
-            href="https://help.akeneo.com/pim/serenity/articles/monitor-jobs.html#how-to-stop-your-jobs"
-            target="_blank"
-          >
-            {translate('pim_datagrid.action.stop.confirmation.link')}
-          </Link>
-        </Helper>
-        <Modal.BottomButtons>
-          <Button level="tertiary" onClick={closeConfirm}>
-            {translate('pim_common.cancel')}
-          </Button>
-          <Button level="danger" onClick={handleStop}>
-            {translate('pim_datagrid.action.stop.confirmation.ok')}
-          </Button>
-        </Modal.BottomButtons>
-      </Modal>
+      {isConfirmOpen && (
+        <Modal closeTitle={translate('pim_common.close')} onClose={closeConfirm} illustration={<ExportIllustration />}>
+          <SectionTitle color="brand">{translate('pim_title.pim_enrich_job_tracker_index')} /</SectionTitle>
+          <Title>{translate('pim_datagrid.action.stop.confirmation.title', {jobLabel})}</Title>
+          <Helper level="info">
+            {translate('pim_datagrid.action.stop.confirmation.content')}
+            <Link
+              href="https://help.akeneo.com/pim/serenity/articles/monitor-jobs.html#how-to-stop-your-jobs"
+              target="_blank"
+            >
+              {translate('pim_datagrid.action.stop.confirmation.link')}
+            </Link>
+          </Helper>
+          <Modal.BottomButtons>
+            <Button level="tertiary" onClick={closeConfirm}>
+              {translate('pim_common.cancel')}
+            </Button>
+            <Button level="danger" onClick={handleStop}>
+              {translate('pim_datagrid.action.stop.confirmation.ok')}
+            </Button>
+          </Modal.BottomButtons>
+        </Modal>
+      )}
       <Button onClick={handleOpenConfirm} level="danger" {...rest}>
         {translate('pim_datagrid.action.stop.title')}
       </Button>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-measurement-family/CreateMeasurementFamily.tsx
@@ -50,10 +50,11 @@ const CreateMeasurementFamily = ({isOpen, onClose}: CreateMeasurementFamilyProps
     }
   }, [form, locale, saveMeasurementFamily, notify, translate, handleClose, setErrors]);
 
+  if (!isOpen) return null;
+
   return (
     <Modal
       closeTitle={translate('pim_common.close')}
-      isOpen={isOpen}
       onClose={() => handleClose()}
       illustration={<MeasurementIllustration />}
     >

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx
@@ -91,13 +91,10 @@ const CreateUnit = ({isOpen, onClose, onNewUnit, measurementFamily}: CreateUnitP
   useShortcut(Key.Enter, handleAdd);
   useShortcut(Key.NumpadEnter, handleAdd);
 
+  if (!isOpen) return null;
+
   return (
-    <Modal
-      closeTitle={translate('pim_common.close')}
-      isOpen={isOpen}
-      onClose={handleClose}
-      illustration={<MeasurementIllustration />}
-    >
+    <Modal closeTitle={translate('pim_common.close')} onClose={handleClose} illustration={<MeasurementIllustration />}>
       <SectionTitle color="brand">
         {translate('measurements.title.measurement')} / {measurementFamilyLabel}
       </SectionTitle>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ConfirmDeleteModal.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ConfirmDeleteModal.tsx
@@ -12,10 +12,11 @@ type ConfirmModalProps = {
 const ConfirmDeleteModal = ({isOpen, description, onConfirm, onCancel}: ConfirmModalProps) => {
   const translate = useTranslate();
 
+  if (!isOpen) return null;
+
   return (
     <Modal
       closeTitle={translate('pim_common.close')}
-      isOpen={isOpen}
       onClose={onCancel}
       illustration={<DeleteIllustration />}
     >

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ConfirmDeleteModal.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/shared/components/ConfirmDeleteModal.tsx
@@ -15,11 +15,7 @@ const ConfirmDeleteModal = ({isOpen, description, onConfirm, onCancel}: ConfirmM
   if (!isOpen) return null;
 
   return (
-    <Modal
-      closeTitle={translate('pim_common.close')}
-      onClose={onCancel}
-      illustration={<DeleteIllustration />}
-    >
+    <Modal closeTitle={translate('pim_common.close')} onClose={onCancel} illustration={<DeleteIllustration />}>
       <SectionTitle color="brand">{translate('measurements.title.measurement')}</SectionTitle>
       <Title>{translate('pim_common.confirm_deletion')}</Title>
       {description}

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -39,80 +39,82 @@ const QuickExportConfigurator = ({
       >
         {translate('pim_datagrid.mass_action_group.quick_export.label')}
       </Button>
-      <Modal closeTitle={translate('pim_common.close')} isOpen={isModalOpen} onClose={closeModal}>
-        <Modal.TopRightButtons>
-          <Button
-            title={translate('pim_common.export')}
-            onClick={() => {
-              onActionLaunch(formValue);
-              closeModal();
-            }}
-            disabled={!readyToSubmit}
-          >
-            {translate('pim_common.export')}
-          </Button>
-        </Modal.TopRightButtons>
-        <SectionTitle color="brand">
-          {translate('pim_datagrid.mass_action.quick_export.configurator.subtitle')}&nbsp;|&nbsp;
-          {translate('pim_common.result_count', {itemsCount: productCount.toString()}, productCount)}
-        </SectionTitle>
-        <Title>{translate('pim_datagrid.mass_action.quick_export.configurator.title')}</Title>
-        <Form value={formValue} onChange={setFormValue}>
-          <Select name="type">
-            <Option value="csv" title={translate('pim_datagrid.mass_action.quick_export.configurator.csv')}>
-              <FileCsvIcon size={48} />
-              {translate('pim_datagrid.mass_action.quick_export.configurator.csv')}
-            </Option>
-            <Option value="xlsx" title={translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}>
-              <FileXlsxIcon size={48} />
-              {translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}
-            </Option>
-          </Select>
-          <Select name="context">
-            <Option
-              value="grid-context"
-              title={translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
+      {isModalOpen && (
+        <Modal closeTitle={translate('pim_common.close')} onClose={closeModal}>
+          <Modal.TopRightButtons>
+            <Button
+              title={translate('pim_common.export')}
+              onClick={() => {
+                onActionLaunch(formValue);
+                closeModal();
+              }}
+              disabled={!readyToSubmit}
             >
-              {translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
-            </Option>
-            <Option
-              value="all-attributes"
-              title={translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
-            >
-              {translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
-            </Option>
-          </Select>
-          {showWithLabelsSelect && (
-            <Select name="with-labels">
-              <Option
-                value="with-codes"
-                title={translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
-              >
-                {translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
+              {translate('pim_common.export')}
+            </Button>
+          </Modal.TopRightButtons>
+          <SectionTitle color="brand">
+            {translate('pim_datagrid.mass_action.quick_export.configurator.subtitle')}&nbsp;|&nbsp;
+            {translate('pim_common.result_count', {itemsCount: productCount.toString()}, productCount)}
+          </SectionTitle>
+          <Title>{translate('pim_datagrid.mass_action.quick_export.configurator.title')}</Title>
+          <Form value={formValue} onChange={setFormValue}>
+            <Select name="type">
+              <Option value="csv" title={translate('pim_datagrid.mass_action.quick_export.configurator.csv')}>
+                <FileCsvIcon size={48} />
+                {translate('pim_datagrid.mass_action.quick_export.configurator.csv')}
               </Option>
-              <Option
-                value="with-labels"
-                title={translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
-              >
-                {translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
+              <Option value="xlsx" title={translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}>
+                <FileXlsxIcon size={48} />
+                {translate('pim_datagrid.mass_action.quick_export.configurator.xlsx')}
               </Option>
             </Select>
-          )}
-          {showWithMediaSelect && (
-            <Select name="with_media">
+            <Select name="context">
               <Option
-                value="false"
-                title={translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+                value="grid-context"
+                title={translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
               >
-                {translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+                {translate('pim_datagrid.mass_action.quick_export.configurator.grid_context')}
               </Option>
-              <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}>
-                {translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}
+              <Option
+                value="all-attributes"
+                title={translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
+              >
+                {translate('pim_datagrid.mass_action.quick_export.configurator.all_attributes')}
               </Option>
             </Select>
-          )}
-        </Form>
-      </Modal>
+            {showWithLabelsSelect && (
+              <Select name="with-labels">
+                <Option
+                  value="with-codes"
+                  title={translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
+                >
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.with_codes')}
+                </Option>
+                <Option
+                  value="with-labels"
+                  title={translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
+                >
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.with_labels')}
+                </Option>
+              </Select>
+            )}
+            {showWithMediaSelect && (
+              <Select name="with_media">
+                <Option
+                  value="false"
+                  title={translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+                >
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.without_media')}
+                </Option>
+                <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}>
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.with_media')}
+                </Option>
+              </Select>
+            )}
+          </Form>
+        </Modal>
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The DSM modal had a prop `isOpen` which does not really make sense.
Either you want to display a modal and you mount `<Modal/>`, or you want to display it conditionally and you do `{isModalOpen && <Modal/>`.
By always mounting it, we consume useless resources and we introduced a bug:
When mounted, the dom is injected and the `useShortcut(Key.Escape, onClose);` is immediatly registered, even if the modal is not visible !

The proposed solution is to remove this prop and fix usages around the PIM.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
