### PR TITLE
DAPI-1470: Fix broken spec

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/CatalogQualityScoreEvolution.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/CatalogQualityScoreEvolution.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\RanksDistribution;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ConsolidationDate;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
 
 final class CatalogQualityScoreEvolution
 {
     private const NUMBER_OF_PAST_MONTHS_TO_RETURN = 5;
+
+    private \DateTimeImmutable $today;
 
     private array $scores;
 
@@ -18,8 +19,9 @@ final class CatalogQualityScoreEvolution
 
     private string $locale;
 
-    public function __construct(array $scores, string $channel, string $locale)
+    public function __construct(\DateTimeImmutable $today, array $scores, string $channel, string $locale)
     {
+        $this->today = $today;
         $this->scores = $scores;
         $this->channel = $channel;
         $this->locale = $locale;
@@ -48,13 +50,11 @@ final class CatalogQualityScoreEvolution
 
     private function initLastMonthsWithEmptyData(): array
     {
-        $monthlyTimePeriodDateFormat = (new ConsolidationDate(new \DateTimeImmutable()))->isLastDayOfMonth() ?
-            new \DateTimeImmutable() :
-            (new \DateTimeImmutable())->setTimestamp(strtotime(date('Y-m-t')));
+        $lastDayThisMonth = $this->today->modify('last day of this month');
 
         $data = [];
         for ($i = self::NUMBER_OF_PAST_MONTHS_TO_RETURN; $i >= 0; $i--) {
-            $newDate = $monthlyTimePeriodDateFormat->modify('last day of ' . $i . ' month ago');
+            $newDate = $lastDayThisMonth->modify('last day of ' . $i . ' month ago');
             $data[$newDate->format('Y-m-d')] = null;
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Dashboard/GetCatalogProductScoreEvolutionQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/Dashboard/GetCatalogProductScoreEvolutionQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Dashboard;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\Clock;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CatalogQualityScoreEvolution;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetCatalogProductScoreEvolutionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
@@ -18,9 +19,12 @@ final class GetCatalogProductScoreEvolutionQuery implements GetCatalogProductSco
 {
     private Connection $db;
 
-    public function __construct(Connection $db)
+    private Clock $clock;
+
+    public function __construct(Connection $db, Clock $clock)
     {
         $this->db = $db;
+        $this->clock = $clock;
     }
 
     public function byCatalog(ChannelCode $channel, LocaleCode $locale): array
@@ -87,6 +91,6 @@ SQL;
             return $productScoreEvolution;
         }
 
-        return (new CatalogQualityScoreEvolution($scores, $channel, $locale))->toArray();
+        return (new CatalogQualityScoreEvolution($this->clock->getCurrentTime(), $scores, $channel, $locale))->toArray();
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -204,6 +204,7 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Dashboard\GetCatalogProductScoreEvolutionQuery:
         arguments:
             - '@database_connection'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetLatestProductScoresByIdentifiersQuery:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Domain/Model/Read/CatalogQualityScoreEvolutionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Domain/Model/Read/CatalogQualityScoreEvolutionSpec.php
@@ -10,15 +10,14 @@ final class CatalogQualityScoreEvolutionSpec extends ObjectBehavior
 {
     public function it_returns_catalog_score_evolution()
     {
-        $year = date('Y');
-        $month = date('m');
-        $currentMonth = (new \DateTime())->format('Y-m-t');
-        $lastMonth = (new \DateTime(sprintf('%d-%d-15', $year, $month - 1)))->format('Y-m-t');
-        $twoMonthsAgo = (new \DateTime(sprintf('%d-%d-15', $year, $month - 2)))->format('Y-m-t');
-        $threeMonthsAgo = (new \DateTime(sprintf('%d-%d-15', $year, $month - 3)))->format('Y-m-t');
-        $fourMonthsAgo = (new \DateTime(sprintf('%d-%d-15', $year, $month - 4)))->format('Y-m-t');
-        $fiveMonthsAgo = (new \DateTime(sprintf('%d-%d-15', $year, $month - 5)))->format('Y-m-t');
-        $sixMonthsAgo = (new \DateTime(sprintf('%d-%d-15', $year, $month - 6)))->format('Y-m-t');
+        $today = new \DateTimeImmutable('2020-12-05');
+        $currentMonth = $today->format('Y-m-t');
+        $lastMonth = $today->modify('last day of 1 month ago')->format('Y-m-t');
+        $twoMonthsAgo = $today->modify('last day of 2 month ago')->format('Y-m-t');
+        $threeMonthsAgo = $today->modify('last day of 3 month ago')->format('Y-m-t');
+        $fourMonthsAgo = $today->modify('last day of 4 month ago')->format('Y-m-t');
+        $fiveMonthsAgo = $today->modify('last day of 5 month ago')->format('Y-m-t');
+        $sixMonthsAgo = $today->modify('last day of 6 month ago')->format('Y-m-t');
 
         $scores = [
             'average_ranks' => [
@@ -96,7 +95,7 @@ final class CatalogQualityScoreEvolutionSpec extends ObjectBehavior
             ],
         ];
 
-        $this->beConstructedWith($scores, 'print', 'en_US');
+        $this->beConstructedWith($today, $scores, 'print', 'en_US');
 
         $this->toArray()->shouldBeLike([
             'average_rank' => 'C',


### PR DESCRIPTION
I changed `CatalogQualityScoreEvolution` to avoid to directly construct DateTime objects. It can cause unexpected issues, and it makes it more complicated to test.