### PR TITLE
API-1512: Refactor storage of Events API logs

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepository.php
@@ -34,6 +34,14 @@ final class ElasticsearchEventsApiDebugRepository implements EventsApiDebugRepos
 
     public function persist(array $log): void
     {
+        $flattenedContext = '';
+
+        array_walk_recursive($log['context'], function($value, $key) use (&$flattenedContext) {
+            $flattenedContext .= $value . ' ';
+        });
+
+        $log['context_flattened'] = trim($flattenedContext);
+
         $this->buffer[] = $log;
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepository.php
@@ -36,7 +36,7 @@ final class ElasticsearchEventsApiDebugRepository implements EventsApiDebugRepos
     {
         $flattenedContext = '';
 
-        array_walk_recursive($log['context'], function($value, $key) use (&$flattenedContext) {
+        array_walk_recursive($log['context'], function ($value, $key) use (&$flattenedContext) {
             $flattenedContext .= $value . ' ';
         });
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml
@@ -11,3 +11,5 @@ mappings:
         context:
             type: 'object'
             enabled: false
+        context_flattened:
+            type: 'text'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
@@ -36,7 +36,10 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
             'connection_code' => null,
             'context' => [
                 'data' => 'Some more informations.',
-                'other_data' => 'Another informations.',
+                'other_data' => 'Other important data',
+                'more' => [
+                    'more_other_data' => 'Deep data'
+                ],
             ],
         ]);
         $this->elasticsearchEventsApiDebugRepository->persist([
@@ -61,9 +64,12 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
                 'connection_code' => null,
                 'context' => [
                     'data' => 'Some more informations.',
-                    'other_data' => 'Another informations.',
+                    'other_data' => 'Other important data',
+                    'more' => [
+                        'more_other_data' => 'Deep data'
+                    ],
                 ],
-                'context_flattened' => 'Some more informations. Another informations.',
+                'context_flattened' => 'Some more informations. Other important data Deep data',
             ],
             $result['hits']['hits'][0]['_source']
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Repository/ElasticsearchEventsApiDebugRepositoryIntegration.php
@@ -36,6 +36,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
             'connection_code' => null,
             'context' => [
                 'data' => 'Some more informations.',
+                'other_data' => 'Another informations.',
             ],
         ]);
         $this->elasticsearchEventsApiDebugRepository->persist([
@@ -60,7 +61,9 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
                 'connection_code' => null,
                 'context' => [
                     'data' => 'Some more informations.',
+                    'other_data' => 'Another informations.',
                 ],
+                'context_flattened' => 'Some more informations. Another informations.',
             ],
             $result['hits']['hits'][0]['_source']
         );
@@ -72,6 +75,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
                 'message' => 'A warning message!',
                 'connection_code' => 'erp_0000',
                 'context' => [],
+                'context_flattened' => '',
             ],
             $result['hits']['hits'][1]['_source']
         );


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We need to flatten the context when storing it in ES.
2 different fields: the full context as `object`, a `text` with only the recursive values.
