### PR TITLE
RAC-511: Fix DSM Button outline style

### DIFF
--- a/akeneo-design-system/src/components/Button/Button.tsx
+++ b/akeneo-design-system/src/components/Button/Button.tsx
@@ -1,6 +1,6 @@
 import React, {isValidElement, ReactNode, Ref, SyntheticEvent} from 'react';
 import styled, {css} from 'styled-components';
-import {AkeneoThemedProps, getColorForLevel, getFontSize, Level} from '../../theme';
+import {AkeneoThemedProps, getColor, getColorForLevel, getFontSize, Level} from '../../theme';
 import {Override} from '../../shared';
 import {IconProps} from '../../icons';
 
@@ -70,7 +70,7 @@ const getColorStyle = ({
   if (ghost) {
     return css`
       color: ${getColorForLevel(level, disabled ? 80 : 120)};
-      background-color: white;
+      background-color: ${getColor('white')};
       border-color: ${getColorForLevel(level, disabled ? 60 : 100)};
 
       &:hover:not([disabled]) {
@@ -87,7 +87,7 @@ const getColorStyle = ({
   }
 
   return css`
-    color: white;
+    color: ${getColor('white')};
     background-color: ${getColorForLevel(level, disabled ? 40 : 100)};
 
     &:hover:not([disabled]) {
@@ -100,7 +100,7 @@ const getColorStyle = ({
   `;
 };
 
-const ContainerStyle = css<
+const Container = styled.button<
   {
     level: Level;
     ghost: boolean;
@@ -119,21 +119,17 @@ const ContainerStyle = css<
   border-style: ${({ghost}) => (ghost ? 'solid' : 'none')};
   padding: ${({size}) => (size === 'small' ? '0 10px' : '0 15px')};
   height: ${({size}) => (size === 'small' ? '24px' : '32px')};
-  outline-color: ${({level}) => getColorForLevel(level, 100)};
   cursor: ${({disabled}) => (disabled ? 'not-allowed' : 'pointer')};
   font-family: inherit;
   transition: background-color 0.1s ease;
+  outline-style: none;
+  text-decoration: none;
+
+  &:focus {
+    box-shadow: 0 0 0 2px ${getColor('blue', 40)};
+  }
 
   ${getColorStyle}
-`;
-
-const ButtonContainer = styled.button`
-  ${ContainerStyle}
-`;
-
-const LinkContainer = styled.a`
-  text-decoration: none;
-  ${ContainerStyle}
 `;
 
 /**
@@ -164,10 +160,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       onClick(event);
     };
 
-    const Component = undefined !== href ? LinkContainer : ButtonContainer;
-
     return (
-      <Component
+      <Container
+        as={undefined !== href ? 'a' : 'button'}
         level={level}
         ghost={ghost}
         disabled={disabled}
@@ -190,7 +185,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
           return child;
         })}
-      </Component>
+      </Container>
     );
   }
 );


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
Before:
<img width="554" alt="image" src="https://user-images.githubusercontent.com/3492179/107940901-3e381e80-6f89-11eb-9168-2a901e65020a.png">

After:
<img width="563" alt="image" src="https://user-images.githubusercontent.com/3492179/107940865-324c5c80-6f89-11eb-8e43-181d2b642bc7.png">

Also simplifying styled component Container using the builtin `as` prop

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
