### PR TITLE
PIM-9622: Fix query that can generate a MySQL memory allocation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details
+- PIM-9622: Fix query that can generate a MySQL memory allocation error
 
 ## New features
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -177,7 +177,8 @@ services:
         arguments:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales'
         tags:
             - { name:  akeneo.pim.automation.data_quality_insights.compute_key_indicator_query}
 


### PR DESCRIPTION
The following query generates a MySQL memory allocation error for big catalogs:
```
SELECT product_id, JSON_OBJECTAGG(criterion_code, result) as results
FROM pim_data_quality_insights_product_criteria_evaluation
WHERE product_id IN(:productIds) AND criterion_code IN(:criterionCodes)
GROUP BY product_id
```

Due to  `GROUP BY`, MySQL performs a "filesort" on the table (it can be seen with an `EXPLAIN`). If the table is huge, the memory needed for this operation can exceed the allocated memory.

The solution is to execute two simple queries instead of this one. It needs some rework to regroup the results of the evaluations of the two completeness criteria, being careful to the PHP memory because all the results are fetched at once.