### PR TITLE
PIM-9610: Replace 2-digit year by 4-digit year in date patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - PIM-9598: Fix quick export when the bs_Cyrl_BA locale is used.
 - RAC-435: Fix fatal error for user that migrate from 4.0 with product values format that doesn't correspond to expected format
 - RAC-449: Fix invalid processed item when remove attribute
+- PIM-9610: Force displaying years with 4 digits in dates for every locale
 
 ## New features
 

--- a/src/Akeneo/Tool/Component/Localization/Factory/DateFactory.php
+++ b/src/Akeneo/Tool/Component/Localization/Factory/DateFactory.php
@@ -27,14 +27,15 @@ class DateFactory
 
     /**
      * @param array $options
+     * @param bool $fourDigitYear replace 2-digit year by 4-digit year format unless the format is explicitly specified
      *
      * @return \IntlDateFormatter
      */
-    public function create(array $options = [])
+    public function create(array $options = [], bool $fourDigitYear = true)
     {
         $options = $this->resolveOptions($options);
 
-        return new \IntlDateFormatter(
+        $formatter = new \IntlDateFormatter(
             $options['locale'],
             $options['datetype'],
             $options['timetype'],
@@ -42,6 +43,12 @@ class DateFactory
             $options['calendar'],
             $options['date_format']
         );
+
+        if ($fourDigitYear && null === $options['date_format']) {
+            $formatter->setPattern(preg_replace('/(^|[^y])yy([^y]|$)/', '$1yyyy$2', $formatter->getPattern()));
+        }
+
+        return $formatter;
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Localization/spec/Factory/DateFactorySpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/Factory/DateFactorySpec.php
@@ -13,13 +13,7 @@ class DateFactorySpec extends ObjectBehavior
 
     function it_returns_intl_formatter()
     {
-        $date = new \IntlDateFormatter(
-            'fr_FR',
-            \IntlDateFormatter::SHORT,
-            \IntlDateFormatter::NONE
-        );
-
-        $this->create([])->shouldReturnAnInstanceOf(get_class($date));
+        $this->create([])->shouldReturnAnInstanceOf(\IntlDateFormatter::class);
     }
 
     function it_creates_a_date_with_intl_format()
@@ -34,9 +28,10 @@ class DateFactorySpec extends ObjectBehavior
         $this->create($options)->getPattern()->shouldReturn('d/M/yy');
     }
 
-    function it_creates_an_english_date_without_locale()
+    function it_replaces_2_digit_years_by_4_digit_when_the_format_is_not_specified(\IntlDateFormatter $formatter)
     {
-        $options = [];
-        $this->create($options)->getPattern()->shouldReturn('M/d/yy');
+        $options = ['locale' => 'en_AU'];
+        $this->create($options, false)->getPattern()->shouldReturn('d/M/yy');
+        $this->create($options, true)->getPattern()->shouldReturn('d/M/yyyy');
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

A lot of locales have a short date representation with only 2 digits for the year. In the PIM such a format makes it really difficult for a user to define a date in the datepicker, and even impossible to set dates before 1970 or after 2069 (e.g: 1/1/69 represents the 1st of January, 2069 whereas 1/1/70 represents the 1st or January, 1970)

This PR forces a 4-digit representation of the year for every locale, unless an exception is explicitly added in the `pim_catalog.localization.factory.date.formats` and/or `pim_catalog.localization.factory.datetime.formats` parameters

(Note: there are currently 3 exceptions en_US, fr_FR and it_IT, and all of them actualmly replace the default 2-digit year by a 4-digit year...)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
