### PR TITLE
PIM-9665: [Backport] PIM-9533: Update wysiwyg editor's style in order to differentiate new paragraphs from mere line breaks

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9665: [Backport] PIM-9533: Update wysiwyg editor's style in order to differentiate new paragraphs from mere line breaks
+
 # 4.0.90 (2021-02-02)
 
 # 4.0.89 (2021-01-29)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/summernote.less
@@ -8,6 +8,10 @@
   margin-bottom: 4px;
 
   .note-editable {
+    p {
+      margin-bottom: 10px;
+    }
+
     ol {
       list-style-type: decimal;
       margin-left: 1em;


### PR DESCRIPTION
… to differentiate new paragraphs from mere line breaks

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Backport of this fix => https://github.com/akeneo/pim-community-dev/pull/13236

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
