### PR TITLE
API-1471 move log buffer to repository

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -15,6 +15,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookRequest;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Exception\WebhookEventDataBuilderNotFoundException;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read\ActiveWebhook;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\SelectActiveWebhooksQuery;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiRequestCountRepository;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
@@ -36,6 +37,7 @@ final class SendBusinessEventToWebhooksHandler
     private SkipOwnEventLogger $skipOwnEventLogger;
     private LoggerInterface $logger;
     private EventsApiDebugLogger $eventsApiDebugLogger;
+    private EventsApiDebugRepository $eventsApiDebugRepository;
     private EventsApiRequestCountRepository $eventsApiRequestRepository;
     private CacheClearerInterface $cacheClearer;
     private string $pimSource;
@@ -50,6 +52,7 @@ final class SendBusinessEventToWebhooksHandler
         SkipOwnEventLogger $skipOwnEventLogger,
         LoggerInterface $logger,
         EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository,
         EventsApiRequestCountRepository $eventsApiRequestRepository,
         CacheClearerInterface $cacheClearer,
         string $pimSource,
@@ -63,6 +66,7 @@ final class SendBusinessEventToWebhooksHandler
         $this->skipOwnEventLogger = $skipOwnEventLogger;
         $this->logger = $logger;
         $this->eventsApiDebugLogger = $eventsApiDebugLogger;
+        $this->eventsApiDebugRepository = $eventsApiDebugRepository;
         $this->eventsApiRequestRepository = $eventsApiRequestRepository;
         $this->cacheClearer = $cacheClearer;
         $this->pimSource = $pimSource;
@@ -132,7 +136,7 @@ final class SendBusinessEventToWebhooksHandler
         $this->client->bulkSend($requests());
 
         $this->cacheClearer->clear();
-        $this->eventsApiDebugLogger->flushLogs();
+        $this->eventsApiDebugRepository->flush();
     }
 
     private function filterConnectionOwnEvents(

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
@@ -17,28 +17,13 @@ use Akeneo\Platform\Component\EventQueue\EventInterface;
  */
 class EventsApiDebugLogger
 {
-    private int $bufferSize;
-
-    /**
-     * @var array<array{
-     *  timestamp: int,
-     *  level: string,
-     *  message: string,
-     *  connection_code: ?string,
-     *  context: array
-     * }>
-     */
-    private array $buffer;
-
     private Clock $clock;
 
     private EventsApiDebugRepository $repository;
 
     private EventNormalizerInterface $defaultEventNormalizer;
 
-    /**
-     * @var iterable<EventNormalizerInterface>
-     */
+    /** @var iterable<EventNormalizerInterface> */
     private iterable $eventNormalizers;
 
     /**
@@ -47,22 +32,19 @@ class EventsApiDebugLogger
     public function __construct(
         EventsApiDebugRepository $repository,
         Clock $clock,
-        iterable $eventNormalizers,
-        int $bufferSize = 100
+        iterable $eventNormalizers
     ) {
         $this->repository = $repository;
         $this->clock = $clock;
         $this->defaultEventNormalizer = new EventNormalizer();
         $this->eventNormalizers = $eventNormalizers;
-        $this->bufferSize = $bufferSize;
-        $this->buffer = [];
     }
 
     public function logEventSubscriptionSkippedOwnEvent(
         string $connectionCode,
         EventInterface $event
     ): void {
-        $this->addLog([
+        $this->repository->persist([
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::NOTICE,
             'message' => 'The event was not sent because it was raised by the same connection.',
@@ -75,41 +57,13 @@ class EventsApiDebugLogger
 
     public function logLimitOfEventsApiRequestsReached(): void
     {
-        $this->addLog([
+        $this->repository->persist([
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::WARNING,
             'message' => 'The maximum number of events sent per hour has been reached.',
             'connection_code' => null,
             'context' => [],
         ]);
-    }
-
-    public function flushLogs(): void
-    {
-        if (0 === count($this->buffer)) {
-            return;
-        }
-
-        $this->repository->bulkInsert($this->buffer);
-        $this->buffer = [];
-    }
-
-    /**
-     * @param array{
-     *  timestamp: int,
-     *  level: string,
-     *  message: string,
-     *  connection_code: ?string,
-     *  context: array
-     * } $log
-     */
-    private function addLog(array $log): void
-    {
-        $this->buffer[] = $log;
-
-        if (count($this->buffer) >= $this->bufferSize) {
-            $this->flushLogs();
-        }
     }
 
     /**

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Persistence/Repository/EventsApiDebugRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Persistence/Repository/EventsApiDebugRepository.php
@@ -11,13 +11,23 @@ namespace Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository;
 interface EventsApiDebugRepository
 {
     /**
-     * @param array<array{
+     * Tells the repository to make a log entry persistent.
+     *
+     * Invoking the persist method does NOT save the log immediately,
+     * you need to call the flush method to effectively do it.
+     *
+     * @param array{
      *  timestamp: int,
      *  level: string,
      *  message: string,
      *  connection_code: ?string,
      *  context: array
-     * }> $documents
+     * } $log
      */
-    public function bulkInsert(array $documents): void;
+    public function persist(array $log): void;
+
+    /**
+     * Saves all the log entries that have been queued up to now.
+     */
+    public function flush(): void;
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
-use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionRequestsLimitReachedLog;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\GetDelayUntilNextRequest;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\Sleep;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -24,19 +24,22 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
     private Sleep $sleep;
     private ReachRequestLimitLogger $reachRequestLimitLogger;
     private EventsApiDebugLogger $eventsApiDebugLogger;
+    private EventsApiDebugRepository $eventsApiDebugRepository;
 
     public function __construct(
         GetDelayUntilNextRequest $getDelayUntilNextRequest,
         int $webhookRequestsLimit,
         Sleep $sleep,
         ReachRequestLimitLogger $reachRequestLimitLogger,
-        EventsApiDebugLogger $eventsApiDebugLogger
+        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository
     ) {
         $this->getDelayUntilNextRequest = $getDelayUntilNextRequest;
         $this->webhookRequestsLimit = $webhookRequestsLimit;
         $this->sleep = $sleep;
         $this->reachRequestLimitLogger = $reachRequestLimitLogger;
         $this->eventsApiDebugLogger = $eventsApiDebugLogger;
+        $this->eventsApiDebugRepository = $eventsApiDebugRepository;
     }
 
     public static function getSubscribedEvents(): array
@@ -61,7 +64,7 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
             );
 
             $this->eventsApiDebugLogger->logLimitOfEventsApiRequestsReached();
-            $this->eventsApiDebugLogger->flushLogs();
+            $this->eventsApiDebugRepository->flush();
 
             $this->sleep->sleep($delayUntilNextRequest);
         }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/event_subscribers.yml
@@ -25,5 +25,6 @@ services:
             - '@akeneo_connectivity.connection.webhook.sleep'
             - '@akeneo_connectivity.connection.webhook.reach_request_limit_logger'
             - '@akeneo_connectivity.connection.webhook.events_api_debug_logger'
+            - '@akeneo_connectivity.connection.persistence.repository.events_api_debug'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -104,6 +104,7 @@ services:
             - '@akeneo_connectivity.connection.webhook.skip_own_event_logger'
             - '@monolog.logger.event_api'
             - '@akeneo_connectivity.connection.webhook.events_api_debug_logger'
+            - '@akeneo_connectivity.connection.persistence.repository.events_api_debug'
             - '@akeneo_connectivity.connection.persistence.repository.events_api_request_count'
             - '@akeneo_connectivity.connection.webhook.cache_clearer'
             - '%env(AKENEO_PIM_URL)%'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
@@ -27,28 +27,25 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
         $this->elasticsearchClient = $this->get('akeneo_connectivity.client.events_api_debug');
     }
 
-    public function test_it_bulk_inserts(): void
+    public function test_it_saves_logs(): void
     {
-        $documents = [
-            [
-                'timestamp' => 631152000,
-                'level' => 'info',
-                'message' => 'An information message.',
-                'connection_code' => null,
-                'context' => [
-                    'data' => 'Some more informations.',
-                ],
+        $this->elasticsearchEventsApiDebugRepository->persist([
+            'timestamp' => 631152000,
+            'level' => 'info',
+            'message' => 'An information message.',
+            'connection_code' => null,
+            'context' => [
+                'data' => 'Some more informations.',
             ],
-            [
-                'timestamp' => 946684800,
-                'level' => 'warning',
-                'message' => 'A warning message!',
-                'connection_code' => 'erp_0000',
-                'context' => [],
-            ],
-        ];
-
-        $this->elasticsearchEventsApiDebugRepository->bulkInsert($documents);
+        ]);
+        $this->elasticsearchEventsApiDebugRepository->persist([
+            'timestamp' => 946684800,
+            'level' => 'warning',
+            'message' => 'A warning message!',
+            'connection_code' => 'erp_0000',
+            'context' => [],
+        ]);
+        $this->elasticsearchEventsApiDebugRepository->flush();
 
         $this->elasticsearchClient->refreshIndex();
         $result = $this->elasticsearchClient->search([]);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -17,6 +17,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Client\WebhookRequest;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read\ActiveWebhook;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\SelectActiveWebhooksQuery;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Repository\DbalEventsApiRequestCountRepository;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
@@ -45,7 +46,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         LoggerInterface $logger,
         DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         CacheClearerInterface $cacheClearer,
-        EventsApiDebugLogger $eventsApiDebugLogger
+        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $this->beConstructedWith(
             $selectActiveWebhooksQuery,
@@ -56,6 +58,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $skipOwnEventLogger,
             $logger,
             $eventsApiDebugLogger,
+            $eventsApiDebugRepository,
             $eventsApiRequestRepository,
             $cacheClearer,
             'staging.akeneo.com'
@@ -320,7 +323,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $eventsApiRequestRepository,
         $cacheClearer,
         LoggerInterface $logger,
-        EventsApiDebugLogger $eventsApiDebugLogger
+        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $getTimeIterable = (function () {
             yield 2; // Start - subscription 1
@@ -347,6 +351,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $skipOwnEventLogger,
             $logger,
             $eventsApiDebugLogger,
+            $eventsApiDebugRepository,
             $eventsApiRequestRepository,
             $cacheClearer,
             'staging.akeneo.com',
@@ -407,6 +412,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         SelectActiveWebhooksQuery $selectActiveWebhooksQuery,
         WebhookUserAuthenticator $webhookUserAuthenticator,
         EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository,
         DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         WebhookClient $client
     ): void {
@@ -429,7 +435,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $eventsApiDebugLogger->logEventSubscriptionSkippedOwnEvent('erp', $pimEvent)
             ->shouldBeCalled();
 
-        $eventsApiDebugLogger->flushLogs()
+        $eventsApiDebugRepository->flush()
             ->shouldBeCalled();
 
         $eventsApiRequestRepository->upsert(Argument::cetera())
@@ -454,7 +460,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $timestamp = 1577836800;
         $uuid = '5d30d0f6-87a6-45ad-ba6b-3a302b0d328c';
 
-        return new class($author, $data, $timestamp, $uuid) extends Event
+        return new class ($author, $data, $timestamp, $uuid) extends Event
         {
             public function getName(): string
             {

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
@@ -46,8 +46,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
             1
         );
 
-        $eventsApiDebugRepository->bulkInsert([
-            [
+        $eventsApiDebugRepository->persist([
                 'timestamp' => 1609459200,
                 'level' => 'notice',
                 'message' => 'The event was not sent because it was raised by the same connection.',
@@ -61,8 +60,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
                         'author_type' => 'ui',
                     ]
                 ],
-            ]
-        ])
+            ])
             ->shouldBeCalled();
 
         $this->logEventSubscriptionSkippedOwnEvent('erp_000', $this->createEvent());
@@ -78,55 +76,21 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
             1
         );
 
-        $eventsApiDebugRepository->bulkInsert([
-            [
+        $eventsApiDebugRepository->persist([
                 'timestamp' => 1609459200,
                 'level' => 'warning',
                 'message' => 'The maximum number of events sent per hour has been reached.',
                 'connection_code' => null,
                 'context' => [],
-            ]
-        ])
+            ])
             ->shouldBeCalled();
 
-        $this->logLimitOfEventsApiRequestsReached();
-    }
-
-    public function it_flushs_logs_in_the_buffer(
-        EventsApiDebugRepository $eventsApiDebugRepository
-    ): void {
-        $eventsApiDebugRepository->bulkInsert(Argument::size(4))
-            ->shouldBeCalled();
-
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->flushLogs();
-    }
-
-    public function it_flushs_logs_once_the_buffer_is_full(
-        EventsApiDebugRepository $eventsApiDebugRepository
-    ): void {
-        $this->beConstructedWith(
-            $eventsApiDebugRepository,
-            new FakeClock(new \DateTimeImmutable('2021-01-01T00:00:00+00:00')),
-            [],
-            2
-        );
-
-        $eventsApiDebugRepository->bulkInsert(Argument::size(2))
-            ->shouldBeCalledTimes(2);
-
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->logLimitOfEventsApiRequestsReached();
-        $this->logLimitOfEventsApiRequestsReached();
         $this->logLimitOfEventsApiRequestsReached();
     }
 
     private function createEvent(): EventInterface
     {
-        $event = new class(
+        $event = new class (
             Author::fromNameAndType('julia', Author::TYPE_UI),
             [],
             0,

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
-use Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionRequestsLimitReachedLog;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitEventSubscriber;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\GetDelayUntilNextRequest;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\Sleep;
@@ -21,14 +21,16 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
         GetDelayUntilNextRequest $getDelayUntilNextRequest,
         Sleep $sleep,
         ReachRequestLimitLogger $reachRequestLimitLogger,
-        EventsApiDebugLogger $eventsApiDebugLogger
+        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $this->beConstructedWith(
             $getDelayUntilNextRequest,
             10,
             $sleep,
             $reachRequestLimitLogger,
-            $eventsApiDebugLogger
+            $eventsApiDebugLogger,
+            $eventsApiDebugRepository
         );
     }
 
@@ -62,7 +64,8 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
 
     public function it_logs_for_the_events_api_debug_that_the_limit_is_reached(
         GetDelayUntilNextRequest $getDelayUntilNextRequest,
-        EventsApiDebugLogger $eventsApiDebugLogger
+        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $getDelayUntilNextRequest
             ->execute(Argument::cetera())
@@ -70,7 +73,7 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
 
         $eventsApiDebugLogger->logLimitOfEventsApiRequestsReached()
             ->shouldBeCalled();
-        $eventsApiDebugLogger->flushLogs()
+        $eventsApiDebugRepository->flush()
             ->shouldBeCalled();
 
         $this->checkWebhookRequestLimit();


### PR DESCRIPTION
We buffer the log to optimise the indexation in elasticsearch.
This PR aime to decouple the buffering from the logger and add it to the persistence layer.