### PR TITLE
PIM-9644: Now using interface in Clean removed attributes command constructor

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,8 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9644: Now using interface in Clean removed attributes command constructor
 # 4.0.86 (2021-01-22)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -46,7 +46,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     /** @var CleanValuesOfRemovedAttributesInterface|null */
     private $cleanValuesOfRemovedAttributes;
 
-    /** @var EventDispatcher|null */
+    /** @var EventDispatcherInterface|null */
     private $eventDispatcher;
 
     public function __construct(
@@ -55,7 +55,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         string $kernelRootDir,
         int $productBatchSize,
         CleanValuesOfRemovedAttributesInterface $cleanValuesOfRemovedAttributes = null,
-        EventDispatcher $eventDispatcher = null
+        EventDispatcherInterface $eventDispatcher = null
     ) {
         parent::__construct();
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fixes `bin/console` list on 4.0
```
 Argument 6 passed to Akeneo\Pim\Enrichment\Bundle\Command\CleanRemovedAttributesFromProductAndProduc  
  tModelCommand::__construct() must be an instance of Symfony\Component\EventDispatcher\EventDispatche  
  r or null, instance of Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher given, called in   
  /var/www/var/cache/dev/ContainerYdVbSQO/getCleanRemovedAttributesFromProductAndProductModelCommandSe  
  rvice.php on line 12
```

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
