### PR TITLE
PIM-9770: Fix proposal filters not loading when no permissions on attribute groups

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9770: Fix proposal filters not loading when no permissions on attribute groups
+
 # 4.0.99 (2021-03-24)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -179,7 +179,7 @@ class FiltersColumn extends BaseView {
     }
 
     return this.fetchFilters(searchValue, 1).then((loadedFilters: GridFilter[]) => {
-      const defaultFilters: GridFilter[] = this.mergeAddedFilters(this.defaultFilters, loadedFilters)
+      const defaultFilters: GridFilter[] = this.mergeAddedFilters(this.defaultFilters, loadedFilters);
       this.loadedFilters = this.mergeAddedFilters(this.loadedFilters, defaultFilters);
       this.searchedFilters = this.filterBySearchTerm(defaultFilters, searchValue);
 
@@ -231,7 +231,7 @@ class FiltersColumn extends BaseView {
   loadFilterList(gridCollection: any, gridElement: JQuery<HTMLElement>): void {
     const metadata = gridElement.data('metadata') || {};
 
-    this.defaultFilters = Object.values(metadata.filters);
+    this.defaultFilters = 'filters' in metadata ? Object.values(metadata.filters) : [];
     this.gridCollection = gridCollection;
     this.showLoading();
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filters-column.ts
@@ -231,7 +231,7 @@ class FiltersColumn extends BaseView {
   loadFilterList(gridCollection: any, gridElement: JQuery<HTMLElement>): void {
     const metadata = gridElement.data('metadata') || {};
 
-    this.defaultFilters = metadata.filters;
+    this.defaultFilters = Object.values(metadata.filters);
     this.gridCollection = gridCollection;
     this.showLoading();
 


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Adding a safeguard on the grid filters that sometimes are returned as an object, this will ensure the filters are always in an array.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
