### PR TITLE
fix #13795: CleanRemovedAttributesFromProductAndProductModelCommand dependency with EventDispatcher  (Akeneo > 4.0.75)

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -46,7 +46,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     /** @var CleanValuesOfRemovedAttributesInterface|null */
     private $cleanValuesOfRemovedAttributes;
 
-    /** @var EventDispatcher|null */
+    /** @var EventDispatcherInterface|null */
     private $eventDispatcher;
 
     public function __construct(
@@ -55,7 +55,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         string $kernelRootDir,
         int $productBatchSize,
         CleanValuesOfRemovedAttributesInterface $cleanValuesOfRemovedAttributes = null,
-        EventDispatcher $eventDispatcher = null
+        EventDispatcherInterface $eventDispatcher = null
     ) {
         parent::__construct();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The interface is used instead of the EventDispatcher so another implementation can be inserted as dependency without breaking the class dependency.

This commit is based on the resolved issue for Akeneo v5.0.1 https://github.com/akeneo/pim-community-dev/pull/13471 and is used to solve the introduced dependency issue in Akeneo 4.0.75.

The error thrown when the `event_dispatcher` service would be decorated in Akeneo 4.0.75 en higher:

```
 It for Argument 6 passed to Akeneo\Pim\Enrichment\Bundle\Command\CleanRemovedAttributesFromProductAndProductModelCommand::__construct() must be an instance of Symfony\Component\EventDispatcher\EventDispatcher, instance of Symfony\Comp  
  onent\HttpKernel\Debug\TraceableEventDispatcher given,
```

Github issue for Akeneo 4.0.75 https://github.com/akeneo/pim-community-dev/issues/13795
Solved Gitbub issue for Akeneo 5.0.1 https://github.com/akeneo/pim-community-dev/pull/13471

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
