### PR TITLE
API-1511: test with two consumers

### DIFF
--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -81,4 +81,4 @@ parameters:
     webhook_timeout: 0.5
     webhook_max_bulk_size: 10
     webhook_active_event_subscriptions_limit: 3
-    webhook_requests_limit: 4000
+    webhook_requests_limit: 8000


### PR DESCRIPTION
Not to be merged.

The goal of this PR is to validate that the events_api webhook performs well with to consumers