### PR TITLE
PIM-9679: Clean existing text attribute values removing linebreaks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - API-9698: Refresh ES index after creating a product from the UI in order to well send product created event to event subscriptions
 - PIM-9711: Check that a category root isn't linked to a user or a channel before moving it to a sub-category
 - PIM-9730: Fix category tree initialization in the PEF when switching tabs
+- PIM-9679: Clean existing text attribute values removing linebreaks
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
@@ -18,6 +18,9 @@ class CleanLineBreaksInTextAttributes
                 }
                 foreach ($channelRawValue as $channelCode => $localeRawValue) {
                     foreach ($localeRawValue as $localeCode => $data) {
+                        if (!is_string($data)) {
+                            continue;
+                        }
                         $cleanedData = preg_replace(
                             '/[\r\n|\r|\n]+/',
                             ' ',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Factory;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+
+class CleanLineBreaksInTextAttributes
+{
+    public static function cleanFromRawValuesFormat(array $rawValueCollections, array $attributes): array
+    {
+        foreach ($rawValueCollections as $productIdentifier => $valueCollection) {
+            foreach ($valueCollection as $attributeCode => $channelRawValue) {
+                $attribute = $attributes[$attributeCode];
+                if ($attribute->type() !== AttributeTypes::TEXT) {
+                    continue;
+                }
+                foreach ($channelRawValue as $channelCode => $localeRawValue) {
+                    foreach ($localeRawValue as $localeCode => $data) {
+                        $cleanedData = preg_replace(
+                            '/[\r\n|\r|\n]+/',
+                            ' ',
+                            $data);
+                        $rawValueCollections[$productIdentifier][$attributeCode][$channelCode][$localeCode] = $cleanedData;
+                    }
+                }
+            }
+        }
+
+        return $rawValueCollections;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -42,12 +42,11 @@ class ReadValueCollectionFactory
 
     public function createMultipleFromStorageFormat(array $rawValueCollections): array
     {
-        $attributes = $this->getAttributesUsedByProducts($rawValueCollections);
-        $rawValueCollections = CleanLineBreaksInTextAttributes::cleanFromRawValuesFormat($rawValueCollections, $attributes);
         $filteredRawValuesCollection = $this->chainedNonExistentValuesFilter->filterAll($rawValueCollections);
-        $valueCollections = $this->createValues($filteredRawValuesCollection, $attributes);
+        $attributes = $this->getAttributesUsedByProducts($rawValueCollections);
+        $filteredRawValuesCollection = CleanLineBreaksInTextAttributes::cleanFromRawValuesFormat($filteredRawValuesCollection, $attributes);
 
-        return $valueCollections;
+        return $this->createValues($filteredRawValuesCollection, $attributes);
     }
 
     private function getAttributesUsedByProducts(array $rawValueCollections): array

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ReadValueCollectionFactory.php
@@ -42,8 +42,10 @@ class ReadValueCollectionFactory
 
     public function createMultipleFromStorageFormat(array $rawValueCollections): array
     {
+        $attributes = $this->getAttributesUsedByProducts($rawValueCollections);
+        $rawValueCollections = CleanLineBreaksInTextAttributes::cleanFromRawValuesFormat($rawValueCollections, $attributes);
         $filteredRawValuesCollection = $this->chainedNonExistentValuesFilter->filterAll($rawValueCollections);
-        $valueCollections = $this->createValues($filteredRawValuesCollection);
+        $valueCollections = $this->createValues($filteredRawValuesCollection, $attributes);
 
         return $valueCollections;
     }
@@ -63,11 +65,9 @@ class ReadValueCollectionFactory
         return $attributes;
     }
 
-    private function createValues(array $rawValueCollections): array
+    private function createValues(array $rawValueCollections, array $attributes): array
     {
         $entities = [];
-        $attributes = $this->getAttributesUsedByProducts($rawValueCollections);
-
         foreach ($rawValueCollections as $productIdentifier => $valueCollection) {
             $values = [];
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/CleanLineBreaksInTextAttributesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/CleanLineBreaksInTextAttributesSpec.php
@@ -1,0 +1,182 @@
+<?php
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use PhpSpec\ObjectBehavior;
+
+final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
+{
+    function it_cleans_text_attributes_and_returns_cleaned_fields()
+    {
+        $rawValueCollections = [
+            'movie' => [
+                'name' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line'.PHP_EOL.'break',
+                    ],
+                ],
+                'title' => [
+                    '<all_channels>' => [
+                        'fr_FR' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line'.PHP_EOL.'break',
+                        'en_US' => "Philips SA4TP404KF Tap 4.3 MP3 video player line\rbreak",
+                        'de_DE' => "Philips SA4TP404KF Tap 4.3 MP3 video player linebreak",
+                    ],
+                ],
+                'subtitle' => [
+                    'print' => [
+                        'en_US' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.'break',
+                        'fr_FR' => "The GoGEAR Tap 4.3 MP3 line\rbreak",
+                    ],
+                    'ecommerce' => [
+                        'en_US' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.'break',
+                        'de_DE' => "The GoGEAR Tap 4.3",
+                    ],
+                ],
+                'comment' => [
+                    'print' => [
+                        '<all_locales>' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.'break',
+                    ],
+                    'ecommerce' => [
+                        '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line\rbreak",
+                    ],
+                ],
+                'description' => [
+                    'print' => [
+                        '<all_locales>' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.'break',
+                    ],
+                    'ecommerce' => [
+                        '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line\rbreak",
+                    ],
+                ],
+            ]
+        ];
+
+        $attributes =
+        [
+            'name' => $this->buildAttribute('name', AttributeTypes::TEXT),
+            'title' => $this->buildAttribute('title', AttributeTypes::TEXT),
+            'subtitle' => $this->buildAttribute('subtitle', AttributeTypes::TEXT),
+            'comment' => $this->buildAttribute('comment', AttributeTypes::TEXT),
+            'description' => $this->buildAttribute('description', AttributeTypes::TEXTAREA),
+        ];
+
+        $this->cleanFromRawValuesFormat($rawValueCollections, $attributes)->shouldReturn(['movie' => [
+            'name' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line break',
+                ],
+            ],
+            'title' => [
+                '<all_channels>' => [
+                    'fr_FR' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line break',
+                    'en_US' => "Philips SA4TP404KF Tap 4.3 MP3 video player line break",
+                    'de_DE' => "Philips SA4TP404KF Tap 4.3 MP3 video player linebreak",
+                ],
+            ],
+            'subtitle' => [
+                'print' => [
+                    'en_US' => 'The GoGEAR Tap 4.3 MP3 line break',
+                    'fr_FR' => "The GoGEAR Tap 4.3 MP3 line break",
+                ],
+                'ecommerce' => [
+                    'en_US' => 'The GoGEAR Tap 4.3 MP3 line break',
+                    'de_DE' => "The GoGEAR Tap 4.3",
+                ],
+            ],
+            'comment' => [
+                'print' => [
+                    '<all_locales>' => 'The GoGEAR Tap 4.3 MP3 line break',
+                ],
+                'ecommerce' => [
+                    '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line break",
+                ],
+            ],
+            'description' => [
+                'print' => [
+                    '<all_locales>' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.'break',
+                ],
+                'ecommerce' => [
+                    '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line\rbreak",
+                ],
+            ],
+        ]]);
+    }
+
+    function it_cleans_several_sort_of_line_breaks()
+    {
+        $rawValueCollections = [
+            'movie' => [
+                'name' => [
+                    '<all_channels>' => [
+                        '<all_locales>' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line'.PHP_EOL.'break',
+                    ],
+                ],
+                'title' => [
+                    '<all_channels>' => [
+                        'en_US' => "Philips SA4TP404KF Tap 4.3 MP3 video player line\rbreak",
+                    ],
+                ],
+                'subtitle' => [
+                    'print' => [
+                        'en_US' => 'The GoGEAR Tap 4.3 MP3 line'.PHP_EOL.PHP_EOL.PHP_EOL.'break',
+                    ],
+                ],
+                'comment' => [
+                    'ecommerce' => [
+                        '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line\r\nbreak",
+                    ],
+                ],
+            ]
+        ];
+
+        $attributes =
+            [
+                'name' => $this->buildAttribute('name', AttributeTypes::TEXT),
+                'title' => $this->buildAttribute('title', AttributeTypes::TEXT),
+                'subtitle' => $this->buildAttribute('subtitle', AttributeTypes::TEXT),
+                'comment' => $this->buildAttribute('comment', AttributeTypes::TEXT),
+            ];
+
+        $this->cleanFromRawValuesFormat($rawValueCollections, $attributes)->shouldReturn(['movie' => [
+            'name' => [
+                '<all_channels>' => [
+                    '<all_locales>' => 'Philips SA4TP404KF Tap 4.3 MP3 video player line break',
+                ],
+            ],
+            'title' => [
+                '<all_channels>' => [
+                    'en_US' => "Philips SA4TP404KF Tap 4.3 MP3 video player line break",
+                ],
+            ],
+            'subtitle' => [
+                'print' => [
+                    'en_US' => 'The GoGEAR Tap 4.3 MP3 line break',
+                ],
+            ],
+            'comment' => [
+                'ecommerce' => [
+                    '<all_locales>' => "The GoGEAR Tap 4.3 MP3 line break",
+                ],
+            ],
+        ]]);
+    }
+
+    private function buildAttribute(string $code, string $type): Attribute
+    {
+        return new Attribute(
+            $code,
+            $type,
+            [],
+            true,
+            true,
+            null,
+            null,
+            null,
+            '',
+            []
+        );
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

**PART 1** done by @nmarniesse => https://github.com/akeneo/pim-community-dev/pull/14001

**PART 2**
For existing line breaks, I added a function that replaces them with spaces when it comes to text attributes, at the product saving.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
