### PR TITLE
PIM-9667: Prevent import of duplicate options in multiselect attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PIM-9649: Fix PDF product renderer disregarding permissions on Attribute groups
 - PIM-9650: Add translation key for mass delete action.
 - PIM-9642: Refresh product image when switching channel or locale
+- PIM-9667: Prevent import of duplicate options in multiselect attributes
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/documentation.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/documentation.yml
@@ -4,7 +4,7 @@ services:
         arguments:
             - !tagged_iterator pim_enrich.error.documentation_builder
 
-    Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\AttributeOptionDoesNotExist:
+    Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\AttributeOptionValidation:
         tags: [pim_enrich.error.documentation_builder]
 
     Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\DefaultAttributeValidation:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -282,6 +282,11 @@ services:
         tags:
             - { name: pim_catalog.constraint_guesser.attribute }
 
+    pim_catalog.validator.constraint_guesser.options:
+        class: 'Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser\OptionsGuesser'
+        tags:
+            - { name: pim_catalog.constraint_guesser.attribute }
+
     # Validator ClassMetadata factory
     pim_catalog.validator.mapping.product_value_metadata_factory:
         public: false

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -120,6 +120,11 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: reference_data_options_exist_validator }
 
+    pim_catalog.validator.constraint.duplicate_options:
+        class: Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptionsValidator
+        tags:
+            - { name: validator.constraint_validator, alias: duplicate_options_validator }
+
     pim_catalog.validator.constraint.not_empty_variant_axes:
         class: '%pim_catalog.validator.constraint.not_empty_variant_axes.class%'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -72,6 +72,7 @@ pim_catalog:
         product_identifier: These identifiers "%s" don't exist.
         blacklisted_attribute_code: Code temporarily blocked until the ongoing cleanup job is complete.
         blacklisted_attribute_code_with_link: "Code temporarily blocked until the ongoing cleanup job is complete. To find out more, please check the <a href='{{ link }}' target='_blank'>job detail</a>."
+        duplicate_options: '{1} The following option was used multiple times: "{{ duplicate_options }}". Please check your option list again.|]1, +Inf] The following options were used multiple times: "{{ duplicate_options }}". Please check your option list again.'
         0: An unexpected error occurred.
         100: Non-expected value
         101: This field expects a boolean value.

--- a/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/AttributeOptionValidation.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/AttributeOptionValidation.php
@@ -10,13 +10,14 @@ use Akeneo\Pim\Enrichment\Component\Error\Documentation\HrefMessageParameter;
 use Akeneo\Pim\Enrichment\Component\Error\Documentation\RouteMessageParameter;
 use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\AttributeOptionsExist;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-final class AttributeOptionDoesNotExist implements DocumentationBuilderInterface
+final class AttributeOptionValidation implements DocumentationBuilderInterface
 {
     public function support($object): bool
     {
@@ -24,6 +25,7 @@ final class AttributeOptionDoesNotExist implements DocumentationBuilderInterface
             switch ($object->getCode()) {
                 case AttributeOptionsExist::ATTRIBUTE_OPTION_DOES_NOT_EXIST:
                 case AttributeOptionsExist::ATTRIBUTE_OPTIONS_DO_NOT_EXIST:
+                case DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS:
                     return true;
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -111,6 +111,6 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
             }
         }
 
-        return $result;
+        return \array_unique($result);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/OptionsGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/OptionsGuesser.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesserInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class OptionsGuesser implements ConstraintGuesserInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function supportAttribute(AttributeInterface $attribute): bool
+    {
+        return AttributeTypes::OPTION_MULTI_SELECT === $attribute->getType();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function guessConstraints(AttributeInterface $attribute): array
+    {
+        return [
+            new DuplicateOptions(),
+        ];
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/OptionsGuesser.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ConstraintGuesser/OptionsGuesser.php
@@ -29,7 +29,7 @@ class OptionsGuesser implements ConstraintGuesserInterface
     public function guessConstraints(AttributeInterface $attribute): array
     {
         return [
-            new DuplicateOptions(),
+            new DuplicateOptions(['attributeCode' => $attribute->getCode()]),
         ];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptions.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptions.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class DuplicateOptions extends Constraint
+{
+    public string $message = 'pim_catalog.constraint.duplicate_options';
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptions.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptions.php
@@ -12,5 +12,18 @@ use Symfony\Component\Validator\Constraint;
  */
 final class DuplicateOptions extends Constraint
 {
+    public const DUPLICATE_ATTRIBUTE_OPTIONS = '11928f5d-3349-4d17-b21d-5eacabe61e01';
+
     public string $message = 'pim_catalog.constraint.duplicate_options';
+    public string $attributeCode;
+
+    public function getRequiredOptions(): array
+    {
+        return ['attributeCode'];
+    }
+
+    public function getDefaultOption(): string
+    {
+        return 'attributeCode';
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class DuplicateOptionsValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        Assert::isInstanceOf($constraint, DuplicateOptions::class);
+        if (!is_array($value) || \count($value) <= 1) {
+            return;
+        }
+        Assert::allStringNotEmpty($value);
+
+        $dataLowercase = \array_map('strtolower', $value);
+        $uniqueDataLowercase = \array_unique($dataLowercase, SORT_STRING);
+        $duplicateOptionsLowerCase = \array_unique(\array_diff_key($dataLowercase, $uniqueDataLowercase));
+
+        if (\count($duplicateOptionsLowerCase) > 0) {
+            // get the duplicate options in the original case submitted by the user
+            $duplicateOptions = [];
+            foreach (\array_keys($duplicateOptionsLowerCase) as $index) {
+                $duplicateOptions[] = $value[$index];
+            }
+
+            $this->context->buildViolation(
+                $constraint->message,
+                [
+                    '{{ duplicate_options }}' => \implode(', ', $duplicateOptions),
+                    '%count%' => count($duplicateOptions),
+                ]
+            )->addViolation();
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
@@ -38,8 +38,9 @@ final class DuplicateOptionsValidator extends ConstraintValidator
                 [
                     '{{ duplicate_options }}' => \implode(', ', $duplicateOptions),
                     '%count%' => count($duplicateOptions),
+                    '%attribute_code%' => $constraint->attributeCode,
                 ]
-            )->addViolation();
+            )->setCode(DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS)->addViolation();
         }
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/DuplicateOptionsValidator.php
@@ -20,7 +20,7 @@ final class DuplicateOptionsValidator extends ConstraintValidator
         if (!is_array($value) || \count($value) <= 1) {
             return;
         }
-        Assert::allStringNotEmpty($value);
+        Assert::allString($value);
 
         $dataLowercase = \array_map('strtolower', $value);
         $uniqueDataLowercase = \array_unique($dataLowercase, SORT_STRING);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValue.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValue.php
@@ -31,7 +31,7 @@ class OptionsValue extends AbstractValue implements OptionsValueInterface
     /**
      * {@inheritdoc}
      */
-    public function getData(): ?array
+    public function getData(): array
     {
         return $this->data;
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueInterface.php
@@ -16,7 +16,7 @@ interface OptionsValueInterface extends ValueInterface
     /**
      * Return options codes
      */
-    public function getData(): ?array;
+    public function getData(): array;
 
     public function hasCode(string $code): bool;
     public function getOptionCodes(): array;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLinkedData.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Value/OptionsValueWithLinkedData.php
@@ -34,7 +34,7 @@ class OptionsValueWithLinkedData extends AbstractValue implements OptionsValueIn
     /**
      * {@inheritdoc}
      */
-    public function getData(): ?array
+    public function getData(): array
     {
         return $this->data;
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/AttributeOptionValidationSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/AttributeOptionValidationSpec.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder;
 
 use Akeneo\Pim\Enrichment\Component\Error\Documentation\DocumentationCollection;
-use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\AttributeOptionDoesNotExist;
+use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\AttributeOptionValidation;
 use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\AttributeOptionsExist;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 
@@ -15,11 +16,11 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class AttributeOptionDoesNotExistSpec extends ObjectBehavior
+class AttributeOptionValidationSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->beAnInstanceOf(AttributeOptionDoesNotExist::class);
+        $this->beAnInstanceOf(AttributeOptionValidation::class);
     }
 
     function it_is_a_documentation_builder()
@@ -37,6 +38,13 @@ class AttributeOptionDoesNotExistSpec extends ObjectBehavior
     function it_supports_the_error_attribute_options_do_not_exist(ConstraintViolationInterface $constraintViolation)
     {
         $constraintViolation->getCode()->willReturn(AttributeOptionsExist::ATTRIBUTE_OPTIONS_DO_NOT_EXIST);
+
+        $this->support($constraintViolation)->shouldReturn(true);
+    }
+
+    function it_supports_the_duplicate_attribute_options_error(ConstraintViolationInterface $constraintViolation)
+    {
+        $constraintViolation->getCode()->willReturn(DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS);
 
         $this->support($constraintViolation)->shouldReturn(true);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilterSpec.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentMultiSelectValuesFilter;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
 use PhpSpec\ObjectBehavior;
 
@@ -39,7 +39,7 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
                                 ],
                                 'tablet' => [
                                     'en_US' => ['jean', 'claude', 'van', 'damm'],
-                                    'fr_FR' => ['des', 'fraises'],
+                                    'fr_FR' => ['des', 'fraises', 'Fraises', 'FRAISES'],
 
                                 ],
                             ]
@@ -70,13 +70,15 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
                 'van',
                 'damm',
                 'des',
-                'fraises'
+                'fraises',
+                'Fraises',
+                'FRAISES',
             ]
         ];
 
-        $getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes)->willReturn(
+        $getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes)->shouldBeCalled()->willReturn(
             [
-                'a_multi_select' => ['michel', 'fraises']
+                'a_multi_select' => ['michel', 'fraises'],
             ]
         );
 
@@ -95,7 +97,6 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
                                 'tablet' => [
                                     'en_US' => [],
                                     'fr_FR' => ['fraises'],
-
                                 ],
                             ]
                         ]

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/OptionsGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/OptionsGuesserSpec.php
@@ -26,6 +26,7 @@ class OptionsGuesserSpec extends ObjectBehavior
 
     function it_guesses_constraints(AttributeInterface $attribute): void
     {
-        $this->guessConstraints($attribute)->shouldBeLike([new DuplicateOptions()]);
+        $attribute->getCode()->shouldBeCalled()->willReturn('colors');
+        $this->guessConstraints($attribute)->shouldBeLike([new DuplicateOptions(['attributeCode' => 'colors'])]);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/OptionsGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/OptionsGuesserSpec.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesser;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ConstraintGuesserInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use PhpSpec\ObjectBehavior;
+
+class OptionsGuesserSpec extends ObjectBehavior
+{
+    function it_is_a_constraint_guesser(): void
+    {
+        $this->shouldImplement(ConstraintGuesserInterface::class);
+    }
+
+    function it_only_supports_multiselect_attribute_types(AttributeInterface $name, AttributeInterface $colors): void
+    {
+        $name->getType()->willReturn(AttributeTypes::TEXT);
+        $colors->getType()->willReturn(AttributeTypes::OPTION_MULTI_SELECT);
+
+        $this->supportAttribute($name)->shouldReturn(false);
+        $this->supportAttribute($colors)->shouldReturn(true);
+    }
+
+    function it_guesses_constraints(AttributeInterface $attribute): void
+    {
+        $this->guessConstraints($attribute)->shouldBeLike([new DuplicateOptions()]);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
@@ -91,7 +91,7 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         $this->validate($value, $constraint);
     }
 
-    function it_builds_the_right_violation_if_an_option_appears_more_tha_twice(
+    function it_builds_the_right_violation_if_an_option_appears_more_than_twice(
         ExecutionContextInterface $context,
         ConstraintViolationBuilderInterface $violationBuilder
     ): void {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
@@ -52,6 +52,11 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         $this->validate(['red'], new DuplicateOptions());
     }
 
+    function it_throws_an_exception_if_one_of_the_values_is_not_a_string()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [['test', 1, null], new DuplicateOptions()]);
+    }
+
     function it_does_not_build_a_violation_if_there_are_no_duplicates(ExecutionContextinterface $context): void
     {
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
@@ -4,7 +4,6 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\Constr
 
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptionsValidator;
-use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Validator\Constraints\IsNull;
@@ -29,38 +28,45 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         $this->shouldHaveType(DuplicateOptionsValidator::class);
     }
 
-    function it_throws_an_exception_when_validating_anything_but_a_duplicate_options_constraint(): void {
+    function it_throws_an_exception_when_validating_anything_but_a_duplicate_options_constraint(): void
+    {
         $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [['red'], new IsNull()]);
-        $this->shouldNotThrow(\Exception::class)->during('validate', [['red'], new DuplicateOptions()]);
+        $this->shouldNotThrow(\Exception::class)->during('validate', [['red'], new DuplicateOptions('colors')]);
     }
 
     function it_does_nothing_if_the_value_is_not_an_array(ExecutionContextinterface $context): void
     {
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
-        $this->validate('red', new DuplicateOptions());
+        $this->validate('red', new DuplicateOptions('colors'));
     }
 
     function it_does_nothing_if_the_value_is_empty(ExecutionContextInterface $context): void
     {
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
-        $this->validate([], new DuplicateOptions());
+        $this->validate([], new DuplicateOptions('colors'));
     }
 
     function it_does_nothing_if_the_value_only_has_one_element(ExecutionContextInterface $context): void
     {
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
-        $this->validate(['red'], new DuplicateOptions());
+        $this->validate(['red'], new DuplicateOptions('colors'));
     }
 
     function it_throws_an_exception_if_one_of_the_values_is_not_a_string()
     {
-        $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [['test', 1, null], new DuplicateOptions()]);
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'validate',
+            [['test', 1, null], new DuplicateOptions(['attributeCode' => 'colors'])]
+        );
     }
 
     function it_does_not_build_a_violation_if_there_are_no_duplicates(ExecutionContextinterface $context): void
     {
         $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
-        $this->validate(OptionsValue::value('colors', ['red', 'yellow']), new DuplicateOptions());
+        $this->validate(
+            ['red', 'yellow'],
+            new DuplicateOptions(['attributeCode' => 'colors'])
+        );
     }
 
     function it_builds_a_violation_if_there_are_duplicate_options(
@@ -68,15 +74,18 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violationBuilder
     ): void {
         $value = ['red', 'yellow', 'red'];
-        $constraint = new DuplicateOptions();
+        $constraint = new DuplicateOptions(['attributeCode' => 'colors']);
 
         $context->buildViolation(
             $constraint->message,
             [
                 '{{ duplicate_options }}' => 'red',
                 '%count%' => 1,
+                '%attribute_code%' => 'colors',
             ]
         )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->setCode(DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS)
+                         ->shouldBeCalled()->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);
@@ -87,15 +96,18 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violationBuilder
     ): void {
         $value = ['red', 'black', 'red', 'yellow', 'red', 'black', 'black'];
-        $constraint = new DuplicateOptions();
+        $constraint = new DuplicateOptions(['attributeCode' => 'colors']);
 
         $context->buildViolation(
             $constraint->message,
             [
                 '{{ duplicate_options }}' => 'red, black',
                 '%count%' => 2,
+                '%attribute_code%' => 'colors',
             ]
         )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->setCode(DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS)
+                         ->shouldBeCalled()->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);
@@ -106,15 +118,18 @@ class DuplicateOptionsValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $value = ['red', 'yellow', 'Red', 'RED', 'black', 'YELLOW'];
-        $constraint = new DuplicateOptions();
+        $constraint = new DuplicateOptions('colors');
 
         $context->buildViolation(
             $constraint->message,
             [
                 '{{ duplicate_options }}' => 'Red, YELLOW',
                 '%count%' => 2,
+                '%attribute_code%' => 'colors',
             ]
         )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->setCode(DuplicateOptions::DUPLICATE_ATTRIBUTE_OPTIONS)
+                         ->shouldBeCalled()->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/DuplicateOptionsValidatorSpec.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptions;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\DuplicateOptionsValidator;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraints\IsNull;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class DuplicateOptionsValidatorSpec extends ObjectBehavior
+{
+    function let(ExecutionContextInterface $context): void
+    {
+        $this->initialize($context);
+    }
+
+    function it_is_a_constraint_validator(): void
+    {
+        $this->shouldImplement(ConstraintValidatorInterface::class);
+    }
+
+    function it_is_a_duplicate_option_constraint_validator(): void
+    {
+        $this->shouldHaveType(DuplicateOptionsValidator::class);
+    }
+
+    function it_throws_an_exception_when_validating_anything_but_a_duplicate_options_constraint(): void {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [['red'], new IsNull()]);
+        $this->shouldNotThrow(\Exception::class)->during('validate', [['red'], new DuplicateOptions()]);
+    }
+
+    function it_does_nothing_if_the_value_is_not_an_array(ExecutionContextinterface $context): void
+    {
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+        $this->validate('red', new DuplicateOptions());
+    }
+
+    function it_does_nothing_if_the_value_is_empty(ExecutionContextInterface $context): void
+    {
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+        $this->validate([], new DuplicateOptions());
+    }
+
+    function it_does_nothing_if_the_value_only_has_one_element(ExecutionContextInterface $context): void
+    {
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+        $this->validate(['red'], new DuplicateOptions());
+    }
+
+    function it_does_not_build_a_violation_if_there_are_no_duplicates(ExecutionContextinterface $context): void
+    {
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+        $this->validate(OptionsValue::value('colors', ['red', 'yellow']), new DuplicateOptions());
+    }
+
+    function it_builds_a_violation_if_there_are_duplicate_options(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $violationBuilder
+    ): void {
+        $value = ['red', 'yellow', 'red'];
+        $constraint = new DuplicateOptions();
+
+        $context->buildViolation(
+            $constraint->message,
+            [
+                '{{ duplicate_options }}' => 'red',
+                '%count%' => 1,
+            ]
+        )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_builds_the_right_violation_if_an_option_appears_more_tha_twice(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $violationBuilder
+    ): void {
+        $value = ['red', 'black', 'red', 'yellow', 'red', 'black', 'black'];
+        $constraint = new DuplicateOptions();
+
+        $context->buildViolation(
+            $constraint->message,
+            [
+                '{{ duplicate_options }}' => 'red, black',
+                '%count%' => 2,
+            ]
+        )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    function it_builds_an_exception_if_there_are_duplicate_options_with_a_different_case(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $violationBuilder
+    ) {
+        $value = ['red', 'yellow', 'Red', 'RED', 'black', 'YELLOW'];
+        $constraint = new DuplicateOptions();
+
+        $context->buildViolation(
+            $constraint->message,
+            [
+                '{{ duplicate_options }}' => 'Red, YELLOW',
+                '%count%' => 2,
+            ]
+        )->shouldBeCalled()->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/tests/features/pim/enrichment/product/validation/option_values.feature
+++ b/tests/features/pim/enrichment/product/validation/option_values.feature
@@ -15,6 +15,8 @@ Feature: Validate simple and multi-select attributes of a product
       | color       | red         |
       | collections | spring_2019 |
       | collections | summer_2019 |
+      | collections | fall_2019   |
+      | collections | winter_2019 |
     And the following locales "en_US"
     And the following "ecommerce" channel with locales "en_US"
 
@@ -51,5 +53,19 @@ Feature: Validate simple and multi-select attributes of a product
   Scenario: Providing non-existing simple select options should raise an error
     When a product is created with values:
       | attribute   | data                                          | scope | locale |
-      | collections | winter_2018,spring_2019,summer_2019,fall_2019 |       |        |
-    Then the error 'The fall_2019, winter_2018 values are not in the collections attribute option list.' is raised
+      | collections | winter_2018,spring_2019,summer_2019,fall_2018 |       |        |
+    Then the error 'The fall_2018, winter_2018 values are not in the collections attribute option list.' is raised
+
+  @acceptance-back
+  Scenario: Providing a duplicate option for a multi select attribute should raise an error
+    When a product is created with values:
+      | attribute   | data                                | scope | locale |
+      | collections | spring_2019,summer_2019,spring_2019 |       |        |
+    Then the error 'The following option was used multiple times: "spring_2019". Please check your option list again.' is raised
+
+  @acceptance-back
+  Scenario: Providing several duplicate options for a multi select attribute should raise an error
+    When a product is created with values:
+      | attribute   | data                                                                  | scope | locale |
+      | collections | winter_2019,spring_2019,winter_2019,fall_2019,winter_2019,spring_2019 |       |        |
+    Then the error 'The following options were used multiple times: "spring_2019, winter_2019". Please check your option list again.' is raised


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The PR validates that a multiselect value doesn't have duplicate options. It also deduplicates options when loading a product from the database, in case there already are duplicates in DB

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | OK
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
