### PR TITLE
CXP-626: Add purge messenger command

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Command/PurgeMessengerCommand.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Command/PurgeMessengerCommand.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MessengerBundle\Command;
+
+use Akeneo\Tool\Bundle\MessengerBundle\Query\PurgeDoctrineQueueQuery;
+use Doctrine\DBAL\DBALException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PurgeMessengerCommand extends Command
+{
+    protected static $defaultName = 'akeneo:messenger:doctrine:purge-messages';
+
+    private PurgeDoctrineQueueQuery $purgeDoctrineQueue;
+
+    public function __construct(PurgeDoctrineQueueQuery $purgeDoctrineQueue)
+    {
+        parent::__construct();
+
+        $this->purgeDoctrineQueue = $purgeDoctrineQueue;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDescription(
+                'Purges the messenger SQL table in terms of the given retention time (default is 7200 seconds)'
+            )
+            ->addArgument(
+                'table-name',
+                InputArgument::REQUIRED,
+                'Name of the messenger table to purge.'
+            )
+            ->addArgument(
+                'queue-name',
+                InputArgument::REQUIRED,
+                'Name of the messenger queue to purge.'
+            )
+            ->addOption(
+                'retention-time',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Deletes messages that are older than the given retention time in seconds.',
+                7200
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    {
+        $retentionTime = $input->getOption('retention-time');
+        $tableName = $input->getArgument('table-name');
+        $queueName = $input->getArgument('queue-name');
+        $olderThan = $this->computeOlderThanDateTime((int) $retentionTime);
+
+        try {
+            $this->purgeDoctrineQueue->execute($tableName, $queueName, $olderThan);
+        } catch (DBALException $dbalException) {
+            $output->writeln($dbalException->getMessage());
+
+            return -1;
+        }
+
+        return 0;
+    }
+
+    private function computeOlderThanDateTime(int $retentionTime): \DateTimeImmutable
+    {
+        $now = (int) (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('U');
+        $retentionTimeAgo =  $now - $retentionTime;
+
+        return \DateTimeImmutable::createFromFormat(
+            'U',
+            (string) $retentionTimeAgo,
+            new \DateTimeZone('UTC')
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/DependencyInjection/AkeneoMessengerExtension.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/DependencyInjection/AkeneoMessengerExtension.php
@@ -19,5 +19,6 @@ class AkeneoMessengerExtension extends Extension
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('transport.yml');
+        $loader->load('purge.yml');
     }
 }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Query/PurgeDoctrineQueueQuery.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Query/PurgeDoctrineQueueQuery.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MessengerBundle\Query;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class PurgeDoctrineQueueQuery
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $tableName, string $queueName, \DateTimeImmutable $olderThan): int
+    {
+        return $this->connection->createQueryBuilder()
+            ->delete($tableName)
+            ->where('created_at < :datetime AND queue_name = :queue')
+            ->setParameter('datetime', $olderThan, Types::DATETIME_IMMUTABLE)
+            ->setParameter('queue', $queueName)
+            ->execute();
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/purge.yml
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/purge.yml
@@ -1,0 +1,11 @@
+services:
+    akeneo_messenger.query.purge:
+        class: Akeneo\Tool\Bundle\MessengerBundle\Query\PurgeDoctrineQueueQuery
+        arguments:
+            - '@database_connection'
+
+    Akeneo\Tool\Bundle\MessengerBundle\Command\PurgeMessengerCommand:
+        arguments:
+            - '@akeneo_messenger.query.purge'
+        tags:
+            - {name: 'console.command'}

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/tests/integration/PurgeDoctrineQueueIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/tests/integration/PurgeDoctrineQueueIntegration.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MessengerBundle\tests\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\MessengerBundle\Query\PurgeDoctrineQueueQuery;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
+use PHPUnit\Framework\Assert;
+
+class PurgeDoctrineQueueIntegration extends TestCase
+{
+    private Connection $dbalConnection;
+    private PurgeDoctrineQueueQuery $purgeDoctrineQueueQuery;
+
+    public function test_it_purges_the_queue_in_terms_the_queue_and_the_given_datetime(): void
+    {
+        $this->insertFixtures();
+
+        $this->purgeDoctrineQueueQuery->execute(
+            'messenger_messages',
+            'webhook',
+            new \DateTimeImmutable('2021-01-18 14:16:53')
+        );
+        $results = $this->fetchRemainingEntries();
+
+        Assert::assertCount(2, $results);
+        Assert::assertContains('body', $results);
+        Assert::assertContains('product_created', $results);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbalConnection = $this->get('database_connection');
+        $this->purgeDoctrineQueueQuery = $this->get('akeneo_messenger.query.purge');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function insertFixtures(): void
+    {
+        $sql = <<<SQL
+INSERT INTO messenger_messages (body, headers, queue_name, created_at, available_at)
+VALUES 
+    (
+        'product_model_created',
+        '{"class":"Akeneo\\Platform\\Component\\EventQueue\\BulkEvent"}',
+        'webhook',
+        '2021-01-18 13:16:53',
+        '2021-01-18 13:16:53'
+    ),
+    (
+        'product_model_updated',
+        '{"class":"Akeneo\\Platform\\Component\\EventQueue\\BulkEvent"}',
+        'webhook',
+        '2021-01-18 13:20:53',
+        '2021-01-18 13:20:53'
+    ),
+    (
+        'body',
+        'this is a header',
+        'another_queue',
+        '2021-01-18 15:16:53',
+        '2021-01-18 15:16:53'
+    ),
+    (
+        'product_created',
+        '{"class":"Akeneo\\Platform\\Component\\EventQueue\\BulkEvent"}',
+        'webhook',
+        '2021-01-18 15:32:53',
+        '2021-01-18 15:32:53'
+    )
+SQL;
+        $this->dbalConnection->executeQuery($sql);
+    }
+
+    private function fetchRemainingEntries(): array
+    {
+        $sql = <<<SQL
+SELECT body
+FROM messenger_messages
+SQL;
+
+        return $this->dbalConnection->executeQuery($sql)->fetchAll(FetchMode::COLUMN);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When you install the PIM on OnPrem the queue is handle by doctrine which uses an SQL table to store messages.
Doctrine does not handle the purge of this table. This PR aims to add a purge command to cover this need.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
