### PR TITLE
CXP-638: Move fixtures loaders outside integration tests folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         },
         "psr-4": {
             "Pim\\Behat\\": "tests/legacy/features/Behat",
-            "Akeneo\\Connectivity\\Connection\\Tests\\Acceptance\\": "src/Akeneo/Connectivity/Connection/back/tests/Acceptance",
+            "Akeneo\\Connectivity\\Connection\\Tests\\": "src/Akeneo/Connectivity/Connection/back/tests",
             "Akeneo\\Connectivity\\Connection\\Tests\\EndToEnd\\": "src/Akeneo/Connectivity/Connection/tests/",
             "AkeneoTest\\": "tests/back",
             "Akeneo\\Test\\IntegrationTestsBundle\\": "tests/back/Integration/IntegrationTestsBundle/",

--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -10,7 +10,7 @@ parameters:
 
 imports:
     # Akeneo/Connectivity/Connection
-    - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/loaders.yml }
+    - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Resources/config/loaders.yml }
     # Akeneo/Platform/CommunicationChannel
     - { resource: ../../../src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/Resources/config/in_memory.yml }
 

--- a/config/services/test_fake/services.yml
+++ b/config/services/test_fake/services.yml
@@ -11,6 +11,7 @@ imports:
     - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/Acceptance/Resources/config/queries.yml }
     - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/Acceptance/Resources/config/repositories.yml }
     - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/Acceptance/Resources/config/services.yml }
+    - { resource: ../../../src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Resources/config/loaders.yml }
 
 services:
     akeneo_integration_tests.doctrine.connection.connection_closer:

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/AuditErrorLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/AuditErrorLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder;
 
 use Akeneo\Connectivity\Connection\Application\ErrorManagement\Command\UpdateConnectionErrorCountCommand;
 use Akeneo\Connectivity\Connection\Application\ErrorManagement\Command\UpdateConnectionErrorCountHandler;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/AuditLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/AuditLoader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder;
 
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\Repository\EventCountRepository;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/ConnectionLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/ConnectionLoader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder;
 
 use Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionCommand;
 use Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionHandler;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/CategoryLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/CategoryLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment;
 
 use Akeneo\Tool\Component\Api\Exception\ViolationHttpException;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductLoader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment;
 
 use Akeneo\Pim\Enrichment\Component\Product\Builder\ProductBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductModelLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductModelLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/EventsApiRequestCountLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/EventsApiRequestCountLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder;
 
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Types\Types;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Resources/config/loaders.yml
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Resources/config/loaders.yml
@@ -1,23 +1,26 @@
 services:
+    _defaults:
+        public: true
+
     akeneo_connectivity.connection.fixtures.connection_loader:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader'
         arguments:
             - '@akeneo_connectivity.connection.application.handler.create_connection'
             - '@akeneo_connectivity.connection.application.handler.update_connection'
 
     akeneo_connectivity.connection.fixtures.audit_loader:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader'
         arguments:
             - '@database_connection'
             - '@akeneo_connectivity.connection.persistence.repository.event_count'
 
     akeneo_connectivity.connection.fixtures.audit_error_loader:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader'
         arguments:
             - '@akeneo_connectivity.connection.application.error_management.handler.update_connection_error_count'
 
     akeneo_connectivity.connection.fixtures.structure.attribute:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader'
         arguments:
             - '@pim_catalog.factory.attribute'
             - '@pim_catalog.updater.attribute'
@@ -25,15 +28,23 @@ services:
             - '@validator'
 
     akeneo_connectivity.connection.fixtures.structure.family:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader'
         arguments:
             - '@pim_catalog.factory.family'
             - '@pim_catalog.updater.family'
             - '@pim_catalog.saver.family'
             - '@validator'
 
+    akeneo_connectivity.connection.fixtures.structure.family_variant:
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyVariantLoader'
+        arguments:
+            - '@pim_catalog.factory.family_variant'
+            - '@pim_catalog.updater.family_variant'
+            - '@validator'
+            - '@pim_catalog.saver.family_variant'
+
     akeneo_connectivity.connection.fixtures.enrichment.product:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader'
         arguments:
             - '@pim_catalog.builder.product'
             - '@pim_catalog.updater.product'
@@ -42,7 +53,7 @@ services:
             - '@akeneo_elasticsearch.client.product_and_product_model'
 
     akeneo_connectivity.connection.fixtures.enrichment.product_model:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductModelLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductModelLoader'
         arguments:
             - '@pim_catalog.factory.product_model'
             - '@pim_catalog.updater.product_model'
@@ -50,16 +61,8 @@ services:
             - '@pim_catalog.saver.product_model'
             - '@akeneo_elasticsearch.client.product_and_product_model'
 
-    akeneo_connectivity.connection.fixtures.enrichment.family_variant:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\FamilyVariantLoader'
-        arguments:
-            - '@pim_catalog.factory.family_variant'
-            - '@pim_catalog.updater.family_variant'
-            - '@validator'
-            - '@pim_catalog.saver.family_variant'
-
     akeneo_connectivity.connection.fixtures.enrichment.category:
-        class: 'Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\CategoryLoader'
+        class: 'Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\CategoryLoader'
         arguments:
             - '@pim_catalog.factory.category'
             - '@pim_catalog.updater.category'
@@ -67,11 +70,11 @@ services:
             - '@pim_catalog.saver.category'
 
     akeneo_connectivity.connection.fixtures.webhook_loader:
-        class: Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader
+        class: Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader
         arguments:
             - '@database_connection'
 
     akeneo_connectivity.connection.fixtures.events_api_request_count_loader:
-        class: Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\EventsApiRequestCountLoader
+        class: Akeneo\Connectivity\Connection\Tests\CatalogBuilder\EventsApiRequestCountLoader
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/AttributeLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/AttributeLoader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure;
 
 use Akeneo\Pim\Structure\Component\Model\AttributeGroup;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/FamilyLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/FamilyLoader.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure;
 
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/FamilyVariantLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Structure/FamilyVariantLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure;
 
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures;
+namespace Akeneo\Connectivity\Connection\Tests\CatalogBuilder;
 
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Types\Types;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/ErrorCountPerConnectionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/ErrorCountPerConnectionEndToEnd.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\AllConnectionCode;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\Write\HourlyErrorCount;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/ErrorCountPerConnectionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/ErrorCountPerConnectionEndToEnd.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\AllConnectionCode;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\Write\HourlyErrorCount;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyAuditEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyAuditEndToEnd.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\AllConnectionCode;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyAuditEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyAuditEndToEnd.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\AllConnectionCode;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyErrorAuditEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyErrorAuditEndToEnd.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyErrorAuditEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/WeeklyErrorAuditEndToEnd.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Audit;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Elasticsearch\Client;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Elasticsearch\Client;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Connection;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiErrorsCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiErrorsCountEndToEnd.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\ErrorManagement;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\ErrorTypes;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiErrorsCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiErrorsCountEndToEnd.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\ErrorManagement;
 
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\ErrorTypes;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductModelEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductModelEventEndToEnd.php
@@ -160,7 +160,7 @@ class ConsumeProductModelEventEndToEnd extends ApiTestCase
             ->create(['code' => 'another_text_attribute', 'type' => 'pim_catalog_text']);
         $this->get('akeneo_connectivity.connection.fixtures.structure.family')
             ->create(['code' => 'family', 'attributes' => ['variant_attribute', 'text_attribute', 'another_text_attribute']]);
-        $familyVariant = $this->get('akeneo_connectivity.connection.fixtures.enrichment.family_variant')
+        $familyVariant = $this->get('akeneo_connectivity.connection.fixtures.structure.family_variant')
             ->create([
                     'code' => 'family_variant',
                     'family' => 'family',

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Infrastructure\MessageHandler\BusinessEventHandler;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\CategoryLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
-use Akeneo\Connectivity\Connection\Infrastructure\MessageHandler\BusinessEventHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\CategoryLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\CategoryLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Infrastructure\MessageHandler\BusinessEventHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductEventEndToEnd.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductEventEndToEnd.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\FamilyVariantLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Enrichment\ProductModelLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\AttributeLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyVariantLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductModelLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
@@ -44,7 +44,7 @@ class ProduceProductModelEventEndToEnd extends ApiTestCase
 
         $this->attributeLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.attribute');
         $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
-        $this->familyVariantLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.family_variant');
+        $this->familyVariantLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family_variant');
         $this->productModelLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.product_model');
         $this->productModelRemover = $this->get('pim_catalog.remover.product_model');
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ProduceProductModelEventEndToEnd.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
-use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyVariantLoader;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductModelLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyVariantLoader;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
 
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\Configuration;
 use PHPUnit\Framework\Assert;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalCountActiveEventSubscriptionsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalCountActiveEventSubscriptionsQueryIntegration.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\CountActiveEventSubscriptionsQuery;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalExtractConnectionsProductEventCountQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalExtractConnectionsProductEventCountQueryIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\EventTypes;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;
 use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\Query\ExtractConnectionsProductEventCountQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalGetAConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalGetAConnectionWebhookQueryIntegration.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read\ConnectionWebhook;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\GetAConnectionWebhookQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalPurgeAuditErrorQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalPurgeAuditErrorQueryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\ErrorTypes;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query\PurgeAuditErrorQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalPurgeAuditProductQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalPurgeAuditProductQueryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\EventTypes;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSaveWebhookSecretQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSaveWebhookSecretQueryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\SaveWebhookSecretQuery;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionWithCredentialsByCodeQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionWithCredentialsByCodeQueryIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Query\SelectConnectionWithCredentialsByCodeQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionsQueryIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\Connection;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Query\SelectConnectionsQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionsWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectConnectionsWebhookQueryIntegration.php
@@ -6,7 +6,7 @@ namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal
 
 use Akeneo\Connectivity\Connection\Application\Settings\Command\UpdateConnectionCommand;
 use Akeneo\Connectivity\Connection\Application\Settings\Command\UpdateConnectionHandler;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\SelectActiveWebhooksQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectErrorCountPerConnectionQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectErrorCountPerConnectionQueryIntegration.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Read\ErrorCount;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Read\ErrorCountPerConnection;
 use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\Query\SelectErrorCountPerConnectionQuery;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectHourlyIntervalsToRefreshQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectHourlyIntervalsToRefreshQueryIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\EventTypes;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Write\HourlyEventCount;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectPeriodErrorCountPerConnectionQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectPeriodErrorCountPerConnectionQueryIntegration.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditErrorLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditErrorLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Read;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\Read\PeriodEventCount;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectPeriodEventCountPerConnectionQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectPeriodEventCountPerConnectionQueryIntegration.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\AuditLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\AuditLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\AllConnectionCode;
 use Akeneo\Connectivity\Connection\Domain\Audit\Model\EventTypes;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\DateTimePeriod;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectWebhookSecretQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalSelectWebhookSecretQueryIntegration.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\WebhookLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\SelectWebhookSecretQuery;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/SelectAllAuditableConnectionCodeQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/SelectAllAuditableConnectionCodeQueryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query\SelectAllAuditableConnectionCodeQuery;
 use Akeneo\Test\Integration\Configuration;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/SelectEventsApiRequestCountWithinLastHourQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/SelectEventsApiRequestCountWithinLastHourQueryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\EventsApiRequestCountLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\EventsApiRequestCountLoader;
 use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\Query\SelectEventsApiRequestCountWithinLastHourQuery;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalConnectionRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalConnectionRepositoryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Repository;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionImage;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionLabel;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalConnectionWebhookRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalConnectionWebhookRepositoryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Repository;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Write\ConnectionWebhook;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\ConnectionWebhookRepository;

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalErrorCountRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Repository/DbalErrorCountRepositoryIntegration.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Repository;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\ErrorTypes;
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\Write\HourlyErrorCount;

--- a/tests/back/Platform/Integration/Analytics/Query/ActiveEventSubscriptionCountIntegration.php
+++ b/tests/back/Platform/Integration/Analytics/Query/ActiveEventSubscriptionCountIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Platform\Integration\Analytics\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Component\Analytics\ActiveEventSubscriptionCountQuery;

--- a/tests/back/Platform/Integration/Analytics/Query/ApiConnectionCountIntegration.php
+++ b/tests/back/Platform/Integration/Analytics/Query/ApiConnectionCountIntegration.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Platform\Integration\Analytics\Query;
 
-use Akeneo\Connectivity\Connection\back\tests\Integration\Fixtures\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Platform\Bundle\AnalyticsBundle\Query\Sql\ApiConnectionCount;
 use Akeneo\Test\Integration\TestCase;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In order to be accessible from each test stack we have to move the catalog builder from acceptance folder to test parent folder