### PR TITLE
add product pagination to bottom of grid

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -141,10 +141,25 @@ extensions:
         config:
             gridName: product-grid
 
+    pim-product-index-pagination-bottom:
+        module: oro/datagrid/pagination-input
+        parent: pim-product-index-grid-container
+        targetZone: toolbar-bottom
+        config:
+            gridName: product-grid
+
     pim-product-index-columns:
         module: pim/datagrid/column-selector
         parent: pim-product-index-grid-container
         targetZone: toolbar
+        position: 10
+        config:
+            route: pim_datagrid_productgrid_available_columns
+
+    pim-product-index-columns-bottom:
+        module: pim/datagrid/column-selector
+        parent: pim-product-index-grid-container
+        targetZone: toolbar-bottom
         position: 10
         config:
             route: pim_datagrid_productgrid_available_columns

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/index.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/index.html
@@ -2,4 +2,5 @@
     <div class="AknFilterBox" data-drop-zone="filters"></div>
     <div class="AknGridToolbar" data-drop-zone="toolbar"></div>
     <div id="grid-<%- gridName %>" data-type="datagrid"></div>
+    <div class="AknGridToolbar" data-drop-zone="toolbar-bottom"></div>
 </div>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
For UX reasons I added the pagination to the bottom of the product grid. Otherwise the user has to scroll to the top each time they want to switch the page.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
