### PR TITLE
 ci: use headless chrome browser to speedup the time by ~15%

### DIFF
--- a/behat.yml
+++ b/behat.yml
@@ -157,7 +157,7 @@ legacy:
                 selenium2:
                     selenium2:
                         wd_host: 'http://selenium:4444/wd/hub'
-                        capabilities: { "browserName": "chrome", "browser": "chrome", "chrome": {"switches":["--no-sandbox"]}}
+                        capabilities: { "browserName": "chrome", "browser": "chrome", "chrome": {"switches":["--no-sandbox", "--headless"]}}
             base_url: 'http://httpd/'
             files_path: 'tests/legacy/features/Context/fixtures/'
         Behat\Symfony2Extension:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Before:

```
curl "https://circleci.com/api/v1.1/project/github/akeneo/pim-community-dev/71836/tests?circle-token=XXXXXX" | jq '.tests |= sort_by(.run_time) | .tests[].run_time' | awk '{sum+=$1} END{printf("%f\n",sum)}'  

12474.341000 (seconds)
```


After:

```
curl "https://circleci.com/api/v1.1/project/github/akeneo/pim-community-dev/71869/tests?circle-token=XXXXXXX" | jq '.tests |= sort_by(.run_time) | .tests[].run_time' | awk '{sum+=$1} END{printf("%f\n",sum)}'  

10187.043000 (seconds)
```

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
