### PR TITLE
PIM-9717: Fix 500 error when filtering with invalid product identifiers value during an API call

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9717: Fix 500 error when filtering with invalid identifiers value during an API call
+
 # 4.0.96 (2021-02-23)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/IdentifierFilter.php
@@ -59,7 +59,7 @@ class IdentifierFilter extends AbstractFieldFilter implements FieldFilterInterfa
     protected function checkValue($property, $operator, $value)
     {
         if (Operators::IN_LIST === $operator || Operators::NOT_IN_LIST === $operator) {
-            FieldFilterHelper::checkArray($property, $value, self::class);
+            FieldFilterHelper::checkArrayOfStrings($property, $value, self::class);
         } else {
             FieldFilterHelper::checkString($property, $value, self::class);
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/Filter/FieldFilterHelper.php
@@ -74,6 +74,17 @@ class FieldFilterHelper
         }
     }
 
+    public static function checkArrayOfStrings($field, $value, $className)
+    {
+        self::checkArray($field, $value, $className);
+
+        foreach ($value as $subValue) {
+            if (!is_string($subValue)) {
+                throw InvalidPropertyTypeException::arrayOfStringsExpected(static::getCode($field), $className, $value);
+            }
+        }
+    }
+
     /**
      * Check if value is a datetime corresponding to a format
      *

--- a/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -277,6 +277,19 @@ class InvalidPropertyTypeException extends PropertyException
         );
     }
 
+    public static function arrayOfStringsExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects an array of strings as data.';
+
+        return new static(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName),
+            self::ARRAY_OF_OBJECTS_EXPECTED_CODE
+        );
+    }
+
     /**
      * Build an exception when the data is an array that does not contain an expected key.
      *

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/IdentifierFilterSpec.php
@@ -215,6 +215,20 @@ class IdentifierFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['identifier', Operators::IN_LIST, 'sku-001', null, null, []]);
     }
 
+    function it_throws_an_exception_when_the_given_value_is_not_an_array_of_strings(
+        SearchQueryBuilder $sqb
+    ) {
+        $this->setQueryBuilder($sqb);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayOfStringsExpected(
+                'identifier',
+                IdentifierFilter::class,
+                ['sku-001', null]
+            )
+        )->during('addFieldFilter', ['identifier', Operators::IN_LIST, ['sku-001', null], null, null, []]);
+    }
+
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator_for_field_filter(SearchQueryBuilder $sqb)
     {
         $this->setQueryBuilder($sqb);


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Filtering on invalid product identifiers during an API call triggers a 500 error with the right operators (IN and NOT IN). It's because the API query is not properly validated. We do validate that the identifiers are an array but not that it's an array of strings. The query is considered as valid and is transformed to an Elasticsearch query, and this is where the 500 error is triggered when we filter for example with a `null` value (because null is not a valid value for ES)

Example of query that triggered the problem : `/api/rest/v1/products?search={"identifier":[{"operator":"IN","value":["15554974",null]}]}`

With this fix, the API now returns a proper 422 error, like other malformed queries.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
