### PR TITLE
PIM-9642: Refresh product image when switching channel or locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - PIM-9631: fix attribute groups not displayed in family due to JS error
 - PIM-9649: Fix PDF product renderer disregarding permissions on Attribute groups
 - PIM-9650: Add translation key for mass delete action.
+- PIM-9642: Refresh product image when switching channel or locale
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -176,14 +176,18 @@ class ProductController
      *
      * @return JsonResponse
      */
-    public function getAction($id)
+    public function getAction(Request $request, string $id)
     {
         $product = $this->findProductOr404($id);
+
+        $context = $this->getNormalizationContext();
+        $context['locale'] = $request->get('locale') ?? $context['locale'];
+        $context['channel'] = $request->get('channel') ?? $context['channel'];
 
         $normalizedProduct = $this->normalizer->normalize(
             $product,
             'internal_api',
-            $this->getNormalizationContext()
+            $context
         );
 
         return new JsonResponse($normalizedProduct);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -181,8 +181,8 @@ class ProductController
         $product = $this->findProductOr404($id);
 
         $context = $this->getNormalizationContext();
-        $context['locale'] = $request->get('locale') ?? $context['locale'];
-        $context['channel'] = $request->get('channel') ?? $context['channel'];
+        $context['catalogLocale'] = $request->get('catalogLocale');
+        $context['catalogScope'] = $request->get('catalogScope');
 
         $normalizedProduct = $this->normalizer->normalize(
             $product,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
@@ -181,6 +181,9 @@ class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodI
         $normalizedProduct['parent_associations'] = $this->parentAssociationsNormalizer->normalize($product, $format, $context);
         $completenesses = $this->getCompletenesses($product);
 
+        $productImageScope = $scopeCode ?? $this->catalogContext->getScopeCode();
+        $productImageLocale = $localeCode ?? $this->catalogContext->getLocaleCode();
+
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),
             'id'                => $product->getId(),
@@ -190,7 +193,7 @@ class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->completenessCollectionNormalizer->normalize($completenesses),
             'required_missing_attributes' => $this->missingRequiredAttributesNormalizer->normalize($completenesses),
-            'image'             => $this->normalizeImage($product->getImage(), $scopeCode, $localeCode),
+            'image'             => $this->normalizeImage($product->getImage(), $productImageScope, $productImageLocale),
             'quantified_associations_for_this_level' => $this->quantifiedAssociationsNormalizer->normalizeWithoutParentsAssociations($product, 'standard', $context),
             'parent_quantified_associations' => $this->quantifiedAssociationsNormalizer->normalizeOnlyParentsAssociations($product, 'standard', $context),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
@@ -177,12 +177,11 @@ class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             ) : null;
 
         $scopeCode = $context['channel'] ?? null;
-        $localeCode = $context['locale'] ?? null;
         $normalizedProduct['parent_associations'] = $this->parentAssociationsNormalizer->normalize($product, $format, $context);
         $completenesses = $this->getCompletenesses($product);
 
-        $productImageScope = $scopeCode ?? $this->catalogContext->getScopeCode();
-        $productImageLocale = $localeCode ?? $this->catalogContext->getLocaleCode();
+        $productImageScope = $context['catalogScope'] ?? $this->catalogContext->getScopeCode();
+        $productImageLocale = $context['catalogLocale'] ?? $this->catalogContext->getLocaleCode();
 
         $normalizedProduct['meta'] = [
             'form'              => $this->formProvider->getForm($product),

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/ProductNormalizer.php
@@ -177,6 +177,7 @@ class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             ) : null;
 
         $scopeCode = $context['channel'] ?? null;
+        $localeCode = $context['locale'] ?? null;
         $normalizedProduct['parent_associations'] = $this->parentAssociationsNormalizer->normalize($product, $format, $context);
         $completenesses = $this->getCompletenesses($product);
 
@@ -189,7 +190,7 @@ class ProductNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             'structure_version' => $this->structureVersionProvider->getStructureVersion(),
             'completenesses'    => $this->completenessCollectionNormalizer->normalize($completenesses),
             'required_missing_attributes' => $this->missingRequiredAttributesNormalizer->normalize($completenesses),
-            'image'             => $this->normalizeImage($product->getImage(), $this->catalogContext->getScopeCode(), $this->catalogContext->getLocaleCode()),
+            'image'             => $this->normalizeImage($product->getImage(), $scopeCode, $localeCode),
             'quantified_associations_for_this_level' => $this->quantifiedAssociationsNormalizer->normalizeWithoutParentsAssociations($product, 'standard', $context),
             'parent_quantified_associations' => $this->quantifiedAssociationsNormalizer->normalizeOnlyParentsAssociations($product, 'standard', $context),
         ] + $this->getLabels($product, $scopeCode) + $this->getAssociationMeta($product);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
@@ -19,7 +19,7 @@ extensions:
             logout: pim_menu.user.logout
 
     pim-product-edit-form-main-image:
-        module: pim/form/common/main-image
+        module: pim/form/common/product/product-main-image
         parent: pim-product-edit-form
         targetZone: main-image
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -901,6 +901,7 @@ config:
     pim/form/common/creation/type:                       pimui/js/form/common/creation/type
     pim/form/common/creation/job:                        pimui/js/form/common/creation/job
     pim/form/common/product/create-button:               pimui/js/form/common/product/create-button
+    pim/form/common/product/product-main-image:          pimui/js/form/common/product/product-main-image
     pim/form/common/section:                             pimui/js/form/common/section.ts
     pim/form/user/login-details:                         pimui/js/form/user/login-details
     pim/form/common/exclusif-boolean: pimui/js/form/common/exclusif-boolean

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-fetcher.js
@@ -16,13 +16,17 @@ define(['jquery', 'backbone', 'pim/base-fetcher', 'routing', 'oro/mediator', 'pi
      *
      * @return {Promise}
      */
-    fetch: function (identifier) {
-      return $.getJSON(Routing.generate(this.options.urls.get, {id: identifier}))
+    fetch: function (identifier, options = {}) {
+      const {cached = false, silent = false, ...routeParams} = options;
+
+      return $.getJSON(Routing.generate(this.options.urls.get, {...routeParams, id: identifier}))
         .then(function (product) {
           const cacheInvalidator = new CacheInvalidator();
           cacheInvalidator.checkStructureVersion(product);
 
-          mediator.trigger('pim_enrich:form:product:post_fetch', product);
+          if (!silent) {
+            mediator.trigger('pim_enrich:form:product:post_fetch', product);
+          }
 
           return product;
         })

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/product-fetcher.js
@@ -17,7 +17,7 @@ define(['jquery', 'backbone', 'pim/base-fetcher', 'routing', 'oro/mediator', 'pi
      * @return {Promise}
      */
     fetch: function (identifier, options = {}) {
-      const {cached = false, silent = false, ...routeParams} = options;
+      const {silent = false, ...routeParams} = options;
 
       return $.getJSON(Routing.generate(this.options.urls.get, {...routeParams, id: identifier}))
         .then(function (product) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/main-image.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/main-image.js
@@ -22,6 +22,7 @@ define(['underscore', 'pim/form', 'pim/template/form/main-image', 'pim/media-url
      */
     initialize: function (config) {
       this.config = config.config;
+      this.imagePath = null;
 
       BaseForm.prototype.initialize.apply(this, arguments);
     },
@@ -56,7 +57,7 @@ define(['underscore', 'pim/form', 'pim/template/form/main-image', 'pim/media-url
         return this.config.path;
       }
 
-      const filePath = _.result(this.getFormData().meta.image, 'filePath', null);
+      const filePath = this.imagePath ?? _.result(this.getFormData().meta.image, 'filePath', null);
 
       if (filePath === null && undefined !== this.config.fallbackPath) {
         return this.config.fallbackPath;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/product/product-main-image.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/product/product-main-image.ts
@@ -1,0 +1,26 @@
+const MainImage = require('pim/form/common/main-image');
+const UserContext = require('pim/user-context');
+const FetcherRegistry = require('pim/fetcher-registry');
+
+class ProductMainImage extends MainImage {
+  /**
+   * {@inheritdoc}
+   */
+  configure() {
+    this.listenTo(UserContext, 'change:catalogScope change:catalogLocale', this.updateImagePath.bind(this));
+
+    return super.configure();
+  }
+
+  private async updateImagePath() {
+    const {meta} = this.getFormData();
+    const locale = UserContext.get('catalogLocale');
+    const channel = UserContext.get('catalogScope');
+    const product = await FetcherRegistry.getFetcher(meta.model_type).fetch(meta.id, {silent: true, locale, channel});
+
+    this.imagePath = product?.meta?.image?.filePath ?? null;
+    this.render();
+  }
+}
+
+export = ProductMainImage;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/product/product-main-image.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/product/product-main-image.ts
@@ -14,9 +14,13 @@ class ProductMainImage extends MainImage {
 
   private async updateImagePath() {
     const {meta} = this.getFormData();
-    const locale = UserContext.get('catalogLocale');
-    const channel = UserContext.get('catalogScope');
-    const product = await FetcherRegistry.getFetcher(meta.model_type).fetch(meta.id, {silent: true, locale, channel});
+    const catalogLocale = UserContext.get('catalogLocale');
+    const catalogScope = UserContext.get('catalogScope');
+    const product = await FetcherRegistry.getFetcher(meta.model_type).fetch(meta.id, {
+      silent: true,
+      catalogLocale,
+      catalogScope,
+    });
 
     this.imagePath = product?.meta?.image?.filePath ?? null;
     this.render();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Adding a custom form extension for the PEF main image to refetch the normalized product with its localized or scoped image

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
