### PR TITLE
PIM-9584: create public service to reindex documents from a migration

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/versions.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/versions.yml
@@ -5,5 +5,6 @@ parameters:
 services:
     pim_catalog.version_provider:
         class: 'Akeneo\Platform\VersionProvider'
+        public: true
         arguments:
             - '%pim_catalog.version.class%'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMappingWrapper.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/IndexConfiguration/UpdateIndexMappingWrapper.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration;
+
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Elasticsearch\Client as NativeClient;
+use Elasticsearch\ClientBuilder;
+
+/**
+ * The UpdateIndexMapping class needs some private services to work, we cannot use it for a migration for instance.
+ * Using this wrapper allows to make only one service public.
+ *
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class UpdateIndexMappingWrapper
+{
+    private NativeClient $nativeClient;
+    private Client $client;
+
+    public function __construct(ClientBuilder $clientBuilder, $hosts, Client $client)
+    {
+        $hosts = is_string($hosts) ? [$hosts] : $hosts;
+        $this->nativeClient = $clientBuilder->setHosts($hosts)->build();
+        $this->client = $client;
+    }
+
+    public function updateIndexMapping(): void
+    {
+        $updateIndexMapping = new UpdateIndexMapping();
+        $updateIndexMapping->updateIndexMapping(
+            $this->nativeClient,
+            $this->client->getIndexName(),
+            $this->client->getConfigurationLoader()
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexMappingWrapperIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexMappingWrapperIntegration.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\tests\integration;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductQueryBuilderFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\UpdateIndexMappingWrapper;
+use Elasticsearch\ClientBuilder;
+use PHPUnit\Framework\Assert;
+
+class UpdateIndexMappingWrapperIntegration extends TestCase
+{
+    public function test_it_moves_the_index_and_the_pqb_still_works()
+    {
+        $indexHost = $this->getParameter('index_hosts');
+        /** @var Client $akeneoProductClient */
+        $akeneoProductClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->setHosts(is_string($indexHost) ? [$indexHost] : $indexHost);
+
+        $client = $clientBuilder->build();
+
+        $aliases = array_map(function (array $index) : string {
+            return $index['alias'];
+        }, $client->cat()->aliases());
+
+        /** @var ProductQueryBuilderFactory $pqb */
+        $pqb = $this->get('pim_catalog.query.product_query_builder_factory');
+        $this->createProduct('product1');
+        Assert::assertEquals(1, $pqb->create()->execute()->count());
+        Assert::assertContains($this->getParameter('product_and_product_model_index_name'), $aliases);
+
+        $updateIndexMappingWrapper = new UpdateIndexMappingWrapper(
+            $clientBuilder,
+            $this->getParameter('index_hosts'),
+            $akeneoProductClient
+        );
+        $updateIndexMappingWrapper->updateIndexMapping();
+
+        $newIndices = array_map(function (array $index) : string {
+            return $index['index'];
+        }, $client->cat()->indices());
+
+        Assert::assertNotContains($this->getParameter('product_and_product_model_index_name'), $newIndices);
+        Assert::assertTrue($client->indices()->existsAlias(['name' => $this->getParameter('product_and_product_model_index_name')]));
+        Assert::assertEquals(1, $pqb->create()->execute()->count());
+    }
+
+    protected function createProduct(string $identifier, array $data = []): ProductInterface
+    {
+        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
+        $this->get('pim_catalog.updater.product')->update($product, $data);
+        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        return $product;
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

From a migration we have access to public services only. Reindexing documents is not easy with this constraint.  
To faciliate the work, the `UpdateIndexMappingWrapper` class helps to handle this problem (see the [EE PR](https://github.com/akeneo/pim-enterprise-dev/pull/10251))

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
