### PR TITLE
PIM-9612: Fix no image preview for Association with quantities when the image is an asset collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - CPM-86: Fix undefined tab on job profile edit
 - PIM-9596: Fix attribute options manual sorting
 - PIM-9598: Fix quick export when the bs_Cyrl_BA locale is used.
+- PIM-9612: Fix no image preview for Association with quantities when the image is an asset collection
 - RAC-435: Fix fatal error for user that migrate from 4.0 with product values format that doesn't correspond to expected format
 - RAC-449: Fix invalid processed item when remove attribute
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/hooks/useProductThumbnail.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/hooks/useProductThumbnail.ts
@@ -2,6 +2,7 @@ import {useRoute} from '@akeneo-pim-community/legacy-bridge';
 import {Product} from '../models';
 
 const PLACEHOLDER_PATH = '/bundles/pimui/img/image_default.png';
+const isAssetManagerImagePath = (path: string): boolean => path.includes('rest/asset_manager/image_preview');
 
 const useProductThumbnail = (product: Product | null) => {
   const thumbnailUrl = useRoute(
@@ -14,7 +15,15 @@ const useProductThumbnail = (product: Product | null) => {
       : undefined
   );
 
-  return product?.image ? thumbnailUrl : PLACEHOLDER_PATH;
+  if (!product?.image) {
+    return PLACEHOLDER_PATH;
+  }
+
+  if (isAssetManagerImagePath(product.image.filePath)) {
+    return product.image.filePath;
+  }
+
+  return thumbnailUrl;
 };
 
 export {useProductThumbnail};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/tests/front/unit/utils.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/tests/front/unit/utils.tsx
@@ -18,12 +18,11 @@ const renderWithProviders = (ui: React.ReactElement) => render(ui, {wrapper: Def
 const renderDOMWithProviders = (ui: React.ReactElement, container: HTMLElement) =>
   ReactDOM.render(<DefaultProviders>{ui}</DefaultProviders>, container);
 
-const renderHookWithProviders = (hook: () => any) =>
-  renderHook(() => hook(), {wrapper: ({children}) => <DefaultProviders>{children}</DefaultProviders>});
+const renderHookWithProviders = (hook: () => any) => renderHook(hook, {wrapper: DefaultProviders});
 
 const fetchMockResponseOnce = (requestUrl: string, responseBody: string) =>
   fetchMock.mockResponseOnce(request =>
     request.url === requestUrl ? Promise.resolve(responseBody) : Promise.reject()
   );
 
-export {renderWithProviders, renderDOMWithProviders, renderHookWithProviders, fetchMockResponseOnce, DefaultProviders};
+export {renderWithProviders, renderDOMWithProviders, renderHookWithProviders, fetchMockResponseOnce};

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/hooks/useProductThumbnail.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/hooks/useProductThumbnail.unit.tsx
@@ -1,19 +1,6 @@
-import React from 'react';
-import '@testing-library/jest-dom/extend-expect';
-import {renderHook} from '@testing-library/react-hooks';
-import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
+import {renderHookWithProviders} from '@akeneo-pim-community/shared/tests/front/unit/utils';
 import {useProductThumbnail} from '../../../../Resources/public/js/product/form/quantified-associations/hooks/useProductThumbnail';
 import {ProductType} from '../../../../Resources/public/js/product/form/quantified-associations/models';
-
-const productWithoutImage = {
-  id: 1,
-  identifier: 'bag',
-  label: 'Nice bag',
-  document_type: ProductType.Product,
-  image: null,
-  completeness: 100,
-  variant_product_completenesses: null,
-};
 
 const productWithImage = {
   id: 2,
@@ -28,16 +15,29 @@ const productWithImage = {
   variant_product_completenesses: null,
 };
 
-const wrapper = ({children}) => <DependenciesProvider>{children}</DependenciesProvider>;
+const productWithoutImage = {...productWithImage, image: null};
+const productWithAssetManagerImage = {
+  ...productWithImage,
+  image: {
+    originalFileName: 'name.jpg',
+    filePath: '/rest/asset_manager/image_preview/nice-image.jpg',
+  },
+};
 
-test('It returns the image path if the product has an image', async () => {
-  const {result} = renderHook(() => useProductThumbnail(productWithImage), {wrapper});
+test('It returns the image path if the product has an image', () => {
+  const {result} = renderHookWithProviders(() => useProductThumbnail(productWithImage));
 
   expect(result.current).toEqual('pim_enrich_media_show');
 });
 
-test('It returns the placeholder path if the product has no image', async () => {
-  const {result} = renderHook(() => useProductThumbnail(productWithoutImage), {wrapper});
+test('It returns the placeholder path if the product has no image', () => {
+  const {result} = renderHookWithProviders(() => useProductThumbnail(productWithoutImage));
 
   expect(result.current).toEqual('/bundles/pimui/img/image_default.png');
+});
+
+test('It returns the ready-to-use filepath if the image is coming from the Asset Manager', () => {
+  const {result} = renderHookWithProviders(() => useProductThumbnail(productWithAssetManagerImage));
+
+  expect(result.current).toEqual('/rest/asset_manager/image_preview/nice-image.jpg');
 });


### PR DESCRIPTION


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When the image is coming from the Asset Manager, it is already a ready-to-use path so we can return it directly. Same workflow as here https://github.com/akeneo/pim-enterprise-dev/blob/master/src/Akeneo/AssetManager/front/domain/model/asset/data/media-file.ts#L4

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
