### PR TITLE
CXP-616: Send akeneo headers when testing an URL during event subscriptions configuration

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/CheckWebhookReachabilityCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/CheckWebhookReachabilityCommand.php
@@ -13,13 +13,22 @@ class CheckWebhookReachabilityCommand
     /** @var string */
     private $webhookUrl;
 
-    public function __construct(string $webhookUrl)
+    /** @var string */
+    private $secret;
+
+    public function __construct(string $webhookUrl, string $secret)
     {
         $this->webhookUrl = $webhookUrl;
+        $this->secret = $secret;
     }
 
     public function webhookUrl(): string
     {
         return $this->webhookUrl;
+    }
+
+    public function secret(): string
+    {
+        return $this->secret;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/CheckWebhookReachabilityHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/CheckWebhookReachabilityHandler.php
@@ -23,6 +23,6 @@ final class CheckWebhookReachabilityHandler
 
     public function handle(CheckWebhookReachabilityCommand $command): UrlReachabilityStatus
     {
-        return $this->reachabilityChecker->check($command->webhookUrl());
+        return $this->reachabilityChecker->check($command->webhookUrl(), $command->secret());
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/UrlReachabilityCheckerInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/UrlReachabilityCheckerInterface.php
@@ -12,5 +12,5 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\DTO\UrlReachabilityStatus;
  */
 interface UrlReachabilityCheckerInterface
 {
-    public function check(string $url): UrlReachabilityStatus;
+    public function check(string $url, string $secret): UrlReachabilityStatus;
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/WebhookController.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/WebhookController.php
@@ -68,8 +68,9 @@ class WebhookController
     public function checkWebhookReachability(Request $request): JsonResponse
     {
         $url = $request->get('url', '');
+        $secret = $request->get('secret', '');
         $checkWebhookReachability = $this->checkWebhookReachabilityHandler->handle(
-            new CheckWebhookReachabilityCommand($url)
+            new CheckWebhookReachabilityCommand($url, $secret)
         );
 
         return new JsonResponse($checkWebhookReachability->normalize());

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -202,6 +202,7 @@ akeneo_connectivity.connection:
         helper:
             message: You can be notified of events happening in the PIM for products synchronized with this connected app. You just need to define a URL and the event type(s) you want to keep track of.
             link: Learn more about event subscription configuration...
+            url.test_disabled: Please, click on the Save button to be able to test the URL.
         form:
             url: URL
             secret: Secret

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Client/GuzzleWebhookClient.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Client/GuzzleWebhookClient.php
@@ -6,6 +6,7 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Client;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionSendApiEventRequestLog;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookClient;
+use Akeneo\Connectivity\Connection\Infrastructure\Webhook\RequestHeaders;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
@@ -21,9 +22,6 @@ use Symfony\Component\Serializer\Encoder\EncoderInterface;
  */
 class GuzzleWebhookClient implements WebhookClient
 {
-    const HEADER_REQUEST_SIGNATURE = 'X-Akeneo-Request-Signature';
-    const HEADER_REQUEST_TIMESTAMP = 'X-Akeneo-Request-Timestamp';
-
     private ClientInterface $client;
     private EncoderInterface $encoder;
     private LoggerInterface $logger;
@@ -55,12 +53,12 @@ class GuzzleWebhookClient implements WebhookClient
                 $body = $this->encoder->encode($webhookRequest->content(), 'json');
 
                 $timestamp = time();
-                $signature = Signature::createSignature($webhookRequest->secret(), $body, $timestamp);
+                $signature = Signature::createSignature($webhookRequest->secret(), $timestamp, $body);
 
                 $headers = [
                     'Content-Type' => 'application/json',
-                    self::HEADER_REQUEST_SIGNATURE => $signature,
-                    self::HEADER_REQUEST_TIMESTAMP => $timestamp,
+                    RequestHeaders::HEADER_REQUEST_SIGNATURE => $signature,
+                    RequestHeaders::HEADER_REQUEST_TIMESTAMP => $timestamp,
                 ];
 
                 $logs[] = new EventSubscriptionSendApiEventRequestLog($webhookRequest, $headers, microtime(true));

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Client/Signature.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Client/Signature.php
@@ -8,7 +8,7 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Client;
  */
 class Signature
 {
-    public static function createSignature(string $secret, string $body, int $timestamp): string
+    public static function createSignature(string $secret, int $timestamp, ?string $body = null): string
     {
         $data = (string)$timestamp . '.' . $body;
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/RequestHeaders.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/RequestHeaders.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RequestHeaders
+{
+    const HEADER_REQUEST_SIGNATURE = 'X-Akeneo-Request-Signature';
+    const HEADER_REQUEST_TIMESTAMP = 'X-Akeneo-Request-Timestamp';
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/CheckWebhookReachabilityCommandSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/CheckWebhookReachabilityCommandSpec.php
@@ -15,7 +15,7 @@ class CheckWebhookReachabilityCommandSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith('http://172.17.0.1:8000/webhook');
+        $this->beConstructedWith('http://172.17.0.1:8000/webhook', '1234');
     }
 
     public function it_is_initializable(): void
@@ -26,6 +26,11 @@ class CheckWebhookReachabilityCommandSpec extends ObjectBehavior
     public function it_returns_the_webhook_url(): void
     {
         $this->webhookUrl()->shouldReturn('http://172.17.0.1:8000/webhook');
+    }
+
+    public function it_returns_the_secret(): void
+    {
+        $this->secret()->shouldReturn('1234');
     }
 }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/CheckWebhookReachabilityHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/CheckWebhookReachabilityHandlerSpec.php
@@ -29,10 +29,10 @@ class CheckWebhookReachabilityHandlerSpec extends ObjectBehavior
 
     public function it_returns_url_reachability_status($reachabilityChecker): void
     {
-        $command = new CheckWebhookReachabilityCommand('http://172.17.0.1:8000/webhook');
+        $command = new CheckWebhookReachabilityCommand('http://172.17.0.1:8000/webhook', '1234');
         $expectedUrlReachabilityStatus = new UrlReachabilityStatus(true, "200: OK");
 
-        $reachabilityChecker->check($command->webhookUrl())->willReturn($expectedUrlReachabilityStatus);
+        $reachabilityChecker->check($command->webhookUrl(), $command->secret())->willReturn($expectedUrlReachabilityStatus);
 
         $handleResult = $this->handle($command);
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Webhook\Client;
 
 use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookRequest;
+use Akeneo\Connectivity\Connection\Infrastructure\Webhook\RequestHeaders;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read\ActiveWebhook;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent;
@@ -98,9 +99,9 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
         $body = '{"events":[{"action":"product.created","event_id":"7abae2fe-759a-4fce-aa43-f413980671b3","event_datetime":"2020-01-01T00:00:00+00:00","author":"julia","author_type":"ui","pim_source":"staging.akeneo.com","data":["data_1"]}]}';
         Assert::assertEquals($body, (string)$request->getBody());
 
-        $timestamp = (int)$request->getHeader(GuzzleWebhookClient::HEADER_REQUEST_TIMESTAMP)[0];
-        $signature = Signature::createSignature('a_secret', $body, $timestamp);
-        Assert::assertEquals($signature, $request->getHeader(GuzzleWebhookClient::HEADER_REQUEST_SIGNATURE)[0]);
+        $timestamp = (int)$request->getHeader(RequestHeaders::HEADER_REQUEST_TIMESTAMP)[0];
+        $signature = Signature::createSignature('a_secret', $timestamp, $body);
+        Assert::assertEquals($signature, $request->getHeader(RequestHeaders::HEADER_REQUEST_SIGNATURE)[0]);
 
         // Request 2
 
@@ -110,9 +111,9 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
         $body = '{"events":[{"action":"product.created","event_id":"7abae2fe-759a-4fce-aa43-f413980671b3","event_datetime":"2020-01-01T00:00:00+00:00","author":"julia","author_type":"ui","pim_source":"staging.akeneo.com","data":["data_2"]}]}';
         Assert::assertEquals($body, (string)$request->getBody());
 
-        $timestamp = (int)$request->getHeader(GuzzleWebhookClient::HEADER_REQUEST_TIMESTAMP)[0];
-        $signature = Signature::createSignature('a_secret', $body, $timestamp);
-        Assert::assertEquals($signature, $request->getHeader(GuzzleWebhookClient::HEADER_REQUEST_SIGNATURE)[0]);
+        $timestamp = (int)$request->getHeader(RequestHeaders::HEADER_REQUEST_TIMESTAMP)[0];
+        $signature = Signature::createSignature('a_secret', $timestamp, $body);
+        Assert::assertEquals($signature, $request->getHeader(RequestHeaders::HEADER_REQUEST_SIGNATURE)[0]);
     }
 
     private function findRequest(array $container, string $url): ?Request

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/SignatureSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/SignatureSpec.php
@@ -22,9 +22,19 @@ class SignatureSpec extends ObjectBehavior
     {
         $this->createSignature(
             '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b',
-            '{"data":"Hello world!"}',
-            1598777637
+            1598777637,
+            '{"data":"Hello world!"}'
         )
             ->shouldReturn('9ac9a8cd3e24a416e7001ebd2ca54c76307c058101102070d0b3a5e7e0bf98a6');
+    }
+
+    public function it_creates_a_signature_even_if_the_body_is_null(): void
+    {
+        $this->createSignature(
+            '2bb80d537b1da3e38bd30361aa855686bde0eacd7162fef6a25fe97bf527a25b',
+            1598777637,
+            null
+        )
+            ->shouldReturn('5ec6023d0c34c6af78ce70e06e496a998882d1f4872a4f33245be00560789fb2');
     }
 }

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -36,7 +36,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
         clearError('url');
         setTestUrl({checking: true});
 
-        const result = await checkReachability(getValues('url'));
+        const result = await checkReachability(getValues('url'), getValues('secret'));
         if (isErr(result)) {
             throw new Error();
         }
@@ -47,6 +47,9 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
             setError('url', 'manual', result.value.message);
         }
     };
+
+    const isTestButtonDisabled = () =>
+        !getValues('url') || '' === getValues('url') || !getValues('secret') || '' === getValues('secret');
 
     const isActiveEventSubscriptionsLimitReached = () =>
         activeEventSubscriptionsLimit.current >= activeEventSubscriptionsLimit.limit;
@@ -94,6 +97,11 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                             <Translate id={testUrl.status.message} />
                         </Helper>
                     ),
+                    isTestButtonDisabled() && (
+                        <Helper inline level='info'>
+                            <Translate id={'akeneo_connectivity.connection.webhook.helper.url.test_disabled'} />
+                        </Helper>
+                    ),
                 ]}
             >
                 <>
@@ -110,7 +118,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                     />
                     <TestUrlButton
                         onClick={handleTestUrl}
-                        disabled={!getValues('url') || '' === getValues('url')}
+                        disabled={isTestButtonDisabled()}
                         loading={testUrl.checking}
                     />
                 </>

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-webhook-check-reachability.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-webhook-check-reachability.ts
@@ -5,12 +5,13 @@ import {WebhookReachability} from '../../model/WebhookReachability';
 const useCheckReachability = (code: string) => {
     const route = useRoute('akeneo_connectivity_connection_webhook_rest_check_reachability', {code});
 
-    return async (url: string) => {
+    return async (url: string, secret: string) => {
         const result = await fetchResult<WebhookReachability, undefined>(route, {
             method: 'POST',
             headers: [['Content-type', 'application/json']],
             body: JSON.stringify({
                 url: url,
+                secret: secret,
             }),
         });
 


### PR DESCRIPTION
Two headers were missing from the request: `x-akeneo-request-timestamp` and `x-akeneo-request-signature`. We need it because when you develop your own app to receive webhook data without the headers there is no solution to know if the request really comes from Akeneo.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
