### PR TITLE
API-1520: Move download logs button

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/shared/router/use-router.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/router/use-router.ts
@@ -1,0 +1,8 @@
+import {useContext} from 'react';
+import {RouterContext} from './router-context';
+
+export const useRouter = () => {
+    const {generate} = useContext(RouterContext);
+
+    return generate;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/DownloadLogsButton.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/DownloadLogsButton.tsx
@@ -1,0 +1,34 @@
+import React, {FC} from 'react';
+import {Button} from 'akeneo-design-system';
+import {Translate} from '../../shared/translate';
+import {useRouter} from '../../shared/router/use-router';
+import {EventSubscription} from '../hooks/api/use-fetch-event-subscription';
+
+type DownloadLogsButtonProps = {
+    eventSubscription?: EventSubscription;
+    disabled?: boolean;
+};
+
+export const DownloadLogsButton: FC<DownloadLogsButtonProps> = ({eventSubscription, disabled}) => {
+    const generateUrl = useRouter();
+
+    const url =
+        undefined !== eventSubscription
+            ? generateUrl('akeneo_connectivity_connection_events_api_debug_rest_download_event_subscription_logs', {
+                  connection_code: eventSubscription.connectionCode,
+              })
+            : undefined;
+
+    return (
+        <Button
+            href={url}
+            disabled={disabled || !eventSubscription?.enabled || false}
+            ghost
+            level='tertiary'
+            size='default'
+            target='_blank'
+        >
+            <Translate id='akeneo_connectivity.connection.webhook.download_logs' />
+        </Button>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
@@ -66,10 +66,7 @@ export const EventLogList: FC<{connectionCode: string}> = ({connectionCode}) => 
                 </Table.Header>
                 <Table.Body ref={scrollContainer}>
                     {logs.map(({timestamp, level, message, context}, index) => (
-                        <ExpandableTableRow
-                            key={index}
-                            contentToExpand={<FormattedJSON>{context}</FormattedJSON>}
-                        >
+                        <ExpandableTableRow key={index} contentToExpand={<FormattedJSON>{context}</FormattedJSON>}>
                             <Table.Cell>
                                 <ArrowRightIcon />
                                 <EventLogDatetime timestamp={timestamp * 1000} />

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
@@ -3,7 +3,7 @@ import {fetchResult} from '../../../shared/fetch-result';
 import {isErr} from '../../../shared/fetch-result/result';
 import {useRoute} from '../../../shared/router';
 
-type EventSubscription = {
+export type EventSubscription = {
     connectionCode: string;
     enabled: boolean;
     secret: string | null;

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -14,7 +14,7 @@ import {EventSubscriptionHelper} from '../components/EventSubscriptionHelper';
 import {useUpdateWebhook} from '../hooks/api/use-update-webhook';
 import {useFetchEventSubscription} from '../hooks/api/use-fetch-event-subscription';
 import {Webhook} from '../model/Webhook';
-import {Breadcrumb, SectionTitle, Button} from 'akeneo-design-system';
+import {Breadcrumb, SectionTitle} from 'akeneo-design-system';
 import {useFetchConnection} from '../hooks/api/use-fetch-connection';
 import {UserButtons} from '../../shared/user';
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -75,8 +75,7 @@ export const EditConnectionWebhook: FC = () => {
                         null === connection.image ? defaultImageUrl : generateMediaUrl(connection.image, 'thumbnail')
                     }
                     buttons={[
-                        <DownloadLogsButton key={0} webhook={eventSubscription} />,
-                        <SaveButton key={1} webhook={eventSubscription} onSaveSuccess={fetchEventSubscription} />,
+                        <SaveButton key={0} webhook={eventSubscription} onSaveSuccess={fetchEventSubscription} />,
                     ]}
                     state={<FormState />}
                 >
@@ -137,21 +136,6 @@ const SaveButton: FC<SaveButtonProps> = ({webhook, onSaveSuccess}) => {
         >
             <Translate id='pim_common.save' />
         </ApplyButton>
-    );
-};
-
-type DownloadLogsButtonProps = {
-    webhook: Webhook;
-};
-
-const DownloadLogsButton: FC<DownloadLogsButtonProps> = ({webhook}) => {
-    const url = useRoute('akeneo_connectivity_connection_events_api_debug_rest_download_event_subscription_logs', {
-        connection_code: webhook.connectionCode,
-    });
-    return (
-        <Button disabled={!webhook.enabled} ghost href={url} level='tertiary' size='default' target='_blank'>
-            <Translate id='akeneo_connectivity.connection.webhook.download_logs' />
-        </Button>
     );
 };
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
@@ -27,9 +27,7 @@ export const EventLogs: FC = () => {
                 <PageHeader
                     breadcrumb={<EventLogsBreadcrumb />}
                     userButtons={<UserButtons />}
-                    buttons={[
-                        <DownloadLogsButton key={0} disabled={true}/>,
-                    ]}
+                    buttons={[<DownloadLogsButton key={0} disabled={true} />]}
                 />
                 <PageContent>
                     <Loading />
@@ -38,27 +36,28 @@ export const EventLogs: FC = () => {
         );
     }
 
-    const downloadUrl = generateUrl('akeneo_connectivity_connection_events_api_debug_rest_download_event_subscription_logs', {
-        connection_code: eventSubscription.connectionCode
-    });
+    const downloadUrl = generateUrl(
+        'akeneo_connectivity_connection_events_api_debug_rest_download_event_subscription_logs',
+        {
+            connection_code: eventSubscription.connectionCode,
+        }
+    );
 
     return (
         <>
             <PageHeader
                 breadcrumb={<EventLogsBreadcrumb />}
                 userButtons={<UserButtons />}
-                buttons={[
-                    <DownloadLogsButton key={0} href={downloadUrl} disabled={!eventSubscription.enabled}/>,
-                ]}
+                buttons={[<DownloadLogsButton key={0} href={downloadUrl} disabled={!eventSubscription.enabled} />]}
             >
                 {connection.label}
             </PageHeader>
             <PageContent>
-                {
-                    eventSubscription.enabled
-                        ? <EventLogList connectionCode={connectionCode} />
-                        : <EventSubscriptionDisabled connectionCode={connectionCode} />
-                }
+                {eventSubscription.enabled ? (
+                    <EventLogList connectionCode={connectionCode} />
+                ) : (
+                    <EventSubscriptionDisabled connectionCode={connectionCode} />
+                )}
             </PageContent>
         </>
     );
@@ -84,10 +83,10 @@ const EventLogsBreadcrumb: FC = () => {
 
 type DownloadLogsButtonProps = {
     disabled?: boolean;
-    href?: string
+    href?: string;
 };
 
-const DownloadLogsButton: FC<DownloadLogsButtonProps> = (props) => {
+const DownloadLogsButton: FC<DownloadLogsButtonProps> = props => {
     return (
         <Button {...props} ghost level='tertiary' size='default' target='_blank'>
             <Translate id='akeneo_connectivity.connection.webhook.download_logs' />

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
@@ -1,4 +1,4 @@
-import {Breadcrumb, Button} from 'akeneo-design-system';
+import {Breadcrumb} from 'akeneo-design-system';
 import React, {FC, useEffect} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 import {Loading, PageContent, PageHeader} from '../../common';
@@ -9,10 +9,9 @@ import {EventSubscriptionDisabled} from '../components/EventSubscriptionDisabled
 import {EventLogList} from '../components/EventLogList';
 import {useFetchConnection} from '../hooks/api/use-fetch-connection';
 import {useFetchEventSubscription} from '../hooks/api/use-fetch-event-subscription';
-import {useRouter} from '../../shared/router/use-router';
+import {DownloadLogsButton} from '../components/DownloadLogsButton';
 
 export const EventLogs: FC = () => {
-    const generateUrl = useRouter();
     const {connectionCode} = useParams<{connectionCode: string}>();
     const {connection} = useFetchConnection(connectionCode);
     const {eventSubscription, fetchEventSubscription} = useFetchEventSubscription(connectionCode);
@@ -36,19 +35,12 @@ export const EventLogs: FC = () => {
         );
     }
 
-    const downloadUrl = generateUrl(
-        'akeneo_connectivity_connection_events_api_debug_rest_download_event_subscription_logs',
-        {
-            connection_code: eventSubscription.connectionCode,
-        }
-    );
-
     return (
         <>
             <PageHeader
                 breadcrumb={<EventLogsBreadcrumb />}
                 userButtons={<UserButtons />}
-                buttons={[<DownloadLogsButton key={0} href={downloadUrl} disabled={!eventSubscription.enabled} />]}
+                buttons={[<DownloadLogsButton key={0} eventSubscription={eventSubscription} />]}
             >
                 {connection.label}
             </PageHeader>
@@ -78,18 +70,5 @@ const EventLogsBreadcrumb: FC = () => {
                 <Translate id='akeneo_connectivity.connection.webhook.title' />
             </Breadcrumb.Step>
         </Breadcrumb>
-    );
-};
-
-type DownloadLogsButtonProps = {
-    disabled?: boolean;
-    href?: string;
-};
-
-const DownloadLogsButton: FC<DownloadLogsButtonProps> = props => {
-    return (
-        <Button {...props} ghost level='tertiary' size='default' target='_blank'>
-            <Translate id='akeneo_connectivity.connection.webhook.download_logs' />
-        </Button>
     );
 };


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

The download logs button was on the event subscription configuration page.
This PR move it to the dedicated new screen for the logs.

![Screenshot_2021-03-18_18-07-35](https://user-images.githubusercontent.com/1421130/111667295-d8071b80-8814-11eb-8201-fcac8a1e9b7d.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -