### PR TITLE
PIM-9611: force the order of a join due to statistics bias for low cardinality

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9611: Improve performance of product indexation by forcing a join due to statistics bias for low cardinality
+
 # 4.0.82 (2021-01-05)
 
 # 4.0.81 (2020-12-23)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -208,7 +208,7 @@ WITH
                 channel.code as channel_code
             FROM
                 product
-                JOIN pim_catalog_completeness completeness ON completeness.product_id = product.id
+                STRAIGHT_JOIN pim_catalog_completeness completeness ON completeness.product_id = product.id
                 JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
                 JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id
             GROUP BY product_id, channel_code 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

## Issue

The indexation command is very slow for a customer (30 hours for 680k products). The issue is the slow query to fetch the results from Mysql. It is not reproducible every time. Sometimes, after a restart, it's slow, Sometimes, it's fast, despite 5 restarts in a row...

The part to fetch the completeness is responsible of this slowness.

The query can be simplified this way:
```
EXPLAIN ANALYZE WITH product as (
        SELECT
            product.id, 
            product.identifier
        FROM 
            pim_catalog_product product 
        WHERE 
            product.identifier IN (1000 products identifiers)
    )

            SELECT
                product_id,
                channel.code as channel_code
            FROM
                product
                JOIN pim_catalog_completeness completeness ON completeness.product_id = product.id
                JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
                JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id
        ;
```

It can take more than 2 min to execute in production.
There are:
- 4 channels
- 14 activated locales
- 680k products
- 21 millions of completeness lines

As a reminder, in the completeness table, there is the completeness for each channel/locale/product.
There are 31 pair channel/locale. So 31 rows/product in the completeness table. 

## How to reproduce efficiently?

When indexing the products, it runs by batch of 1000 products identifiers.

When it's slow with 1000 product identifiers, it's possible to get a faster query just by lowering the number of products.
When it's fast with 1000 product identifiers, it's possible to get a slower query just by increasing the number of products.

In the analyzed plan below, it was slow for 969 product identifiers and fast for 968 products identifiers.

## Why is it slow?

### When it's fast

The ANALYZED PLAN is (968 products identifiers):
```
| -> Nested loop inner join  (cost=53694.06 rows=29732) (actual time=0.139..81.835 rows=30008 loops=1)
    -> Nested loop inner join  (cost=43288.03 rows=29732) (actual time=0.133..55.214 rows=30008 loops=1)
        -> Nested loop inner join  (cost=32882.00 rows=29732) (actual time=0.125..40.811 rows=30008 loops=1)
            -> Filter: (product.identifier in (993 products ids))  (cost=314.05 rows=968) (actual time=0.072..4.864 rows=968 loops=1)
                -> Index range scan on product using UNIQ_91CD19C0772E836A  (cost=314.05 rows=968) (actual time=0.066..3.128 rows=968 loops=1)
            -> Index lookup on completeness using IDX_113BA8544584665A (product_id=product.id)  (cost=30.58 rows=31) (actual time=0.030..0.034 rows=31 loops=968)
        -> Single-row index lookup on channel using PRIMARY (id=completeness.channel_id)  (cost=0.25 rows=1) (actual time=0.000..0.000 rows=1 loops=30008)
    -> Single-row index lookup on locale using PRIMARY (id=completeness.locale_id)  (cost=0.25 rows=1) (actual time=0.001..0.001 rows=1 loops=30008)
 |
```

Let's describe this plan.
- it fetches the product id from the UNIQUE index on product identifiers (estimate 968 rows)
- it joins these product ids to the completeness table (estimate 31 rows per product, total 29732 rows)
- then it merges channel and locale, it estimates that these joins will not filter anything


### When it's slow

The ANALYZED PLAN is (969 products identifiers):
```
-> Nested loop inner join  (cost=53717.11 rows=3355) (actual time=0.086..47123.881 rows=30039 loops=1)
    -> Nested loop inner join  (cost=30227.08 rows=67095) (actual time=0.075..14654.013 rows=21133598 loops=1)
        -> Nested loop inner join  (cost=6743.85 rows=67095) (actual time=0.065..7559.950 rows=21133598 loops=1)
            -> Index scan on channel using UNIQ_E07E932A77153098  (cost=0.65 rows=4) (actual time=0.025..0.037 rows=4 loops=1)
            -> Index lookup on completeness using searchunique_idx (channel_id=`channel`.id)  (cost=427.77 rows=16774) (actual time=0.053..1437.428 rows=5283400 loops=4)
        -> Single-row index lookup on locale using PRIMARY (id=completeness.locale_id)  (cost=0.25 rows=1) (actual time=0.000..0.000 rows=1 loops=21133598)
    -> Filter: (product.identifier in (994 product ids))  (cost=0.25 rows=0) (actual time=0.001..0.001 rows=0 loops=21133598)
        -> Single-row index lookup on product using PRIMARY (id=completeness.product_id)  (cost=0.25 rows=1) (actual time=0.001..0.001 rows=1 loops=21133598)
```

- it fetches all the channel ids (4 channels)
- it joins with the completeness table, from the index `channel_id` (estimates 16774 per channel, so a total of 67095 lines, **which is totally wrong**)
- it joins to the locale table (expect ~1 line per row)
- it joins to the products (estimates less than 1 lines per previous rows, which is wrong)

Actually, the join from channel table to completeness table does not generate 67k lines, but the same number as the number of lines in the completeness table: 21 millions.

It's even much slower than FULL TABLE SCAN on completeness table, because it reads at first the index and then is doing a row look-up.

The cost based optimizer selects the query plan that is the best. Here,the cost is almost the same: if you add one product identifier in the batch of the first plan, it's enough to consider that the second query plan is better. 

Which is absolutely not the case. Filtering on products at first always better than filtering on completeness table.


## Why statistics are so wrong?

To build statistics, it takes randomly 20 pages in each index to guess the number of distinct values (= cardinality). 

For example, in the completeness table, it selects 20 pages = ~67k rows for the "channel, locale, product" index. It counts the number of distinct channels in this sample to build a projection.

For 64k rows, there are 4 distinct channels in this sample. 
So, it estimates that for 21 million lines, there are ~1200 channels. 
Said differently, it estimates that there is ~16k rows per channel in the completeness table.

```
| INDEX_TYPE | COMMENT | INDEX_COMMENT | IS_VISIBLE | EXPRESSION |
+---------------+--------------+--------------------------+------------+--------------+----------------------+--------------+-------------+-----------+-------------+----------+--------+----------+------------+---------+---------------+------------+------------+
| def           | akeneo_pim   | pim_catalog_completeness |          1 | akeneo_pim   | IDX_113BA8544584665A |            1 | product_id  | A         |      668997 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          1 | akeneo_pim   | IDX_113BA85472F5A1AA |            1 | channel_id  | A         |        2293 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          1 | akeneo_pim   | IDX_113BA854E559DFD1 |            1 | locale_id   | A         |        5867 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          0 | akeneo_pim   | PRIMARY              |            1 | id          | A         |    20547828 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          0 | akeneo_pim   | searchunique_idx     |            1 | channel_id  | A         |        1225 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          0 | akeneo_pim   | searchunique_idx     |            2 | locale_id   | A         |       12418 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
| def           | akeneo_pim   | pim_catalog_completeness |          0 | akeneo_pim   | searchunique_idx     |            3 | product_id  | A         |    17802106 |     NULL |   NULL |          | BTREE      |         |               | YES        | NULL       |
+---------------+--------------+--------------------------+------------+--------------+----------------------+--------------+-------------+-----------+-------------+----------+--------+----------+------------+---------+---------------+------------+------------+
```


So, when it tries to merge 4 channels to the completeness table, the optimizer thinks that the result set will be only  67k lines.

This is wrong. the number of channels is 4. The real number of lines per channel in the completeness table is 5.5 million.

Also explained here: https://www.percona.com/blog/2017/09/11/updating-innodb-table-statistics-manually/

## Why is it not always the same size of batch to reproduce the issue?

I don't know exactly the reason why. The cost to merge product to completeness table can be different over time (sometimes the cost is 30, sometimes it's 10 :shrug: ). For each operation, there is a default cost in Mysql, but it can be also session based, changed sometimes by Mysql at runtime, etc (https://dev.mysql.com/doc/refman/8.0/en/analyze-table.html).

Therefore, as the cost of this join operation change over time, it has an impact on the overall cost. And therefore the query plan to choose is different.

## How to fix it?

- Increasing the number of pages in the sample. The estimation will still be wrong, but less wrong :smile: 
- Force the merge or the index: the products is always the best possible join in that case. 

I chose the second one, to avoid a migration. But maybe the default settings of the database are not good enough for small tables containing very low cardinality (channel column, locale column, etc). 


## Why Mysql is bad in its estimations :disappointed:  ?

There are foreign keys in channel and locale columns for the completeness. But these foreign keys seem totally useless to build the statistics of `pim_catalog_completeness` table...

It's not normal that it estimates the number of different channels to 1200 when the number of distinct channels in `pim_catalog_channel` table is only 4...  
