### PR TITLE
API-1432 create event dispatcher observer test service

### DIFF
--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -242,3 +242,13 @@ services:
             $attributeRemover: '@pim_catalog.remover.attribute'
             $entityValidator: '@validator'
             $productAndProductModelEsClient: '@akeneo_elasticsearch.client.product_and_product_model'
+
+    akeneo_integration_tests.event_dispatcher_observer:
+        class: 'Akeneo\Test\IntegrationTestsBundle\EventDispatcher\EventDispatcherObserver'
+        decorates: event_dispatcher
+        decoration_inner_name: event_dispatcher.inner
+        arguments:
+            - '@event_dispatcher.inner'
+            - '@debug.stopwatch'
+            - '@logger'
+            - '@request_stack'

--- a/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/AssertStorageEventCountTrait.php
+++ b/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/AssertStorageEventCountTrait.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\EventDispatcher;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+trait AssertStorageEventCountTrait
+{
+    public function assertStorageEventCount(int $expectedCount, string $eventName, string $className): void
+    {
+        /** @var EventDispatcherObserver */
+        $eventDispatcher = $this->get('akeneo_integration_tests.event_dispatcher_observer');
+
+        $this->assertSame(
+            $expectedCount,
+            $eventDispatcher->getStorageEventCount($eventName, $className)
+        );
+    }
+}

--- a/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/EventDispatcherObserver.php
+++ b/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/EventDispatcherObserver.php
@@ -30,11 +30,13 @@ class EventDispatcherObserver extends TraceableEventDispatcher
 
     private function incrementStorageEvents(string $eventName, GenericEvent $event): void
     {
-        if (!isset($this->storageEvents[$eventName][get_class($event->getSubject())])) {
-            $this->storageEvents[$eventName][get_class($event->getSubject())] = 0;
+        $className = get_class($event->getSubject());
+
+        if (!isset($this->storageEvents[$eventName][$className])) {
+            $this->storageEvents[$eventName][$className] = 0;
         }
 
-        $this->storageEvents[$eventName][get_class($event->getSubject())] += 1;
+        $this->storageEvents[$eventName][$className] += 1;
     }
 
     public function getStorageEventCount(string $eventName, string $className): int

--- a/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/EventDispatcherObserver.php
+++ b/tests/back/Integration/IntegrationTestsBundle/EventDispatcher/EventDispatcherObserver.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\EventDispatcher;
+
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EventDispatcherObserver extends TraceableEventDispatcher
+{
+    private $storageEvents = [];
+
+    protected function beforeDispatch(string $eventName, $event)
+    {
+        switch ($eventName) {
+            case StorageEvents::POST_SAVE:
+            case StorageEvents::POST_REMOVE:
+                $this->incrementStorageEvents($eventName, $event);
+                break;
+        }
+
+        parent::beforeDispatch($eventName, $event);
+    }
+
+    private function incrementStorageEvents(string $eventName, GenericEvent $event): void
+    {
+        if (!isset($this->storageEvents[$eventName][get_class($event->getSubject())])) {
+            $this->storageEvents[$eventName][get_class($event->getSubject())] = 0;
+        }
+
+        $this->storageEvents[$eventName][get_class($event->getSubject())] += 1;
+    }
+
+    public function getStorageEventCount(string $eventName, string $className): int
+    {
+        return $this->storageEvents[$eventName][$className] ?? 0;
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -4,12 +4,17 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\EventDispatcher\AssertStorageEventCountTrait;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\HttpFoundation\Response;
 
 class CreateProductEndToEnd extends AbstractProductTestCase
 {
+    use AssertStorageEventCountTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -81,6 +86,8 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'product_creation_family');
+
+        $this->assertStorageEventCount(1, StorageEvents::POST_SAVE, Product::class);
     }
 
     public function testProductCreationWithGroups()


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Create a new test service that wrap the EventDispatcher to keep in-memory dispatched events.
Useful to test that all StorageEvents are really dispatched in Integration and e2e tests.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
