### PR TITLE
Fix color of the tags for announcements in communication panel

### DIFF
--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Tag.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/announcement/Tag.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import styled from 'styled-components';
 import {AkeneoThemedProps} from '../../../shared/src/theme';
 
-type Tag = 'new' | 'updates';
+type Tag = 'new' | 'update' | 'announcement';
 type TagProps = {
   tag: Tag;
 };
@@ -26,15 +26,24 @@ const StyledTag = styled.div`
           color: #5da8a6;
           border: 1px solid #81cccc;
         `;
-      case 'updates':
+      case 'update':
         return `
           background-color: #f3eef9;
           color: #763e9e;
           border: 1px solid #9452ba;
         `;
-
+      case 'announcement':
+        return `
+          background-color: #f0f7fc;
+          color: #3278b7;
+          border: 1px solid #4ca8e0;
+        `;
       default:
-        return;
+        return `
+          background-color: #efeff8;
+          color: #3b438c;
+          border: 1px solid #5e63b6;
+        `;
     }
   }}
 `;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The tag (in blue on the image below after fix) didn't have any style. This is the fix to add it.
It also fixes `updates` as `update` to be consistent, and add a default color for an unknown tag.

![Screenshot from 2020-12-28 18-02-13](https://user-images.githubusercontent.com/1942439/103230918-dc6b1900-4936-11eb-807f-221ccba43b10.png)


https://github.com/akeneo/actionable-product-data/issues/270

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
