### PR TITLE
PIM-9649: Fix PDF product renderer disregarding permissions on Attribute groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - PIM-9630: Fix SQL sort buffer size issue when the catalog has a very large number of categories
 - PIM-9636: Fix add posibility to contextualize translation when create a variant depending on number of axes
 - PIM-9631: fix attribute groups not displayed in family due to JS error
-
+- PIM-9649: Fix PDF product renderer disregarding permissions on Attribute groups
 ## New features
 
 ## Improvements

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Renderer/ProductPdfRenderer.php
@@ -105,9 +105,15 @@ class ProductPdfRenderer implements RendererInterface
     }
 
     /**
-     * get attributes grouped by attribute group
-     *
-     * @param ProductInterface $product
+     * Return true if the attribute should be rendered
+     */
+    protected function canRenderAttribute(?AttributeInterface $attribute): bool
+    {
+        return null !== $attribute;
+    }
+
+    /**
+     * Get attributes grouped by attribute group
      *
      * @return AttributeInterface[]
      */
@@ -122,7 +128,7 @@ class ProductPdfRenderer implements RendererInterface
 
         foreach ($attributeCodes as $attributeCode) {
             $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode);
-            if (null !== $attribute) {
+            if ($this->canRenderAttribute($attribute)) {
                 $groupLabel = $attribute->getGroup()->getLabel();
                 if (!isset($groups[$groupLabel])) {
                     $groups[$groupLabel] = [];


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Following https://github.com/akeneo/pim-community-dev/pull/12945, attributes from the family were added to the PDF render of the Product, but these are added after the values are filtered out based on permissions, so we need to check afterwards whether each attribute should be rendered.
See: https://github.com/akeneo/pim-enterprise-dev/pull/10277

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
