### PR TITLE
PIM-9627: fix empty family field when creating a product model with family not present in first page

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9627: Empty Family field when creating a product model with family not present in first page
+
 # 4.0.83 (2021-01-06)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -60,6 +60,11 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
             $qb->setParameter('search', '%' . $search . '%');
         }
 
+        if (isset($options['identifiers'])) {
+            $qb->andWhere('f.code IN (:identifiers)')
+                ->setParameter('identifiers', $options['identifiers']);
+        }
+
         if ($limit) {
             $qb->setMaxResults((int) $limit);
             if (isset($options['page'])) {

--- a/tests/back/Pim/Structure/Integration/Doctrine/ORM/Repository/FamilyRepositoryIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Doctrine/ORM/Repository/FamilyRepositoryIntegration.php
@@ -81,6 +81,17 @@ class FamilyRepositoryIntegration extends TestCase
         Assert::assertSame('tshirt', $firstPage[0]->getCode());
     }
 
+    public function test_it_is_able_to_search_family_by_identifiers(): void
+    {
+        $this->loadFixtures();
+
+        $results = $this->familyRepository->getWithVariants(null, ['identifiers' => ['tshirt', 'jacket']], 2);
+        Assert::assertCount(2, $results);
+        Assert::assertContainsOnlyInstancesOf(FamilyInterface::class, $results);
+        Assert::assertSame('jacket', $results[0]->getCode());
+        Assert::assertSame('tshirt', $results[1]->getCode());
+    }
+
     private function loadFixtures(): void
     {
         $this->createAttribute([


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When we select a family not present in the first page on create product model page, the family is not displayed.
![Capture du 2021-01-11 12-31-00](https://user-images.githubusercontent.com/7239572/104177364-ec8bf980-5408-11eb-887e-c1e84e765346.png)

**Why ?**
Because when we select the value an ajax call is made :
https://github.com/akeneo/pim-community-dev/blob/8a7f6f25553b5f4887a4e0918a4d7207dacb88a3/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/simple-select-async.js#L172

Currently the parameters identifiers is ignored, it does not make problem when identifier is in the twenty first result but it make problem when family is in the second page. In this PR, if the parameter identifier is given I also filter result by identifiers

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | Done
| Changelog updated                 | Done
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
