### PR TITLE
API-1523: Fix es purge query

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Query/PurgeEventsApiErrorLogsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Elasticsearch/Query/PurgeEventsApiErrorLogsQuery.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query;
@@ -39,7 +40,7 @@ class PurgeEventsApiErrorLogsQuery
                                 ],
                             ],
                         ],
-                        ['range' => ['timestamp' => ['gte' => $olderThanDatetime->getTimestamp()]]],
+                        ['range' => ['timestamp' => ['lt' => $olderThanDatetime->getTimestamp()]]],
                     ],
                 ],
             ],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The query purged the logs the wrong way. It purged the logs that were sooner than the DateTime and not older than.
Moreover, the test is more robust testing the timestamps.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
