### PR TITLE
PIM-9636: add posibility to contextualize translation when create a variant depending on number of axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details
 - PIM-9622: Fix query that can generate a MySQL memory allocation error
+- PIM-9636: Fix add posibility to contextualize translation when create a variant depending on number of axes
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -172,7 +172,7 @@ pim_enrich.entity.product_model:
         variant_axis:
             label: 'variant axis'
             create: Add new
-            create_label: "Add a new {{ axes }}"
+            title_create_label: "]-Inf, 1]Add a new {{ axes }}|]1, Inf[Add a new {{ axes }}"
             required_label: '(variant axis)'
         completeness:
             variant_product: "]-Inf, 1]{{ complete }} / {{ total }} variant product|]1, Inf[{{ complete }} / {{ total }} variant products"

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/add-child/header.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product-model/form/add-child/header.js
@@ -43,6 +43,7 @@ define([
                   this.template({
                     __: __,
                     axes: axesLabels.sort().join(', '),
+                    axesCount: axesLabels.length,
                   })
                 );
               });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product_model/add-child/header.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product_model/add-child/header.html
@@ -1,4 +1,4 @@
 <div class="AknFullPage-titleContainer">
     <div class="AknFullPage-subTitle"><%- __('pim_enrich.entity.product_model.plural_label') %></div>
-    <div class="AknFullPage-title"><%- __('pim_enrich.entity.product_model.module.variant_axis.create_label', { axes: axes }) %></div>
+    <div class="AknFullPage-title"><%- __('pim_enrich.entity.product_model.module.variant_axis.title_create_label', { axes: axes }, axesCount) %></div>
 </div>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In this PR:
- Add possibility to have plurial on add variant page depending on number of variant

**Why use an another key ?**
Because when axesCount is greater than 1 and the message is not plurialized, the translator display nothing when the translation does not have multiple translations.

By adding a new key, this force translator to create a new translation instead of having a bug on all languages ​​except English because they doesn't follow the convention of plurialized translation.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
