### PR TITLE
PIM-9718: Decimals attribute values with no separators are well formatted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - PIM-9699: Fix clicking detail on last operation return 404 on import and export jobs
 - API-1483: Fix the test button of the Event Subscription
 - PLG-63: Fix product-grid grouped variant filter dropdown
+- PIM-9718: Decimals attribute values with no separators are well formatted
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/ProductValueNormalizer.php
@@ -154,15 +154,18 @@ class ProductValueNormalizer implements NormalizerInterface, CacheableSupportsMe
         }
 
         $data = $value->getData();
-        $integer = substr($data, 0, strpos($data, '.') + 1);
-        $decimals = substr($data, strpos($data, '.') + 1);
+        $splitNumber = preg_split('/\./', $data);
+        if (!isset($splitNumber[1])) {
+            return number_format($data, static::DECIMAL_PRECISION, '.', '');
+        }
+        [$integer, $decimals] = $splitNumber;
 
         if (strlen($decimals) <= static::DECIMAL_PRECISION) {
             return number_format($data, static::DECIMAL_PRECISION, '.', '');
         }
 
         return sprintf(
-            '%s%s%s',
+            '%s.%s%s',
             $integer,
             substr($decimals, 0, static::DECIMAL_PRECISION),
             rtrim(substr($decimals, static::DECIMAL_PRECISION), '0')

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Standard/Product/ProductValueNormalizerSpec.php
@@ -5,6 +5,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\Stand
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValueInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
@@ -332,6 +333,67 @@ class ProductValueNormalizerSpec extends ObjectBehavior
                 'locale' => 'en_US',
                 'scope'  => 'ecommerce',
                 'data'   => '15.0000',
+            ]
+        );
+    }
+
+    function it_normalizes_an_integer_as_number_product_value_with_decimal_allowed(
+        NormalizerInterface $normalizer,
+        GetAttributes $getAttributes
+    ) {
+        $value = ScalarValue::value('attribute_with_decimal_allowed', '1535000');
+        $attribute = new Attribute(
+            'attribute_with_decimal_allowed',
+            AttributeTypes::NUMBER,
+            [],
+            true,
+            true,
+            null,
+            null,
+            true,
+            'decimal',
+            []
+        );
+
+        $normalizer->normalize('1535000', null, [])
+            ->shouldNotBeCalled();
+        $getAttributes->forCode('attribute_with_decimal_allowed')->willReturn($attribute);
+
+        $this->normalize($value)->shouldReturn(
+            [
+                'locale' => null,
+                'scope'  => null,
+                'data'   => '1535000.0000',
+            ]
+        );
+    }
+
+    function it_normalizes_an_integer_with_decimal_allowed_and_add_trailing_zeros(
+        NormalizerInterface $normalizer,
+        GetAttributes $getAttributes
+    ) {
+        $value = ScalarValue::value('attribute_with_decimal_allowed', 15);
+        $attribute = new Attribute(
+            'attribute_with_decimal_allowed',
+            AttributeTypes::NUMBER,
+            [],
+            true,
+            true,
+            null,
+            null,
+            true,
+            'decimal',
+            []
+        );
+
+        $normalizer->normalize(15, null, [])->shouldNotBeCalled();
+        $getAttributes->forCode('attribute_with_decimal_allowed')->willReturn($attribute);
+
+        $this->normalize($value)->shouldReturn(
+            [
+                'locale' => null,
+                'scope'  => null,
+                'data'   => "15.0000",
             ]
         );
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an attribute number allows the decimal values, the number of values saved on the product is limited to 5 digits if the number finished by one or several zeros. IE the PIM removes all zeros after 5 digits. 
Here is an example 

If I input 1234500 > 12345 is saved
If I input 123000 > 12300 is saved 
If I input 1234567 > 1234567 is saved 



**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | 
| Added acceptance tests            | 
| Added integration tests           | 
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
