### PR TITLE
PIM-9623: String filter is now able to filter on codes with spaces

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Improvements
+
+- PIM-9623: String filter is now able to filter on codes with spaces
+
 # 4.0.86 (2021-01-22)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/StringFilter.php
@@ -75,7 +75,8 @@ class StringFilter extends OroStringFilter
         }
 
         if (FilterType::TYPE_IN_LIST === $data['type']) {
-            $data['value'] = explode(',', $data['value']);
+            // Here we replace the non-breaking spaces with actual spaces, see: PIM-9623
+            $data['value'] = explode(',', preg_replace('/\xc2\xa0/', ' ', $data['value']));
         }
 
         return $data;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

It has been decided that the IN_LIST string filter operator now accepts non-breaking spaces in values to mean actual spaces. This PRs modifies the value parsing to replace all non-breaking spaces with actual spaces.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
