### PR TITLE
API-1448: Events API - Add Behat tests

### DIFF
--- a/tests/legacy/features/pim/enrichment/product-model/add_product_model_children.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/add_product_model_children.feature
@@ -75,7 +75,7 @@ Feature: Add children to product model
     And I confirm the child creation
     Then I should be on the product model "apollon_black" edit page
 
-  @critical
+  @critical @purge-messenger
   Scenario: Successfully add a variant product to a root product model
     Given I am on the "amor" product model page
     When I open the variant navigation children selector for level 1
@@ -87,6 +87,7 @@ Feature: Add children to product model
       | Size (variant axis)  | XL            |
     And I confirm the child creation
     Then I should be on the product "amor_black_xl" edit page
+    And 1 event of type "product.created" should have been raised
 
   @critical
   Scenario: Successfully add a variant product to a sub product model

--- a/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
@@ -9,7 +9,7 @@ Feature: Create a product model
     And I am logged in as "Julia"
     And I am on the products grid
 
-  @critical
+  @critical @purge-messenger
   Scenario: Create a product model with a single level variant
     When I create a product model
     And I should see the Code, Family and Variant fields
@@ -21,6 +21,7 @@ Feature: Create a product model
     And I press the "Save" button
     And I should be on the product model "shoes_variant" edit page
     And I should see the text "shoes_variant"
+    And 1 event of type "product_model.created" should have been raised
 
   @critical
   Scenario: Create a product model with multiple level variant

--- a/tests/legacy/features/pim/enrichment/product-model/import/csv/create_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/import/csv/create_product_model.feature
@@ -6,7 +6,7 @@ Feature: Create product models through CSV import
   Background:
     Given the "catalog_modeling" catalog configuration
 
-  @critical
+  @critical @purge-messenger
   Scenario: Julia imports new root products models in CSV
     Given the following CSV file to import:
       """
@@ -17,6 +17,7 @@ Feature: Create product models through CSV import
     Then there should be the following root product model:
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And 1 event of type "product_model.created" should have been raised
 
   @critical
   Scenario: Julia imports new products sub product models in CSV

--- a/tests/legacy/features/pim/enrichment/product-model/import/xlsx/create_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/import/xlsx/create_product_model.feature
@@ -6,6 +6,7 @@ Feature: Create product models through XLSX import
   Background:
     Given the "catalog_modeling" catalog configuration
 
+  @purge-messenger
   Scenario: Julia imports new root products models in XLSX
     Given the following XLSX file to import:
       """
@@ -16,3 +17,4 @@ Feature: Create product models through XLSX import
     Then there should be the following root product model:
       | code     | categories | family_variant     | collection   | description-en_US-ecommerce | erp_name-en_US | price      |
       | code-001 | master_men | clothing_colorsize | [Spring2017] | description                 | Blazers_1654   | 100.00 EUR |
+    And 1 event of type "product_model.created" should have been raised

--- a/tests/legacy/features/pim/enrichment/product-model/remove.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/remove.feature
@@ -17,3 +17,4 @@ Feature: Remove a product model
     Then I should not see product 1111111111
     And  I should not see product 1111111112
     And 1 event of type "product_model.removed" should have been raised
+    And 0 event of type "product.removed" should have been raised

--- a/tests/legacy/features/pim/enrichment/product-model/remove.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/remove.feature
@@ -8,6 +8,7 @@ Feature: Remove a product model
     Given a "catalog_modeling" catalog configuration
     And I am logged in as "Julia"
 
+  @purge-messenger
   Scenario: Successfully delete a product model from the edit form
     Given I am on the "amor" product model page
     And  I press the secondary action "Delete"
@@ -15,3 +16,4 @@ Feature: Remove a product model
     When I confirm the removal
     Then I should not see product 1111111111
     And  I should not see product 1111111112
+    And 1 event of type "product_model.removed" should have been raised

--- a/tests/legacy/features/pim/enrichment/product/import/import_variant_products.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_variant_products.feature
@@ -6,6 +6,7 @@ Feature: Import variant products through CSV import
   Background:
     Given the "catalog_modeling" catalog configuration
 
+  @purge-messenger
   Scenario: Create new variant products through CSV import
     Given the following CSV file to import:
       """
@@ -22,6 +23,7 @@ Feature: Import variant products through CSV import
       | size   | xl            |
       | weight | 800.0000 GRAM |
       | ean    | EAN           |
+    And 1 event of type "product.created" should have been raised
 
   Scenario: Update values of existing variant products through CSV import
     Given the following CSV file to import:

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_and_remove_a_product.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_and_remove_a_product.feature
@@ -23,8 +23,10 @@ Feature: Edit and remove a product
     And I press the "Save" button
     Then I should not see the text "There are unsaved changes."
 
+  @purge-messenger
   Scenario: Successfully delete a product from the edit form
     Given I press the secondary action "Delete"
     Then I should see the text "Confirm deletion"
     When I confirm the removal
     Then I should not see product boots
+    And 1 event of type "product.removed" should have been raised


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

> Given Julia has all the required permissions to delete a product model,
> When Julia deletes a product model in the PEF,
> Then no event is raised on its sub-product models and no event is raised on its product variant children.

> Given Julia has all the required permissions to delete a product model,
> When Julia deletes a product model in the PEF,
> Then no event is raised on its product variant children.

> Given Julia has all the required permissions to delete a product,
> When Julia deletes a simple product in the product grid
> Then an event product.removed is raised and added to the Events API message queue.

> Given everything is set up to launch a product import thanks to an import profile,
> And Julia has permission to launch product import jobs,
> When Julia imports a product model,
> Then an event product_model.created is raised and added to the Events API message queue.

> Given Julia has all the required permissions to create a product model,
> When Julia creates a product model in the product grid
> Then an event product_model.created is raised and added to the Events API message queue.

> Given Julia has all the required permissions to create a product,
> When Julia creates a product variant in the product grid
> Then an event product.created is raised and added to the Events API message queue.

> Given everything is set up to launch a product import thanks to an import profile,
> And Julia has permission to launch product import jobs,
> When Julia imports a product variant,
> Then an event product.created is raised and added to the Events API message queue.