### PR TITLE
API-1471 add interfaces to events api debug logger

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Application\Webhook\Command;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
-use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventSubscriptionSkippedOwnEventLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\EventBuildLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\SkipOwnEventLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookEventBuilder;
@@ -36,7 +36,7 @@ final class SendBusinessEventToWebhooksHandler
     private EventBuildLogger $eventBuildLogger;
     private SkipOwnEventLogger $skipOwnEventLogger;
     private LoggerInterface $logger;
-    private EventsApiDebugLogger $eventsApiDebugLogger;
+    private EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger;
     private EventsApiDebugRepository $eventsApiDebugRepository;
     private EventsApiRequestCountRepository $eventsApiRequestRepository;
     private CacheClearerInterface $cacheClearer;
@@ -51,7 +51,7 @@ final class SendBusinessEventToWebhooksHandler
         EventBuildLogger $eventBuildLogger,
         SkipOwnEventLogger $skipOwnEventLogger,
         LoggerInterface $logger,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger,
         EventsApiDebugRepository $eventsApiDebugRepository,
         EventsApiRequestCountRepository $eventsApiRequestRepository,
         CacheClearerInterface $cacheClearer,
@@ -65,7 +65,7 @@ final class SendBusinessEventToWebhooksHandler
         $this->eventBuildLogger = $eventBuildLogger;
         $this->skipOwnEventLogger = $skipOwnEventLogger;
         $this->logger = $logger;
-        $this->eventsApiDebugLogger = $eventsApiDebugLogger;
+        $this->eventSubscriptionSkippedOwnEventLogger = $eventSubscriptionSkippedOwnEventLogger;
         $this->eventsApiDebugRepository = $eventsApiDebugRepository;
         $this->eventsApiRequestRepository = $eventsApiRequestRepository;
         $this->cacheClearer = $cacheClearer;
@@ -150,7 +150,7 @@ final class SendBusinessEventToWebhooksHandler
                 if ($username === $event->getAuthor()->name()) {
                     $this->skipOwnEventLogger->log($event, $webhook->connectionCode());
 
-                    $this->eventsApiDebugLogger
+                    $this->eventSubscriptionSkippedOwnEventLogger
                         ->logEventSubscriptionSkippedOwnEvent(
                             $webhook->connectionCode(),
                             $event

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventSubscriptionSkippedOwnEventLogger.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventSubscriptionSkippedOwnEventLogger.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
+
+use Akeneo\Platform\Component\EventQueue\EventInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface EventSubscriptionSkippedOwnEventLogger
+{
+    public function logEventSubscriptionSkippedOwnEvent(
+        string $connectionCode,
+        EventInterface $event
+    ): void;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
@@ -15,7 +15,7 @@ use Akeneo\Platform\Component\EventQueue\EventInterface;
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class EventsApiDebugLogger
+class EventsApiDebugLogger implements EventSubscriptionSkippedOwnEventLogger, LimitOfEventsApiRequestsReachedLogger
 {
     private Clock $clock;
 

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/LimitOfEventsApiRequestsReachedLogger.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/LimitOfEventsApiRequestsReachedLogger.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface LimitOfEventsApiRequestsReachedLogger
+{
+    public function logLimitOfEventsApiRequestsReached(): void;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
-use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\LimitOfEventsApiRequestsReachedLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\GetDelayUntilNextRequest;
@@ -23,7 +23,7 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
     private int $webhookRequestsLimit;
     private Sleep $sleep;
     private ReachRequestLimitLogger $reachRequestLimitLogger;
-    private EventsApiDebugLogger $eventsApiDebugLogger;
+    private LimitOfEventsApiRequestsReachedLogger $limitOfEventsApiRequestsReachedLogger;
     private EventsApiDebugRepository $eventsApiDebugRepository;
 
     public function __construct(
@@ -31,14 +31,14 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
         int $webhookRequestsLimit,
         Sleep $sleep,
         ReachRequestLimitLogger $reachRequestLimitLogger,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        LimitOfEventsApiRequestsReachedLogger $limitOfEventsApiRequestsReachedLogger,
         EventsApiDebugRepository $eventsApiDebugRepository
     ) {
         $this->getDelayUntilNextRequest = $getDelayUntilNextRequest;
         $this->webhookRequestsLimit = $webhookRequestsLimit;
         $this->sleep = $sleep;
         $this->reachRequestLimitLogger = $reachRequestLimitLogger;
-        $this->eventsApiDebugLogger = $eventsApiDebugLogger;
+        $this->limitOfEventsApiRequestsReachedLogger = $limitOfEventsApiRequestsReachedLogger;
         $this->eventsApiDebugRepository = $eventsApiDebugRepository;
     }
 
@@ -63,7 +63,7 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
                 $delayUntilNextRequest
             );
 
-            $this->eventsApiDebugLogger->logLimitOfEventsApiRequestsReached();
+            $this->limitOfEventsApiRequestsReachedLogger->logLimitOfEventsApiRequestsReached();
             $this->eventsApiDebugRepository->flush();
 
             $this->sleep->sleep($delayUntilNextRequest);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -7,7 +7,7 @@ namespace spec\Akeneo\Connectivity\Connection\Application\Webhook\Command;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\CacheClearerInterface;
-use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventSubscriptionSkippedOwnEventLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\EventBuildLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\SkipOwnEventLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\WebhookEventBuilder;
@@ -46,7 +46,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         LoggerInterface $logger,
         DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         CacheClearerInterface $cacheClearer,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger,
         EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $this->beConstructedWith(
@@ -57,7 +57,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $eventBuildLogger,
             $skipOwnEventLogger,
             $logger,
-            $eventsApiDebugLogger,
+            $eventSubscriptionSkippedOwnEventLogger,
             $eventsApiDebugRepository,
             $eventsApiRequestRepository,
             $cacheClearer,
@@ -323,7 +323,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $eventsApiRequestRepository,
         $cacheClearer,
         LoggerInterface $logger,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger,
         EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $getTimeIterable = (function () {
@@ -350,7 +350,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $eventBuildLogger,
             $skipOwnEventLogger,
             $logger,
-            $eventsApiDebugLogger,
+            $eventSubscriptionSkippedOwnEventLogger,
             $eventsApiDebugRepository,
             $eventsApiRequestRepository,
             $cacheClearer,
@@ -411,7 +411,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
     public function test_it_logs_for_the_events_api_debug_when_an_event_subscription_skipped_its_own_event(
         SelectActiveWebhooksQuery $selectActiveWebhooksQuery,
         WebhookUserAuthenticator $webhookUserAuthenticator,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger,
         EventsApiDebugRepository $eventsApiDebugRepository,
         DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         WebhookClient $client
@@ -432,7 +432,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $pimEvent = $this->createEvent($author, []);
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
-        $eventsApiDebugLogger->logEventSubscriptionSkippedOwnEvent('erp', $pimEvent)
+        $eventSubscriptionSkippedOwnEventLogger->logEventSubscriptionSkippedOwnEvent('erp', $pimEvent)
             ->shouldBeCalled();
 
         $eventsApiDebugRepository->flush()

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace spec\Akeneo\Connectivity\Connection\Application\Webhook\Service;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
-use Akeneo\Connectivity\Connection\Domain\Webhook\EventNormalizer\EventNormalizer;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventSubscriptionSkippedOwnEventLogger;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\LimitOfEventsApiRequestsReachedLogger;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\Service\Clock\FakeClock;
-use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\Event;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -45,6 +44,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
             [],
             1
         );
+        $this->shouldImplement(EventSubscriptionSkippedOwnEventLogger::class);
 
         $eventsApiDebugRepository->persist([
                 'timestamp' => 1609459200,
@@ -75,6 +75,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
             [],
             1
         );
+        $this->shouldImplement(LimitOfEventsApiRequestsReachedLogger::class);
 
         $eventsApiDebugRepository->persist([
                 'timestamp' => 1609459200,

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
-use Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger;
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\LimitOfEventsApiRequestsReachedLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitEventSubscriber;
@@ -21,7 +21,7 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
         GetDelayUntilNextRequest $getDelayUntilNextRequest,
         Sleep $sleep,
         ReachRequestLimitLogger $reachRequestLimitLogger,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        LimitOfEventsApiRequestsReachedLogger $limitOfEventsApiRequestsReachedLogger,
         EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $this->beConstructedWith(
@@ -29,7 +29,7 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
             10,
             $sleep,
             $reachRequestLimitLogger,
-            $eventsApiDebugLogger,
+            $limitOfEventsApiRequestsReachedLogger,
             $eventsApiDebugRepository
         );
     }
@@ -64,14 +64,14 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
 
     public function it_logs_for_the_events_api_debug_that_the_limit_is_reached(
         GetDelayUntilNextRequest $getDelayUntilNextRequest,
-        EventsApiDebugLogger $eventsApiDebugLogger,
+        LimitOfEventsApiRequestsReachedLogger $limitOfEventsApiRequestsReachedLogger,
         EventsApiDebugRepository $eventsApiDebugRepository
     ): void {
         $getDelayUntilNextRequest
             ->execute(Argument::cetera())
             ->willReturn(1);
 
-        $eventsApiDebugLogger->logLimitOfEventsApiRequestsReached()
+        $limitOfEventsApiRequestsReachedLogger->logLimitOfEventsApiRequestsReached()
             ->shouldBeCalled();
         $eventsApiDebugRepository->flush()
             ->shouldBeCalled();


### PR DESCRIPTION
Add two interfaces to the Events API logger:
- limit of events api request reached
- event subscription skipped own event