### PR TITLE
PIM-9635: make the attribute option code insensitive in cache

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9638: Fix security issue in Symfony < 4.4.13 (see https://symfony.com/blog/cve-2020-15094-prevent-rce-when-calling-untrusted-remote-with-cachinghttpclient)
+- PIM-9635: Fix case insensitive attribute option code in product validation
 
 # 4.0.84 (2021-01-14)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
@@ -39,33 +39,19 @@ class LRUCachedGetExistingAttributeOptions implements GetExistingAttributeOption
                 return [];
             }
 
+            $results = array_fill_keys($nonCachedAttributeOptionKeys, '');
             $existingAttributeOptionCodes = $this->getExistingOptionCodes->fromOptionCodesByAttributeCode(
                 $this->fromCacheKeys($nonCachedAttributeOptionKeys)
             );
-
             $newCacheKeys = $this->toCacheKeys($existingAttributeOptionCodes);
 
-            // We build the cache as:
-            //  - the key represents the attribute option code that can be asked
-            //  - the value represents the real attribute option code
-            // The key and the value can be different because the search is case insensitive. So we could have
-            // in cache:
-            // {
-            //      "simple_attribute.yes": "simple_attribute.yes",
-            //      "simple_attribute.YES": "simple_attribute.yes",
-            // }
-            $results = array_combine($newCacheKeys, $newCacheKeys); // Add in cache real attribute option code
-            // Add in cache attribute option code specified by the user
-            $indexedNewCacheKeys = array_combine(array_map('strtolower', $newCacheKeys), $newCacheKeys);
-            foreach ($nonCachedAttributeOptionKeys as $nonCachedAttributeOptionKey) {
-                $results[$nonCachedAttributeOptionKey] = $indexedNewCacheKeys[strtolower($nonCachedAttributeOptionKey)] ?? '';
-            }
+            $existingKeys = array_combine(array_map('strtolower', $newCacheKeys), $newCacheKeys);
 
-            return $results;
+            return array_replace($results, $existingKeys);
         };
 
         $values = $this->cache->getForKeys(
-            $this->toCacheKeys($optionCodesIndexedByAttributeCodes),
+            array_map('strtolower', $this->toCacheKeys($optionCodesIndexedByAttributeCodes)),
             $fetchNonCachedAttributeOptions
         );
 

--- a/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
@@ -65,4 +65,20 @@ class LRUCachedGetExistingAttributeOptionsSpec extends ObjectBehavior
                  'attribute_2' => ['other_option'],
              ]);
     }
+
+    function it_uses_the_cache_with_case_insensitive(GetExistingAttributeOptionCodes $sqlQuery)
+    {
+        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+                 ->shouldBeCalledOnce()
+                 ->willReturn(['attribute_1' => ['option1']]);
+
+        // The first time, the cache is set.
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['OPTION1', 'option2']])
+             ->shouldReturn(['attribute_1' => ['option1']]);
+        // Nex times, the cache is used.
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['OPTION1', 'option2']])
+            ->shouldReturn(['attribute_1' => ['option1']]);
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+            ->shouldReturn(['attribute_1' => ['option1']]);
+    }
 }


### PR DESCRIPTION
When the product is updated with a simple option attribute, the validation uses the cache to validate the existence of the option code. There was an error when we used code with bad case.

For instance when the attribute code is `simple` and the option code is `yes`, and we update product with "YES" through API:

**Before this PR**

We make the query and put in cache:

```json
{"simple.YES": false, "simple.yes": true}
```
=> The validation is ok because there is ` "simple.yes": true`.

The second time, we don't make the query because we have the key `simple.YES` in cache, we use it so we have:

```json
{"simple.YES": false}
```
=> The validation fails. It misses the ` "simple.yes": true` part

**The fix**

To fix that I change the caching method. Now I cache:

- key: always in lower case (ex: `simple.yes`)
- value: the real code. It can be with lower and/or upper characters

This way by asking key cache in lower case we can retrieve the real codes.