### PR TITLE
PIM-9699: Fix clicking detail on last operation return 404 on import and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PIM-9690: Fix job remaining in stopping status forever
 - PIM-9700: Add batch-size option in index products command and index product-models command
 - PIM-9701: Fix role deletion when a user do not have any role
+- PIM-9699: Fix clicking detail on last operation return 404 on import and export jobs
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobExecutionController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobExecutionController.php
@@ -87,7 +87,7 @@ class JobExecutionController
         return $archives;
     }
 
-    private function isJobGranted(JobExecution $jobExecution)
+    private function isJobGranted(JobExecution $jobExecution): bool
     {
         $jobExecutionType = $jobExecution->getJobInstance()->getType();
         if (!array_key_exists($jobExecutionType, $this->jobSecurityMapping)) {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Datagrid/GridHelper.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Datagrid/GridHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\ImportExportBundle\Datagrid;
+
+use Oro\Bundle\DataGridBundle\Datasource\ResultRecordInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+
+class GridHelper
+{
+    private SecurityFacade $securityFacade;
+    private array $jobSecurityMapping;
+
+    public function __construct(SecurityFacade $securityFacade, array $jobSecurityMapping)
+    {
+        $this->securityFacade = $securityFacade;
+        $this->jobSecurityMapping = $jobSecurityMapping;
+    }
+
+    public function getActionConfigurationClosure()
+    {
+        return function (ResultRecordInterface $record) {
+            $jobExecutionType = $record->getValue('type');
+            $canViewDetail = true;
+            if (array_key_exists($jobExecutionType, $this->jobSecurityMapping)) {
+                $canViewDetail = $this->securityFacade->isGranted($this->jobSecurityMapping[$jobExecutionType]);
+            }
+
+            return [
+                'view' => $canViewDetail,
+            ];
+        };
+    }
+}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Datagrid/GridHelper.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Datagrid/GridHelper.php
@@ -5,6 +5,10 @@ namespace Akeneo\Platform\Bundle\ImportExportBundle\Datagrid;
 use Oro\Bundle\DataGridBundle\Datasource\ResultRecordInterface;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 
+/**
+ * This class is used by oro datagrid to decide which action is allowed in the product tracker grid.
+ * Here we decide for each row if user can access to the job (there is a specific acl for import an export jobs details)
+ */
 class GridHelper
 {
     private SecurityFacade $securityFacade;

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -55,7 +55,9 @@ services:
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
             - '@pim_internal_api_serializer'
-            -
+            - '@oro_security.security_facade'
+            - {'import': 'pim_importexport_import_execution_show', 'export': 'pim_importexport_export_execution_show'}
+
     pim_enrich.controller.job_tracker:
         public: true
         class: 'Akeneo\Platform\Bundle\ImportExportBundle\Controller\Ui\JobTrackerController'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_tracker.yml
@@ -49,6 +49,7 @@ datagrid:
                     isStoppable: boolean
                     showLink: string
                 data_name: id
+        action_configuration: '@pim_import_export.datagrid.grid_helper->getActionConfigurationClosure'
         actions:
             view:
                 type: navigate

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/grid.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/grid.yml
@@ -7,3 +7,10 @@ services:
         class: '%pim_import_export.datagrid.provider.job.class%'
         arguments:
             - '@akeneo_batch.job.job_registry'
+
+    pim_import_export.datagrid.grid_helper:
+        public: true
+        class: 'Akeneo\Platform\Bundle\ImportExportBundle\Datagrid\GridHelper'
+        arguments:
+            - '@oro_security.security_facade'
+            - {'import': 'pim_importexport_import_execution_show', 'export': 'pim_importexport_export_execution_show'}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/last-operations-widget.js
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/last-operations-widget.js
@@ -31,19 +31,7 @@ define([
      */
     showOperationDetails: function (event) {
       event.preventDefault();
-      var operationType = $(event.currentTarget).data('operation-type');
-
-      switch (operationType) {
-        case 'import':
-        case 'export':
-          router.redirectToRoute('pim_importexport_' + operationType + '_execution_show', {
-            id: $(event.currentTarget).data('id'),
-          });
-          break;
-        default:
-          router.redirectToRoute('pim_enrich_job_tracker_show', {id: $(event.currentTarget).data('id')});
-          break;
-      }
+      router.redirectToRoute('pim_enrich_job_tracker_show', {id: $(event.currentTarget).data('id')});
     },
 
     /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/index.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/execution/index.tsx
@@ -4,9 +4,9 @@ import {ExecutionDetail} from './ExecutionDetail';
 
 const Index = () => {
   return (
-    <Router basename="/job/show">
+    <Router>
       <Switch>
-        <Route path="/:jobExecutionId">
+        <Route path="/job/show/:jobExecutionId">
           <ExecutionDetail />
         </Route>
       </Switch>

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Datagrid/GridHelperSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Datagrid/GridHelperSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Datagrid;
+
+use Oro\Bundle\DataGridBundle\Datasource\ResultRecordInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class GridHelperSpec extends ObjectBehavior
+{
+    public function let(SecurityFacade $securityFacade)
+    {
+        $this->beConstructedWith($securityFacade, [
+            'import' => 'pim_importexport_import_execution_show',
+            'export' => 'pim_importexport_export_execution_show'
+        ]);
+    }
+
+    public function it_enabled_view_action_when_user_have_permission_to_view_job(
+        SecurityFacade $securityFacade,
+        ResultRecordInterface $record
+    ) {
+        $actionConfigurationClosure = $this->getActionConfigurationClosure();
+        $record->getValue('type')->willReturn('export');
+
+        $securityFacade->isGranted('pim_importexport_export_execution_show')->shouldBeCalled()->willReturn(true);
+        $actionConfigurationClosure($record)->shouldReturn([
+            'view' => true
+        ]);
+    }
+
+    public function it_disable_view_action_when_user_does_not_have_permission_to_view_job(
+        SecurityFacade $securityFacade,
+        ResultRecordInterface $record
+    ) {
+        $actionConfigurationClosure = $this->getActionConfigurationClosure();
+        $record->getValue('type')->willReturn('export');
+
+        $securityFacade->isGranted('pim_importexport_export_execution_show')->shouldBeCalled()->willReturn(false);
+        $actionConfigurationClosure($record)->shouldReturn([
+            'view' => false
+        ]);
+    }
+
+    public function it_enabled_view_action_when_there_is_no_acl_related_to_the_job_type(
+        SecurityFacade $securityFacade,
+        ResultRecordInterface $record
+    ) {
+        $actionConfigurationClosure = $this->getActionConfigurationClosure();
+        $record->getValue('type')->willReturn('quick_export');
+
+        $securityFacade->isGranted(Argument::any())->shouldNotBeCalled();
+        $actionConfigurationClosure($record)->shouldReturn([
+            'view' => true
+        ]);
+    }
+}

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Datagrid/GridHelperSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Datagrid/GridHelperSpec.php
@@ -17,7 +17,7 @@ class GridHelperSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_enabled_view_action_when_user_have_permission_to_view_job(
+    public function it_enables_view_action_when_user_have_permission_to_view_job(
         SecurityFacade $securityFacade,
         ResultRecordInterface $record
     ) {
@@ -30,7 +30,7 @@ class GridHelperSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_disable_view_action_when_user_does_not_have_permission_to_view_job(
+    public function it_disables_view_action_when_user_does_not_have_permission_to_view_job(
         SecurityFacade $securityFacade,
         ResultRecordInterface $record
     ) {
@@ -43,7 +43,7 @@ class GridHelperSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_enabled_view_action_when_there_is_no_acl_related_to_the_job_type(
+    public function it_enables_view_action_when_there_is_no_acl_related_to_the_job_type(
         SecurityFacade $securityFacade,
         ResultRecordInterface $record
     ) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR :
- Last operation dashboard redirect to job_tracker view
- Add permission check on process tracker view (user can view export/import detail only if the permission is given)
- Now user cannot click on export/import row in process tracker when user doesn't have permission to display import details

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
