### PR TITLE
API-1432: Test that event are well handled during variant product actions

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
@@ -38,7 +38,7 @@ trait AssertEventCountTrait
             $expectedCount,
             $count,
             sprintf(
-                'Expecting to have %s event of type "%s", but got %s.',
+                'Expecting to have %d event(s) of type "%s", but got %d.',
                 $expectedCount,
                 $eventClassName,
                 $count

--- a/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
@@ -34,6 +34,15 @@ trait AssertEventCountTrait
             }
         }
 
-        $this->assertSame($expectedCount, $count);
+        $this->assertSame(
+            $expectedCount,
+            $count,
+            sprintf(
+                'Expecting to have %s event of type "%s", but got %s.',
+                $expectedCount,
+                $eventClassName,
+                $count
+            )
+        );
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -2,11 +2,15 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateProductModelEndToEnd extends AbstractProductModelTestCase
 {
+    use AssertEventCountTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -79,6 +83,7 @@ JSON;
             $response->headers->get('location')
         );
         $this->assertSame('', $response->getContent());
+        $this->assertEventCount(0, ProductUpdated::class);
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
@@ -370,6 +375,7 @@ JSON;
             $response->headers->get('location')
         );
         $this->assertSame('', $response->getContent());
+        $this->assertEventCount(0, ProductUpdated::class);
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('apollon_optionb_false');
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\VariantProduct\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateVariantProductEndToEnd extends AbstractProductTestCase
 {
+    use AssertEventCountTrait;
+
     /** @var Collection */
     private $products;
 
@@ -65,6 +69,7 @@ class PartialUpdateVariantProductEndToEnd extends AbstractProductTestCase
         $this->createVariantProduct('apollon_optionb_false', [
             'categories' => ['master'],
             'parent' => 'amor',
+            'groups' => ['groupA'],
             'values' => [
                 'a_yes_no' => [
                     [
@@ -475,6 +480,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithTheGroupsDeleted(): void
@@ -560,6 +566,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithTheCategoriesUpdated(): void
@@ -646,6 +653,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithTheCategoriesDeleted(): void
@@ -732,6 +740,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithTheAssociationsUpdated(): void
@@ -848,6 +857,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithTheAssociationsDeletedOnGroups(): void
@@ -1041,6 +1051,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWithProductDisable(): void
@@ -1128,6 +1139,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWhenProductValueAddedOnAttribute(): void
@@ -1221,6 +1233,7 @@ JSON;
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
         $this->assertSameProducts($expectedProduct, 'apollon_optionb_false');
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testProductVariantPartialUpdateWhenProductValueDeletedOnAttribute(): void
@@ -1609,7 +1622,7 @@ JSON;
             'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "amor",
-            'groups'        => [],
+            'groups'        => ['groupA'],
             'categories'    => ['master'],
             'enabled'       => true,
             'values'        => [
@@ -1739,7 +1752,7 @@ JSON;
             'identifier'    => 'apollon_optionb_false',
             'family'        => "familyA",
             'parent'        => "apollon",
-            'groups'        => [],
+            'groups'        => ['groupA'],
             'categories'    => ['master'],
             'enabled'       => true,
             'values'        => [
@@ -1800,6 +1813,7 @@ JSON;
             'http://localhost/api/rest/v1/products/apollon_optionb_false',
             $response->headers->get('location')
         );
+        $this->assertEventCount(1, ProductUpdated::class);
     }
 
     public function testPartialUpdateResponseWhenMissingIdentifierPropertyAndProvidedIdentifierInValues(): void


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR adds a more explicit error message during the assert event count.
It completes tests on product variant actions from API to be able to assert that all events are sent or not.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
