### PR TITLE
PIM-9648: [Backport] Mitigate DDoS risk on API auth endpoint by rejecting too large content

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+# Technical Improvements
+
+- PIM-9648: Mitigate DDoS risk on API auth endpoint by rejecting too large content
+
 # 3.2.80 (2021-01-04)
 
 ## Bug fixes

--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -24,10 +24,11 @@ class PimApiExtension extends Extension
 
         $container->setParameter('pim_api.configuration', $config);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('checkers.yml');
         $loader->load('converters.yml');
+        $loader->load('event_listeners.yml');
         $loader->load('event_subscribers.yml');
         $loader->load('hateoas.yml');
         $loader->load('negotiators.yml');

--- a/src/Akeneo/Tool/Bundle/ApiBundle/EventListener/CheckApiRequestContentSizeListener.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/EventListener/CheckApiRequestContentSizeListener.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\ApiBundle\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * It is possible to create a lot of collisions in an PHP array by a malicious user.
+ * Doing it allows to DDoS easily and almost without any resource a server.
+ *
+ * To prevent it, it's important to protect the size sent in the JSON body, when the user is not authenticated.
+ * Do note that $_GET and $_POST variables are already protected by the PHP setting `max_input_vars`.
+ * Therefore, `application/x-www-form-urlencoded` content-type is not concerned by this vulnerability.
+ *
+ * The goal of this Listener is to prevent it.
+ *
+ * See:
+ * https://nikic.github.io/2011/12/28/Supercolliding-a-PHP-array.html
+ * https://www.securityweek.com/hash-table-collision-attacks-could-trigger-ddos-massive-scale
+ */
+final class CheckApiRequestContentSizeListener
+{
+    // Maximum allowed request content size in bytes
+    private const MAX_CONTENT_SIZE = 300;
+
+    private const API_AUTH_ROUTE = 'fos_oauth_server_token';
+
+    public function onKernelRequest(KernelEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (self::API_AUTH_ROUTE !== $request->get('_route')) {
+            return;
+        }
+
+        if (self::MAX_CONTENT_SIZE < strlen($request->getContent())) {
+            throw new HttpException(
+                Response::HTTP_REQUEST_ENTITY_TOO_LARGE,
+                sprintf('Request content exceeded the maximum allowed size of %s bytes', self::MAX_CONTENT_SIZE)
+            );
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/event_listeners.yml
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/event_listeners.yml
@@ -1,0 +1,6 @@
+services:
+    pim_api.event_listener.check_api_request_content_size:
+        class: Akeneo\Tool\Bundle\ApiBundle\EventListener\CheckApiRequestContentSizeListener
+        tags:
+            # Priority 11 because we need to be above FOSRestBundle's BodyListener at 10 and below Router at 32
+            - { name: kernel.event_listener, event: kernel.request, priority: 11 }

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -336,6 +336,33 @@ JSON;
         $this->assertSame('The access token provided is invalid.', $responseBody['message']);
     }
 
+    public function testGetAccessTokenWithTooLargeRequestContent()
+    {
+        $client = static::createClient();
+
+        $client->request(
+            'POST',
+            'api/oauth/v1/token',
+            [],
+            [],
+            [],
+            json_encode([
+                'large_content' => str_repeat('a', 300)
+            ])
+        );
+
+        $expectedContent = <<<JSON
+    {
+        "code": 413,
+        "message": "Request content exceeded the maximum allowed size of 300 bytes"
+    }
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION


<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Backporting https://github.com/akeneo/pim-community-dev/pull/13801

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
