### PR TITLE
API fix event subscription documentation link

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -200,7 +200,7 @@ akeneo_connectivity.connection:
         title: Event subscription
         event_subscription: Event subscription
         helper:
-            message: You can be notified of events happening in the PIM for products synchronized with this connected app. You just need to define a URL and the event type(s) you want to keep track of.
+            message: You can be notified of events happening in the PIM for products synchronized with this connected app. You just need to define a URL.
             link: Learn more about event subscription configuration...
             url.test_disabled: Please, click on the Save button to be able to test the URL.
         form:

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -66,7 +66,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                                 placeholders={{limit: activeEventSubscriptionsLimit.limit.toString()}}
                             />{' '}
                             <Link
-                                href='https://help.akeneo.com/pim/serenity/articles/manage-your-connections.html#subscribe-to-events'
+                                href='https://help.akeneo.com/pim/serenity/articles/manage-event-subscription.html'
                                 target='_blank'
                             >
                                 <Translate id='akeneo_connectivity.connection.webhook.active_event_subscriptions_limit_reached.link' />

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -66,7 +66,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                                 placeholders={{limit: activeEventSubscriptionsLimit.limit.toString()}}
                             />{' '}
                             <Link
-                                href='https://help.akeneo.com/pim/serenity/articles/manage-event-subscription.html'
+                                href='https://help.akeneo.com/pim/serenity/articles/manage-event-subscription.html#activation'
                                 target='_blank'
                             >
                                 <Translate id='akeneo_connectivity.connection.webhook.active_event_subscriptions_limit_reached.link' />


### PR DESCRIPTION
Fix documentation link on the helper displayed when the maximum number of enabled subscriptions is reached.