### PR TITLE
PIM-9605: Display unit label instead of code in variant navigation dropdown

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9605: Display the unit label instead of its code in the variant navigation component
+
 # 4.0.80 (2020-12-21)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/normalizers.yml
@@ -101,6 +101,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.product.metric'
             - '@pim_catalog.localization.localizer.metric'
+            - '@translator'
         tags:
             - { name: pim_axis_value_label_normalizer }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizer.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Localization\Localizer\MetricLocaliz
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\MetricNormalizer as StandardMetricNormalizer;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Symfony\Component\Translation\TranslatorInterface;
 
 /**
  * @author Julian Prud'homme <julian.prudhomme@akeneo.com>
@@ -20,15 +21,26 @@ class MetricNormalizer implements AxisValueLabelsNormalizer
     /** @var MetricLocalizer */
     private $metricLocalizer;
 
-    public function __construct(StandardMetricNormalizer $metricNormalizer, MetricLocalizer $metricLocalizer)
-    {
+    /** @var TranslatorInterface */
+    private $translator;
+
+    /**
+     * @todo @merge master/5.0: replace translator argument by the adequate service
+     * (probably Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface)
+     */
+    public function __construct(
+        StandardMetricNormalizer $metricNormalizer,
+        MetricLocalizer $metricLocalizer,
+        ?TranslatorInterface $translator = null
+    ) {
         $this->metricNormalizer = $metricNormalizer;
         $this->metricLocalizer = $metricLocalizer;
+        $this->translator = $translator;
     }
 
     /**
      * @param ValueInterface $value
-     * @param string         $locale
+     * @param string $locale
      *
      * @return string
      */
@@ -40,16 +52,36 @@ class MetricNormalizer implements AxisValueLabelsNormalizer
 
         $metric = [
             'amount' => $normalizedMetric['amount']->getData(),
-            'unit' => $value->getUnit()
+            'unit' => $value->getUnit(),
         ];
 
         $localizedMetric = $this->metricLocalizer->localize($metric, $context);
 
-        return sprintf('%s %s', $localizedMetric['amount'], $localizedMetric['unit']);
+        return sprintf(
+            '%s %s',
+            $localizedMetric['amount'],
+            $this->localizeUnit($localizedMetric['unit'], $locale)
+        );
     }
 
     public function supports(string $attributeType): bool
     {
         return AttributeTypes::METRIC === $attributeType;
+    }
+
+    /**
+     * @todo @merge master/5.0: rework this method
+     * it should probably use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface
+     */
+    private function localizeUnit(string $unit, string $locale): string
+    {
+        if (null === $this->translator) {
+            return $unit;
+        }
+
+        $translationKey = sprintf('pim_measure.units.%s', $unit);
+        $translation = $this->translator->trans($translationKey, [], 'messages', $locale);
+
+        return ($translation === $translationKey) ? $unit : $translation;
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/AxisValueLabelsNormalizer/MetricNormalizerSpec.php
@@ -2,42 +2,51 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\AxisValueLabelsNormalizer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Localization\Localizer\MetricLocalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Metric;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\MetricNormalizer as StandardMetricNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MetricValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\MetricNormalizer as StandardMetricNormalizer;
-use Akeneo\Pim\Enrichment\Component\Product\Localization\Localizer\MetricLocalizer;
-
+use Symfony\Component\Translation\TranslatorInterface;
 
 class MetricNormalizerSpec extends ObjectBehavior
 {
-    function let(StandardMetricNormalizer $metricNormalizer, MetricLocalizer $metricLocalizer)
-    {
-        $this->beConstructedWith($metricNormalizer, $metricLocalizer);
+    function let(
+        StandardMetricNormalizer $metricNormalizer,
+        MetricLocalizer $metricLocalizer,
+        TranslatorInterface $translator
+    ) {
+        $this->beConstructedWith($metricNormalizer, $metricLocalizer, $translator);
     }
 
-    function it_normalizes_a_metric_product_value(StandardMetricNormalizer $metricNormalizer, MetricLocalizer $metricLocalizer, MetricValue $value)
-    {
+    function it_normalizes_a_metric_product_value(
+        StandardMetricNormalizer $metricNormalizer,
+        MetricLocalizer $metricLocalizer,
+        TranslatorInterface $translator,
+        MetricValue $value
+    ) {
         $metricNormalizer->normalize($value, 'standard', ['locale' => 'en_US'])->willReturn(
             [
-                'amount' => new Metric('weight', 'KILOGRAM', 10, 'GRAM', 10)
+                'amount' => new Metric('weight', 'KILOGRAM', 10, 'GRAM', 10),
             ]
         );
 
         $metric = [
             'amount' => 10,
-            'unit' => 'KILOGRAM'
+            'unit' => 'KILOGRAM',
         ];
 
         $metricLocalizer->localize($metric, ['locale' => 'en_US'])->willReturn($metric);
 
+        $translator->trans('pim_measure.units.KILOGRAM', [], 'messages', 'en_US')->willReturn('Kilogram');
+
         $value->getAmount()->willReturn(10);
         $value->getUnit()->willReturn('KILOGRAM');
-        $this->normalize($value, 'en_US')->shouldReturn('10 KILOGRAM');
+        $this->normalize($value, 'en_US')->shouldReturn('10 Kilogram');
     }
 
-    function it_supports_only_metric_attributes()
+    function it_only_supports_metric_attributes()
     {
         $this->supports(AttributeTypes::METRIC)->shouldReturn(true);
         $this->supports(AttributeTypes::TEXT)->shouldReturn(false);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the variant navigation component, display the label of the unit instead of its code for measurement attribute axes

**:warning: this PR cannot be pulled up as is into master** (the way to get unit labels has changed in master), it will need to be reworked during the next pull-up

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
