### PR TITLE
PIM-9709: Fix missing translation on move to categories mass edit action

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,5 +1,9 @@
 # 3.2.x
 
+## Bug fixes
+
+- PIM-9709: Fix missing translation on move to categories mass edit action
+
 # 3.2.82 (2021-02-16)
 
 # 3.2.81 (2021-02-15)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -324,6 +324,7 @@ pim_enrich.mass_edit.product:
             label: Move between categories
             label_count: "{1}Move <span class=\"AknFullPage-title--highlight\">1 product</span> between categories|]1, Inf[Move <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> between categories"
             description: The products will be classified into following categories, the existing classification is lost.
+            no_update: There is no category checked to move the selected products to.
         remove_from_category:
             label: Remove from categories
             label_count: "{1}Remove <span class=\"AknFullPage-title--highlight\">1 product</span> from categories|]1, Inf[Remove <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> from categories"

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -324,7 +324,7 @@ pim_enrich.mass_edit.product:
             label: Move between categories
             label_count: "{1}Move <span class=\"AknFullPage-title--highlight\">1 product</span> between categories|]1, Inf[Move <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> between categories"
             description: The products will be classified into following categories, the existing classification is lost.
-            no_update: There is no category checked to move the selected products to.
+            no_update: Please select a category.
         remove_from_category:
             label: Remove from categories
             label_count: "{1}Remove <span class=\"AknFullPage-title--highlight\">1 product</span> from categories|]1, Inf[Remove <span class=\"AknFullPage-title--highlight\">{{ itemsCount }} products</span> from categories"


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix missing translation on move to categories mass edit action

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
