### PR TITLE
PIM-9767: Fix minimum & maximum user password validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PIM-9740: Prevent to delete a channel used in a product export job
 - PIM-9764: Fix DSM Card component to handle links properly
 - PIM-9773: Fix unique variant axis validator considering 01 and 1 as equal
+- PIM-9767: Fix minimum & maximum user password validation
 
 ## New features
 

--- a/config/packages/test/security.yml
+++ b/config/packages/test/security.yml
@@ -4,7 +4,8 @@ security:
             http_basic:
                 realm:      "Secured REST Area"
             provider:       pim_user
-            form_login:     false
+            form_login:
+                check_path: pim_user_security_check
             logout:         false
             remember_me:    false
             anonymous:      true

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\UserManagement\Bundle\Controller\Rest;
 
 use Akeneo\Tool\Component\Localization\Factory\NumberFactory;
@@ -41,53 +43,25 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  */
 class UserController
 {
-    /** @var TokenStorageInterface */
-    protected $tokenStorage;
+    private const PASSWORD_MINIMUM_LENGTH = 8;
+    private const PASSWORD_MAXIMUM_LENGTH = 64;
 
-    /** @var NormalizerInterface */
-    protected $normalizer;
-
-    /** @var ObjectRepository */
-    protected $repository;
-
-    /** @var ObjectUpdaterInterface */
-    protected $updater;
-
-    /** @var ValidatorInterface */
-    protected $validator;
-
-    /** @var SaverInterface */
-    protected $saver;
-
-    /** @var NormalizerInterface */
-    protected $constraintViolationNormalizer;
-
-    /** @var SimpleFactoryInterface */
-    protected $factory;
-
-    /** @var UserPasswordEncoderInterface */
-    protected $encoder;
-
-    /** @var EventDispatcherInterface */
-    private $eventDispatcher;
-
-    /** @var Session */
-    private $session;
-
-    /** @var ObjectManager */
-    private $objectManager;
-
-    /** @var NumberFactory */
-    private $numberFactory;
-
-    /** @var RemoverInterface */
-    private $remover;
-
-    /** @var TranslatorInterface */
-    private $translator;
-
-    /** @var SecurityFacade */
-    private $securityFacade;
+    protected TokenStorageInterface $tokenStorage;
+    protected NormalizerInterface $normalizer;
+    protected ObjectRepository $repository;
+    protected ObjectUpdaterInterface $updater;
+    protected ValidatorInterface $validator;
+    protected SaverInterface $saver;
+    protected NormalizerInterface $constraintViolationNormalizer;
+    protected SimpleFactoryInterface $factory;
+    protected UserPasswordEncoderInterface $encoder;
+    private EventDispatcherInterface $eventDispatcher;
+    private Session $session;
+    private ObjectManager $objectManager;
+    private NumberFactory $numberFactory;
+    private RemoverInterface $remover;
+    private TranslatorInterface $translator;
+    private SecurityFacade $securityFacade;
 
     public function __construct(
         TokenStorageInterface $tokenStorage,
@@ -154,8 +128,10 @@ class UserController
         $token = $this->tokenStorage->getToken();
         $currentUserIdentifier = null !== $token ? $token->getUser()->getId() : null;
 
-        if ($currentUserIdentifier !== $identifier &&
-            !$this->securityFacade->isGranted('pim_user_user_index')) {
+        if (
+            $currentUserIdentifier !== $identifier &&
+            !$this->securityFacade->isGranted('pim_user_user_index')
+        ) {
             throw new AccessDeniedHttpException();
         }
 
@@ -412,79 +388,92 @@ class UserController
         return new JsonResponse($this->normalizer->normalize($this->update($user, $previousUserName), 'internal_api'));
     }
 
-    /**
-     * @param array $data
-     *
-     * @return ConstraintViolationListInterface
-     */
     private function validatePasswordCreate(array $data): ConstraintViolationListInterface
     {
-        $violations = [];
+        $violations = new ConstraintViolationList();
 
-        if (!isset($data['password'])) {
-            return new ConstraintViolationList([]);
-        }
+        $newPassword = $data['password'] ?? '';
+        $newPasswordRepeat = $data['password_repeat'] ?? '';
 
-        if (($data['password_repeat'] ?? '') !== $data['password']) {
-            $violations[] = new ConstraintViolation('Passwords do not match', '', [], '', 'password_repeat', '');
-        }
+        $violations->addAll($this->validatePasswordLength($newPassword, 'password'));
+        $violations->addAll($this->validatePasswordMatch($newPassword, $newPasswordRepeat, 'password_repeat'));
 
-        return new ConstraintViolationList($violations);
+        return $violations;
     }
 
-    private function validatePassword(UserInterface $user, $data): ConstraintViolationListInterface
+    private function validatePassword(UserInterface $user, array $data): ConstraintViolationListInterface
     {
-        $violations = [];
-        if (
-            isset($data['current_password']) &&
-            '' !== $data['current_password'] &&
-            !$this->encoder->isPasswordValid($user, $data['current_password']) ||
-            (isset($data['current_password']) && '' === $data['current_password']) ||
-            !isset($data['current_password'])
-        ) {
-            $violations[] = new ConstraintViolation(
+        $violations = new ConstraintViolationList();
+
+        $currentPassword = $data['current_password'] ?? '';
+        $newPassword = $data['new_password'] ?? '';
+        $newPasswordRepeat = $data['new_password_repeat'] ?? '';
+
+        if (!$this->encoder->isPasswordValid($user, $currentPassword)) {
+            $violations->add(new ConstraintViolation(
                 $this->translator->trans('pim_user.user.fields_errors.current_password.wrong'),
                 '',
                 [],
                 '',
                 'current_password',
                 ''
-            );
+            ));
         }
-        if (
-            isset($data['new_password']) &&
-            isset($data['new_password_repeat']) &&
-            '' !== $data['new_password'] &&
-            '' !== $data['new_password_repeat'] &&
-            $data['new_password'] !== $data['new_password_repeat']
-        ) {
-            $violations[] = new ConstraintViolation(
+
+        $violations->addAll($this->validatePasswordLength($newPassword, 'new_password'));
+        $violations->addAll($this->validatePasswordMatch($newPassword, $newPasswordRepeat, 'new_password_repeat'));
+
+        return $violations;
+    }
+
+    private function validatePasswordMatch(string $password, string $passwordRepeat, string $propertyPath): ConstraintViolationListInterface
+    {
+        $violations = new ConstraintViolationList();
+
+        if ($password !== $passwordRepeat) {
+            $violations->add(new ConstraintViolation(
                 $this->translator->trans('pim_user.user.fields_errors.new_password_repeat.not_match'),
                 '',
                 [],
                 '',
-                'new_password_repeat',
+                $propertyPath,
                 ''
-            );
-        }
-        if (
-            isset($data['new_password']) && strlen($data['new_password']) < 2
-        ) {
-            $violations[] = new ConstraintViolation(
-                $this->translator ?
-                    $this->translator->trans(
-                        'pim_user.user.fields_errors.new_password.minimum_length'
-                    ) : 'Password must contains at least 2 characters', '', [], '', 'new_password', ''
-            );
+            ));
         }
 
-        return new ConstraintViolationList($violations);
+        return $violations;
+    }
+
+    private function validatePasswordLength(string $password, string $propertyPath): ConstraintViolationListInterface
+    {
+        $violations = new ConstraintViolationList();
+
+        if (self::PASSWORD_MINIMUM_LENGTH > strlen($password)) {
+            $violations->add(new ConstraintViolation(
+                $this->translator->trans('pim_user.user.fields_errors.new_password.minimum_length'),
+                '',
+                [],
+                '',
+                $propertyPath,
+                ''
+            ));
+        } elseif (self::PASSWORD_MAXIMUM_LENGTH < strlen($password)) {
+            $violations->add(new ConstraintViolation(
+                $this->translator->trans('pim_user.user.fields_errors.new_password.maximum_length'),
+                '',
+                [],
+                '',
+                $propertyPath,
+                ''
+            ));
+        }
+
+        return $violations;
     }
 
     private function isPasswordUpdating($data): bool
     {
-        return
-            (isset($data['current_password']) && !empty($data['current_password'])) ||
+        return (isset($data['current_password']) && !empty($data['current_password'])) ||
             (isset($data['new_password']) && !empty($data['new_password'])) ||
             (isset($data['new_password_repeat']) && !empty($data['new_password_repeat']));
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints\Length;
 class ResetType extends AbstractType
 {
     private const PASSWORD_MINIMUM_LENGTH = 8;
-    private const PASSWORD_MAXIMUM_LENGTH = 64;
+    private const PASSWORD_MAXIMUM_LENGTH = 4096;
 
     /**
      * @var string

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
@@ -36,11 +36,11 @@ class ResetType extends AbstractType
             'plainPassword',
             RepeatedType::class,
             [
-                'type'            => PasswordType::class,
-                'required'        => true,
-                'first_options'   => ['label' => 'Password'],
-                'second_options'  => ['label' => 'Again'],
-                'constraints' => [
+                'type'           => PasswordType::class,
+                'required'       => true,
+                'first_options'  => ['label' => 'Password'],
+                'second_options' => ['label' => 'Again'],
+                'constraints'    => [
                     new Length([
                         'min' => self::PASSWORD_MINIMUM_LENGTH,
                         'max' => self::PASSWORD_MAXIMUM_LENGTH

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
@@ -7,9 +7,13 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 
 class ResetType extends AbstractType
 {
+    private const PASSWORD_MINIMUM_LENGTH = 8;
+    private const PASSWORD_MAXIMUM_LENGTH = 64;
+
     /**
      * @var string
      */
@@ -28,12 +32,21 @@ class ResetType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('plainPassword', RepeatedType::class, [
-            'type'            => PasswordType::class,
-            'required'        => true,
-            'first_options'   => ['label' => 'Password'],
-            'second_options'  => ['label' => 'Again'],
-        ]
+        $builder->add(
+            'plainPassword',
+            RepeatedType::class,
+            [
+                'type'            => PasswordType::class,
+                'required'        => true,
+                'first_options'   => ['label' => 'Password'],
+                'second_options'  => ['label' => 'Again'],
+                'constraints' => [
+                    new Length([
+                        'min' => self::PASSWORD_MINIMUM_LENGTH,
+                        'max' => self::PASSWORD_MAXIMUM_LENGTH
+                    ])
+                ],
+            ]
         );
     }
 
@@ -44,8 +57,8 @@ class ResetType extends AbstractType
     {
         $resolver->setDefaults(
             [
-            'data_class' => $this->class,
-            'intention'  => 'reset',
+                'data_class' => $this->class,
+                'intention'  => 'reset',
             ]
         );
     }

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
@@ -42,9 +42,10 @@ pim_user:
             inactive: Inactive
         fields_errors:
             new_password:
-                minimum_length: Password must contains at least 2 characters
+                minimum_length: Password must contain at least 8 characters
+                maximum_length: Password must contain less than 64 characters
             new_password_repeat:
-                not_match: Password does not match
+                not_match: Passwords do not match
             current_password:
                 wrong: Wrong password
         tabs:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/messages.en_US.yml
@@ -43,7 +43,7 @@ pim_user:
         fields_errors:
             new_password:
                 minimum_length: Password must contain at least 8 characters
-                maximum_length: Password must contain less than 64 characters
+                maximum_length: Password must contain less than 4096 characters
             new_password_repeat:
                 not_match: Passwords do not match
             current_password:

--- a/tests/back/UserManagement/Integration/Bundle/ControllerIntegrationTestCase.php
+++ b/tests/back/UserManagement/Integration/Bundle/ControllerIntegrationTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace AkeneoTest\UserManagement\Integration\Bundle;
@@ -23,7 +24,7 @@ abstract class ControllerIntegrationTestCase extends WebTestCase
 {
     protected KernelBrowser $client;
     protected CatalogInterface $catalog;
-    private RouterInterface $router;
+    protected RouterInterface $router;
 
     abstract protected function getConfiguration(): Configuration;
 
@@ -106,13 +107,14 @@ abstract class ControllerIntegrationTestCase extends WebTestCase
         $this->client->getCookieJar()->set($cookie);
     }
 
-    private function createUser(string $username): User
+    protected function createUser(string $username, string $password = 'fake'): User
     {
         $user = $this->get('pim_user.factory.user')->create();
         $user->setId(uniqid());
         $user->setUsername($username);
         $user->setEmail(sprintf('%s@example.com', uniqid()));
-        $user->setPassword('fake');
+        $user->setPlainPassword($password);
+        $this->get('pim_user.manager')->updatePassword($user);
 
         $groups = $this->get('pim_user.repository.group')->findAll();
         foreach ($groups as $group) {

--- a/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
@@ -6,6 +6,7 @@ namespace AkeneoTest\UserManagement\Integration\Bundle;
 
 use Akeneo\Test\Integration\Configuration;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 final class UserPasswordIntegration extends ControllerIntegrationTestCase
 {
@@ -42,15 +43,16 @@ final class UserPasswordIntegration extends ControllerIntegrationTestCase
 }
 JSON;
 
+        $this->assertStatusCode($response, Response::HTTP_BAD_REQUEST);
         self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
-    public function test_it_can_not_create_a_user_with_password_more_than_64_characters(): void
+    public function test_it_can_not_create_a_user_with_password_more_than_4096_characters(): void
     {
         $params = [
             'username' => 'test2',
-            'password' => str_repeat('a', 65),
-            'password_repeat' => str_repeat('a', 65),
+            'password' => str_repeat('a', 4097),
+            'password_repeat' => str_repeat('a', 4097),
             'first_name' => 'first',
             'last_name' => 'last',
             'email' => 'new@example.com',
@@ -71,13 +73,14 @@ JSON;
   "values": [
     {
       "path": "password",
-      "message": "Password must contain less than 64 characters",
+      "message": "Password must contain less than 4096 characters",
       "global": false
     }
   ]
 }
 JSON;
 
+        $this->assertStatusCode($response, Response::HTTP_BAD_REQUEST);
         self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -114,6 +117,7 @@ JSON;
 }
 JSON;
 
+        $this->assertStatusCode($response, Response::HTTP_BAD_REQUEST);
         self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 

--- a/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\UserManagement\Integration\Bundle;
+
+use Akeneo\Test\Integration\Configuration;
+use Symfony\Component\HttpFoundation\Request;
+
+final class UserPasswordIntegration extends ControllerIntegrationTestCase
+{
+    public function test_it_can_not_create_a_user_with_password_less_than_8_characters(): void
+    {
+        $params = [
+            'username' => 'test2',
+            'password' => '2short',
+            'password_repeat' => '2short',
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'email' => 'new@example.com',
+        ];
+
+        $this->logIn('admin');
+        $response = $this->callRoute(
+            'pim_user_user_rest_create',
+            [],
+            Request::METHOD_POST,
+            ['HTTP_X-Requested-With' => 'XMLHttpRequest', 'CONTENT_TYPE' => 'application/json'],
+            [],
+            \json_encode($params)
+        );
+
+        $expectedResponse = <<<JSON
+{
+  "values": [
+    {
+      "path": "password",
+      "message": "Password must contain at least 8 characters",
+      "global": false
+    }
+  ]
+}
+JSON;
+
+        self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
+    public function test_it_can_not_create_a_user_with_password_more_than_64_characters(): void
+    {
+        $params = [
+            'username' => 'test2',
+            'password' => str_repeat('a', 65),
+            'password_repeat' => str_repeat('a', 65),
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'email' => 'new@example.com',
+        ];
+
+        $this->logIn('admin');
+        $response = $this->callRoute(
+            'pim_user_user_rest_create',
+            [],
+            Request::METHOD_POST,
+            ['HTTP_X-Requested-With' => 'XMLHttpRequest', 'CONTENT_TYPE' => 'application/json'],
+            [],
+            \json_encode($params)
+        );
+
+        $expectedResponse = <<<JSON
+{
+  "values": [
+    {
+      "path": "password",
+      "message": "Password must contain less than 64 characters",
+      "global": false
+    }
+  ]
+}
+JSON;
+
+        self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
+    public function test_it_can_not_create_a_user_with_password_mismatch(): void
+    {
+        $params = [
+            'username' => 'test2',
+            'password' => 'thisShouldBeALongEnoughPassword',
+            'password_repeat' => 'thisAlsoShouldBeALongEnoughPasswordButDifferent',
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'email' => 'new@example.com',
+        ];
+
+        $this->logIn('admin');
+        $response = $this->callRoute(
+            'pim_user_user_rest_create',
+            [],
+            Request::METHOD_POST,
+            ['HTTP_X-Requested-With' => 'XMLHttpRequest', 'CONTENT_TYPE' => 'application/json'],
+            [],
+            \json_encode($params)
+        );
+
+        $expectedResponse = <<<JSON
+{
+  "values": [
+    {
+      "path": "password_repeat",
+      "message": "Passwords do not match",
+      "global": false
+    }
+  ]
+}
+JSON;
+
+        self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/tests/legacy/features/user-management/user/create_and_delete_user.feature
+++ b/tests/legacy/features/user-management/user/create_and_delete_user.feature
@@ -15,8 +15,8 @@ Feature: Create a user
       | Username          | jack                 |
       | First name        | Jack                 |
       | Last name         | Doe                  |
-      | Password          | DoeDoe               |
-      | Password (repeat) | DoeDoe               |
+      | Password          | DoeDoeDoe            |
+      | Password (repeat) | DoeDoeDoe            |
       | Email             | jack+doe@example.com |
     When I press the "Save" button
     Then there should be a "jack" user


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Setting new validation constraints on user password length, minimum of 8 characters and maximum of 4096 as it's the Symfony's encoder limit https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php#L27.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
