### PR TITLE
API-1521: Fix order of NOTICE & INFO logs

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Query/GetAllEventSubscriptionDebugLogsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Query/GetAllEventSubscriptionDebugLogsQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query;
 
 use Akeneo\Connectivity\Connection\Domain\Clock;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Model\EventsApiDebugLogLevels;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Query\GetAllEventSubscriptionDebugLogsQueryInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 
@@ -44,7 +45,7 @@ class GetAllEventSubscriptionDebugLogsQuery implements GetAllEventSubscriptionDe
                 'bool' => [
                     'should' => [
                         ['bool' => ['must' => [
-                            ['terms' => ['level' => ['info', 'notice']]],
+                            ['terms' => ['level' => [EventsApiDebugLogLevels::NOTICE, EventsApiDebugLogLevels::INFO]]],
                             ['terms' => ['_id' => $lastNoticeAndInfoIdentifiers]],
                             ['bool' => ['should' => [
                                 ['term' => ['connection_code' => $connectionCode]],
@@ -52,7 +53,7 @@ class GetAllEventSubscriptionDebugLogsQuery implements GetAllEventSubscriptionDe
                             ]]],
                         ]]],
                         ['bool' => ['must' => [
-                            ['terms' => ['level' => ['error', 'warning']]],
+                            ['terms' => ['level' => [EventsApiDebugLogLevels::ERROR, EventsApiDebugLogLevels::WARNING]]],
                             ['range' => ['timestamp' => ['gte' => $nowTimestamp - self::MAX_LIFETIME_OF_WARNING_AND_ERROR_LOGS]]],
                             ['bool' => ['should' => [
                                 ['term' => ['connection_code' => $connectionCode]],
@@ -81,12 +82,12 @@ class GetAllEventSubscriptionDebugLogsQuery implements GetAllEventSubscriptionDe
         $result = $this->elasticsearchClient->search(
             [
                 '_source' => ['id'],
-                'sort' => [['timestamp' => ['order' => 'ASC']]],
+                'sort' => [['timestamp' => ['order' => 'DESC']]],
                 'size' => self::MAX_NUMBER_OF_NOTICE_AND_INFO_LOGS,
                 'query' => [
                     'bool' => [
                         'must' => [
-                            ['terms' => ['level' => ['info', 'notice']]],
+                            ['terms' => ['level' => [EventsApiDebugLogLevels::INFO, EventsApiDebugLogLevels::NOTICE]]],
                             [
                                 'bool' => [
                                     'should' => [

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Query/GetEventSubscriptionLogsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Query/GetEventSubscriptionLogsQueryIntegration.php
@@ -60,7 +60,7 @@ class GetEventSubscriptionLogsQueryIntegration extends TestCase
     {
         $timestampNow = $this->clock->now()->getTimestamp() - 10;
         $timestampStep = 10;
-        $NumberOfGeneratedLogs = 101;
+        $countOfGeneratedLogs = 101;
         $excludeTimestamp = $timestampNow - $timestampStep * $NumberOfGeneratedLogs;
 
         $this->generateLogs(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Query/GetEventSubscriptionLogsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Persistence/Elasticsearch/Query/GetEventSubscriptionLogsQueryIntegration.php
@@ -61,7 +61,7 @@ class GetEventSubscriptionLogsQueryIntegration extends TestCase
         $timestampNow = $this->clock->now()->getTimestamp() - 10;
         $timestampStep = 10;
         $countOfGeneratedLogs = 101;
-        $excludeTimestamp = $timestampNow - $timestampStep * $NumberOfGeneratedLogs;
+        $excludeTimestamp = $timestampNow - $timestampStep * $countOfGeneratedLogs;
 
         $this->generateLogs(
             function ($index) use (&$timestampNow, $timestampStep) {
@@ -75,7 +75,7 @@ class GetEventSubscriptionLogsQueryIntegration extends TestCase
                     'context' => [],
                 ];
             },
-            $NumberOfGeneratedLogs
+            $countOfGeneratedLogs
         );
 
         $logs = iterator_to_array($this->getEventSubscriptionLogsQuery->execute('a_connection_code'));


### PR DESCRIPTION
In the download logs feature,the 100 oldest NOTICE & INFO logs are retrieved.
It should be the newest logs and there must be something wrong in the tests.
+ Add EventsApiDebugLogLevels constants 