### PR TITLE
RAC-450: Handle confirm when hitting enter on the Delete Attribute modal

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -61,19 +61,21 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
   const removeRoute = useRoute('pim_enrich_attribute_rest_remove', {code: attributeCode});
   const [productCount, productModelCount] = useImpactedItemCount(attributeCode);
   const [attributeCodeConfirm, setAttributeCodeConfirm] = useState<string>('');
+  const [isLoading, setLoading] = useState<boolean>(false);
   const isValid = attributeCodeConfirm === attributeCode;
 
   const handleConfirm = async () => {
-    if (!isValid) return;
+    if (!isValid || isLoading) return;
 
     try {
-      setAttributeCodeConfirm('');
+      setLoading(true);
       const response = await fetch(removeRoute, {
         method: 'DELETE',
         headers: new Headers({
           'X-Requested-With': 'XMLHttpRequest',
         }),
       });
+      setLoading(false);
 
       if (response.ok) {
         notify(NotificationLevel.SUCCESS, translate('pim_enrich.entity.attribute.flash.delete.success'));
@@ -83,6 +85,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
         notify(NotificationLevel.ERROR, message ?? translate('pim_enrich.entity.attribute.flash.delete.fail'));
       }
     } catch (error) {
+      setLoading(false);
       notify(NotificationLevel.ERROR, translate('pim_enrich.entity.attribute.flash.delete.fail'));
     }
   };
@@ -128,7 +131,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
         </Link>
       </SpacedHelper>
       <Field label={translate('pim_enrich.entity.attribute.module.delete.type', {attributeCode})}>
-        <TextInput value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
+        <TextInput readOnly={isLoading} value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
       </Field>
       <Modal.BottomButtons>
         <Button level="tertiary" onClick={onCancel}>

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteModal.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/attribute/form/delete/DeleteModal.unit.tsx
@@ -74,6 +74,34 @@ test('it does not allow confirmation until the attributeCodeConfirm field is val
   expect(dependencies.notify).toHaveBeenCalledWith('success', 'pim_enrich.entity.attribute.flash.delete.success');
 });
 
+test('it is submitable using the Enter key (when the confirm is valid)', async () => {
+  const onSuccess = jest.fn();
+
+  renderWithProviders(<DeleteModal onCancel={jest.fn()} onSuccess={onSuccess} attributeCode="nice_attribute" />);
+
+  const input = screen.getByLabelText('pim_enrich.entity.attribute.module.delete.type') as HTMLInputElement;
+
+  await act(async () => {
+    fireEvent.keyDown(input, {key: 'Enter', code: 'Enter'});
+  });
+
+  expect(screen.getByText('pim_common.delete')).toHaveAttribute('disabled');
+  expect(onSuccess).not.toHaveBeenCalled();
+
+  fireEvent.change(input, {target: {value: 'nice_attribute'}});
+
+  await act(async () => {
+    fireEvent.keyDown(input, {key: 'Enter', code: 'Enter'});
+  });
+
+  expect(global.fetch).toHaveBeenCalledWith('pim_enrich_attribute_rest_remove', {
+    method: 'DELETE',
+    headers: new Headers({'X-Requested-With': 'XMLHttpRequest'}),
+  });
+  expect(onSuccess).toHaveBeenCalled();
+  expect(dependencies.notify).toHaveBeenCalledWith('success', 'pim_enrich.entity.attribute.flash.delete.success');
+});
+
 test('it displays an error when the delete failed', async () => {
   global.fetch.mockImplementation(async (url: string) => {
     switch (url) {


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

RAC-450: Handle confirm when hitting enter on the Delete Attribute modal, also rewriting the `fetch` call using `async/await`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
