### PR TITLE
PLG-89: display the last operations widget on the dashboard

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/DashboardIndex.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/DashboardIndex.tsx
@@ -3,15 +3,20 @@ import {PageContent} from '@akeneo-pim-community/shared';
 import {Header} from './Header';
 import {CompletenessWidget} from './Widgets/CompletenessWidget';
 import {LastOperationsWidget} from './Widgets/LastOperationsWidget';
+import styled from 'styled-components';
+
+const StyledPageContent = styled(PageContent)`
+  height: calc(100vh - 240px);
+`;
 
 const DashboardIndex = () => {
   return (
     <>
       <Header />
-      <PageContent>
+      <StyledPageContent>
         <CompletenessWidget />
         <LastOperationsWidget />
-      </PageContent>
+      </StyledPageContent>
     </>
   );
 };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
@@ -1,21 +1,109 @@
 import React from 'react';
-import {SectionTitle, SettingsIllustration} from 'akeneo-design-system';
-import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
+import {Badge, Button, SectionTitle, SettingsIllustration, Table} from 'akeneo-design-system';
+import {useRouter, useTranslate} from '@akeneo-pim-community/legacy-bridge';
 import {NoDataSection, NoDataText} from '@akeneo-pim-community/shared';
+import {useDashboardLastOperations} from '../../hooks';
+import {Operation} from '../../domain';
+
+const JOB_STARTING = '2';
+const JOB_STARTED = '3';
+const JOB_FAILED = '6';
 
 const LastOperationsWidget = () => {
   const translate = useTranslate();
+  const router = useRouter();
+  const data: Operation[] | null = useDashboardLastOperations();
+
+  const redirectToJob = (jobId: string) => {
+    // @ts-ignore
+    router.redirectToRoute('pim_enrich_job_tracker_show', {id: jobId});
+  };
 
   return (
     <>
       <SectionTitle>
         <SectionTitle.Title>{translate('pim_dashboard.widget.last_operations.title')}</SectionTitle.Title>
+        {data !== null && data.length > 0 && (
+          <>
+            <SectionTitle.Spacer />
+            <Button
+              ghost
+              size={'small'}
+              level={'tertiary'}
+              title="Show job tracker"
+              // @ts-ignore
+              onClick={() => router.redirectToRoute('pim_enrich_job_tracker_index')}
+            >
+              {translate('pim_import_export.widget.last_operations.header.view_all')}
+            </Button>
+          </>
+        )}
       </SectionTitle>
 
-      <NoDataSection style={{marginTop: 0}}>
-        <SettingsIllustration width={128} height={128} />
-        <NoDataText>{translate('pim_import_export.widget.last_operations.empty')}</NoDataText>
-      </NoDataSection>
+      {data === null ||
+        (data.length === 0 && (
+          <NoDataSection style={{marginTop: 0}}>
+            <SettingsIllustration width={128} height={128} />
+            <NoDataText>{translate('pim_import_export.widget.last_operations.empty')}</NoDataText>
+          </NoDataSection>
+        ))}
+
+      {data !== null && data.length > 0 && (
+        <Table>
+          <Table.Header>
+            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.date')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('pim_common.type')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.profile_name')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.username')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('pim_common.status')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.warning_count')}</Table.HeaderCell>
+            <Table.HeaderCell />
+          </Table.Header>
+          <Table.Body>
+            {data.map((operation: Operation) => {
+              const badgeLevel =
+                operation.status === JOB_FAILED
+                  ? 'danger'
+                  : operation.warningCount !== null && operation.warningCount !== '0'
+                  ? 'warning'
+                  : 'primary';
+              const counter = operation.status === JOB_FAILED ? 1 : operation.warningCount;
+
+              return (
+                <Table.Row key={`operation${operation.id}`}>
+                  <Table.Cell>{operation.date}</Table.Cell>
+                  <Table.Cell>
+                    {translate(`pim_import_export.widget.last_operations.job_type.${operation.type}`)}
+                  </Table.Cell>
+                  <Table.Cell>{operation.label}</Table.Cell>
+                  <Table.Cell>{operation.username}</Table.Cell>
+                  <Table.Cell>
+                    <Badge level={badgeLevel}>
+                      {translate(operation.statusLabel)}
+                      {(operation.status === JOB_STARTING || operation.status === JOB_STARTED) &&
+                        ` ${operation.tracking.currentStep}/${operation.tracking.totalSteps}`}
+                    </Badge>
+                  </Table.Cell>
+                  <Table.Cell>{counter > 0 ? counter : '-'}</Table.Cell>
+                  <Table.Cell>
+                    {operation.canSeeReport && (
+                      <Button
+                        type="button"
+                        ghost
+                        size="small"
+                        level="tertiary"
+                        onClick={() => redirectToJob(operation.id)}
+                      >
+                        {translate('pim_import_export.widget.last_operations.details')}
+                      </Button>
+                    )}
+                  </Table.Cell>
+                </Table.Row>
+              );
+            })}
+          </Table.Body>
+        </Table>
+      )}
     </>
   );
 };

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/domain/index.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/domain/index.ts
@@ -1,1 +1,2 @@
 export * from './completeness';
+export * from './operation';

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/domain/operation.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/domain/operation.ts
@@ -1,0 +1,17 @@
+type Operation = {
+  id: string;
+  date: string;
+  username: string;
+  type: string;
+  label: string;
+  status: string;
+  warningCount: string;
+  statusLabel: string;
+  tracking: {
+    currentStep: number;
+    totalSteps: number;
+  };
+  canSeeReport: boolean;
+};
+
+export {Operation};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/index.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useDashboardCompleteness';
+export * from './useDashboardLastOperations';

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/useDashboardLastOperations.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/hooks/useDashboardLastOperations.ts
@@ -1,0 +1,21 @@
+import {useEffect, useState} from 'react';
+import {Operation} from '../domain';
+
+const Routing = require('routing');
+
+const useDashboardLastOperations = () => {
+  const [data, setData] = useState<Operation[] | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const result = await fetch(Routing.generate('pim_dashboard_widget_data', {alias: 'last_operations'}), {
+        method: 'GET',
+      });
+      setData(await result.json());
+    })();
+  }, []);
+
+  return data;
+};
+
+export {useDashboardLastOperations};

--- a/tests/front/unit/jest/unit.jest.js
+++ b/tests/front/unit/jest/unit.jest.js
@@ -21,6 +21,7 @@ const unitConfig = {
     'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts',
     'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/fetchers',
     'src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/store',
+    'src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity',
   ],
   moduleNameMapper: {
     '^require-context$': `${__dirname}/../../../../frontend/webpack/require-context.js`,

--- a/tests/legacy/features/Behat/Context/NavigationContext.php
+++ b/tests/legacy/features/Behat/Context/NavigationContext.php
@@ -157,10 +157,6 @@ class NavigationContext extends PimContext implements PageObjectAware
 
             return $signInButton;
         }, sprintf('Cannot log in as %s', $username));
-
-        $this->spin(function () {
-            return $this->getSession()->getPage()->find('css', '.AknWidget');
-        }, 'Can not reach Dashboard after login');
     }
 
     /**

--- a/tests/legacy/features/platform/dashboard/display_last_operations_widget.feature
+++ b/tests/legacy/features/platform/dashboard/display_last_operations_widget.feature
@@ -13,7 +13,7 @@ Feature: Display last operations widget
   Scenario: Display last operations widget
     When I am on the dashboard page
     Then I should see the text "Last operations"
-    Then I should see the text "No operations found"
+    Then I should see the text "There is no operation to display for now"
     When I am on the "csv_footwear_category_export" export job page
     And I launch the export job
     And I wait for the "csv_footwear_category_export" job to finish
@@ -27,5 +27,5 @@ Feature: Display last operations widget
     And I wait for the "csv_footwear_category_export" job to finish
     When I am on the dashboard page
     Then I should see the text "Last operations"
-    And I follow the link "Show job tracker"
+    And I press the "Show job tracker" button
     Then I should be redirected on the job tracker page

--- a/tests/legacy/features/platform/security/login.feature
+++ b/tests/legacy/features/platform/security/login.feature
@@ -5,3 +5,4 @@ Feature: Login as a user into the application
     Given the "default" catalog configuration
     When I am logged in through the UI as "Mary"
     Then I am on the dashboard page
+    And I should see the text "Hello Mary"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**
![image](https://user-images.githubusercontent.com/1978756/111186611-74ca7e80-85b3-11eb-95c8-29471a82a2b5.png)

![image](https://user-images.githubusercontent.com/1978756/111187276-25d11900-85b4-11eb-8f59-68ed84cc8b53.png)

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
