### PR TITLE
PIM-9679: Clean line breaks in product and product model imports

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/processors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/processors.yml
@@ -13,6 +13,7 @@ services:
             - '@pim_connector.processor.attribute_filter.product'
             - '@pim_connector.processor.denormalization.media_storer'
             - '@pim_catalog.entity_with_family_variant.remove_parent_from_product'
+            - '@pim_connector.processor.attribute_cleaner.text_attribute_line_break'
 
     pim_connector.processor.denormalization.product_to_import:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer\FindProductToImport'
@@ -103,3 +104,8 @@ services:
         arguments:
             - '@akeneo_file_storage.file_storage.file.file_storer'
             - '@pim_catalog.repository.attribute'
+
+    pim_connector.processor.attribute_cleaner.text_attribute_line_break:
+        class: Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\CleanLineBreaksInTextAttributes
+        arguments:
+            - '@akeneo.pim.structure.query.get_attributes'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/processors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/processors.yml
@@ -32,6 +32,7 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.attribute_filter.product_model'
             - '@pim_connector.processor.denormalization.media_storer'
+            - '@pim_connector.processor.attribute_cleaner.text_attribute_line_break'
             - 'root_product_model'
 
     pim_connector.processor.denormalization.sub_product_model:
@@ -45,6 +46,7 @@ services:
             - '@akeneo_storage_utils.doctrine.object_detacher'
             - '@pim_connector.processor.attribute_filter.product_model'
             - '@pim_connector.processor.denormalization.media_storer'
+            - '@pim_connector.processor.attribute_cleaner.text_attribute_line_break'
             - 'sub_product_model'
 
     pim_connector.processor.denormalization.product_association:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Processor;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\Tool\Component\Batch\Model\Warning;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class CleanLineBreaksInTextAttributes
+{
+    private const LINE_BREAK_REGULAR_EXPRESSION = '/[\r\n|\r|\n]+/';
+
+    private GetAttributes $getAttributes;
+
+    public function __construct(GetAttributes $getAttributes)
+    {
+        $this->getAttributes = $getAttributes;
+    }
+
+    public function cleanStandardFormat(array $item): array
+    {
+        if (!is_array($item['values'] ?? null)) {
+            return $item;
+        }
+
+        $fieldsWithLineBreak = $this->getFieldsWithLineBreak($item);
+        if (0 === count($fieldsWithLineBreak)) {
+            return $item;
+        }
+
+        $textAttributeFieldsToClean = $this->getTextAttributeFieldsToClean($fieldsWithLineBreak);
+
+        foreach ($textAttributeFieldsToClean as $field) {
+            $valuesForField = $item['values'][$field] ?? null;
+            foreach ($valuesForField as $key => $value) {
+                if (is_string($value['data'])) {
+                    $cleanedData = preg_replace(
+                        static::LINE_BREAK_REGULAR_EXPRESSION,
+                        ' ',
+                        $value['data']
+                    );
+                    if ($cleanedData !== $value['data']) {
+                        $item['values'][$field][$key]['data'] = $cleanedData;
+                    }
+                }
+            }
+        }
+
+        return $item;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getFieldsWithLineBreak(array $item): array
+    {
+        $fieldsWithLineBreak = [];
+        foreach ($item['values'] as $field => $values) {
+            foreach ($values as $value) {
+                if (is_string($value['data']) && preg_match(static::LINE_BREAK_REGULAR_EXPRESSION, $value['data'])) {
+                    $fieldsWithLineBreak[] = $field;
+
+                    break;
+                }
+            }
+        }
+
+        return $fieldsWithLineBreak;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getTextAttributeFieldsToClean(array $fieldsWithLineBreak): array
+    {
+        $attributes = $this->getAttributes->forCodes($fieldsWithLineBreak);
+
+        return array_keys(array_filter(
+            $attributes,
+            fn (Attribute $attribute): bool => AttributeTypes::TEXT === $attribute->type()
+        ));
+    }
+}

--- a/src/Akeneo/Tool/Component/Batch/Item/NonBlockingWarningAggregatorInterface.php
+++ b/src/Akeneo/Tool/Component/Batch/Item/NonBlockingWarningAggregatorInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Batch\Item;
+
+use Akeneo\Tool\Component\Batch\Model\Warning;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface NonBlockingWarningAggregatorInterface
+{
+    /**
+     * Return the non blocking warnings. It flushes the warning, that means if we call this method 2 times
+     * in a row the second call will return an empty array.
+     *
+     * @return Warning[]
+     */
+    public function flushNonBlockingWarnings(): array;
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributesSpec.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Processor;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use PhpSpec\ObjectBehavior;
+
+final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
+{
+    function let(GetAttributes $getAttributes)
+    {
+        $this->beConstructedWith($getAttributes);
+    }
+
+    function it_cleans_text_atributes_and_returns_cleaned_fields(GetAttributes $getAttributes)
+    {
+        $item = ['values' => [
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => "line\nbreak"],
+            ],
+            'subtitle' => [
+                ['data' => "another line\nbreak"],
+            ],
+            'description' => [
+                ['data' => 'ok'],
+                ['data' => "line\r\nbreak"],
+            ],
+        ]];
+
+        $getAttributes->forCodes(['title', 'subtitle', 'description'])->willReturn([
+            'title' => $this->buildAttribute('title', AttributeTypes::TEXT),
+            'subtitle' => $this->buildAttribute('subtitle', AttributeTypes::TEXT),
+            'description' => $this->buildAttribute('description', AttributeTypes::TEXTAREA),
+        ]);
+
+        $this->cleanStandardFormat($item)->shouldReturn(['values' => [
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => 'line break'],
+            ],
+            'subtitle' => [
+                ['data' => 'another line break'],
+            ],
+            'description' => [
+                ['data' => 'ok'],
+                ['data' => "line\r\nbreak"],
+            ],
+        ]]);
+    }
+
+    function it_cannot_clean_if_field_is_unknown(GetAttributes $getAttributes)
+    {
+        $item = ['values' => [
+            'unknown' => [
+                ['data' => 'ok'],
+                ['data' => "line\nbreak"],
+            ],
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => "line\nbreak1"],
+                ['data' => "line\nbreak2"],
+            ],
+        ]];
+
+        $getAttributes->forCodes(['unknown', 'title'])->willReturn([
+            'title' => $this->buildAttribute('title', AttributeTypes::TEXT),
+        ]);
+
+        $this->cleanStandardFormat($item)->shouldReturn(['values' => [
+            'unknown' => [
+                ['data' => 'ok'],
+                ['data' => "line\nbreak"],
+            ],
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => 'line break1'],
+                ['data' => 'line break2'],
+            ],
+        ]]);
+    }
+
+    function it_cleans_several_sort_of_line_breaks(GetAttributes $getAttributes)
+    {
+        $item = ['values' => [
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => "line\r\nbreak1"],
+                ['data' => "line\rbreak2"],
+                ['data' => "line\nbreak3"],
+                ['data' => "line\n\n\nbreak4"],
+            ],
+        ]];
+
+        $getAttributes->forCodes(['title'])->willReturn([
+            'title' => $this->buildAttribute('title', AttributeTypes::TEXT),
+        ]);
+
+        $this->cleanStandardFormat($item)->shouldReturn(['values' => [
+            'title' => [
+                ['data' => 'ok'],
+                ['data' => 'line break1'],
+                ['data' => 'line break2'],
+                ['data' => 'line break3'],
+                ['data' => 'line break4'],
+            ],
+        ]]);
+    }
+
+    private function buildAttribute(string $code, string $type): Attribute
+    {
+        return new Attribute(
+            $code,
+            $type,
+            [],
+            true,
+            true,
+            null,
+            null,
+            null,
+            '',
+            []
+        );
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Denormalizer/ProductProcessorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Denormalizer/ProductProcessorSpec.php
@@ -2,9 +2,12 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\CleanLineBreaksInTextAttributes;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer\MediaStorer;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Tool\Component\Batch\Item\NonBlockingWarningAggregatorInterface;
+use Akeneo\Tool\Component\Batch\Model\Warning;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
 use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
@@ -39,7 +42,8 @@ class ProductProcessorSpec extends ObjectBehavior
         FilterInterface $productFilter,
         AttributeFilterInterface $productAttributeFilter,
         MediaStorer $mediaStorer,
-        RemoveParentInterface $removeParent
+        RemoveParentInterface $removeParent,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes
     ) {
         $productRepository->getIdentifierProperties()->willReturn(['sku']);
         $this->beConstructedWith(
@@ -52,7 +56,8 @@ class ProductProcessorSpec extends ObjectBehavior
             $productFilter,
             $productAttributeFilter,
             $mediaStorer,
-            $removeParent
+            $removeParent,
+            $cleanLineBreaksInTextAttributes
         );
         $this->setStepExecution($stepExecution);
     }
@@ -61,6 +66,7 @@ class ProductProcessorSpec extends ObjectBehavior
     {
         $this->shouldImplement(ItemProcessorInterface::class);
         $this->shouldImplement(StepExecutionAwareInterface::class);
+        $this->shouldImplement(NonBlockingWarningAggregatorInterface::class);
     }
 
     function it_updates_an_existing_product(
@@ -72,6 +78,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productToImport,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -155,6 +162,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -166,6 +174,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $this
             ->process($convertedData)
             ->shouldReturn($product);
+        $this->flushNonBlockingWarnings()->shouldHaveCount(0);
     }
 
     function it_updates_an_existing_product_with_filtered_values(
@@ -177,6 +186,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -262,6 +272,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $preFilteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -284,6 +295,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -367,6 +379,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, [])->shouldNotBeCalled();
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -426,6 +439,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -510,6 +524,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->willThrow(new InvalidPropertyException('family', 'value', 'className', 'family does not exists'));
@@ -535,6 +550,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -619,6 +635,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -648,6 +665,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         JobParameters $jobParameters
     ) {
@@ -729,6 +747,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn([]);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)->shouldNotBeCalled();
 
@@ -749,6 +768,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -834,6 +854,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -856,6 +877,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ConstraintViolationListInterface $violationList,
         JobParameters $jobParameters
@@ -901,6 +923,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -924,6 +947,7 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter,
         $addParent,
         $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
         ProductInterface $product,
         ProductInterface $productInDB,
         ConstraintViolationListInterface $violationList,
@@ -996,6 +1020,7 @@ class ProductProcessorSpec extends ObjectBehavior
 
         $productFilter->filter($product, $filteredData)->willReturn($filteredData);
 
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($filteredData);
         $productUpdater
             ->update($product, $filteredData)
             ->shouldBeCalled();
@@ -1017,7 +1042,8 @@ class ProductProcessorSpec extends ObjectBehavior
         ValidatorInterface $productValidator,
         RemoveParentInterface $removeParent,
         JobParameters $jobParameters,
-        ProductInterface $product
+        ProductInterface $product,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes
     ) {
         $item = [
             'identifier' => 'my_sku',
@@ -1036,6 +1062,8 @@ class ProductProcessorSpec extends ObjectBehavior
         $productAttributeFilter->filter($item)->willReturn($filteredItem);
         $product->isVariant()->willReturn(true);
         $productToImport->fromFlatData('my_sku', 'clothing')->willReturn($product);
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat(['parent' => ''])
+            ->willReturn(['parent' => '']);
 
         $removeParent->from($product)->shouldBeCalled();
         $productUpdater->update($product, ['parent' => ''])->shouldBeCalled();
@@ -1052,7 +1080,8 @@ class ProductProcessorSpec extends ObjectBehavior
         ValidatorInterface $productValidator,
         RemoveParentInterface $removeParent,
         JobParameters $jobParameters,
-        ProductInterface $product
+        ProductInterface $product,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes
     ) {
         $item = [
             'identifier' => 'my_sku',
@@ -1074,11 +1103,116 @@ class ProductProcessorSpec extends ObjectBehavior
             'enabled' => true,
         ])->shouldBeCalled()->willReturn($filteredItem);
         $productToImport->fromFlatData('my_sku', 'clothing')->willReturn($product);
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat(['enabled' => true])->willReturn(['enabled' => true]);
 
         $removeParent->from($product)->shouldNotBeCalled();
         $productUpdater->update($product, ['enabled' => true])->shouldBeCalled();
         $productValidator->validate($product)->willReturn(new ConstraintViolationList([]));
 
         $this->process($item)->shouldReturn($product);
+    }
+
+    function it_flushes_non_blocking_warnings_when_text_attributes_contain_a_line_break(
+        FindProductToImport $productToImport,
+        AddParent $addParent,
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
+        StepExecution $stepExecution,
+        FilterInterface $productFilter,
+        AttributeFilterInterface $productAttributeFilter,
+        MediaStorer $mediaStorer,
+        CleanLineBreaksInTextAttributes $cleanLineBreaksInTextAttributes,
+        ProductInterface $product,
+        JobParameters $jobParameters
+    ) {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('enabledComparison')->willReturn(true);
+        $jobParameters->get('familyColumn')->willReturn('family');
+        $jobParameters->get('categoriesColumn')->willReturn('categories');
+        $jobParameters->get('groupsColumn')->willReturn('groups');
+        $jobParameters->get('enabled')->willReturn(true);
+        $jobParameters->get('decimalSepara7tor')->willReturn('.');
+        $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
+        $jobParameters->get('convertVariantToSimple')->willReturn(false);
+
+        $productToImport->fromFlatData('tshirt', 'Summer Tshirt')->willReturn($product);
+        $product->getId()->willReturn(42);
+
+        $addParent->to($product, '')->willReturn($product);
+
+        $convertedData = [
+            'identifier' => 'tshirt',
+            'family'     => 'Summer Tshirt',
+            'values'     => [
+                'sku'         => [
+                    [
+                        'locale' => null,
+                        'scope'  => null,
+                        'data'   => 'tshirt'
+                    ],
+                ],
+                'name'        => [
+                    [
+                        'locale' => 'fr_FR',
+                        'scope'  => null,
+                        'data'   => "Mon super beau \nt-shirt",
+                    ],
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => null,
+                        'data'   => 'My very awesome T-shirt',
+                    ]
+                ],
+                'description' => [
+                    [
+                        'locale' => 'en_US',
+                        'scope'  => 'mobile',
+                        'data'   => "My awesome description\n",
+                    ]
+                ]
+            ]
+        ];
+
+        $productAttributeFilter->filter(Argument::type('array'))->willReturn($convertedData);
+
+        $filteredData = [
+            'family' => 'Summer Tshirt',
+            'family' => 'Summer Tshirt',
+            'values' => [
+                'name' => [
+                    ['locale' => 'fr_FR', 'scope' => null, 'data' => "Mon super beau \nt-shirt"],
+                    ['locale' => 'en_US', 'scope' => null, 'data' => 'My very awesome T-shirt'],
+                ],
+                'description' => [
+                    ['locale' => 'en_US', 'scope' => 'mobile', 'data' => "My awesome description\n"],
+                ],
+            ],
+        ];
+
+        $mediaStorer->store($filteredData['values'])->willReturn($filteredData['values']);
+        $productFilter->filter($product, $filteredData)->willReturn($filteredData);
+        $cleanedFilteredItem = [
+            'family' => 'Summer Tshirt',
+            'values' => [
+                'name' => [
+                    ['locale' => 'fr_FR', 'scope' => null, 'data' => 'Mon super beau t-shirt'],
+                    ['locale' => 'en_US', 'scope' => null, 'data' => 'My very awesome T-shirt'],
+                ],
+                'description' => [
+                    ['locale' => 'en_US', 'scope' => 'mobile', 'data' => 'My awesome description'],
+                ],
+            ],
+        ];
+        $cleanLineBreaksInTextAttributes->cleanStandardFormat($filteredData)->willReturn($cleanedFilteredItem);
+        $productUpdater->update($product, $cleanedFilteredItem)->shouldBeCalled();
+
+        $productValidator->validate($product)->willReturn(new ConstraintViolationList([]));
+
+        $this->process($convertedData)->shouldReturn($product);
+        $nonBlockingwarnings = $this->flushNonBlockingWarnings();
+        $nonBlockingwarnings->shouldHaveCount(2);
+        $nonBlockingwarnings[0]->shouldBeAnInstanceOf(Warning::class);
+        $nonBlockingwarnings[1]->shouldBeAnInstanceOf(Warning::class);
+        $this->flushNonBlockingWarnings()->shouldHaveCount(0);
     }
 }


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-9679

During import we display a warning message when a value is fixed

Part1:
- [x] skip line break in product import and display message
- [x] skip line break in product model import and display message

Part2: Done in another PR

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
