### PR TITLE
PIM-9743: Add the "change input" event so that the SKU/code doesn't disappear when doing copy/paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PIM-9730: Fix category tree initialization in the PEF when switching tabs
 - PIM-9679: Clean existing text attribute values removing linebreaks
 - PIM-9758: Fix bad replacement for line breaks introduced in PIM-9658
+- PIM-9743: Add the "change input" event so that the SKU/code doesn't disappear when doing copy/paste 
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/creation/field.js
@@ -18,6 +18,7 @@ define(['jquery', 'underscore', 'oro/translator', 'pim/form', 'pim/template/form
     dialog: null,
     events: {
       'keyup input': 'updateModel',
+      'change input': 'updateModel',
     },
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When creating a new product, after filling in the SKU/code by making a right-click / paste, then after selecting the family, the code disappeared.

A PR was done for fixing a bug with the boolean field => https://github.com/akeneo/pim-community-dev/pull/11906
It updated the model only on "keyup input" this is why the model wasn't updated anymore when pasting with the mouse.
So, I added the "change input" event on the field.js file to fix the issue.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
