### PR TITLE
AOB-1300: Fix Onboarder bundle front build

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@babel/core": "^7.11.0",
     "@babel/preset-env": "^7.3.4",
     "@babel/types": "~7.11.5",
-    "@types/backbone": "^1.3.42",
+    "@types/backbone": "1.4.8",
     "@types/node": "11.9.5",
     "@types/underscore": "~1.9.4",
     "@types/react-dom": "^16.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,10 +1020,10 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/backbone@^1.3.42":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@types/backbone/-/backbone-1.4.5.tgz#057d89987fb672a20b896b1df5cc802f7b87c624"
-  integrity sha512-pSqM0eryp6V3G0srBtndUd9IJmiG2BAwYLQGPDcEPMjbfbgitlrN40+Lc1rrMjNMbV5QWywe6WPmNjdqyNTyIw==
+"@types/backbone@1.4.8":
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/@types/backbone/-/backbone-1.4.8.tgz#4ccd5553263d2d6052033df2b55257c73451620f"
+  integrity sha512-j0hwWnvp4UvMkI3mFwDBz6ETFbuFl+gvsO2EFMGALt4LY5KTQZ7hRR4q6S8V6wqH0NeU5K6GEyZdMRaCNRS9EQ==
   dependencies:
     "@types/jquery" "*"
     "@types/underscore" "*"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In one the latest version of `@types/backbone` (1.4.9), a breaking change was introduced in the View interface.
see https://github.com/DefinitelyTyped/DefinitelyTyped/commit/01db383f12ef1c1499a6acc826fcfac01c9095e5#diff-d60bebcbc6b7b8fc4d481b68f93d350fe46e7c01dff65af9ab447dcd87eaf236R579-R580

I think that the newer interface is correct but it's clearly incompatible with a lot of our inherited classes.
Yes, we should update our code accordingly (I've looked into it, at least a dozen classes) but it's not something we should do in 3.2, which is in maintenance mode only.
 
This error does not directly happen in `pim-community-dev@3.2` because we have a yarn.lock, but it does appear in `pim-enterprise-standard@3.2` when using the onboarder bundle, because there is no yarn.lock in this repository.

Alternative to https://github.com/akeneo/pim-community-dev/pull/13890

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
