### PR TITLE
PIM-9639: Fix sequential edit when selecting All with a filter on parent

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9639: Fix sequential edit when selecting All with a filter on parent
+
 # 4.0.85 (2021-01-19)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -91,6 +91,7 @@ class MassActionDispatcher
      */
     public function getRawFilters(array $parameters)
     {
+        $actionName = $parameters['actionName'] ?? '';
         $parameters = $this->prepareMassActionParameters($parameters);
         $datagrid = $parameters['datagrid'];
         $datasource = $datagrid->getDatasource();
@@ -122,7 +123,9 @@ class MassActionDispatcher
             }
         }
 
-        $filters = $this->convertParentFieldIfAllRowsAreSelected($filters);
+        if ($actionName !== 'sequential_edit') {
+            $filters = $this->convertParentFieldIfAllRowsAreSelected($filters);
+        }
 
         return $filters;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Extension/MassAction/MassActionDispatcherSpec.php
@@ -327,4 +327,62 @@ class MassActionDispatcherSpec extends ObjectBehavior
             ],
         ]);
     }
+
+    function it_does_not_convert_parent_filter_when_using_sequential_edit(
+        DatagridInterface $grid,
+        Acceptor $acceptor,
+        MassActionExtension $massActionExtension,
+        MassActionInterface $massActionInterface,
+        QueryBuilder $queryBuilder,
+        ProductDatasource $datasource,
+        ProductMassActionRepositoryInterface $massActionRepository,
+        MassActionParametersParser $parametersParser,
+        ProductQueryBuilderInterface $productQueryBuilder
+    ) {
+        $massActionName = 'sequential_edit';
+        $request = new Request([
+            'inset'      => 'inset',
+            'values'     => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => $massActionName,
+        ]);
+
+        $parametersParser->parse($request)->willReturn([
+            'inset' => 'inset',
+            'values' => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => $massActionName,
+        ]);
+        $datasource->getMassActionRepository()->willReturn($massActionRepository);
+        $massActionRepository->applyMassActionParameters($queryBuilder, '', [1])->willReturn(null);
+        $massActionExtension->getMassAction('sequential_edit', $grid)->willReturn($massActionInterface);
+        $acceptor->getExtensions()->willReturn([$massActionExtension]);
+
+        $datasource->getProductQueryBuilder()->willReturn($productQueryBuilder);
+        $productQueryBuilder->getRawFilters()->willReturn([
+            [
+                'field' => 'parent',
+                'operator' => 'IN',
+                'values' => ['CODE1', 'CODE2'],
+            ],
+        ]);
+        $datasource->getParameters()->willReturn(null);
+
+        $this->getRawFilters([
+            'inset'      => '',
+            'values'     => [1],
+            'gridName'   => 'grid',
+            'massAction' => $massActionInterface,
+            'actionName' => $massActionName,
+        ])->shouldReturn([
+            [
+                'field' => 'parent',
+                'operator' => 'IN',
+                'values' => ['CODE1', 'CODE2'],
+                'context' => [],
+            ],
+        ]);
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
This PR fixes a bug in the sequential edit feature when selecting All (in the mass action toolbar) with a filter on parent. There was a rule in the code that transformed the parent filter in an Ancestor filter when all rows were selected. This was to fix a bug where we wanted to be sure to apply the action on ALL the variants. But in the sequential edit, we only want to apply the action on the selected products and not on the variants. 

So basically we want 2 opposite behaviors with the same code base. The fix was simply to apply the transformation I described before only when this is not a sequential edit.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
