### PR TITLE
PIM-9700: Add batch-size option in index products command and index product-models command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PIM-9681: Fix criteria selector closing behavior on the product grid filters
 - PIM-9686: Fix memory leak during "set_attribute_requirements" job
 - PIM-9690: Fix job remaining in stopping status forever
+- PIM-9700: Add batch-size option in index products command and index product-models command
 
 ## New features
 

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -166,8 +166,8 @@ class Client
         } catch (BadRequest400Exception $e) {
             $chunkLength = intdiv($length, self::NUMBER_OF_BATCHES);
             $chunkLength = $chunkLength % 2 == 0 ? $chunkLength : $chunkLength + 1;
-            $mergedResponse = $this->doChunkedBulkIndex($params, $mergedResponse, $chunkLength);
 
+            $mergedResponse = $this->doChunkedBulkIndex($params, $mergedResponse, $chunkLength);
         } catch (\Exception $e) {
             throw new IndexationException($e->getMessage(), $e->getCode(), $e);
         }
@@ -178,7 +178,10 @@ class Client
     private function doChunkedBulkIndex(array $params, array $mergedResponse, int $chunkLength): array
     {
         $bulkRequest = [];
-        $bulkRequest['refresh'] = $params['refresh'];
+        if (isset($params['refresh'])) {
+            $bulkRequest['refresh'] = $params['refresh'];
+        }
+
         $chunkedBody = array_chunk($params['body'], $chunkLength);
         foreach ($chunkedBody as $chunk) {
             $bulkRequest['body'] = $chunk;

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -162,11 +162,11 @@ class Client
     {
         $length = count($params['body']);
         try {
-            $mergedResponse = $this->doChuckedBulkIndex($params, $mergedResponse, $length);
+            $mergedResponse = $this->doChunkedBulkIndex($params, $mergedResponse, $length);
         } catch (BadRequest400Exception $e) {
             $chunkLength = intdiv($length, self::NUMBER_OF_BATCHES);
             $chunkLength = $chunkLength % 2 == 0 ? $chunkLength : $chunkLength + 1;
-            $mergedResponse = $this->doChuckedBulkIndex($params, $mergedResponse, $chunkLength);
+            $mergedResponse = $this->doChunkedBulkIndex($params, $mergedResponse, $chunkLength);
 
         } catch (\Exception $e) {
             throw new IndexationException($e->getMessage(), $e->getCode(), $e);
@@ -175,12 +175,12 @@ class Client
         return $mergedResponse;
     }
 
-    private function doChuckedBulkIndex(array $params, array $mergedResponse, int $chunkLength): array
+    private function doChunkedBulkIndex(array $params, array $mergedResponse, int $chunkLength): array
     {
         $bulkRequest = [];
         $bulkRequest['refresh'] = $params['refresh'];
-        $chunkedParams = array_chunk($params['body'], $chunkLength);
-        foreach ($chunkedParams as $chunk) {
+        $chunkedBody = array_chunk($params['body'], $chunkLength);
+        foreach ($chunkedBody as $chunk) {
             $bulkRequest['body'] = $chunk;
             $response = $this->client->bulk($bulkRequest);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Add a new option to the product/product-models index command to choose the number of records to index per batch (batch-size).
The default batch-size value is 1000
Affected commands:
1 - "bin/console pim:product:index"
2 - "bin/console pim:product-model:index"

ex:
"bin/console pim:product:index --all"  >> batch-size is 1000
"bin/console pim:product:index --all --batch-size=100" >> batch-size is 100
"bin/console pim:product:index  identifier_1 identifier_2 ... --batch-size=100"  >> batch-size is 100

Tested on duplicated env:
https://stellamccartney-dev-sds-17219.dev.cloud.akeneo.com

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
