### PR TITLE
PIM-9721: make command launcher service public

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/console.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/console.yml
@@ -8,3 +8,4 @@ services:
           - '%kernel.root_dir%'
           - '%kernel.environment%'
           - '%kernel.logs_dir%'
+        public: true


### PR DESCRIPTION
In the https://github.com/akeneo/pim-enterprise-dev/pull/10504 we launch asset re-indexation in a migration. To do that we have to make the service public