### PR TITLE
RAC-477: expose selection to handle the mode on mass delete action

### DIFF
--- a/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
+++ b/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
@@ -105,7 +105,7 @@ type CheckboxProps = Override<
     /**
      * The handler called when clicking on Checkbox.
      */
-    onChange?: (value: CheckboxChecked, event: SyntheticEvent) => void;
+    onChange?: (value: boolean, event: SyntheticEvent) => void;
 
     /**
      * Label of the checkbox.

--- a/akeneo-design-system/src/hooks/useSelection.ts
+++ b/akeneo-design-system/src/hooks/useSelection.ts
@@ -66,7 +66,7 @@ const useSelection = <Type = string>(totalCount: number) => {
     'in' === selection.mode ? selection.collection.length : totalCount - selection.collection.length;
 
   return [
-    selection.collection,
+    selection,
     currentSelectionState(selection, totalCount),
     isSelected,
     onSelectionChange,
@@ -76,3 +76,4 @@ const useSelection = <Type = string>(totalCount: number) => {
 };
 
 export {useSelection};
+export type {Selection};

--- a/akeneo-design-system/src/hooks/useSelection.unit.ts
+++ b/akeneo-design-system/src/hooks/useSelection.unit.ts
@@ -10,7 +10,7 @@ test('It can generate a basic selection', () => {
   expect(isItemSelected('donald')).toBe(false);
   expect(isItemSelected('melania')).toBe(false);
   expect(selectedCount).toEqual(0);
-  expect(collection).toEqual([]);
+  expect(collection.collection).toEqual([]);
 
   void act(() => {
     onSelectionChange('donald', true);
@@ -22,7 +22,8 @@ test('It can generate a basic selection', () => {
   expect(isHalfItemSelected('melania')).toBe(false);
   expect(halfSelectionState).toBe('mixed');
   expect(halfSelectedCount).toEqual(1);
-  expect(halfCollection).toEqual(['donald']);
+  expect(halfCollection.collection).toEqual(['donald']);
+  expect(halfCollection.mode).toEqual('in');
 
   void act(() => {
     onSelectionChange('melania', true);
@@ -41,7 +42,8 @@ test('It can generate a basic selection', () => {
   expect(isCompleteItemSelected('melania')).toBe(true);
   expect(completeSelectionState).toBe(true);
   expect(completeSelectedCount).toEqual(2);
-  expect(completeCollection).toEqual(['donald', 'melania']);
+  expect(completeCollection.collection).toEqual(['donald', 'melania']);
+  expect(completeCollection.mode).toEqual('in');
 });
 
 test('It can handle unselection all', () => {
@@ -84,7 +86,7 @@ test('It can handle selection all', () => {
   expect(isEmptyItemSelected('melania')).toBe(true);
   expect(emptySelectionState).toBe(true);
   expect(emptySelectedCount).toBe(3);
-  expect(emptyCollection).toEqual([]);
+  expect(emptyCollection.collection).toEqual([]);
 
   void act(() => {
     onSelectionChange('donald', false);
@@ -100,7 +102,8 @@ test('It can handle selection all', () => {
   ] = result.current;
   expect(isUnselectedItemSelected('donald')).toBe(false);
   expect(unselectedSelectionState).toBe('mixed');
-  expect(unselectedCollection).toEqual(['donald']);
+  expect(unselectedCollection.collection).toEqual(['donald']);
+  expect(unselectedCollection.mode).toEqual('not_in');
   expect(unselectedCount).toEqual(2);
 });
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
In this PR, we expose the selection to be able to transform the selection mode into filters

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
