### PR TITLE
PIM-9614: Fix missing overlay when the announcements panel is open

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9614: Fix missing overlay when the announcements panel is open
+
 # 3.2.79 (2020-12-17)
 
 ## Improvement

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-app.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-app.js
@@ -1,3 +1,5 @@
+const mediator = require('oro/mediator');
+
 /**
  * Akeneo app
  *
@@ -47,6 +49,9 @@ define(
             className: 'app',
             template: _.template(template),
             flashTemplate: _.template(flashTemplate),
+            events: {
+              'click #overlay': 'onClickToCollapsePanel',
+            },
 
             /**
              * {@inheritdoc}
@@ -54,6 +59,9 @@ define(
             initialize: function () {
                 initLayout();
                 initSignin();
+
+                this.listenTo(mediator, 'pim-app:overlay:show', this.showOverlay);
+                this.listenTo(mediator, 'pim-app:overlay:hide', this.hideOverlay);
 
                 return BaseForm.prototype.initialize.apply(this, arguments);
             },
@@ -91,6 +99,18 @@ define(
                 }
 
                 return BaseForm.prototype.render.apply(this, arguments);
+            },
+
+            showOverlay: function () {
+                $('#overlay').addClass('AknOverlay--show');
+            },
+
+            hideOverlay: function () {
+                $('#overlay').removeClass('AknOverlay--show');
+            },
+
+            onClickToCollapsePanel: function() {
+                mediator.trigger('pim-app:panel:close');
             }
         });
     });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Overlay.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Overlay.less
@@ -1,0 +1,12 @@
+.AknOverlay {
+  height: 100%;
+  width: 100%;
+  position: fixed;
+  background: rgba(0,0,0,.2);
+  z-index: 999;
+  display: none;
+
+  &--show {
+    display: block;
+  }
+}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/index.less
@@ -87,6 +87,7 @@
 @import "./web/bundles/pimui/less/components/Notification.less";
 @import "./web/bundles/pimui/less/components/NotificationList.less";
 @import "./web/bundles/pimui/less/components/NotificationMenu.less";
+@import "./web/bundles/pimui/less/components/Overlay.less";
 @import "./web/bundles/pimui/less/components/Progress.less";
 @import "./web/bundles/pimui/less/components/ProjectWidget.less";
 @import "./web/bundles/pimui/less/components/Rule.less";


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

- Adding Overlay less file (backported from `master`)
- Adding click behaviour & mediator event listener

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
