### PR TITLE
CI: Run Behat tests on EE only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,15 +648,9 @@ workflows:
                     - test_front_static_acceptance_and_integration
                     - test_back_phpunit
 
-          - ready_to_build_only_ce?:
-                type: approval
-                filters:
-                    branches:
-                        ignore:
-                            - master
           - checkout_ce:
                 requires:
-                    - ready_to_build_only_ce?
+                    - ready_to_build?
           - build_dev:
                 name: build_dev_ce
                 is_ee_built: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,12 +647,6 @@ workflows:
                     - test_back_static_and_acceptance
                     - test_front_static_acceptance_and_integration
                     - test_back_phpunit
-          - pull_request_success:
-                requires:
-                    - test_back_behat_legacy
-                    - test_back_performance
-                    - test_back_data_migrations
-                    - test_onboarder_bundle
 
           - ready_to_build_only_ce?:
                 type: approval
@@ -680,6 +674,16 @@ workflows:
                 name: test_back_phpunit_ce
                 requires:
                     - build_dev_ce
+
+          - pull_request_success:
+                requires:
+                    - test_back_behat_legacy
+                    - test_back_performance
+                    - test_back_data_migrations
+                    - test_onboarder_bundle
+                    - test_front_static_acceptance_and_integration_ce
+                    - test_back_static_and_acceptance_ce
+                    - test_back_phpunit_ce
 
   nightly:
       triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -680,16 +680,6 @@ workflows:
                 name: test_back_phpunit_ce
                 requires:
                     - build_dev_ce
-          - test_back_data_migrations:
-                name: test_back_data_migrations_ce
-                requires:
-                    - test_back_phpunit_ce
-          - test_back_behat_legacy:
-                name: test_back_behat_legacy_ce
-                requires:
-                    - test_back_static_and_acceptance_ce
-                    - test_front_static_acceptance_and_integration_ce
-                    - test_back_phpunit_ce
 
   nightly:
       triggers:


### PR DESCRIPTION
Behat tests will still be run every night, but we may not need them on every PR