### PR TITLE
RAC-454: useShortcut doesnt stop propagation by default

### DIFF
--- a/akeneo-design-system/src/hooks/useShortcut.ts
+++ b/akeneo-design-system/src/hooks/useShortcut.ts
@@ -16,7 +16,6 @@ const useShortcut = <NodeType extends HTMLElement>(
   const memoizedCallback = useCallback(
     (event: KeyboardEvent) => {
       if (key === event.code) {
-        event.stopImmediatePropagation();
         callback(event);
 
         return true;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The current version of `useShortcut` automatically stop the propagation of the event.
IMHO, since this event is passed to the callback, it's the responsibility of the listener to decide whether the event should be stopped or not.
Enforcing such behavior in the DSM does not really allow flexibility when using it.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Ok
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -