### PR TITLE
API-1483: Fix the test button of the Event Subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PIM-9700: Add batch-size option in index products command and index product-models command
 - PIM-9701: Fix role deletion when a user do not have any role
 - PIM-9699: Fix clicking detail on last operation return 404 on import and export jobs
+- API-1483: Fix the test button of the Event Subscription
 
 ## New features
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -1,5 +1,5 @@
 import {Helper, Link} from 'akeneo-design-system';
-import React, {FC, useContext, useState} from 'react';
+import React, {FC, useContext, useState, SyntheticEvent} from 'react';
 import {useFormContext} from 'react-hook-form';
 import {useHistory} from 'react-router';
 import styled from 'styled-components';
@@ -32,7 +32,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
         checking: false,
     });
 
-    const handleTestUrl = async (e: Event) => {
+    const handleTestUrl = async (e: SyntheticEvent) => {
         e.preventDefault();
         clearError('url');
         setTestUrl({checking: true});
@@ -115,7 +115,7 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                                 message: 'akeneo_connectivity.connection.webhook.error.required',
                             },
                         })}
-                        onKeyDown={event => 'enter' === event.key && handleTestUrl()}
+                        onKeyDown={event => 'enter' === event.key && handleTestUrl(event)}
                     />
                     <TestUrlButton
                         onClick={handleTestUrl}

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -32,7 +32,8 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
         checking: false,
     });
 
-    const handleTestUrl = async () => {
+    const handleTestUrl = async (e: Event) => {
+        e.preventDefault();
         clearError('url');
         setTestUrl({checking: true});
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/TestUrlButton.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/TestUrlButton.tsx
@@ -1,11 +1,11 @@
-import React, {FC} from 'react';
+import React, {FC, SyntheticEvent} from 'react';
 import {GhostButton} from '../../common';
 import styled from '../../common/styled-with-theme';
 import {Translate} from '../../shared/translate';
 import {LoaderIcon} from 'akeneo-design-system';
 
 type Props = {
-    onClick: () => void;
+    onClick: (event: SyntheticEvent) => void;
     disabled: boolean;
     loading: boolean;
 };


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the Event Subscription page, there is `test` button.
Problem is, it's a `<button>` inside a `<form>`, in certains conditions, the button submit a form with `GET`, breaking the URI.

![Screenshot_2021-02-25_10-29-25](https://user-images.githubusercontent.com/1421130/109132901-a5f22480-7754-11eb-936c-2e5a14ad2760.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | yes
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
