### PR TITLE
PIM-9748: Upgrade JQuery for security reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Bug fixes
 
+- PIM-9748: Upgrade JQuery for security reasons
 - PIM-9678: The time counter is still running despite the job failed
 - PIM-9672: Error 500 on the API when inputing [null] on an array
 - PIM-9595: Avoid 403 error when launching import with no view rights on import details

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "dep-diff": "1.0.1",
     "dropzone": "4.0.1",
     "formik": "^2.0.6",
-    "jquery": "3.6.0",
+    "jquery": "3.5.0",
     "json-schema-ref-parser": "^7.1.2",
     "json-schema-to-typescript": "^7.1.0",
     "less": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "dep-diff": "1.0.1",
     "dropzone": "4.0.1",
     "formik": "^2.0.6",
-    "jquery": "3.5.0",
+    "jquery": "^3.6.0",
     "json-schema-ref-parser": "^7.1.2",
     "json-schema-to-typescript": "^7.1.0",
     "less": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "dep-diff": "1.0.1",
     "dropzone": "4.0.1",
     "formik": "^2.0.6",
-    "jquery": "3.4.0",
+    "jquery": "3.6.0",
     "json-schema-ref-parser": "^7.1.2",
     "json-schema-to-typescript": "^7.1.0",
     "less": "^3.9.0",

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/init-layout.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/init-layout.js
@@ -73,7 +73,7 @@ define([
     };
 
     if (!anchor.length) {
-      anchor = $('<div id="bottom-anchor"/>')
+      anchor = $('<div id="bottom-anchor"></div>')
         .css({
           position: 'fixed',
           bottom: '0',

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/router.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/router.js
@@ -93,7 +93,7 @@ define([
           }
 
           $('#container').empty();
-          var $view = $('<div class="view"/>').appendTo($('#container'));
+          var $view = $('<div class="view"></div>').appendTo($('#container'));
 
           if (controller.feature && !FeatureFlags.isEnabled(controller.feature)) {
             this.hideLoadingMask();

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
@@ -441,7 +441,7 @@
       if (!isActive) {
         if ('ontouchstart' in document.documentElement) {
           // if mobile we we use a backdrop because click events don't delegate
-          $('<div class="dropdown-backdrop"/>').insertBefore($(this)).on('click', clearMenus);
+          $('<div class="dropdown-backdrop"></div>').insertBefore($(this)).on('click', clearMenus);
         }
 
         // This little code block will set correct position for dropdown elements.
@@ -719,7 +719,7 @@
       if (this.isShown && this.options.backdrop) {
         var doAnimate = $.support.transition && animate;
 
-        this.$backdrop = $('<div class="modal-backdrop ' + animate + '" />').appendTo(document.body);
+        this.$backdrop = $('<div class="modal-backdrop ' + animate + '"></div>').appendTo(document.body);
 
         this.$backdrop.click(
           this.options.backdrop == 'static'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/jstree/jquery.jstree.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/jstree/jquery.jstree.js
@@ -1050,7 +1050,7 @@
         create_node: function (obj, position, js, callback, is_loaded) {
           obj = this._get_node(obj);
           position = typeof position === 'undefined' ? 'last' : position;
-          var d = $('<li />'),
+          var d = $('<li></li>'),
             s = this._get_settings().core,
             tmp;
 
@@ -1090,7 +1090,7 @@
             js.data.push(tmp);
           }
           $.each(js.data, function (i, m) {
-            tmp = $('<a />');
+            tmp = $('<a></a>');
             if ($.isFunction(m)) {
               m = m.call(this, js);
             }
@@ -1143,21 +1143,21 @@
             case 'inside':
             case 'first':
               if (!obj.children('ul').length) {
-                obj.append('<ul />');
+                obj.append('<ul></ul>');
               }
               obj.children('ul').prepend(d);
               tmp = obj;
               break;
             case 'last':
               if (!obj.children('ul').length) {
-                obj.append('<ul />');
+                obj.append('<ul></ul>');
               }
               obj.children('ul').append(d);
               tmp = obj;
               break;
             default:
               if (!obj.children('ul').length) {
-                obj.append('<ul />');
+                obj.append('<ul></ul>');
               }
               if (!position) {
                 position = 0;
@@ -1384,7 +1384,7 @@
             obj.or.before(o);
           } else {
             if (!obj.np.children('ul').length) {
-              $('<ul />').appendTo(obj.np);
+              $('<ul></ul>').appendTo(obj.np);
             }
             obj.np.children('ul:eq(0)').append(o);
           }
@@ -1429,10 +1429,10 @@
         scrollbar_width = e1.width() - e2.width();
         e1.add(e2).remove();
       } else {
-        e1 = $('<div />')
+        e1 = $('<div></div>')
           .css({width: 100, height: 100, overflow: 'auto', position: 'absolute', top: -1000, left: 0})
           .prependTo('body')
-          .append('<div />')
+          .append('<div></div>')
           .find('div')
           .css({width: '100%', height: 200});
         scrollbar_width = 100 - e1.width();
@@ -1842,7 +1842,7 @@
             w1 = obj.children('ins').width(),
             w2 = obj.find('> a:visible > ins').width() * obj.find('> a:visible > ins').length,
             t = this.get_text(obj),
-            h1 = $('<div />', {
+            h1 = $('<div></div>', {
               css: {position: 'absolute', top: '-200px', left: rtl ? '0px' : '-1000px', visibility: 'hidden'},
             }).appendTo('body'),
             h2 = obj
@@ -2608,7 +2608,7 @@
             if (!js.data && js.data !== '') {
               return d;
             }
-            d = $('<li />');
+            d = $('<li></li>');
             if (js.attr) {
               d.attr(js.attr);
             }
@@ -2624,7 +2624,7 @@
               js.data.push(tmp);
             }
             $.each(js.data, function (i, m) {
-              tmp = $('<a />');
+              tmp = $('<a></a>');
               if ($.isFunction(m)) {
                 m = m.call(this, js);
               }
@@ -2666,7 +2666,7 @@
                 if ($.isArray(js.children) && js.children.length) {
                   tmp = this._parse_json(js.children, obj, true);
                   if (tmp.length) {
-                    ul2 = $('<ul />');
+                    ul2 = $('<ul></ul>');
                     ul2.append(tmp);
                     d.append(ul2);
                   }
@@ -2675,7 +2675,7 @@
             }
           }
           if (!is_callback) {
-            ul1 = $('<ul />');
+            ul1 = $('<ul></ul>');
             ul1.append(d);
             d = ul1;
           }
@@ -3150,7 +3150,7 @@
         $.vakata.dnd.init_y = e.pageY;
         $.vakata.dnd.user_data = data;
         $.vakata.dnd.is_down = true;
-        $.vakata.dnd.helper = $("<div id='vakata-dragged' />").html(html); //.fadeTo(10,0.25);
+        $.vakata.dnd.helper = $("<div id='vakata-dragged'></div>").html(html); //.fadeTo(10,0.25);
         $(document).bind('mousemove', $.vakata.dnd.drag);
         $(document).bind('mouseup', $.vakata.dnd.drag_stop);
         return false;
@@ -3883,7 +3883,7 @@
         '}' +
         '';
       $.vakata.css.add_sheet({str: css_string, title: 'jstree'});
-      m = $('<div />')
+      m = $('<div></div>')
         .attr({id: 'jstree-marker'})
         .hide()
         .html('&raquo;')
@@ -3895,7 +3895,7 @@
           return false;
         })
         .appendTo('body');
-      ml = $('<div />')
+      ml = $('<div></div>')
         .attr({id: 'jstree-marker-line'})
         .hide()
         .bind('mouseup', function (e) {
@@ -4346,7 +4346,7 @@
         p = new XSLTProcessor();
         p.importStylesheet(xsl);
         r = p.transformToFragment(xml, document);
-        r = $('<div />').append(r).html();
+        r = $('<div></div>').append(r).html();
       }
       // OLD IE
       if (r === false && typeof xml.transformNode !== 'undefined') {
@@ -5047,7 +5047,7 @@
     $.vakata.context = {
       hide_on_mouseleave: false,
 
-      cnt: $("<div id='vakata-contextmenu' />"),
+      cnt: $("<div id='vakata-contextmenu'></div>"),
       vis: false,
       tgt: false,
       par: false,
@@ -5800,7 +5800,7 @@
                   if (d && d !== '' && d.toString && d.toString().replace(/^[\s\n]+$/, '') !== '') {
                     d = $(d);
                     if (!d.is('ul')) {
-                      d = $('<ul />').append(d);
+                      d = $('<ul></ul>').append(d);
                     }
                     if (obj == -1 || !obj) {
                       this.get_container()
@@ -5886,7 +5886,7 @@
               if (!obj || obj == -1) {
                 d = $(s.data);
                 if (!d.is('ul')) {
-                  d = $('<ul />').append(d);
+                  d = $('<ul></ul>').append(d);
                 }
                 this.get_container()
                   .children('ul')
@@ -5941,7 +5941,7 @@
                 if (d) {
                   d = $(d);
                   if (!d.is('ul')) {
-                    d = $('<ul />').append(d);
+                    d = $('<ul></ul>').append(d);
                   }
                   if (obj == -1 || !obj) {
                     this.get_container()
@@ -6530,7 +6530,7 @@
               o
                 .clone()
                 .removeClass('jstree-wholerow-real')
-                .wrapAll("<div class='jstree-wholerow' />")
+                .wrapAll("<div class='jstree-wholerow'></div>")
                 .parent()
                 .width(o.parent()[0].scrollWidth)
                 .css('top', (o.height() + (is_ie7 ? 5 : 0)) * -1)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/slimbox2/slimbox2.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/slimbox2/slimbox2.js
@@ -34,26 +34,26 @@
   w(function () {
     w('body').append(
       w([
-        (H = w('<div id="lbOverlay" />')[0]),
-        (a = w('<div id="lbCenter" />')[0]),
-        (G = w('<div id="lbBottomContainer" />')[0]),
+        (H = w('<div id="lbOverlay"></div>')[0]),
+        (a = w('<div id="lbCenter"></div>')[0]),
+        (G = w('<div id="lbBottomContainer"></div>')[0]),
       ]).css('display', 'none')
     );
-    g = w('<div id="lbImage" />')
+    g = w('<div id="lbImage"></div>')
       .appendTo(a)
       .append(
-        (p = w('<div style="position: relative;" />').append([
-          (I = w('<a id="lbPrevLink" href="#" />').click(B)[0]),
-          (d = w('<a id="lbNextLink" href="#" />').click(e)[0]),
+        (p = w('<div style="position: relative;"></div>').append([
+          (I = w('<a id="lbPrevLink" href="#"></a>').click(B)[0]),
+          (d = w('<a id="lbNextLink" href="#"></a>').click(e)[0]),
         ])[0])
       )[0];
-    c = w('<div id="lbBottom" />')
+    c = w('<div id="lbBottom"></div>')
       .appendTo(G)
       .append([
-        w('<a id="lbCloseLink" href="#" />').add(H).click(C)[0],
-        (A = w('<div id="lbCaption" />')[0]),
-        (K = w('<div id="lbNumber" />')[0]),
-        w('<div style="clear: both;" />')[0],
+        w('<a id="lbCloseLink" href="#"></a>').add(H).click(C)[0],
+        (A = w('<div id="lbCaption"></div>')[0]),
+        (K = w('<div id="lbNumber"></div>')[0]),
+        w('<div style="clear: both;"></div>')[0],
       ])[0];
   });
   w.slimbox = function (O, N, M) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/common/edit/upload.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/common/edit/upload.html
@@ -3,19 +3,19 @@
         <% if (!file) { %>
             <input class="AknMediaField-fileUploaderInput" type="file" name="Drag and drop a file or click here"/>
             <div class="AknMediaField-emptyContainer">
-                <span title="upload icon" class="AknMediaField-uploadIcon"/>
+                <span title="upload icon" class="AknMediaField-uploadIcon"></span>
                 <span><%- __('pim_enrich.entity.job_execution.module.create.upload', {type})%></span>
             </div>
         <% } else { %>
             <div class="AknMediaField-preview preview">
                 <div class="AknMediaField-thumb file">
-                    <span title="upload icon" class="AknMediaField-uploadIcon"/>
+                    <span title="upload icon" class="AknMediaField-uploadIcon"></span>
                 </div>
                 <div class="AknMediaField-info info">
                     <div class="filename" title="<%- file.name %>"><%- file.name %></div>
                     <div class="AknButtonList AknButtonList--centered actions">
                         <span class="AknButtonList-item clear-field">
-                            <span class="AknMediaField-remove"/>
+                            <span class="AknMediaField-remove"></span>
                         </span>
                     </div>
                 </div>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/common/fields/media.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/common/fields/media.html
@@ -2,7 +2,7 @@
     <% if (media.filePath === null) { %>
         <input class="AknMediaField-fileUploaderInput<%- readOnly ? ' AknMediaField-fileUploaderInput--disabled' : '' %>" type="file" />
         <div class="AknMediaField-emptyContainer">
-            <span title="upload icon" class="AknMediaField-uploadIcon"/>
+            <span title="upload icon" class="AknMediaField-uploadIcon"></span>
             <span><%- uploadLabel %></span>
         </div>
     <% } else { %>
@@ -14,7 +14,7 @@
                 <div class="AknMediaField-thumb file"><img src="<%- mediaThumbnailUrl %>" class="AknMediaField-image"/></div>
             <% } else { %>
                 <div class="AknMediaField-thumb file">
-                    <span title="upload icon" class="AknMediaField-uploadIcon"/>
+                    <span title="upload icon" class="AknMediaField-uploadIcon"></span>
                 </div>
             <% } %>
             <div class="AknMediaField-info info">

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/grid/mass-actions.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/grid/mass-actions.html
@@ -1,6 +1,6 @@
 <div class="select-button AknSelectButton"></div>
 <div class="AknDropdown select-dropdown">
-    <div class="AknMassActions-dropdown" data-toggle="dropdown"/>
+    <div class="AknMassActions-dropdown" data-toggle="dropdown"></div>
     <div class="AknDropdown-menu">
         <div class="AknDropdown-menuTitle"><%- select %></div>
         <div class="AknDropdown-menuLink select-all"><%- selectAll %></div>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
@@ -1,5 +1,5 @@
 <div class="AknFullPage AknFullPage--withBottom">
-    <span class="AknButtonList-item AknFullPage-cancel wizard-action" data-action-target="grid"/>
+    <span class="AknButtonList-item AknFullPage-cancel wizard-action" data-action-target="grid"></span>
     <% if (currentStep === 'choose') { %>
         <span class="AknButton AknFullPage-ok AknButton--apply<% if (!currentOperation) { %> AknButton--disabled<% } %> wizard-action next" data-action-target="configure">
             <%- nextLabel %>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/media.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/media.html
@@ -2,7 +2,7 @@
     <% if (!value || !value.data || value.data.filePath === null) { %>
         <input class="AknMediaField-fileUploaderInput" id="<%- fieldId %>" type="file" data-locale="<%- locale %>" data-scope="<%- scope %>" <%- editMode === 'view' ? 'disabled' : '' %>/>
         <div class="AknMediaField-emptyContainer">
-            <span title="upload icon" class="AknMediaField-uploadIcon"/>
+            <span title="upload icon" class="AknMediaField-uploadIcon"></span>
             <span><%- _.__('pim_common.media_upload')%></span>
         </div>
     <% } else { %>
@@ -14,7 +14,7 @@
                 <div class="AknMediaField-thumb file"><img src="<%- mediaThumbnailUrl %>" class="AknMediaField-image"/></div>
             <% } else { %>
                 <div class="AknMediaField-thumb file">
-                    <span title="upload icon" class="AknMediaField-uploadIcon"/>
+                    <span title="upload icon" class="AknMediaField-uploadIcon"></span>
                 </div>
             <% } %>
             <div class="AknMediaField-info info">

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
@@ -31,7 +31,7 @@ define([
         '<span class="AknFilterBox-filterCriteria AknFilterBox-filterCriteria--limited filter-criteria-hint"><%= criteriaHint %></span>' +
         '<span class="AknFilterBox-filterCaret"></span>' +
         '</div>' +
-        '<div class="filter-criteria dropdown-menu" />' +
+        '<div class="filter-criteria dropdown-menu"></div>' +
         '<% if (canDisable) { %><div class="AknFilterBox-disableFilter AknIconButton AknIconButton--remove disable-filter"></div><% } %>'
     ),
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/lib/multiselect/jquery.multiselect.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/lib/multiselect/jquery.multiselect.js
@@ -59,15 +59,15 @@ define(['jquery'], function ($) {
           .addClass(o.classes)
           .attr({title: el.attr('title'), 'aria-haspopup': true, tabIndex: el.attr('tabIndex')})
           .insertAfter(el),
-        buttonlabel = (this.buttonlabel = $('<span />')).html(o.noneSelectedText).appendTo(button),
-        menu = (this.menu = $('<div />'))
+        buttonlabel = (this.buttonlabel = $('<span></span>')).html(o.noneSelectedText).appendTo(button),
+        menu = (this.menu = $('<div></div>'))
           .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all')
           .addClass(o.classes)
           .appendTo(document.body),
-        header = (this.header = $('<div />'))
+        header = (this.header = $('<div></div>'))
           .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
           .appendTo(menu),
-        headerLinkContainer = (this.headerLinkContainer = $('<ul />'))
+        headerLinkContainer = (this.headerLinkContainer = $('<ul></ul>'))
           .addClass('ui-helper-reset')
           .html(function () {
             if (o.header === true) {
@@ -88,7 +88,7 @@ define(['jquery'], function ($) {
             '<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon ui-icon-circle-close"></span></a></li>'
           )
           .appendTo(header),
-        checkboxContainer = (this.checkboxContainer = $('<ul />'))
+        checkboxContainer = (this.checkboxContainer = $('<ul></ul>'))
           .addClass('ui-multiselect-checkboxes ui-helper-reset')
           .appendTo(menu);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6163,10 +6163,10 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery@3.5.0:
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
-  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
+jquery@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-base64@^2.3.2:
   version "2.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,15 +3178,15 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.8.3.tgz#10e9e3b2592ecaede4283e8f3ad7020811587c02"
   integrity sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
-
-core-js@^3.6.4:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.9.1.tgz#cec8de593db8eb2a85ffb0dbdeb312cb6e5460ae"
-  integrity sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3809,19 +3809,19 @@ domutils@^2.4.2, domutils@^2.4.3, domutils@^2.4.4:
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
 
-draft-js@^0.11.7:
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.7.tgz#be293aaa255c46d8a6647f3860aa4c178484a206"
-  integrity sha512-ne7yFfN4sEL82QPQEn80xnADR8/Q6ALVworbC5UOSzOvjffmYfFsr3xSZtxbIirti14R7Y33EZC5rivpLgIbsg==
+draft-js@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.10.5.tgz#bfa9beb018fe0533dbb08d6675c371a6b08fa742"
+  integrity sha512-LE6jSCV9nkPhfVX2ggcRLA4FKs6zWq9ceuO/88BpXdNCS7mjRTgs0NsV6piUCJX9YxMsB9An33wnkMmU2sD2Zg==
   dependencies:
-    fbjs "^2.0.0"
+    fbjs "^0.8.15"
     immutable "~3.7.4"
-    object-assign "^4.1.1"
+    object-assign "^4.1.0"
 
-draftjs-to-html@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/draftjs-to-html/-/draftjs-to-html-0.9.1.tgz#1c870fbb588d2390204cb4d0ee7e04ad0c709969"
-  integrity sha512-fFstE6+IayaVFBEvaFt/wN8vdj8FsTRzij7dy7LI9QIwf5LgfHFi9zSpvCg+feJ2tbYVqHxUkjcibwpsTpgFVQ==
+draftjs-to-html@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/draftjs-to-html/-/draftjs-to-html-0.8.4.tgz#bda0adc00945db1f1baf0191b34b49b24191f1df"
+  integrity sha512-+4hekxc8dTJvKk6usiEsFX9O1uOD9vLZZOs9ZI3RhTe89yNmtazYII/ILDXfbMPfzNaYfX7Gf3zjRm6UUFxqyg==
 
 draftjs-utils@^0.10.2:
   version "0.10.2"
@@ -3901,6 +3901,13 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encoding@^0.1.11:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
@@ -4504,19 +4511,13 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs-css-vars@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
-  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
-
-fbjs@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-2.0.0.tgz#01fb812138d7e31831ed3e374afe27b9169ef442"
-  integrity sha512-8XA8ny9ifxrAWlyhAbexXcs3rRMtxWcs3M0lctLfB49jRDHiaxj+Mo0XxbwE7nKZYzgCFoq64FS+WFd4IycPPQ==
+fbjs@^0.8.15:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
   dependencies:
-    core-js "^3.6.4"
-    cross-fetch "^3.0.4"
-    fbjs-css-vars "^1.0.0"
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
@@ -5220,6 +5221,13 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-4.1.1.tgz#21170b53789ee27447c2f47dd683081403f9a467"
@@ -5624,7 +5632,7 @@ is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.1:
     call-bind "^1.0.2"
     has-symbols "^1.0.1"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5719,6 +5727,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6147,10 +6163,10 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+jquery@3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-base64@^2.3.2:
   version "2.6.4"
@@ -6943,6 +6959,14 @@ node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -7830,7 +7854,7 @@ raw-loader@1.0.0:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-react-dom@^16.14.0:
+react-dom@^16.13.1, react-dom@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -7840,7 +7864,7 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-draft-wysiwyg@^1.14.5:
+react-draft-wysiwyg@^1.12.13:
   version "1.14.5"
   resolved "https://registry.yarnpkg.com/react-draft-wysiwyg/-/react-draft-wysiwyg-1.14.5.tgz#82e34ae3472b815b5d9f70615f40e13afcbc2055"
   integrity sha512-utbJEs91757QXYoBwKRb/4kB3JdswLlj0heUiAeXs/OxZAUISJXxLMFLBIixRlIcUnNkwxOsMikRshDMtWIS3g==
@@ -7935,7 +7959,7 @@ react-test-renderer@^16.0.0-0, react-test-renderer@^16.8.0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react@^16.14.0:
+react@^16.13.1, react@^16.14.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -8449,7 +8473,7 @@ safe-regex@^1.1.0:
   dependencies:
     ret "~0.1.10"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10223,6 +10247,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6163,7 +6163,7 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery@3.6.0:
+jquery@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
   integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6163,10 +6163,10 @@ jest@^26.4.2:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jquery@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+jquery@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.0.tgz#9980b97d9e4194611c36530e7dc46a58d7340fc9"
+  integrity sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ==
 
 js-base64@^2.3.2:
   version "2.6.4"


### PR DESCRIPTION
This PR upgrades jQuery version following a XSS vulnerability that was fixed in version 3.5.0.
As this version introduces a breaking change on a specific method (see https://jquery.com/upgrade-guide/3.5/), this PR also updates all self-closing tags in HTML templates and in JS files using jQuery.