### PR TITLE
PIM-9620: Fix performance issue on API attributes partial update list

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -15,6 +15,7 @@
 - DAPI-1470: Fix DateTime bad usage
 - DAPI-1469: Fix the size issue with the logo on login page
 - PIM-9622: Fix query that can generate a MySQL memory allocation error
+- PIM-9620: Fix performance issue on API attributes partial update list
 
 # 5.0.0 (2020-12-31)
 

--- a/src/Akeneo/Pim/Structure/.php_cd.php
+++ b/src/Akeneo/Pim/Structure/.php_cd.php
@@ -23,6 +23,7 @@ $rules = [
         'Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface',
         'Oro\Bundle\FilterBundle\Filter\ChoiceFilter',
         'Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface',
+        'Psr\Log\LoggerInterface',
 
         // TIP-906: Functional problem to query products before removing AttributeOption
         'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory',

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ApiAggregatorForAttributePostSaveEventSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ApiAggregatorForAttributePostSaveEventSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ApiAggregatorForAttributePostSaveEventSubscriber implements EventSubscriberInterface
+{
+    private EventDispatcherInterface $eventDispatcher;
+
+    private bool $isActivated;
+
+    private array $eventsAttributes;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->isActivated = false;
+        $this->eventsAttributes = [];
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Priority must be high in order to catch events before any other subscribers.
+            StorageEvents::POST_SAVE => ['aggregateEvent', 10000],
+        ];
+    }
+
+    public function activate(): void
+    {
+        $this->isActivated = true;
+    }
+
+    public function deactivate(): void
+    {
+        $this->isActivated = false;
+    }
+
+    public function aggregateEvent(GenericEvent $event)
+    {
+        $attribute = $event->getSubject();
+        $unitary = $event->getArguments()['unitary'] ?? false;
+
+        if (!$this->isActivated || !$attribute instanceof AttributeInterface || !$unitary) {
+            return;
+        }
+
+        $this->eventsAttributes[$attribute->getId()] = $attribute;
+
+        $event->setArgument('unitary', false);
+    }
+
+    public function dispatchAllEvents(): void
+    {
+        if (empty($this->eventsAttributes)) {
+            return;
+        }
+
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($this->eventsAttributes));
+        $this->eventsAttributes = [];
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -15,6 +15,8 @@ services:
             - '@pim_api.pagination.parameter_validator'
             - '@pim_api.stream.attribute_partial_update_stream'
             - '%pim_api.configuration%'
+            - '@Akeneo\Pim\Structure\Bundle\EventSubscriber\ApiAggregatorForAttributePostSaveEventSubscriber'
+            - '@logger'
 
     pim_api.controller.attribute_group:
         public: true

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -62,3 +62,9 @@ services:
             - '@pim_catalog.factory.attribute_requirement'
         tags:
             - { name: doctrine.event_subscriber }
+
+    Akeneo\Pim\Structure\Bundle\EventSubscriber\ApiAggregatorForAttributePostSaveEventSubscriber:
+        arguments:
+            - '@event_dispatcher'
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
There are a performance issue when updating attributes with the API end-point "PATCH attributes".

It's because an event POST_SAVE with the parameter `unitary` at `true` is dispatched for each attribute while it's a "batch" process. A subscriber of the DQI context listen to these events and launch computations that takes time.

The parameter `unitary` was designed for this kind of cases. It allows to distinct a single update from a multiple/batch update.

This kind of problem has already been spotted and fixed for the products. A subscriber has been added to put the parameter `unitary` to false and dispatch a POST_SAVE_ALL event.
dev/blob/master/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnSave/ApiAggregatorForProductPostSaveEventSubscriber.php
