### PR TITLE
BH-350: update cloud-deployer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ aliases:
 
   - &dockerCloudDeployer
       docker:
-        - image: eu.gcr.io/akeneo-cloud/cloud-deployer:2.3
+        - image: eu.gcr.io/akeneo-cloud/cloud-deployer:2.4
           auth:
             username: _json_key  # default username when using a JSON key file to authenticate
             password: $GCLOUD_SERVICE_KEY_DEV  # JSON service account you created, do not encode to base64


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since few days,the CI step 'test_deploy' failed at a cleanup command.

The first hypothesis was a side effect on a non-consistent operation on GCS (link to the terraform backend).

But not!

We disabled the `-m` option in gsutil to disable the operation parallelism and show the real error. It's not clear in the gsutil documentation, but `-m` doesn't print errors, but catch all of them and print a generic message.

And the error is linked to a python issue, so a Gcloud SDK problem.

I upgrade the cloud-deployer version to use the last one, and the same as EE Circle CI workflow.




**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
