### PR TITLE
PLG-63: Fix product-grid grouped variant filter dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PIM-9701: Fix role deletion when a user do not have any role
 - PIM-9699: Fix clicking detail on last operation return 404 on import and export jobs
 - API-1483: Fix the test button of the Event Subscription
+- PLG-63: Fix product-grid grouped variant filter dropdown
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/grouped-variant-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/grouped-variant-filter.js
@@ -11,12 +11,12 @@ define([
     template: _.template(template),
     className: 'AknDropdown AknDropdown--left AknTitleContainer-variantSelector',
     events: {
-      'click .display-grouped-item': '_onValueChange',
+      'click .AknDropdown-menuLink': '_onValueChange',
     },
     placeholder: __('pim_datagrid.filters.entity_type.grouped'),
 
     _onValueChange: function (event) {
-      const value = this.$(event.target).data('value');
+      const value = this.$(event.currentTarget).find('.display-grouped-item').data('value');
       this.setValue({value});
     },
 


### PR DESCRIPTION
On the product-grid, the "click" to switch the view between "group" and "ungrouped" variants was only on the word, and not the full line.