### PR TITLE
fix #14117: check for cookies property in ScriptNonceGenerator

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ScriptNonceGenerator.php
@@ -42,7 +42,11 @@ class ScriptNonceGenerator
     public function getGeneratedNonce(): string
     {
         $request = $this->request->getCurrentRequest();
-        $bapId = $request->cookies->get('BAPID');
+
+        $bapId = '';
+        if ($request !== null && isset($request->cookies)) {
+            $bapId = $request->cookies->get('BAPID');
+        }
 
         return hash_hmac('ripemd160', $bapId, $this->kernelSecret);
     }


### PR DESCRIPTION
When the command `bin/console debug:event-dispatcher` is used the `ScriptNonceGenerator::getGeneratedNonce` is called. At this point the `ScriptNonceGenerator` object has been constructed with an `RequestStack` which has an empty Request object inside missing the `cookies` property.

The fix checkes whether a request was found (a null pointer can occure based on the `getCurrentRequest` method signature) and if the `cookies` property is present before using it to fill the `bapId` variable. If those conditions are not met, an empty string is used as a placeholder.

Github issue for Akeneo 4.0.98 | master https://github.com/akeneo/pim-community-dev/issues/14117

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
