### PR TITLE
Product API: include search_locale in pagination links

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -665,6 +665,9 @@ class ProductController
         if (null !== $query->searchChannelCode) {
             $queryParameters['search_scope'] = $query->searchChannelCode;
         }
+        if (null !== $query->searchLocaleCode) {
+            $queryParameters['search_locale'] = $query->searchLocaleCode;
+        }
         if (null !== $query->localeCodes) {
             $queryParameters['locales'] = join(',', $query->localeCodes);
         }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -477,6 +477,9 @@ class ProductModelController
         if (null !== $query->searchChannelCode) {
             $queryParameters['search_scope'] = $query->searchChannelCode;
         }
+        if (null !== $query->searchLocaleCode) {
+            $queryParameters['search_locale'] = $query->searchLocaleCode;
+        }
         if (null !== $query->localeCodes) {
             $queryParameters['locales'] = join(',', $query->localeCodes);
         }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
@@ -40,17 +40,17 @@ JSON;
         $search = sprintf('{"updated":[{"operator":">","value":"%s"}]}', $discriminantDatetime->format('Y-m-d H:i:s'));
         $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
 
-        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $client->request('GET', 'api/rest/v1/products?search_locale=en_US&search=' . $search);
         $response = $client->getResponse();
 
         $expected = <<<JSON
 {
     "_links":{
         "self":{
-            "href":"http:\/\/localhost\/api\/rest\/v1\/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"
+            "href":"http:\/\/localhost\/api\/rest\/v1\/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}&search_locale=en_US"
         },
         "first":{
-            "href":"http:\/\/localhost\/api\/rest\/v1\/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"
+            "href":"http:\/\/localhost\/api\/rest\/v1\/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}&search_locale=en_US"
         }
     },
     "current_page":1,


### PR DESCRIPTION
Previously, the pagination links in both Product and ProductModel list
api responses would have the search_locale param stripped if it was
used. This meant that the first page would be retrieved, but then
following the nextLink url in the response would throw a 422 when
visited (because of a lack of search_locale).

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed

I'm not sure which of the above is my responsibility. I've added to the only tests I was able to find that cover this code, but I'm not sure which category these fall into.

Also, this is a more complete fix than #11723 (which seems to have been accidentally closed by an unrelated commit)

Closes #11722