### PR TITLE
PIM-9650: Add translation key for mass delete action and the corresponding word on the job page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - PIM-9630: Fix SQL sort buffer size issue when the catalog has a very large number of categories
 - PIM-9636: Fix add posibility to contextualize translation when create a variant depending on number of axes
 - PIM-9631: fix attribute groups not displayed in family due to JS error
-- PIM-9650: Add translation keys for mass delete action and corresponding message on the job page
+- PIM-9650: Add translation key for mass delete action.
 
 ## New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - PIM-9630: Fix SQL sort buffer size issue when the catalog has a very large number of categories
 - PIM-9636: Fix add posibility to contextualize translation when create a variant depending on number of axes
 - PIM-9631: fix attribute groups not displayed in family due to JS error
+- PIM-9650: Add translation keys for mass delete action and corresponding message on the job page
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -1,6 +1,7 @@
 pim_notification:
     types:
         settings: Settings
+        mass_delete: Deletion
 flash:
     comment:
         create:


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When making a mass delete action, on the notification panel, instead of "Deletion", "pim_notification.types.mass_delete" was displayed.

So, I added the missing corresponding key in the jsmessages.en_US.yml file.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
