### PR TITLE
RAC-375: add dropdown subcomponent documentation on storybook

### DIFF
--- a/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
+++ b/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,6 @@
 import React, {ReactNode, Ref, SyntheticEvent} from 'react';
 import styled, {css, keyframes} from 'styled-components';
-import {AkeneoThemedProps, getColor} from '../../theme';
+import {AkeneoThemedProps, getColor, getFontSize} from '../../theme';
 import {CheckIcon, CheckPartialIcon} from '../../icons';
 import {useId, useShortcut} from '../../hooks';
 import {Key, Override} from '../../shared';
@@ -77,7 +77,7 @@ const CheckboxContainer = styled.div<{checked: boolean; readOnly: boolean} & Ake
 const LabelContainer = styled.label<{readOnly: boolean} & AkeneoThemedProps>`
   color: ${getColor('grey140')};
   font-weight: 400;
-  font-size: 15px;
+  font-size: ${getFontSize('big')};
   padding-left: 10px;
 
   ${props =>

--- a/akeneo-design-system/src/components/Dropdown/Dropdown.stories.mdx
+++ b/akeneo-design-system/src/components/Dropdown/Dropdown.stories.mdx
@@ -1,22 +1,22 @@
 import {Meta, Story, ArgsTable, Canvas} from '@storybook/addon-docs/blocks';
 import {Dropdown} from './Dropdown';
-import {Button, Image, Badge, Link, Checkbox} from '..';
+import {Button, Image, Badge, Link, Checkbox} from '../../components';
 import {useBooleanState} from '../../hooks';
 import {SpaceContainer, useSelection} from '../../storybook/PreviewGallery';
 
 <Meta
   title="Components/Dropdown"
   subcomponents={{
-      'Dropdown': Dropdown,
-      'Dropdown.Header': Dropdown.Header,
-      'Dropdown.Title': Dropdown.Title,
-      'Dropdown.Overlay': Dropdown.Overlay,
-      'Dropdown.ItemCollection': Dropdown.ItemCollection,
-      'Dropdown.Item': Dropdown.Item
+    Dropdown: Dropdown,
+    'Dropdown.Header': Dropdown.Header,
+    'Dropdown.Title': Dropdown.Title,
+    'Dropdown.Overlay': Dropdown.Overlay,
+    'Dropdown.ItemCollection': Dropdown.ItemCollection,
+    'Dropdown.Item': Dropdown.Item,
   }}
 />
 
-# Dropdown
+# Dropdown (Beta)
 
 ## Usage
 

--- a/akeneo-design-system/src/components/Dropdown/Dropdown.stories.mdx
+++ b/akeneo-design-system/src/components/Dropdown/Dropdown.stories.mdx
@@ -1,11 +1,20 @@
 import {Meta, Story, ArgsTable, Canvas} from '@storybook/addon-docs/blocks';
-import {Dropdown} from './Dropdown.tsx';
-import {Button, Image, Badge, Link, Checkbox} from '../../components';
+import {Dropdown} from './Dropdown';
+import {Button, Image, Badge, Link, Checkbox} from '..';
 import {useBooleanState} from '../../hooks';
-import {useState} from 'react';
-import {SpaceContainer, useSelection} from '../../storybook/PreviewGallery.tsx';
+import {SpaceContainer, useSelection} from '../../storybook/PreviewGallery';
 
-<Meta title="Components/Dropdown" component={Dropdown} />
+<Meta
+  title="Components/Dropdown"
+  subcomponents={{
+      'Dropdown': Dropdown,
+      'Dropdown.Header': Dropdown.Header,
+      'Dropdown.Title': Dropdown.Title,
+      'Dropdown.Overlay': Dropdown.Overlay,
+      'Dropdown.ItemCollection': Dropdown.ItemCollection,
+      'Dropdown.Item': Dropdown.Item
+  }}
+/>
 
 # Dropdown
 
@@ -15,21 +24,21 @@ The dropdown shows a list of options that can be used to select, filter or sort 
 
 ### Dropdown options
 
-The dropdown option should fit in one single line. If there are several lines, limit it by adding an ellipsis for the overflowing content. We display the full text in the hover state. We recommend that you present the options by alphabetical order.
+The dropdown option should fit in one single line. If there are several lines, limit it by adding an ellipsis for the overflowing content. We display the full text on hover. We recommend that you present the options by alphabetical order.
 
 ### Interaction
 
 By default, the dropdown list displays a label on closing. An open dropdown menu appears on the click. The open dropdown should appear above all other elements of the user interface. They can be close by clicking outside the dropdown element.
 
-Selecting an item close the dropdown and the selected option will replace the placeholder.
+Selecting an item close the dropdown, and the selected option will replace the placeholder.
 
 ### Microcopy
 
-**Ellipsis:** If the text is too long, we use an ellipsis.
+**Ellipsis:** If the text is too long, we use an ellipsis.
 
 For accessibility reasons, we must put the full text in an HTML title attribute.
 
-**Punctuation:** Never use punctuation in a dropdown list.
+**Punctuation:** Never use punctuation in a dropdown list.
 
 ## Playground
 

--- a/akeneo-design-system/src/components/Dropdown/Dropdown.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Dropdown.tsx
@@ -1,9 +1,10 @@
 import React, {ReactNode} from 'react';
 import styled from 'styled-components';
 import {Overlay} from './Overlay/Overlay';
-import {Item, ItemLabel} from './Item/Item';
+import {Item} from './Item/Item';
 import {ItemCollection} from './ItemCollection/ItemCollection';
-import {getColor} from '../../theme';
+import {Header} from './Header/Header';
+import {Title} from './Header/Title';
 
 const DropdownContainer = styled.div`
   position: relative;
@@ -17,25 +18,6 @@ type DropdownProps = {
   children?: ReactNode;
 };
 
-const Header = styled.div`
-  box-sizing: border-box;
-  border-bottom: 1px solid ${getColor('brand', 100)};
-  height: 44px;
-  line-height: 44px;
-  margin: 0 20px 10px 20px;
-`;
-
-const Content = styled.div``;
-
-const Title = styled.div`
-  font-size: 11px;
-  text-transform: uppercase;
-  color: ${getColor('brand', 100)};
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;
-
 /**
  * The dropdown shows a list of options that can be used to select, filter or sort content.
  */
@@ -43,17 +25,16 @@ const Dropdown = ({children, ...rest}: DropdownProps) => {
   return <DropdownContainer {...rest}>{children}</DropdownContainer>;
 };
 
+Overlay.displayName = 'Dropdown.Overlay';
 Header.displayName = 'Dropdown.Header';
 Title.displayName = 'Dropdown.Title';
 ItemCollection.displayName = 'Dropdown.ItemCollection';
-Content.displayName = 'Dropdown.Content';
+Item.displayName = 'Dropdown.Item';
 
 Dropdown.Overlay = Overlay;
 Dropdown.Header = Header;
 Dropdown.Item = Item;
-Dropdown.ItemLabel = ItemLabel;
 Dropdown.Title = Title;
 Dropdown.ItemCollection = ItemCollection;
-Dropdown.Content = Content;
 
 export {Dropdown};

--- a/akeneo-design-system/src/components/Dropdown/Dropdown.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Dropdown.tsx
@@ -13,7 +13,7 @@ const DropdownContainer = styled.div`
 
 type DropdownProps = {
   /**
-   * The content of the Dropdown
+   * The content of the Dropdown.
    */
   children?: ReactNode;
 };

--- a/akeneo-design-system/src/components/Dropdown/Header/Header.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Header/Header.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import {getColor} from '../../../theme';
+import {Override} from '../../../shared';
+import React, {ReactNode, Ref} from 'react';
+
+const HeaderContainer = styled.div`
+  box-sizing: border-box;
+  border-bottom: 1px solid ${getColor('brand', 100)};
+  height: 44px;
+  line-height: 44px;
+  margin: 0 20px 10px 20px;
+`;
+
+type HeaderProps = Override<
+  React.HTMLAttributes<HTMLDivElement>,
+  {
+    /**
+     * The content of the header
+     */
+    children: ReactNode;
+  }
+>;
+
+const Header = React.forwardRef<HTMLDivElement, HeaderProps>(
+  ({children}: HeaderProps, forwardedRef: Ref<HTMLDivElement>): React.ReactElement => {
+    return <HeaderContainer ref={forwardedRef}>{children}</HeaderContainer>;
+  }
+);
+
+export {Header};

--- a/akeneo-design-system/src/components/Dropdown/Header/Header.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Header/Header.tsx
@@ -15,7 +15,7 @@ type HeaderProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
     /**
-     * The content of the header
+     * The content of the header.
      */
     children: ReactNode;
   }

--- a/akeneo-design-system/src/components/Dropdown/Header/Title.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Header/Title.tsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import {getColor} from '../../../theme';
+import {Override} from '../../../shared';
+import React, {ReactNode, Ref} from 'react';
+
+const TitleContainer = styled.div`
+  font-size: 11px;
+  text-transform: uppercase;
+  color: ${getColor('brand', 100)};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+type TitleProps = Override<
+  React.HTMLAttributes<HTMLDivElement>,
+  {
+    /**
+     * The title of the dropdown
+     */
+    children: ReactNode;
+  }
+>;
+
+const Title = React.forwardRef<HTMLDivElement, TitleProps>(
+  ({children}: TitleProps, forwardedRef: Ref<HTMLDivElement>): React.ReactElement => {
+    return <TitleContainer ref={forwardedRef}>{children}</TitleContainer>;
+  }
+);
+
+export {Title};

--- a/akeneo-design-system/src/components/Dropdown/Header/Title.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Header/Title.tsx
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
-import {getColor} from '../../../theme';
+import {getColor, getFontSize} from '../../../theme';
 import {Override} from '../../../shared';
 import React, {ReactNode, Ref} from 'react';
 
 const TitleContainer = styled.div`
-  font-size: 11px;
+  font-size: ${getFontSize('small')};
   text-transform: uppercase;
   color: ${getColor('brand', 100)};
   white-space: nowrap;
@@ -16,7 +16,7 @@ type TitleProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
     /**
-     * The title of the dropdown
+     * The title of the dropdown.
      */
     children: ReactNode;
   }

--- a/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
@@ -51,7 +51,7 @@ type ItemProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
     /**
-     * The content of the item
+     * The content of the item.
      */
     children: ReactNode;
   }

--- a/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
@@ -48,6 +48,9 @@ const ItemContainer = styled.div<{tall: boolean} & AkeneoThemedProps>`
 type ItemProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
+    /**
+     * The content of the item
+     */
     children: ReactNode;
   }
 >;
@@ -125,8 +128,5 @@ const Item = React.forwardRef<HTMLDivElement, ItemProps>(
     );
   }
 );
-
-Item.displayName = 'Dropdown.Item';
-ItemLabel.displayName = 'Dropdown.ItemLabel';
 
 export {Item, ItemLabel};

--- a/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Item/Item.tsx
@@ -1,7 +1,9 @@
 import React, {KeyboardEvent, ReactNode, Ref, useCallback, useRef} from 'react';
 import styled from 'styled-components';
 import {AkeneoThemedProps, getColor} from '../../../theme';
-import {Checkbox, Image, Link} from '../../../components';
+import {Image} from '../../../components/Image/Image';
+import {Checkbox} from '../../../components/Checkbox/Checkbox';
+import {Link} from '../../../components/Link/Link';
 import {Key, Override} from '../../../shared';
 
 const ItemLabel = styled.span`

--- a/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
+++ b/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
@@ -12,6 +12,9 @@ const ItemCollectionContainer = styled.div`
 type ItemCollectionProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
+    /**
+     * The list of item
+     */
     children: ReactNode;
   }
 >;

--- a/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
+++ b/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
@@ -13,7 +13,7 @@ type ItemCollectionProps = Override<
   React.HTMLAttributes<HTMLDivElement>,
   {
     /**
-     * The list of item
+     * The list of items.
      */
     children: ReactNode;
   }

--- a/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
@@ -110,4 +110,6 @@ const Overlay = ({verticalPosition: defaultVerticalPosition, onClose, children}:
   );
 };
 
+Overlay.displayName = 'Overlay';
+
 export {Overlay};

--- a/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
@@ -44,12 +44,12 @@ const Container = styled.div<
 
 type OverlayProps = {
   /**
-   * Vertical position of the overlay (forced)
+   * Vertical position of the overlay (forced).
    */
   verticalPosition?: VerticalPosition;
 
   /**
-   * What to do on overlay closing
+   * What to do on overlay closing.
    */
   onClose: () => void;
 

--- a/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
+++ b/akeneo-design-system/src/components/Dropdown/Overlay/Overlay.tsx
@@ -1,6 +1,6 @@
 import React, {ReactNode, useRef, useState, useEffect} from 'react';
 import styled, {css} from 'styled-components';
-import {Key} from '../../../shared/key';
+import {Key} from '../../../shared';
 import {useShortcut} from '../../../hooks';
 import {AkeneoThemedProps, getColor} from '../../../theme';
 
@@ -110,5 +110,4 @@ const Overlay = ({verticalPosition: defaultVerticalPosition, onClose, children}:
   );
 };
 
-Overlay.displayName = 'Dropdown.Overlay';
 export {Overlay};


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
In this PR: 
- Add Dropdown sub components in the dropdown documentation page
![Capture du 2021-01-07 16-45-24](https://user-images.githubusercontent.com/7239572/103912592-c49a4e80-5107-11eb-868e-b1a4d22b5c94.png)
- Remove Dropdown.ItemLabel because for the moment we don't need it, this component is used when we have string in Dropdown.Item component
- Remove Dropdown.Content because it's never used
- Move Dropdown.Tile and Dropdown.Header into function component because Storybook expose styled component props instead of children 

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
