### PR TITLE
PIM-9630: Dashboard completeness broken due to mysql buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+
 # master
 
 ## Bug fixes
 
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details
 - PIM-9622: Fix query that can generate a MySQL memory allocation error
+- PIM-9630: Fix SQL sort buffer size issue when the catalog has a very large number of categories
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
@@ -122,14 +122,6 @@ SQL;
             $rows[$i]['channel_labels'] = \json_decode($categoriesCodeAndLocalesByChannel['channel_labels'], true);
         }
 
-        return $this->sortCategoriesCodesAndLocalesByChannel($rows);
-    }
-
-    private function sortCategoriesCodesAndLocalesByChannel(array $rows): array {
-        usort($rows, function ($completenessA, $completenessB) {
-            return strcmp($completenessA['channel_code'], $completenessB['channel_code']);
-        });
-
         return $rows;
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
@@ -69,7 +69,7 @@ class GetCompletenessPerChannelAndLocale implements GetCompletenessPerChannelAnd
             SELECT
                 channel.code as channel_code,
                 channel_translation.labels as channel_labels,
-                JSON_ARRAY_APPEND(COALESCE(child.children_codes, "[]"), '$', root.code) as category_codes_in_channel,
+                JSON_ARRAY_APPEND(COALESCE(child.children_codes, '[]'), '$', root.code) as category_codes_in_channel,
                 pim_locales.json_locales as locales
             FROM
                 pim_catalog_category AS root
@@ -111,9 +111,7 @@ class GetCompletenessPerChannelAndLocale implements GetCompletenessPerChannelAnd
                         channel.code
                 ) AS pim_locales on pim_locales.channel_code = channel.code
             WHERE
-                root.parent_id IS NULL 
-            ORDER BY
-                channel.code, root.code
+                root.parent_id IS NULL
 SQL;
 
         $rows = $this->connection->executeQuery($sql)->fetchAll();
@@ -123,6 +121,14 @@ SQL;
             $rows[$i]['category_codes_in_channel'] = \json_decode($categoriesCodeAndLocalesByChannel['category_codes_in_channel']);
             $rows[$i]['channel_labels'] = \json_decode($categoriesCodeAndLocalesByChannel['channel_labels'], true);
         }
+
+        return $this->sortCategoriesCodesAndLocalesByChannel($rows);
+    }
+
+    private function sortCategoriesCodesAndLocalesByChannel(array $rows): array {
+        usort($rows, function ($completenessA, $completenessB) {
+            return strcmp($completenessA['channel_code'], $completenessB['channel_code']);
+        });
 
         return $rows;
     }
@@ -138,7 +144,7 @@ SQL;
     private function countTotalProductsInCategoriesByChannel(array $categoriesCodeAndLocalesByChannels): array
     {
         if (empty($categoriesCodeAndLocalesByChannels)) {
-            return null;
+            return [];
         }
 
         $body = [];
@@ -199,7 +205,7 @@ SQL;
     private function countTotalProductInCategoriesByChannelAndLocale(array $categoriesCodeAndLocalesByChannels): array
     {
         if (empty($categoriesCodeAndLocalesByChannels)) {
-            return null;
+            return [];
         }
 
         $body = [];


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
Fixes SQL sort buffer size issue when the catalog has a very large number of categories
Remove the ordering on channel codes which it seems to be useless

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
