### PR TITLE
PIM-9758: Fix bad replacement for line breaks introduced in PIM-9658

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - PIM-9711: Check that a category root isn't linked to a user or a channel before moving it to a sub-category
 - PIM-9730: Fix category tree initialization in the PEF when switching tabs
 - PIM-9679: Clean existing text attribute values removing linebreaks
+- PIM-9758: Fix bad replacement for line breaks introduced in PIM-9658
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
@@ -14,8 +14,6 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
  */
 class CleanLineBreaksInTextAttributes
 {
-    private const LINE_BREAK_CHARACTERS = ['\r\n', '\r', '\n'];
-
     private GetAttributes $getAttributes;
 
     public function __construct(GetAttributes $getAttributes)
@@ -41,7 +39,7 @@ class CleanLineBreaksInTextAttributes
             foreach ($valuesForField as $key => $value) {
                 if (is_string($value['data'])) {
                     $cleanedData = str_replace(
-                        static::LINE_BREAK_CHARACTERS,
+                        ['\r\n', '\r', '\n'],
                         ' ',
                         $value['data']
                     );

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
@@ -39,7 +39,7 @@ class CleanLineBreaksInTextAttributes
             foreach ($valuesForField as $key => $value) {
                 if (is_string($value['data'])) {
                     $cleanedData = str_replace(
-                        ['\r\n', '\r', '\n'],
+                        ["\r\n", "\r", "\n"],
                         ' ',
                         $value['data']
                     );
@@ -63,7 +63,7 @@ class CleanLineBreaksInTextAttributes
             foreach ($values as $value) {
                 if (
                     is_string($value['data'])
-                    && (false !== strpos($value['data'], '\r') || false !== strpos($value['data'], '\n') )
+                    && (false !== strpos($value['data'], "\r") || false !== strpos($value['data'], "\n") )
                 ) {
                     $fieldsWithLineBreak[] = $field;
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Processor;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
-use Akeneo\Tool\Component\Batch\Model\Warning;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -15,7 +14,7 @@ use Akeneo\Tool\Component\Batch\Model\Warning;
  */
 class CleanLineBreaksInTextAttributes
 {
-    private const LINE_BREAK_REGULAR_EXPRESSION = '/[\r\n|\r|\n]+/';
+    private const LINE_BREAK_CHARACTERS = ['\r\n', '\r', '\n'];
 
     private GetAttributes $getAttributes;
 
@@ -41,8 +40,8 @@ class CleanLineBreaksInTextAttributes
             $valuesForField = $item['values'][$field] ?? null;
             foreach ($valuesForField as $key => $value) {
                 if (is_string($value['data'])) {
-                    $cleanedData = preg_replace(
-                        static::LINE_BREAK_REGULAR_EXPRESSION,
+                    $cleanedData = str_replace(
+                        static::LINE_BREAK_CHARACTERS,
                         ' ',
                         $value['data']
                     );
@@ -64,7 +63,10 @@ class CleanLineBreaksInTextAttributes
         $fieldsWithLineBreak = [];
         foreach ($item['values'] as $field => $values) {
             foreach ($values as $value) {
-                if (is_string($value['data']) && preg_match(static::LINE_BREAK_REGULAR_EXPRESSION, $value['data'])) {
+                if (
+                    is_string($value['data'])
+                    && (false !== strpos($value['data'], '\r') || false !== strpos($value['data'], '\n') )
+                ) {
                     $fieldsWithLineBreak[] = $field;
 
                     break;
@@ -84,7 +86,7 @@ class CleanLineBreaksInTextAttributes
 
         return array_keys(array_filter(
             $attributes,
-            fn (Attribute $attribute): bool => AttributeTypes::TEXT === $attribute->type()
+            fn(Attribute $attribute): bool => AttributeTypes::TEXT === $attribute->type()
         ));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributes.php
@@ -63,7 +63,7 @@ class CleanLineBreaksInTextAttributes
             foreach ($values as $value) {
                 if (
                     is_string($value['data'])
-                    && (false !== strpos($value['data'], "\r") || false !== strpos($value['data'], "\n") )
+                    && (false !== strpos($value['data'], "\r") || false !== strpos($value['data'], "\n"))
                 ) {
                     $fieldsWithLineBreak[] = $field;
 
@@ -84,7 +84,7 @@ class CleanLineBreaksInTextAttributes
 
         return array_keys(array_filter(
             $attributes,
-            fn(Attribute $attribute): bool => AttributeTypes::TEXT === $attribute->type()
+            fn (Attribute $attribute): bool => AttributeTypes::TEXT === $attribute->type()
         ));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
@@ -22,7 +22,7 @@ class CleanLineBreaksInTextAttributes
                             continue;
                         }
                         $cleanedData = str_replace(
-                            ['\r\n', '\r', '\n'],
+                            ["\r\n", "\r", "\n"],
                             ' ',
                             $data
                         );

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/CleanLineBreaksInTextAttributes.php
@@ -21,10 +21,11 @@ class CleanLineBreaksInTextAttributes
                         if (!is_string($data)) {
                             continue;
                         }
-                        $cleanedData = preg_replace(
-                            '/[\r\n|\r|\n]+/',
+                        $cleanedData = str_replace(
+                            ['\r\n', '\r', '\n'],
                             ' ',
-                            $data);
+                            $data
+                        );
                         $rawValueCollections[$productIdentifier][$attributeCode][$channelCode][$localeCode] = $cleanedData;
                     }
                 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/CleanLineBreaksInTextAttributesSpec.php
@@ -23,7 +23,7 @@ final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
                 ['data' => "line\nbreak"],
             ],
             'subtitle' => [
-                ['data' => "another line\nbreak"],
+                ['data' => "another line\nbreak with |pipe|"],
             ],
             'description' => [
                 ['data' => 'ok'],
@@ -43,7 +43,7 @@ final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
                 ['data' => 'line break'],
             ],
             'subtitle' => [
-                ['data' => 'another line break'],
+                ['data' => 'another line break with |pipe|'],
             ],
             'description' => [
                 ['data' => 'ok'],
@@ -105,7 +105,7 @@ final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
                 ['data' => 'line break1'],
                 ['data' => 'line break2'],
                 ['data' => 'line break3'],
-                ['data' => 'line break4'],
+                ['data' => 'line   break4'],
             ],
         ]]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/CleanLineBreaksInTextAttributesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/CleanLineBreaksInTextAttributesSpec.php
@@ -153,7 +153,7 @@ final class CleanLineBreaksInTextAttributesSpec extends ObjectBehavior
             ],
             'subtitle' => [
                 'print' => [
-                    'en_US' => 'The GoGEAR Tap 4.3 MP3 line break',
+                    'en_US' => 'The GoGEAR Tap 4.3 MP3 line   break',
                 ],
             ],
             'comment' => [


### PR DESCRIPTION
Small mistake, big impact in PIM-9658.
I fix it in this PR without using a regex.