### PR TITLE
API-1407: Add tests on variant products

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountInTransportTrait.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Messenger/AssertEventCountInTransportTrait.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Test\IntegrationTestsBundle\Messenger;
+
+use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Akeneo\Platform\Component\EventQueue\Event;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+trait AssertEventCountInTransportTrait
+{
+    protected array $envelopes = [];
+
+    public function assertEventCount(int $expectedCount, string $eventClassName): void
+    {
+        if (!is_subclass_of($eventClassName, Event::class)) {
+            throw new \LogicException(sprintf('%s is not a valid Event class', $eventClassName));
+        }
+        $this->pullMessages();
+
+        $count = 0;
+        foreach ($this->envelopes as $envelope) {
+            $payload = $envelope->getMessage();
+            if (!$payload instanceof BulkEventInterface) {
+                continue;
+            }
+            foreach ($payload->getEvents() as $event) {
+                if ($event instanceof $eventClassName) {
+                    $count++;
+                }
+            }
+        }
+
+        $this->assertSame(
+            $expectedCount,
+            $count,
+            sprintf(
+                'Expecting to have %d event(s) of type "%s", but got %d.',
+                $expectedCount,
+                $eventClassName,
+                $count
+            )
+        );
+    }
+
+    public function clearMessengerTransport(): void
+    {
+        $this->pullMessages();
+        $this->envelopes = [];
+    }
+
+    private function pullMessages(): void
+    {
+        $transport = $this->get('messenger.transport.business_event');
+
+        while (!empty($envelopes = $transport->get())) {
+            foreach ($envelopes as $envelope) {
+                $transport->ack($envelope);
+                $this->envelopes[] = $envelope;
+            }
+        }
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
@@ -1,0 +1,186 @@
+<?php
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\MassEdit;
+
+use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountInTransportTrait;
+use Akeneo\Tool\Component\Batch\Job\BatchStatus;
+use AkeneoTest\Pim\Enrichment\EndToEnd\InternalApiTestCase;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractMassEditEndToEnd extends InternalApiTestCase
+{
+    use AssertEventCountInTransportTrait;
+
+    protected JobLauncher $jobLauncher;
+    protected Connection $dbalConnection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->jobLauncher = $this->get('akeneo_integration_tests.launcher.job_launcher');
+        $this->dbalConnection = $this->get('database_connection');
+        $this->authenticate($this->getAdminUser());
+        $this->clearMessengerTransport();
+    }
+
+    protected function executeMassEdit(array $data): void
+    {
+        $this->client->request(
+            'POST',
+            '/rest/mass_edit/',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($data)
+        );
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+
+        $this->launchAndWaitForJob($data['jobInstanceCode']);
+    }
+
+    protected function launchAndWaitForJob(string $jobInstanceCode): void
+    {
+        $this->jobLauncher->launchConsumerOnce();
+
+        $query = <<<SQL
+SELECT exec.status, exec.id
+FROM akeneo_batch_job_execution as exec
+INNER JOIN akeneo_batch_job_instance as instance ON exec.job_instance_id = instance.id AND instance.code = :instance_code   
+ORDER BY exec.id DESC
+LIMIT 1;
+SQL;
+        $timeout = 0;
+        $isCompleted = false;
+
+        $stmt = $this->dbalConnection->prepare($query);
+
+        while (!$isCompleted) {
+            if ($timeout > 30) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Timeout: last job execution from "%s" job instance is not complete.',
+                        $jobInstanceCode
+                    )
+                );
+            }
+            $stmt->bindValue('instance_code', $jobInstanceCode);
+            $stmt->execute();
+            $result = $stmt->fetch();
+
+            $isCompleted = isset($result['status']) && BatchStatus::COMPLETED === (int) $result['status'];
+
+            $timeout++;
+
+            sleep(1);
+        }
+    }
+
+    protected function findESIdFor(string $identifier, string $type): string
+    {
+        switch ($type) {
+            case 'product':
+                $idFromDatabase = $this->getProductId($identifier);
+                break;
+            case 'product_model':
+                $idFromDatabase = $this->getProductModelId($identifier);
+                break;
+            default:
+                throw new \InvalidArgumentException(
+                    'Only "product" or "product_model" types are allowed. Product variant is a product.'
+                );
+        }
+
+        return sprintf('%s_%s', $type, $idFromDatabase);
+    }
+
+    protected function getProductId(string $identifier): string
+    {
+            $query = <<<SQL
+SELECT id
+FROM pim_catalog_product
+WHERE identifier = :identifier
+SQL;
+
+        $stmt = $this->dbalConnection->prepare($query);
+        $stmt->bindValue('identifier', $identifier);
+        $stmt->execute();
+        $idFromDatabase = $stmt->fetchColumn();
+
+        if (false === $idFromDatabase) {
+            throw new \InvalidArgumentException(sprintf(
+                'Product with identifier "%s" does not exist.',
+                $identifier
+            ));
+        }
+
+        return $idFromDatabase;
+    }
+
+    protected function getProductModelId(string $code): string
+    {
+        $query = <<<SQL
+SELECT id
+FROM pim_catalog_product_model
+WHERE code = :code
+SQL;
+
+        $stmt = $this->dbalConnection->prepare($query);
+        $stmt->bindValue('code', $code);
+        $stmt->execute();
+        $idFromDatabase = $stmt->fetchColumn();
+
+        if (false === $idFromDatabase) {
+            throw new \InvalidArgumentException(sprintf(
+                'Product model with code "%s" does not exist.',
+                $code
+            ));
+        }
+
+        return $idFromDatabase;
+    }
+
+    protected function updateProductWithInternalApi(string $identifier, array $data): Response
+    {
+        $this->client->request(
+            'POST',
+            sprintf('/enrich/product/rest/%s', $this->getProductId($identifier)),
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode($data)
+        );
+
+        return $this->client->getResponse();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    protected function getAdminUser(): UserInterface
+    {
+        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
@@ -56,7 +56,9 @@ abstract class AbstractMassEditEndToEnd extends InternalApiTestCase
 
     protected function launchAndWaitForJob(string $jobInstanceCode): void
     {
-        $this->jobLauncher->launchConsumerOnce();
+        while ($this->jobLauncher->hasJobInQueue()) {
+            $this->jobLauncher->launchConsumerOnce();
+        }
 
         $query = <<<SQL
 SELECT exec.status, exec.id

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/MassEditCategoriesOfEntitiesEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/MassEditCategoriesOfEntitiesEndToEnd.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\MassEdit;
+
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Symfony\Component\HttpFoundation\Response;
+
+class MassEditCategoriesOfEntitiesEndToEnd extends AbstractMassEditEndToEnd
+{
+    public function test_adding_a_category_to_entities_produces_event(): void
+    {
+        $this->executeMassEdit([
+            'filters' => [
+                [
+                    'field' => 'id',
+                    'operator' => Operators::IN_LIST,
+                    'value' => [
+                        $this->findESIdFor('1111111111', 'product'), // variant product
+                        $this->findESIdFor('watch', 'product'), // product
+                        $this->findESIdFor('apollon_yellow', 'product_model'),
+                    ],
+                    'context' => [
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ]
+            ],
+            'jobInstanceCode' => 'add_to_category',
+            'actions' => [
+                [
+                    'field' => 'categories',
+                    'value' => ['master_men_pants_jeans'],
+                ]
+            ],
+            'itemsCount' => 3,
+            'familyVariant' => null,
+            'operation' => 'add_to_category',
+        ]);
+
+        $this->assertEventCount(2, ProductUpdated::class);
+        $this->assertEventCount(1, ProductModelUpdated::class);
+    }
+
+    public function test_removing_a_category_to_entities_produces_event(): void
+    {
+        $response = $this->updateProductWithInternalApi('1111111119', [
+            'identifier' => '1111111119',
+            'values' => [],
+            'categories' => ['print_accessories'],
+        ]);
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->clearMessengerTransport();
+
+        $this->executeMassEdit([
+            'filters' => [
+                [
+                    'field' => 'id',
+                    'operator' => Operators::IN_LIST,
+                    'value' => [
+                        $this->findESIdFor('1111111119', 'product'), // variant product
+                        $this->findESIdFor('1111111171', 'product'), // product
+                        $this->findESIdFor('amor', 'product_model'),
+                    ],
+                    'context' => [
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ]
+            ],
+            'jobInstanceCode' => 'remove_from_category',
+            'actions' => [
+                [
+                    'field' => 'categories',
+                    'value' => ['master_men_blazers', 'print_accessories'],
+                ]
+            ],
+            'itemsCount' => 3,
+            'familyVariant' => null,
+            'operation' => 'remove_from_category',
+        ]);
+
+        $this->assertEventCount(2, ProductUpdated::class);
+        $this->assertEventCount(1, ProductModelUpdated::class);
+    }
+}

--- a/tests/legacy/features/pim/enrichment/product-model/edit_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/edit_product_model.feature
@@ -23,6 +23,7 @@ Feature: Edit a product model
     Then I should not see the text "There are unsaved changes."
     And the product Model name should be "Heritage jacket navy chilly tiki"
     And 0 event of type "product.updated" should have been raised
+    And 1 event of type "product_model.updated" should have been raised
 
   @critical @purge-messenger
   Scenario: Successfully edit and save a sub product model
@@ -35,6 +36,7 @@ Feature: Edit a product model
     Then I should not see the text "There are unsaved changes."
     And the product Variation Name should be "Apollonito blue"
     And 0 event of type "product.updated" should have been raised
+    And 1 event of type "product_model.updated" should have been raised
 
   @critical
   Scenario: Parent attributes of a sub product model are read only


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Add 2 legacy tests on variant products.

Add a way to easily create EndToEnd tests on bulk actions. 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
