### PR TITLE
PIM-9690: Fix HeathCheck system doesn't handle stopping status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - PIM-9664: Display Ziggy as asset image when the preview cannot be generated
 - PIM-9681: Fix criteria selector closing behavior on the product grid filters
 - PIM-9686: Fix memory leak during "set_attribute_requirements" job
+- PIM-9690: Fix job remaining in stopping status forever
 
 ## New features
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
@@ -46,7 +46,7 @@ class JobExecutionManager
     public function resolveJobExecutionStatus(JobExecution $jobExecution): JobExecution
     {
         if (BatchStatus::STARTING === $jobExecution->getStatus()->getValue() ||
-            !$jobExecution->getExitStatus()->isRunning()) {
+            (!$jobExecution->getExitStatus()->isRunning() && !$jobExecution->isStopping())) {
             return $jobExecution;
         }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
The healthcheck system doesn't handle stopping status, now the status is also mark as failed when healthcheck is not up to date


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
