### PR TITLE
Use correct php binary for database command

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
@@ -340,7 +341,10 @@ class DatabaseCommand extends Command
 
     private function getLatestMigration(InputInterface $input): string
     {
-        $params = ['bin/console', 'doctrine:migrations:latest'];
+        $executable = new PhpExecutableFinder();
+        $php = $executable->find();
+        
+        $params = [$php, 'bin/console', 'doctrine:migrations:latest'];
 
         $params[] = '--no-debug';
 


### PR DESCRIPTION
| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | no
| Added Behats                      | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
| Migration script                  | no
| Tech Doc                          | no

**Description (for Contributor and Core Developer)**

The issue currently is that if you run `pim:installer:db` with a different binary other than the default `php` one, it may potentially break due to the child process not using the original binary the execution was originated from.
I've used Symfony's `PhpExecutableFinder` to fix that issue but I wasn't sure whether that's what the `CommandExecutor` was meant for. I couldn't see how I'm supposed to access the results of that command though (unless I instantiate yet another instance of it and do something along the lines of this:

```php
$outputBuffer = new BufferedOutput();
$commandExecutor = new CommandExecutor(
    new ArrayInput($params),
    $outputBuffer,
    $this->getApplication()
);
```

Sorry, first time contributor. I hope I did everything correcly. Couldn't find any tests covering the `DatabaseCommand` on first sight. I just figured I'm creating this PR quickly and see where this takes me from here :D 
