### PR TITLE
PIM-9686 fix memory issue of compute completeness task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PIM-9670: Fix attribute filter "Group" issue when several attribute groups have the same label
 - PIM-9664: Display Ziggy as asset image when the preview cannot be generated
 - PIM-9681: Fix criteria selector closing behavior on the product grid filters
+- PIM-9686: Fix memory leak during "set_attribute_requirements" job
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -31,7 +31,7 @@ use Webmozart\Assert\Assert;
  */
 class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, TrackableTaskletInterface
 {
-    private const BATCH_SIZE = 1000;
+    private const BATCH_SIZE = 100;
 
     private StepExecution $stepExecution;
     private ProductQueryBuilderFactoryInterface $productQueryBuilderFactory;
@@ -94,6 +94,7 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
 
             if (count($productsToCompute) >= self::BATCH_SIZE) {
                 $this->computeCompleteness($productsToCompute);
+                $this->cacheClearer->clear();
                 $productsToCompute = [];
             }
         }


### PR DESCRIPTION
Fix a memory leak caused by products fetch by the ORM in the tasklet `ComputeCompletenessOfFamilyProductsTasklet`