### PR TITLE
PIM-9670: Fix attribute filter Group issue when several attribute groups have the same label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PIM-9658: Add missing backend permission checks
 - PIM 9657: Make open filters close when opening a new one.
 - PIM-9671: Provide a data quality insight status context for attribute groups
+- PIM-9670: Fix attribute filter "Group" issue when several attribute groups have the same label
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AttributeGroupRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/InternalApi/AttributeGroupRepository.php
@@ -39,7 +39,12 @@ class AttributeGroupRepository extends EntityRepository implements TranslatedLab
 
         $choices = [];
         foreach ($queryBuilder->getArrayResult() as $code) {
-            $choices[$code['label']] = $code['code'];
+            $label = $code['label'];
+
+            if (isset($choices[$label])) {
+                $label = "${code['label']} [${code['code']}]";
+            }
+            $choices[$label] = $code['code'];
         }
 
         return $choices;


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

This pull request fixes the display of the filter groups in the attribute grid when there are several attribute groups with the same label.

![pim-9670](https://user-images.githubusercontent.com/50582517/107549558-416d8c00-6bd0-11eb-97d1-ea81d19a688c.gif)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
