### PR TITLE
PIM-9631: fix attribute groups not displayed in family due to JS error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details
 - PIM-9622: Fix query that can generate a MySQL memory allocation error
+- PIM-9631: fix attribute groups not displayed in family due to JS error
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -115,6 +115,7 @@ define([
         FetcherRegistry.getFetcher('attribute-group').fetchByIdentifiers(attributeGroupsToFetch, {
           full_attributes: false,
           apply_filters: false,
+          options: {limit: -1},
         })
       ).then((channels, attributeGroups) => {
         this.channels = channels;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
This PR fixes a JS error that prevented attribute groups to be displayed in the family edit form where there was more that 20 attribute groups in the family. The endpoints to get attribute groups accepts a `limit` option that has a default value to 20 if not set. The option was indeed not set so the returned attribute groups were capped to 20, and this triggered a JS error because we tried to access a group that didn't exist.

We don't want a limit in this particular use case and the only to do it is to set a limit to a negative number.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
