### PR TITLE
PIM-9730: Fix PEF category tree initialization when switching tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - PIM-9718: Decimals attribute values with no separators are well formatted
 - PIM-9727: Add missing query params to hatoas links
 - API-9698: Refresh ES index after creating a product from the UI in order to well send product created event to event subscriptions
+- PIM-9730: Fix category tree initialization in the PEF when switching tabs
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/categories.js
@@ -98,39 +98,42 @@ define([
      * {@inheritdoc}
      */
     render: function () {
-      this.loadTrees().done(
-        function (trees) {
-          this.trees = trees;
+      if (null === this.treeAssociate || 0 === this.trees.length) {
+        this.loadTrees().done(
+          function (trees) {
+            this.trees = trees;
 
-          if (undefined === this.state.toJSON().currentTree) {
-            this.state.set('currentTree', _.first(this.trees).code);
-            this.state.set('currentTreeId', _.first(this.trees).id);
-          }
+            if (undefined === this.state.toJSON().currentTree) {
+              this.state.set('currentTree', _.first(this.trees).code);
+              this.state.set('currentTreeId', _.first(this.trees).id);
+            }
 
-          this.$el.html(
-            this.template({
-              product: this.getFormData(),
-              locale: UserContext.get('catalogLocale'),
-              state: this.state.toJSON(),
-              trees: this.trees,
-            })
-          );
+            this.$el.html(
+              this.template({
+                product: this.getFormData(),
+                locale: UserContext.get('catalogLocale'),
+                state: this.state.toJSON(),
+                trees: this.trees,
+              })
+            );
 
-          const lockedCategoryIds = this.getFormData().meta.ascendant_category_ids;
+            const lockedCategoryIds = this.getFormData().meta.ascendant_category_ids;
 
-          this.treeAssociate = new TreeAssociate(
-            {
-              list_categories: this.config.itemCategoryListRoute,
-              children: 'pim_enrich_categorytree_children',
-            },
-            this.isReadOnly(),
-            lockedCategoryIds
-          );
+            this.treeAssociate = new TreeAssociate(
+              {
+                list_categories: this.config.itemCategoryListRoute,
+                children: 'pim_enrich_categorytree_children',
+              },
+              this.isReadOnly(),
+              lockedCategoryIds
+            );
 
-          this.initCategoryCount();
-          this.renderCategorySwitcher();
-        }.bind(this)
-      );
+            this.initCategoryCount();
+            this.renderCategorySwitcher();
+          }.bind(this)
+        );
+      }
+      this.delegateEvents();
 
       return this;
     },


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When switching out of and then back into the 'Categories' tab of the PEF, the category tree events were not listened to anymore, making it impossible to update the categories or even switch to a different category tree.
In this PR, the category trees are built and rendered only once (when the `render()` method is called for the first time), and the events are delegated ate each call of this method

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
