### PR TITLE
PIM-9696: Associations and categories display according to the ownership rights

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9696: Associations and categories display according to the ownership rights
+
 # 4.0.95 (2021-02-19)
 
 # 4.0.94 (2021-02-17)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
@@ -119,6 +119,10 @@ define(
                         children:        'pim_enrich_categorytree_children'
                     }, 'POST');
 
+                    if (this.isReadOnly()) {
+                        this.treeAssociate.lock(false);
+                    }
+
                     this.delegateEvents();
 
                     this.onLoadedEvent = this.lockCategories.bind(this);
@@ -144,6 +148,10 @@ define(
              * Locks a set of categories
              */
             lockCategories: function() {
+                if (this.isReadOnly()) {
+                    return;
+                }
+
                 const lockedCategoryIds = this.getFormData().meta.ascendant_category_ids;
                 lockedCategoryIds.forEach((categoryId) => {
                     const node = $('#node_' + categoryId);
@@ -266,7 +274,11 @@ define(
              */
             isVisible: function () {
                 return true;
-            }
+            },
+
+            isReadOnly: function () {
+                return false;
+            },
         });
     }
 );

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/lib/jquery.jstree.less
@@ -123,6 +123,17 @@
     }
   }
 
+  .jstree-locked {
+    a {
+      color: @AknDarkBlue !important;
+      cursor: default;
+    }
+
+    .jstree-checkbox {
+      display: none;
+    }
+  }
+
   .jstree-tree-toolbar {
     .select2-container-active .select2-choice {
       box-shadow: none;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/jstree/jquery.jstree.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/jstree/jquery.jstree.js
@@ -540,12 +540,12 @@
 
                 lock : function () {
                     this.data.core.locked = true;
-                    this.get_container().children('ul').addClass('jstree-locked').css('opacity', '0.7');
+                    this.get_container().children('ul').addClass('jstree-locked');
                     this.__callback({});
                 },
                 unlock : function () {
                     this.data.core.locked = false;
-                    this.get_container().children('ul').removeClass('jstree-locked').css('opacity', '1');
+                    this.get_container().children('ul').removeClass('jstree-locked');
                     this.__callback({});
                 },
                 is_locked : function () {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- Allow possibility to define category tab is read only => backport of https://github.com/akeneo/pim-community-dev/pull/13362

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
