### PR TITLE
API: Add a way to clear message bus observer

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountTrait.php
@@ -45,4 +45,9 @@ trait AssertEventCountTrait
             )
         );
     }
+
+    public function clearMessageBusObserver(): void
+    {
+        $this->get('akeneo_integration_tests.message_bus_observer')->reset();
+    }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
