### PR TITLE
PIM-9150: Remove progress bar for pim:versioning:purge command

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9150: Remove progressbar for pim:versioning:purge command
+
 # 3.2.80 (2021-01-04)
 
 ## Bug fixes

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -71,12 +71,6 @@ class VersionPurger implements VersionPurgerInterface
 
     private function purgeVersionsByResourceName($resourceName, array $options, OutputInterface $output): int
     {
-        $versionsToPurgeCount = $this->countVersionsToPurge($resourceName, $options);
-
-        if (0 === $versionsToPurgeCount) {
-            return 0;
-        }
-
         $versionsToPurge = $this->getVersionsToPurge($resourceName, $options);
         $purgedVersionsCount = 0;
 
@@ -87,7 +81,7 @@ class VersionPurger implements VersionPurgerInterface
                 $purgedVersionsCount += count($purgeableVersionList);
             }
 
-            $output->writeln(sprintf('%d versions purged', purgedVersionsCount));
+            $output->writeln(sprintf('%d versions purged', $purgedVersionsCount));
         }
 
         $output->writeln('');

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -87,7 +87,7 @@ class VersionPurger implements VersionPurgerInterface
                 $purgedVersionsCount += count($purgeableVersionList);
             }
 
-            $output->write('.');
+            $output->writeln(sprintf('%d versions purged', purgedVersionsCount));
         }
 
         $output->writeln('');

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -78,23 +78,19 @@ class VersionPurger implements VersionPurgerInterface
         }
 
         $versionsToPurge = $this->getVersionsToPurge($resourceName, $options);
-        $progressBar = new ProgressBar($output, $versionsToPurgeCount);
-        $progressBar->start();
         $purgedVersionsCount = 0;
 
         foreach ($versionsToPurge as $purgeableVersionList) {
             $purgeableVersionList = $this->filterPurgeableVersionList($purgeableVersionList);
-
             if (!empty($purgeableVersionList)) {
                 $this->deleteVersionsByIdsQuery->execute($purgeableVersionList->getVersionIds());
                 $purgedVersionsCount += count($purgeableVersionList);
             }
 
-            $progressBar->advance($options['batch_size']);
+            $output->write('.');
         }
 
-        $progressBar->finish();
-        $progressBar->clear();
+        $output->writeln('');
 
         return $purgedVersionsCount;
     }


### PR DESCRIPTION
In order to avoid misleading, remove the Symfony ProgressBar for` pim:versioning:purge`
