### PR TITLE
AOB-1317: Fix deprecated nested ternary expression

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- AOB-1317: Fix deprecated nested ternary expression
 - DAPI-1490: Fix redirect to product grid from DQI dashboard when a default view is activated on the user profile
 - PIM-9686: Fix memory leak during "set_attribute_requirements" job
 

--- a/src/Oro/Bundle/SecurityBundle/DependencyInjection/Compiler/AclConfigurationPass.php
+++ b/src/Oro/Bundle/SecurityBundle/DependencyInjection/Compiler/AclConfigurationPass.php
@@ -155,7 +155,7 @@ class AclConfigurationPass implements CompilerPassInterface
             function ($a, $b) {
                 return $a['priority'] == $b['priority']
                     ? 0
-                    : ($a['priority'] < $b['priority']) ? -1 : 1;
+                    : (($a['priority'] < $b['priority']) ? -1 : 1);
             }
         );
 


### PR DESCRIPTION
Working on the PIM V5 compatibility on the Supplier Onboarder, we've found a nested ternary expression that prevents us from running our integration tests. This is deprecated [since PHP 7.4.](https://wiki.php.net/rfc/ternary_associativity)
Here a fix adding paranthesis to the second ternary.

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
