### PR TITLE
PIM-9773: Fix unique variant axis validator considering 01 and 1 as equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - PIM-9759: Fix step name translation for product models csv import
 - PIM-9740: Prevent to delete a channel used in a product export job
 - PIM-9764: Fix DSM Card component to handle links properly
+- PIM-9773: Fix unique variant axis validator considering 01 and 1 as equal
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueVariantAxisValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/UniqueVariantAxisValidator.php
@@ -105,7 +105,7 @@ class UniqueVariantAxisValidator extends ConstraintValidator
             $siblingsCombinations[$siblingIdentifier] = $this->getCombinationOfAxisValues($values, $axes);
         }
 
-        if (in_array($ownCombination, $siblingsCombinations)) {
+        if (in_array($ownCombination, $siblingsCombinations, true)) {
             $alreadyInDatabaseSiblingIdentifier = array_search($ownCombination, $siblingsCombinations);
 
             $this->addViolation(


### PR DESCRIPTION

<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix unique variant axis validator considering 01 and 1 as equal because `in_array('01', ['code' => '1'])` returns `true` without the `strict` option.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
