### PR TITLE
Fix dates that do not properly apply server timezone for product and product models API

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiers.php
@@ -72,8 +72,12 @@ SQL;
                 'identifier' => Type::getType(Type::STRING)->convertToPHPValue($row['identifier'], $platform),
                 'is_enabled' => Type::getType(Type::BOOLEAN)->convertToPHPValue($row['is_enabled'], $platform),
                 'product_model_code' => Type::getType(Type::STRING)->convertToPHPValue($row['product_model_code'], $platform),
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue($row['created'], $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue($row['updated'], $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue($row['created'], $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue($row['updated'], $platform)
+                ),
                 'family_code' => Type::getType(Type::STRING)->convertToPHPValue($row['family_code'], $platform),
                 'group_codes' => $groupCodes,
                 'raw_values' => json_decode($row['raw_values'], true)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodes.php
@@ -71,8 +71,12 @@ SQL;
                 'family_variant' => Type::getType(Type::STRING)->convertToPHPValue($row['family_variant'], $platform),
                 'parent' => Type::getType(Type::STRING)->convertToPHPValue($row['parent'], $platform),
                 'raw_values' => json_decode($row['raw_values'], true),
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue($row['created'], $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue($row['updated'], $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue($row['created'], $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue($row['updated'], $platform)
+                ),
             ];
         }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetValuesAndPropertiesFromProductIdentifiersIntegration.php
@@ -91,8 +91,12 @@ class GetValuesAndPropertiesFromProductIdentifiersIntegration extends TestCase
                 'identifier' => 'productA',
                 'is_enabled' => true,
                 'product_model_code' => null,
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
                 'family_code' => 'family',
                 'group_codes' => [],
                 'raw_values' => [
@@ -125,8 +129,12 @@ class GetValuesAndPropertiesFromProductIdentifiersIntegration extends TestCase
                 'identifier' => 'VariantProductA',
                 'is_enabled' => true,
                 'product_model_code' => 'SubProductModel',
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
                 'family_code' => 'FamilyWithVariant',
                 'group_codes' => [],
                 'raw_values' => [

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetValuesAndPropertiesFromProductModelCodesIntegration.php
@@ -85,8 +85,12 @@ class GetValuesAndPropertiesFromProductModelCodesIntegration extends TestCase
                 'raw_values' => [
                     'first_yes_no' => ['<all_channels>' => ['<all_locales>' => false]]
                 ],
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
             ],
             'sub_product_model_1_1' => [
                 'code' => 'sub_product_model_1_1',
@@ -97,8 +101,12 @@ class GetValuesAndPropertiesFromProductModelCodesIntegration extends TestCase
                     'first_yes_no' => ['<all_channels>' => ['<all_locales>' => false]],
                     'second_yes_no' => ['<all_channels>' => ['<all_locales>' => true]],
                 ],
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
             ],
             'root_product_model_2' => [
                 'code' => 'root_product_model_2',
@@ -108,8 +116,12 @@ class GetValuesAndPropertiesFromProductModelCodesIntegration extends TestCase
                 'raw_values' => [
                     'first_yes_no' => ['<all_channels>' => ['<all_locales>' => true]]
                 ],
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
             ],
             'sub_product_model_2_1' => [
                 'code' => 'sub_product_model_2_1',
@@ -120,8 +132,12 @@ class GetValuesAndPropertiesFromProductModelCodesIntegration extends TestCase
                     'first_yes_no' => ['<all_channels>' => ['<all_locales>' => true]],
                     'second_yes_no' => ['<all_channels>' => ['<all_locales>' => false]],
                 ],
-                'created' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::CREATED, $platform),
-                'updated' => Type::getType(Type::DATETIME_IMMUTABLE)->convertToPhpValue(self::UPDATED, $platform),
+                'created' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::CREATED, $platform)
+                ),
+                'updated' => \DateTimeImmutable::createFromMutable(
+                    Type::getType(Type::DATETIME)->convertToPhpValue(self::UPDATED, $platform)
+                ),
             ],
 
         ];


### PR DESCRIPTION
If the server timezone is not UTC, the dates returned by the API for the created and updated fields of products and product models are the UTC "value" of the date with the server timezone, resulting in wrong dates.

For example, I use Europe/Paris timezone, currently one hour ahead of UTC.
I updated a product at 17:45:00 local time, so 16:45:00 UTC. If I query this product through the API, I will find this line in the result :
```
"updated": "2021-02-08T16:45:00+01:00"
```

Instead of :

```
"updated": "2021-02-08T17:45:00+01:00"
```
