### PR TITLE
PIM-9727 add missing query params to hatoas links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - API-1483: Fix the test button of the Event Subscription
 - PLG-63: Fix product-grid grouped variant filter dropdown
 - PIM-9718: Decimals attribute values with no separators are well formatted
+- PIM-9727: Add missing query params to hatoas links
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -793,6 +793,12 @@ class ProductController
         if (null !== $query->attributeCodes) {
             $queryParameters['attributes'] = join(',', $query->attributeCodes);
         }
+        if (true === $query->withAttributeOptionsAsBoolean()) {
+            $queryParameters['with_attribute_options'] = 'true';
+        }
+        if (true === $query->withQualityScores()) {
+            $queryParameters['with_quality_scores'] = 'true';
+        }
 
         if (PaginationTypes::OFFSET === $query->paginationType) {
             $queryParameters = ['page' => $query->page] + $queryParameters;

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -473,8 +473,8 @@ JSON;
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&with_attribute_options=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&with_attribute_options=true"}
     },
     "current_page" : 1,
     "_embedded"    : {
@@ -546,8 +546,8 @@ JSON;
         $expected = <<<JSON
 {
     "_links"       : {
-        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded"},
-        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded"}
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_quality_scores=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_quality_scores=true"}
     },
     "current_page" : 1,
     "_embedded"    : {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1671213/110297943-44537500-7ff4-11eb-806b-70ae9d77826e.png)
