### PR TITLE
AOB-1340: Add InMemory implem for GetExistingReferenceDataCodes query

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,10 @@
 
 - PIM-9717: Fix 500 error when filtering with invalid identifiers value during an API call
 
+## Technical Improvements
+
+- AOB-1340: Add InMemory implem for GetExistingReferenceDataCodes query 
+
 # 4.0.96 (2021-02-23)
 
 ## Bug fixes

--- a/tests/back/Acceptance/Attribute/InMemoryGetExistingReferenceDataCodes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetExistingReferenceDataCodes.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Test\Acceptance\Attribute;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetExistingReferenceDataCodes;
+
+final class InMemoryGetExistingReferenceDataCodes implements GetExistingReferenceDataCodes
+{
+    /** @var array */
+    private $referenceDataCodesIndexedByReferenceDataName = [];
+
+    public function fromReferenceDataNameAndCodes(string $referenceDataName, array $codes): array
+    {
+        if (!\array_key_exists($referenceDataName, $this->referenceDataCodesIndexedByReferenceDataName)) {
+            return [];
+        }
+
+        return \array_values(
+            \array_intersect($codes, $this->referenceDataCodesIndexedByReferenceDataName[$referenceDataName])
+        );
+    }
+
+    public function add(string $referenceDataName, string $referenceDataCode): void
+    {
+        if (!\array_key_exists($referenceDataName, $this->referenceDataCodesIndexedByReferenceDataName)) {
+            $this->referenceDataCodesIndexedByReferenceDataName[$referenceDataName] = [];
+        }
+
+        if (\in_array($referenceDataCode, $this->referenceDataCodesIndexedByReferenceDataName[$referenceDataName])) {
+            return;
+        }
+
+        $this->referenceDataCodesIndexedByReferenceDataName[$referenceDataName][] = $referenceDataCode;
+    }
+}

--- a/tests/back/Acceptance/Resources/config/pim/queries.yml
+++ b/tests/back/Acceptance/Resources/config/pim/queries.yml
@@ -19,3 +19,6 @@ services:
         class: Akeneo\Test\Acceptance\FamilyVariant\InMemoryFamilyVariantsByAttributeAxes
         arguments:
             - '@pim_catalog.repository.family_variant'
+
+    akeneo.pim.enrichment.product.query.get_existing_reference_data_codes:
+        class: Akeneo\Test\Acceptance\Attribute\InMemoryGetExistingReferenceDataCodes

--- a/tests/back/Acceptance/spec/Attribute/InMemoryGetExistingReferenceDataCodesSpec.php
+++ b/tests/back/Acceptance/spec/Attribute/InMemoryGetExistingReferenceDataCodesSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace spec\Akeneo\Test\Acceptance\Attribute;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetExistingReferenceDataCodes;
+use Akeneo\Test\Acceptance\Attribute\InMemoryGetExistingReferenceDataCodes;
+use PhpSpec\ObjectBehavior;
+
+final class InMemoryGetExistingReferenceDataCodesSpec extends ObjectBehavior
+{
+    function it_is_a_query_to_get_existing_reference_data_codes()
+    {
+        $this->shouldImplement(GetExistingReferenceDataCodes::class);
+    }
+
+    function it_is_an_in_memory_query()
+    {
+        $this->shouldBeAnInstanceOf(InMemoryGetExistingReferenceDataCodes::class);
+    }
+
+    function it_returns_reference_data_codes_for_reference_data_name()
+    {
+        $this->add('color', 'purple');
+        $this->add('akeneoonboardersupplier', 'michel');
+
+        $this->fromReferenceDataNameAndCodes('akeneoonboardersupplier', ['michel', 'purple'])->shouldReturn(['michel']);
+        $this->fromReferenceDataNameAndCodes('color', ['michel', 'purple'])->shouldReturn(['purple']);
+    }
+
+    function it_returns_an_empty_array_if_there_is_no_reference_data_code_for_the_given_reference_data_name()
+    {
+        $this->fromReferenceDataNameAndCodes('akeneoonboardersupplier', ['michel'])->shouldReturn([]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->
We would like to add an acceptance test for an Onboarder use case but an in memory query is missing. The SQL implem is called instead and prevent us from testing as we'd like to. In this PR, we are adding this in memory query.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
