### PR TITLE
PIM-9672: Error 500 on the API when inputing [null] on an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Bug fixes
 
+- PIM-9672: Error 500 on the API when inputing [null] on an array
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details
 - PIM-9622: Fix query that can generate a MySQL memory allocation error
 - PIM-9630: Fix SQL sort buffer size issue when the catalog has a very large number of categories

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -19,6 +19,7 @@ use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\AddParent;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Event\Connector\ReadProductsEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Event\ProductDomainErrorEvent;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidArgumentException as ProductInvalidArgumentException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownProductException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
@@ -549,7 +550,8 @@ class ProductController
                     $exception
                 );
             }
-            if ($exception instanceof InvalidArgumentException) {
+
+            if ($exception instanceof InvalidArgumentException || $exception instanceof ProductInvalidArgumentException) {
                 throw new AccessDeniedHttpException($exception->getMessage(), $exception);
             }
 


### PR DESCRIPTION
Turn a 500 Exception into a formatted Exception when 
**"data": [null]**
In API update product