### PR TITLE
API-1490 add event logs page

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/form_extensions.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/form_extensions.yml
@@ -77,6 +77,16 @@ extensions:
             routeParams:
                 code: '_'
 
+    pim-menu-connection-event-logs:
+        module: pim/menu/item
+        parent: pim-menu-connection-navigation-block
+        position: 3
+        config:
+            title: pim_menu.item.connection_webhook_event_logs
+            to: akeneo_connectivity_connection_webhook_event_logs
+            routeParams:
+                code: '_'
+
     # Activity
 
     pim-menu-activity-connection-audit:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
@@ -13,6 +13,9 @@ config:
                 akeneo_connectivity_connection_webhook_regenerate_secret:
                     module: pim/controller/connectivity/connection/webhook
                     aclResourceId: akeneo_connectivity_connection_manage_settings
+                akeneo_connectivity_connection_webhook_event_logs:
+                    module: pim/controller/connectivity/connection/webhook
+                    aclResourceId: akeneo_connectivity_connection_manage_settings
                 akeneo_connectivity_connection_settings_index:
                     module: pim/controller/connectivity/connection/settings
                     aclResourceId: akeneo_connectivity_connection_manage_settings

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -53,6 +53,11 @@ akeneo_connectivity_connection_webhook_edit:
     requirements:
         code: '[a-zA-Z0-9_]+'
 
+akeneo_connectivity_connection_webhook_event_logs:
+    path: '/connections/{code}/event-logs'
+    requirements:
+        code: '[a-zA-Z0-9_]+'
+
 ## Settings
 akeneo_connectivity_connection_settings_index:
     path: '/connections'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/menu/connection-params-provider.ts
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/menu/connection-params-provider.ts
@@ -8,6 +8,7 @@ class ConnectionParamsProvider extends View {
         case 'akeneo_connectivity_connection_settings_edit':
         case 'akeneo_connectivity_connection_error_management_connection_monitoring':
         case 'akeneo_connectivity_connection_webhook_edit':
+        case 'akeneo_connectivity_connection_webhook_event_logs':
           this.getRoot().trigger('pim_menu:item:update_route_params', {
             route: 'akeneo_connectivity_connection_settings_edit',
             routeParams: {code: params.code},
@@ -18,6 +19,10 @@ class ConnectionParamsProvider extends View {
           });
           this.getRoot().trigger('pim_menu:item:update_route_params', {
             route: 'akeneo_connectivity_connection_webhook_edit',
+            routeParams: {code: params.code},
+          });
+          this.getRoot().trigger('pim_menu:item:update_route_params', {
+            route: 'akeneo_connectivity_connection_webhook_event_logs',
             routeParams: {code: params.code},
           });
       }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/menu/highlight-menu.ts
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/menu/highlight-menu.ts
@@ -35,6 +35,11 @@ const highlightConnectionNavigationMenuItems = (routeName: string) => {
         extension: 'pim-menu-connection-event-subscriptions',
       });
       break;
+    case 'akeneo_connectivity_connection_webhook_event_logs':
+      mediator.trigger('pim_menu:highlight:item', {
+        extension: 'pim-menu-connection-event-logs',
+      });
+      break;
   }
 };
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -10,6 +10,7 @@ pim_menu:
         connection_settings_edit: Connection settings
         connection_monitoring: Monitoring
         connection_webhook_edit: Event subscription
+        connection_webhook_event_logs: Event logs
 
 pim_title:
     akeneo_connectivity_connection_settings_index: Connections
@@ -21,6 +22,7 @@ pim_title:
     akeneo_connectivity_connection_error_management_connection_monitoring: Connection monitoring
     akeneo_connectivity_connection_webhook_edit: Event subscription
     akeneo_connectivity_connection_webhook_regenerate_secret: Event subscription
+    akeneo_connectivity_connection_webhook_event_logs: Event logs
 
 akeneo_connectivity.connection:
     connections: Connections
@@ -228,6 +230,13 @@ akeneo_connectivity.connection:
         active_event_subscriptions_limit_reached:
             message: You can connect up to {{ limit }} connections to the Event subscription feature. You have reached this limit.
             link: Learn more about event subscription configuration.
+        event_logs:
+            event_subscription_disabled:
+                title: The event subscription isn’t enabled for this connection. 
+                link: Enable the event subscription
+            no_event_logs:
+                title: There is no log for the moment.
+
     error_management:
         connection_monitoring:
             title: Monitoring

--- a/src/Akeneo/Connectivity/Connection/front/jest.config.js
+++ b/src/Akeneo/Connectivity/Connection/front/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
     preset: 'ts-jest',
     globals: {
         'ts-jest': {
-            tsConfig: './tests/tsconfig.json',
+            tsconfig: './tests/tsconfig.json',
         },
     },
     moduleDirectories: ['<rootDir>/../../../../../node_modules/'],

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/pages/AuditErrorBoundary.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/pages/AuditErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import React, {Component} from 'react';
 import {PageContent, PageHeader, RuntimeError} from '../../common/components';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {useRoute} from '../../shared/router';
 import {Translate} from '../../shared/translate';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 const AuditBreadcrumb = () => {
     const dashboardHref = `#${useRoute('pim_dashboard_index')}`;
@@ -34,15 +34,7 @@ export class AuditErrorBoundary extends Component<unknown, {hasError: boolean}> 
         if (this.state.hasError) {
             return (
                 <>
-                    <PageHeader
-                        breadcrumb={<AuditBreadcrumb />}
-                        userButtons={
-                            <PimView
-                                className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-                                viewName='pim-connectivity-connection-user-navigation'
-                            />
-                        }
-                    />
+                    <PageHeader breadcrumb={<AuditBreadcrumb />} userButtons={<UserButtons />} />
 
                     <PageContent>
                         <RuntimeError />

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Dashboard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Dashboard.tsx
@@ -1,6 +1,5 @@
 import React, {memo, useEffect} from 'react';
 import {Helper, HelperLink, HelperTitle, PageContent, PageHeader} from '../../common';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {AuditEventType} from '../../model/audit-event-type.enum';
 import {useRoute} from '../../shared/router';
 import {Translate} from '../../shared/translate';
@@ -10,6 +9,7 @@ import {useDashboardDispatch} from '../dashboard-context';
 import {useConnections} from '../hooks/api/use-connections';
 import {useFetchConnectionsAuditData} from '../hooks/api/use-fetch-connections-audit-data';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 export const Dashboard = memo(() => {
     const {connections} = useConnections();
@@ -40,16 +40,9 @@ export const Dashboard = memo(() => {
         </Breadcrumb>
     );
 
-    const userButtons = (
-        <PimView
-            className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-            viewName='pim-connectivity-connection-user-navigation'
-        />
-    );
-
     return (
         <>
-            <PageHeader breadcrumb={breadcrumb} userButtons={userButtons}>
+            <PageHeader breadcrumb={breadcrumb} userButtons={<UserButtons />}>
                 <Translate id='pim_menu.item.connection_audit' />
             </PageHeader>
 

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/pages/ConnectionMonitoring.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/pages/ConnectionMonitoring.tsx
@@ -1,7 +1,6 @@
 import React, {FC, memo} from 'react';
 import {useHistory, useParams} from 'react-router';
 import {Loading, PageContent, PageHeader} from '../../common';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {FlowType} from '../../model/flow-type.enum';
 import {useRoute} from '../../shared/router';
 import {Translate} from '../../shared/translate';
@@ -10,6 +9,7 @@ import {NotAuditableConnection} from '../components/NotAuditableConnection';
 import {NotDataSourceConnection} from '../components/NotDataSourceConnection';
 import {useConnection} from '../hooks/api/use-connection';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 const ConnectionMonitoring: FC = memo(() => {
     const history = useHistory();
@@ -35,16 +35,9 @@ const ConnectionMonitoring: FC = memo(() => {
         </Breadcrumb>
     );
 
-    const userButtons = (
-        <PimView
-            className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-            viewName='pim-connectivity-connection-user-navigation'
-        />
-    );
-
     return (
         <>
-            <PageHeader breadcrumb={breadcrumb} userButtons={userButtons}>
+            <PageHeader breadcrumb={breadcrumb} userButtons={<UserButtons />}>
                 {connection.label}
             </PageHeader>
 

--- a/src/Akeneo/Connectivity/Connection/front/src/settings/pages/EditConnection.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/settings/pages/EditConnection.tsx
@@ -4,7 +4,6 @@ import {useHistory, useParams} from 'react-router';
 import styled from 'styled-components';
 import {ApplyButton, DropdownLink, PageContent, PageHeader, SecondaryActionsDropdownButton} from '../../common';
 import defaultImageUrl from '../../common/assets/illustrations/NewAPI.svg';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {Connection} from '../../model/connection';
 import {FlowType} from '../../model/flow-type.enum';
 import {WrongCredentialsCombinations} from '../../model/wrong-credentials-combinations';
@@ -26,6 +25,7 @@ import {
     useWrongCredentialsCombinationsState,
 } from '../wrong-credentials-combinations-context';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 export type FormValues = {
     label: string;
@@ -186,12 +186,7 @@ const HeaderContent = ({connection}: {connection: Connection}) => {
                 </SecondaryActionsDropdownButton>,
                 <SaveButton key={1} />,
             ]}
-            userButtons={
-                <PimView
-                    className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-                    viewName='pim-connectivity-connection-user-navigation'
-                />
-            }
+            userButtons={<UserButtons />}
             state={<FormState />}
             imageSrc={
                 null === formik.values.image ? defaultImageUrl : generateMediaUrl(formik.values.image, 'thumbnail')

--- a/src/Akeneo/Connectivity/Connection/front/src/settings/pages/ListConnections.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/settings/pages/ListConnections.tsx
@@ -1,7 +1,6 @@
 import React, {useEffect} from 'react';
 import {useHistory} from 'react-router';
 import {ApplyButton, Helper, HelperLink, HelperTitle, PageContent, PageHeader} from '../../common';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {Connection} from '../../model/connection';
 import {FlowType} from '../../model/flow-type.enum';
 import {fetchResult} from '../../shared/fetch-result';
@@ -19,6 +18,7 @@ import {
     useWrongCredentialsCombinationsState,
 } from '../wrong-credentials-combinations-context';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 const MAXIMUM_NUMBER_OF_ALLOWED_CONNECTIONS = 50;
 
@@ -70,13 +70,6 @@ export const ListConnections = () => {
         </Breadcrumb>
     );
 
-    const userButtons = (
-        <PimView
-            className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-            viewName='pim-connectivity-connection-user-navigation'
-        />
-    );
-
     const createButton = (
         <ApplyButton
             onClick={handleCreate}
@@ -97,7 +90,7 @@ export const ListConnections = () => {
 
     return (
         <>
-            <PageHeader breadcrumb={breadcrumb} buttons={[createButton]} userButtons={userButtons}>
+            <PageHeader breadcrumb={breadcrumb} buttons={[createButton]} userButtons={<UserButtons />}>
                 <Translate id='pim_menu.item.connection_settings' />
             </PageHeader>
 

--- a/src/Akeneo/Connectivity/Connection/front/src/settings/pages/SettingsErrorBoundary.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/settings/pages/SettingsErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import React, {Component} from 'react';
 import {PageContent, PageHeader, RuntimeError} from '../../common/components';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {useRoute} from '../../shared/router';
 import {Translate} from '../../shared/translate';
 import {Breadcrumb} from 'akeneo-design-system';
+import {UserButtons} from '../../shared/user';
 
 const SettingsBreadcrumb = () => {
     const systemHref = `#${useRoute('oro_config_configuration_system')}`;
@@ -34,15 +34,7 @@ export class SettingsErrorBoundary extends Component<unknown, {hasError: boolean
         if (this.state.hasError) {
             return (
                 <>
-                    <PageHeader
-                        breadcrumb={<SettingsBreadcrumb />}
-                        userButtons={
-                            <PimView
-                                className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-                                viewName='pim-connectivity-connection-user-navigation'
-                            />
-                        }
-                    />
+                    <PageHeader breadcrumb={<SettingsBreadcrumb />} userButtons={<UserButtons />} />
 
                     <PageContent>
                         <RuntimeError />

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/user/UserButtons.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/user/UserButtons.tsx
@@ -1,0 +1,9 @@
+import React, {FC} from 'react';
+import {PimView} from '../../infrastructure/pim-view/PimView';
+
+export const UserButtons: FC = () => (
+    <PimView
+        className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
+        viewName='pim-connectivity-connection-user-navigation'
+    />
+);

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/user/index.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/user/index.ts
@@ -1,4 +1,5 @@
 import {User as UserInterface} from './user.interface';
 import {UserContext} from './user-context';
+import {UserButtons} from './UserButtons';
 
-export {UserContext, UserInterface};
+export {UserContext, UserInterface, UserButtons};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
@@ -1,0 +1,4 @@
+import React, {FC} from 'react';
+import {NoEventLogs} from './NoEventLogs';
+
+export const EventLogList: FC = () => <NoEventLogs />;

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionDisabled.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventSubscriptionDisabled.tsx
@@ -1,0 +1,33 @@
+import {ApiIllustration, Link} from 'akeneo-design-system';
+import React, {FC} from 'react';
+import {generatePath, useHistory} from 'react-router-dom';
+import {EmptyState} from '../../common';
+import {Translate} from '../../shared/translate';
+
+const EventSubscriptionDisabled: FC<{connectionCode: string}> = ({connectionCode}) => {
+    const history = useHistory();
+
+    return (
+        <EmptyState.EmptyState>
+            <ApiIllustration size={200} />
+
+            <EmptyState.Heading>
+                <Translate id='akeneo_connectivity.connection.webhook.event_logs.event_subscription_disabled.title' />
+            </EmptyState.Heading>
+
+            <EmptyState.Caption>
+                <Link
+                    decorated
+                    href={history.createHref({
+                        pathname: generatePath('/connections/:connectionCode/event-subscription', {connectionCode}),
+                    })}
+                    target='_self'
+                >
+                    <Translate id='akeneo_connectivity.connection.webhook.event_logs.event_subscription_disabled.link' />
+                </Link>
+            </EmptyState.Caption>
+        </EmptyState.EmptyState>
+    );
+};
+
+export {EventSubscriptionDisabled};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/NoEventLogs.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/NoEventLogs.tsx
@@ -1,0 +1,18 @@
+import {GraphIllustration} from 'akeneo-design-system';
+import React, {FC} from 'react';
+import {EmptyState} from '../../common';
+import {Translate} from '../../shared/translate';
+
+const NoEventLogs: FC = () => {
+    return (
+        <EmptyState.EmptyState>
+            <GraphIllustration size={200} />
+
+            <EmptyState.Heading>
+                <Translate id='akeneo_connectivity.connection.webhook.event_logs.no_event_logs.title' />
+            </EmptyState.Heading>
+        </EmptyState.EmptyState>
+    );
+};
+
+export {NoEventLogs};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-connection.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-connection.ts
@@ -7,5 +7,7 @@ type Connection = {
 };
 
 export function useFetchConnection(code: string) {
-    return useQuery<Connection>('akeneo_connectivity_connection_rest_get', {code});
+    const {loading, data} = useQuery<Connection>('akeneo_connectivity_connection_rest_get', {code});
+
+    return {loading, connection: data};
 }

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
@@ -20,13 +20,13 @@ type FormData = {
     active_event_subscriptions_limit: EventSubscriptionsLimit;
 };
 
-export const useFetchEventSubscriptionFormData = (connectionCode: string) => {
+export const useFetchEventSubscription = (connectionCode: string) => {
     const url = useRoute('akeneo_connectivity_connection_webhook_rest_get', {code: connectionCode});
 
     const [eventSubscription, setEventSubscription] = useState<EventSubscription>();
     const [eventSubscriptionsLimit, setEventSubscriptionsLimit] = useState<EventSubscriptionsLimit>();
 
-    const fetchEventSubscriptionFormData = useCallback(() => {
+    const fetchEventSubscription = useCallback(() => {
         fetchResult<FormData, unknown>(url).then(result => {
             if (isErr(result)) {
                 throw new Error(`Webhook for connection '${connectionCode}' not found.`);
@@ -37,5 +37,5 @@ export const useFetchEventSubscriptionFormData = (connectionCode: string) => {
         });
     }, [url]);
 
-    return {eventSubscription, eventSubscriptionsLimit, fetchEventSubscriptionFormData};
+    return {eventSubscription, eventSubscriptionsLimit, fetchEventSubscription};
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import defaultImageUrl from '../../common/assets/illustrations/NewAPI.svg';
 import {ApplyButton, PageContent, PageHeader} from '../../common/components';
 import {Loading} from '../../common/components/Loading';
-import {PimView} from '../../infrastructure/pim-view/PimView';
 import {useMediaUrlGenerator} from '../../settings/use-media-url-generator';
 import {isErr} from '../../shared/fetch-result/result';
 import {useRoute} from '../../shared/router';
@@ -13,10 +12,11 @@ import {Translate} from '../../shared/translate';
 import {EditForm} from '../components/EditForm';
 import {EventSubscriptionHelper} from '../components/EventSubscriptionHelper';
 import {useUpdateWebhook} from '../hooks/api/use-update-webhook';
-import {useFetchEventSubscriptionFormData} from '../hooks/api/use-fetch-event-subscription-form-data';
+import {useFetchEventSubscription} from '../hooks/api/use-fetch-event-subscription';
 import {Webhook} from '../model/Webhook';
 import {Breadcrumb, SectionTitle} from 'akeneo-design-system';
 import {useFetchConnection} from '../hooks/api/use-fetch-connection';
+import {UserButtons} from '../../shared/user';
 
 export type FormInput = {
     connectionCode: string;
@@ -32,16 +32,14 @@ export const EditConnectionWebhook: FC = () => {
     const systemHref = `#${useRoute('oro_config_configuration_system')}`;
 
     const {connectionCode} = useParams<{connectionCode: string}>();
-    const {data: connection} = useFetchConnection(connectionCode);
-    const {
-        eventSubscription,
-        eventSubscriptionsLimit,
-        fetchEventSubscriptionFormData,
-    } = useFetchEventSubscriptionFormData(connectionCode);
+    const {connection} = useFetchConnection(connectionCode);
+    const {eventSubscription, eventSubscriptionsLimit, fetchEventSubscription} = useFetchEventSubscription(
+        connectionCode
+    );
 
     useEffect(() => {
-        fetchEventSubscriptionFormData();
-    }, [fetchEventSubscriptionFormData]);
+        fetchEventSubscription();
+    }, [fetchEventSubscription]);
 
     useEffect(() => {
         if (eventSubscription) {
@@ -67,28 +65,17 @@ export const EditConnectionWebhook: FC = () => {
         </Breadcrumb>
     );
 
-    const userButtons = (
-        <PimView
-            className='AknTitleContainer-userMenuContainer AknTitleContainer-userMenu'
-            viewName='pim-connectivity-connection-user-navigation'
-        />
-    );
-
     return (
         <FormContext {...formMethods}>
             <form>
                 <PageHeader
                     breadcrumb={breadcrumb}
-                    userButtons={userButtons}
+                    userButtons={<UserButtons />}
                     imageSrc={
                         null === connection.image ? defaultImageUrl : generateMediaUrl(connection.image, 'thumbnail')
                     }
                     buttons={[
-                        <SaveButton
-                            key={0}
-                            webhook={eventSubscription}
-                            onSaveSuccess={fetchEventSubscriptionFormData}
-                        />,
+                        <SaveButton key={0} webhook={eventSubscription} onSaveSuccess={fetchEventSubscription} />,
                     ]}
                     state={<FormState />}
                 >

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
@@ -1,0 +1,68 @@
+import {Breadcrumb} from 'akeneo-design-system';
+import React, {FC, useEffect} from 'react';
+import {useHistory, useParams} from 'react-router-dom';
+import {Loading, PageContent, PageHeader} from '../../common';
+import {useRoute} from '../../shared/router';
+import {Translate} from '../../shared/translate';
+import {UserButtons} from '../../shared/user';
+import {EventSubscriptionDisabled} from '../components/EventSubscriptionDisabled';
+import {EventLogList} from '../components/EventLogList';
+import {useFetchConnection} from '../hooks/api/use-fetch-connection';
+import {useFetchEventSubscription} from '../hooks/api/use-fetch-event-subscription';
+
+export const EventLogs: FC = () => {
+    const {connectionCode} = useParams<{connectionCode: string}>();
+    const {connection} = useFetchConnection(connectionCode);
+
+    return (
+        <>
+            <PageHeader breadcrumb={<EventLogsBreadcrumb />} userButtons={<UserButtons />}>
+                {connection?.label}
+            </PageHeader>
+            <PageContent>
+                {undefined === connection ? (
+                    <Loading />
+                ) : (
+                    <EnabledEventSubscriptionGuard connectionCode={connection.code}>
+                        <EventLogList />
+                    </EnabledEventSubscriptionGuard>
+                )}
+            </PageContent>
+        </>
+    );
+};
+
+const EventLogsBreadcrumb: FC = () => {
+    const history = useHistory();
+
+    return (
+        <Breadcrumb>
+            <Breadcrumb.Step href={'#' + useRoute('oro_config_configuration_system')}>
+                <Translate id='pim_menu.tab.system' />
+            </Breadcrumb.Step>
+            <Breadcrumb.Step href={history.createHref({pathname: '/connections'})}>
+                <Translate id='pim_menu.item.connection_settings' />
+            </Breadcrumb.Step>
+            <Breadcrumb.Step>
+                <Translate id='akeneo_connectivity.connection.webhook.title' />
+            </Breadcrumb.Step>
+        </Breadcrumb>
+    );
+};
+
+const EnabledEventSubscriptionGuard: FC<{connectionCode: string}> = ({children, connectionCode}) => {
+    const {eventSubscription, fetchEventSubscription} = useFetchEventSubscription(connectionCode);
+    useEffect(() => {
+        fetchEventSubscription();
+    }, [fetchEventSubscription]);
+
+    if (undefined === eventSubscription) {
+        return <Loading />;
+    }
+
+    if (false === eventSubscription.enabled) {
+        return <EventSubscriptionDisabled connectionCode={connectionCode} />;
+    }
+
+    return <>{children}</>;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/Index.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/Index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Route, Switch} from 'react-router-dom';
 import {EditConnectionWebhook} from './EditConnectionWebhook';
 import {ErrorBoundary} from './ErrorBoundary';
+import {EventLogs} from './EventLogs';
 import {RegenerateWebhookSecret} from './RegenerateWebhookSecret';
 
 const Index = () => (
@@ -12,6 +13,9 @@ const Index = () => (
             </Route>
             <Route path='/connections/:connectionCode/event-subscription'>
                 <EditConnectionWebhook />
+            </Route>
+            <Route path='/connections/:connectionCode/event-logs'>
+                <EventLogs />
             </Route>
         </Switch>
     </ErrorBoundary>

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/pages/EventLogs.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/pages/EventLogs.test.tsx
@@ -1,0 +1,74 @@
+import {Index} from '@src/webhook/pages/Index';
+import {createMemoryHistory} from 'history';
+import React from 'react';
+import {Router} from 'react-router-dom';
+import {fetchMockResponseOnce, renderWithProviders} from '../../../test-utils';
+
+describe('testing events logs page', () => {
+    const history = createMemoryHistory({
+        initialEntries: ['/connections/alkemics/event-logs'],
+    });
+
+    const mockFetchConnection = () =>
+        fetchMockResponseOnce(
+            'akeneo_connectivity_connection_rest_get?code=alkemics',
+            JSON.stringify({
+                code: 'alkemics',
+                label: 'Alkemics',
+                image: null,
+            })
+        );
+
+    const mockFetchEventSubscription = ({enabled} = {enabled: true}) =>
+        fetchMockResponseOnce(
+            'akeneo_connectivity_connection_webhook_rest_get?code=alkemics',
+            JSON.stringify({
+                event_subscription: {
+                    enabled,
+                },
+            })
+        );
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+    });
+
+    test('renders the events logs page for the "Alkemics" connection', async () => {
+        mockFetchConnection();
+        mockFetchEventSubscription();
+
+        const {findByText} = renderWithProviders(
+            <Router history={history}>
+                <Index />
+            </Router>
+        );
+
+        await findByText('Alkemics');
+    });
+
+    test('displays a message when the connection event subscription is not enabled', async () => {
+        mockFetchConnection();
+        mockFetchEventSubscription({enabled: false});
+
+        const {findByText} = renderWithProviders(
+            <Router history={history}>
+                <Index />
+            </Router>
+        );
+
+        await findByText('akeneo_connectivity.connection.webhook.event_logs.event_subscription_disabled.title');
+    });
+
+    test('displays a message when there is no logs', async () => {
+        mockFetchConnection();
+        mockFetchEventSubscription();
+
+        const {findByText} = renderWithProviders(
+            <Router history={history}>
+                <Index />
+            </Router>
+        );
+
+        await findByText('akeneo_connectivity.connection.webhook.event_logs.no_event_logs.title');
+    });
+});


### PR DESCRIPTION
Add initial page and menu entry for displaying the logs of the Events API.
Also,
- display a message if the event subscription is disabled
- display a message if there is not logs

![Peek 2021-03-04 19-43](https://user-images.githubusercontent.com/1671213/110013460-f0117200-7d21-11eb-9dbc-12095ff50076.gif)
