### PR TITLE
API-1414 fix event subscription edit form

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read;
@@ -22,21 +23,16 @@ class ConnectionWebhook
     /** @var bool */
     private $enabled;
 
-    /** @var ?string */
-    private $connectionImage;
-
     public function __construct(
         string $connectionCode,
         bool $enabled,
         ?string $secret = null,
-        ?string $url = null,
-        ?string $connectionImage = null
+        ?string $url = null
     ) {
         $this->enabled = $enabled;
         $this->connectionCode = $connectionCode;
         $this->secret = $secret;
         $this->url = $url;
-        $this->connectionImage = $connectionImage;
     }
 
     public function connectionCode(): string
@@ -59,18 +55,12 @@ class ConnectionWebhook
         return $this->enabled;
     }
 
-    public function connectionImage(): ?string
-    {
-        return $this->connectionImage;
-    }
-
     /**
      * @return array{
      *  connectionCode: string,
      *  enabled: boolean,
      *  secret: ?string,
      *  url: ?string,
-     *  connectionImage: ?string
      * }
      */
     public function normalize(): array
@@ -80,7 +70,6 @@ class ConnectionWebhook
             'enabled' => $this->enabled(),
             'secret' => $this->secret(),
             'url' => $this->url(),
-            'connectionImage' => $this->connectionImage(),
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
@@ -30,8 +30,7 @@ class EventSubscriptionFormData
      *      connectionCode: string,
      *      enabled: boolean,
      *      secret: ?string,
-     *      url: ?string,
-     *      connectionImage: ?string
+     *      url: ?string
      *  },
      *  active_event_subscriptions_limit: array{
      *      limit: int,

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Query/DbalGetAConnectionWebhookQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Query/DbalGetAConnectionWebhookQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query;
@@ -25,7 +26,7 @@ class DbalGetAConnectionWebhookQuery implements GetAConnectionWebhookQuery
     public function execute(string $code): ?ConnectionWebhook
     {
         $query = <<<SQL
-    SELECT code, webhook_secret, webhook_url, webhook_enabled, image
+    SELECT code, webhook_secret, webhook_url, webhook_enabled
     FROM akeneo_connectivity_connection
     WHERE code = :code
 SQL;
@@ -39,8 +40,7 @@ SQL;
             $connectionWebhook['code'],
             (bool) $connectionWebhook['webhook_enabled'],
             $connectionWebhook['webhook_secret'],
-            $connectionWebhook['webhook_url'],
-            $connectionWebhook['image']
+            $connectionWebhook['webhook_url']
         );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/GetEventSubscriptionFormDataEndToEnd.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Webhook;
@@ -57,7 +58,6 @@ class GetEventSubscriptionFormDataEndToEnd extends WebTestCase
                     'enabled' => true,
                     'secret' => 'secret',
                     'url' => 'http://test.com',
-                    'connectionImage' => null,
                 ],
                 'active_event_subscriptions_limit' => [
                     'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalGetAConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Dbal/Query/DbalGetAConnectionWebhookQueryIntegration.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\back\tests\Integration\Persistence\Dbal\Query;
@@ -36,7 +37,6 @@ class DbalGetAConnectionWebhookQueryIntegration extends TestCase
         Assert::assertTrue($webhook->enabled());
         Assert::assertEquals('secret', $webhook->secret());
         Assert::assertEquals('http://test.com', $webhook->url());
-        Assert::assertNull($webhook->connectionImage());
     }
 
     public function test_it_gets_a_disabled_connection_webhook_for_a_given_code(): void
@@ -51,7 +51,6 @@ class DbalGetAConnectionWebhookQueryIntegration extends TestCase
         Assert::assertFalse($webhook->enabled());
         Assert::assertNull($webhook->secret());
         Assert::assertNull($webhook->url());
-        Assert::assertNull($webhook->connectionImage());
     }
 
     public function test_it_gets_null_if_there_is_no_result(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read;
@@ -49,18 +50,6 @@ class ConnectionWebhookSpec extends ObjectBehavior
         $this->url()->shouldReturn('any-url.com');
     }
 
-    public function it_could_have_no_image(): void
-    {
-        $this->beConstructedWith('magento', false);
-        $this->connectionImage()->shouldReturn(null);
-    }
-
-    public function it_provides_an_image(): void
-    {
-        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', 'an image.jpg');
-        $this->connectionImage()->shouldReturn('an image.jpg');
-    }
-
     public function it_provides_the_enabled_status(): void
     {
         $this->beConstructedWith('magento', true);
@@ -69,13 +58,12 @@ class ConnectionWebhookSpec extends ObjectBehavior
 
     public function it_provides_a_normalized_format(): void
     {
-        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', 'an image.jpg');
+        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com');
         $this->normalize()->shouldReturn([
             'connectionCode' => 'magento',
             'enabled' => true,
             'secret' => 'secret_magento',
             'url' => 'any-url.com',
-            'connectionImage' => 'an image.jpg',
         ]);
     }
 
@@ -87,7 +75,6 @@ class ConnectionWebhookSpec extends ObjectBehavior
             'enabled' => false,
             'secret' => null,
             'url' => null,
-            'connectionImage' => null,
         ]);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
@@ -32,7 +32,6 @@ class EventSubscriptionFormDataSpec extends ObjectBehavior
                 'enabled' => true,
                 'secret' => null,
                 'url' => null,
-                'connectionImage' => null,
             ],
             'active_event_subscriptions_limit' => [
                 'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionHelper.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionHelper.tsx
@@ -9,7 +9,7 @@ export const EventSubscriptionHelper: FC = () => (
             <Translate id='akeneo_connectivity.connection.webhook.helper.message' />
             &nbsp;
             <HelperLink
-                href='https://help.akeneo.com/pim/serenity/articles/manage-your-connections.html#subscribe-to-events'
+                href='https://help.akeneo.com/pim/serenity/articles/manage-event-subscription.html'
                 target='_blank'
                 rel='noopener noreferrer'
             >

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-connection.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-connection.ts
@@ -1,0 +1,11 @@
+import {useQuery} from '../../../shared/fetch';
+
+type Connection = {
+    code: string;
+    label: string;
+    image: string | null;
+};
+
+export function useFetchConnection(code: string) {
+    return useQuery<Connection>('akeneo_connectivity_connection_rest_get', {code});
+}

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription-form-data.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription-form-data.ts
@@ -8,7 +8,6 @@ type EventSubscription = {
     enabled: boolean;
     secret: string | null;
     url: string | null;
-    connectionImage: string | null;
 };
 
 type EventSubscriptionsLimit = {
@@ -24,18 +23,8 @@ type FormData = {
 export const useFetchEventSubscriptionFormData = (connectionCode: string) => {
     const url = useRoute('akeneo_connectivity_connection_webhook_rest_get', {code: connectionCode});
 
-    const [eventSubscription, setEventSubscription] = useState<{
-        connectionCode: string;
-        enabled: boolean;
-        secret: string | null;
-        url: string | null;
-        connectionImage: string | null;
-    }>();
-
-    const [eventSubscriptionsLimit, setEventSubscriptionsLimit] = useState<{
-        limit: number;
-        current: number;
-    }>();
+    const [eventSubscription, setEventSubscription] = useState<EventSubscription>();
+    const [eventSubscriptionsLimit, setEventSubscriptionsLimit] = useState<EventSubscriptionsLimit>();
 
     const fetchEventSubscriptionFormData = useCallback(() => {
         fetchResult<FormData, unknown>(url).then(result => {

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
@@ -3,5 +3,4 @@ export type Webhook = {
     url: string | null;
     secret: string | null;
     enabled: boolean;
-    connectionImage: string | null;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -16,6 +16,7 @@ import {useUpdateWebhook} from '../hooks/api/use-update-webhook';
 import {useFetchEventSubscriptionFormData} from '../hooks/api/use-fetch-event-subscription-form-data';
 import {Webhook} from '../model/Webhook';
 import {Breadcrumb} from 'akeneo-design-system';
+import {useFetchConnection} from '../hooks/api/use-fetch-connection';
 
 export type FormInput = {
     connectionCode: string;
@@ -31,6 +32,7 @@ export const EditConnectionWebhook: FC = () => {
     const systemHref = `#${useRoute('oro_config_configuration_system')}`;
 
     const {connectionCode} = useParams<{connectionCode: string}>();
+    const {data: connection} = useFetchConnection(connectionCode);
     const {
         eventSubscription,
         eventSubscriptionsLimit,
@@ -47,7 +49,7 @@ export const EditConnectionWebhook: FC = () => {
         }
     }, [eventSubscription]);
 
-    if (!eventSubscription || !eventSubscriptionsLimit) {
+    if (!connection || !eventSubscription || !eventSubscriptionsLimit) {
         return <Loading />;
     }
 
@@ -79,9 +81,7 @@ export const EditConnectionWebhook: FC = () => {
                     breadcrumb={breadcrumb}
                     userButtons={userButtons}
                     imageSrc={
-                        null === eventSubscription.connectionImage
-                            ? defaultImageUrl
-                            : generateMediaUrl(eventSubscription.connectionImage, 'thumbnail')
+                        null === connection.image ? defaultImageUrl : generateMediaUrl(connection.image, 'thumbnail')
                     }
                     buttons={[
                         <SaveButton
@@ -92,7 +92,7 @@ export const EditConnectionWebhook: FC = () => {
                     ]}
                     state={<FormState />}
                 >
-                    {connectionCode}
+                    {connection.label}
                 </PageHeader>
 
                 <PageContent>


### PR DESCRIPTION
- Fix event subscription form to display the connection label as title (instead of the code)
![image](https://user-images.githubusercontent.com/1671213/105507508-930ab100-5ccb-11eb-81e5-5724350e4107.png)
- Fix the helper link