### PR TITLE
BH-420: reactivate Behat retry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,12 +637,6 @@ workflows:
                     - test_back_static_and_acceptance
                     - test_front_static_acceptance_and_integration
                     - test_back_phpunit
-          - pull_request_success:
-                requires:
-                    - test_back_behat_legacy
-                    - test_back_performance
-                    - test_back_data_migrations
-                    - test_onboarder_bundle
 
           - ready_to_build_only_ce?:
                 type: approval
@@ -677,6 +671,14 @@ workflows:
                     - test_back_static_and_acceptance_ce
                     - test_front_static_acceptance_and_integration_ce
                     - test_back_phpunit_ce
+
+          - pull_request_success:
+                requires:
+                    - test_back_behat_legacy
+                    - test_back_performance
+                    - test_back_data_migrations
+                    - test_onboarder_bundle
+                    - test_back_behat_legacy_ce
 
   nightly:
       triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,16 @@ jobs:
           paths:
             - project
 
+  checkout_ce:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - persist_to_workspace:
+          root: ~/
+          paths:
+              - project
+
   build_dev:
     parameters:
         is_ee_built:
@@ -56,7 +66,8 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     steps:
-      - checkout
+      - attach_workspace:
+            at: ~/
       - run:
           name: Copy docker-compose.override.yml.dist
           command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
@@ -644,11 +655,14 @@ workflows:
                     branches:
                         ignore:
                             - master
+          - checkout_ce:
+                requires:
+                    - ready_to_build_only_ce?
           - build_dev:
                 name: build_dev_ce
                 is_ee_built: false
                 requires:
-                    - ready_to_build_only_ce?
+                    - checkout_ce
           - test_back_static_and_acceptance:
                 name: test_back_static_and_acceptance_ce
                 requires:
@@ -690,8 +704,11 @@ workflows:
                             - master
 
       jobs:
+          - checkout_ce
           - build_dev:
                 is_ee_built: false
+                requires:
+                    - checkout_ce
           - test_back_static_and_acceptance:
                 requires:
                     - build_dev
@@ -715,10 +732,13 @@ workflows:
                 filters:
                     branches:
                         only: master
+          - checkout_ce:
+                requires:
+                    - ready_to_build?
           - build_dev:
                 is_ee_built: false
                 requires:
-                    - ready_to_build?
+                    - checkout_ce
           - test_back_static_and_acceptance:
                 requires:
                     - build_dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,16 +45,6 @@ jobs:
           paths:
             - project
 
-  checkout_ce:
-    machine:
-      image: ubuntu-1604:201903-01
-    steps:
-      - checkout
-      - persist_to_workspace:
-          root: ~/
-          paths:
-              - project
-
   build_dev:
     parameters:
         is_ee_built:
@@ -66,8 +56,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
     steps:
-      - attach_workspace:
-            at: ~/
+      - checkout
       - run:
           name: Copy docker-compose.override.yml.dist
           command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
@@ -661,14 +650,11 @@ workflows:
                     branches:
                         ignore:
                             - master
-          - checkout_ce:
-                requires:
-                    - ready_to_build_only_ce?
           - build_dev:
                 name: build_dev_ce
                 is_ee_built: false
                 requires:
-                    - checkout_ce
+                    - ready_to_build_only_ce?
           - test_back_static_and_acceptance:
                 name: test_back_static_and_acceptance_ce
                 requires:
@@ -702,11 +688,8 @@ workflows:
                             - master
 
       jobs:
-          - checkout_ce
           - build_dev:
                 is_ee_built: false
-                requires:
-                    - checkout_ce
           - test_back_static_and_acceptance:
                 requires:
                     - build_dev
@@ -730,13 +713,10 @@ workflows:
                 filters:
                     branches:
                         only: master
-          - checkout_ce:
-                requires:
-                    - ready_to_build?
           - build_dev:
                 is_ee_built: false
                 requires:
-                    - checkout_ce
+                    - ready_to_build?
           - test_back_static_and_acceptance:
                 requires:
                     - build_dev

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -16,7 +16,12 @@ for TEST_FILE in $TEST_FILES; do
     output=$(basename $TEST_FILE)_$(uuidgen)
 
     set +e
-    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
+    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
+    (
+      echo Retrying $TEST_FILE &&
+      docker-compose exec -u www-data -T fpm /bin/bash -c "echo $TEST_FILE >> var/tests/behat/behats_retried.txt" &&
+      docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
+    )
 
     fail=$(($fail + $?))
     counter=$(($counter + 1))


### PR DESCRIPTION
We are experiencing CI issues from unstable Behat Selenium tests.

While studying other test solution (fixing our Behats, stop using Selenium, etc) we can reactivate the retry feature to facilitate PR validation.