### PR TITLE
Pim-9772: Docker php image build for 4.0 are broken

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -13,7 +13,10 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     apt-get update && \
-    apt-get --yes install imagemagick libmagickcore-6.q16-2-extra \
+    apt-get --yes install \
+        wget \
+        imagemagick \
+        libmagickcore-6.q16-2-extra \
         ghostscript \
         php7.3-fpm \
         php7.3-cli \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,6 +14,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     echo 'path-exclude=/usr/share/doc/*' >> /etc/dpkg/dpkg.cfg.d/path_exclusions && \
     apt-get update && \
     apt-get --yes install \
+        ca-certificates \
         wget \
         imagemagick \
         libmagickcore-6.q16-2-extra \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,15 +2,14 @@ FROM akeneo/pim-php-base:4.0
 
 ENV PHP_CONF_OPCACHE_VALIDATE_TIMESTAMP=1
 
-RUN apt-get update && \
-    apt-get --yes install gnupg &&\
-    sh -c 'wget -q -O - https://packages.blackfire.io/gpg.key |APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' &&\
-    sh -c 'echo "deb http://packages.blackfire.io/debian any main" >  /etc/apt/sources.list.d/blackfire.list' &&\
-    apt-get update && \
+RUN apt-get update
+RUN    apt-get --yes install gnupg
+RUN    sh -c 'wget -q -O - https://packages.blackfire.io/gpg.key |APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -'
+RUN    sh -c 'echo "deb http://packages.blackfire.io/debian any main" >  /etc/apt/sources.list.d/blackfire.list'
+RUN    apt-get update && \
     apt-get --yes install \
         blackfire-agent \
         blackfire-php \
-        ca-certificates \
         curl \
         default-mysql-client \
         git \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,11 +2,11 @@ FROM akeneo/pim-php-base:4.0
 
 ENV PHP_CONF_OPCACHE_VALIDATE_TIMESTAMP=1
 
-RUN apt-get update
-RUN    apt-get --yes install gnupg
-RUN    sh -c 'wget -q -O - https://packages.blackfire.io/gpg.key |APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -'
-RUN    sh -c 'echo "deb http://packages.blackfire.io/debian any main" >  /etc/apt/sources.list.d/blackfire.list'
-RUN    apt-get update && \
+RUN apt-get update && \
+    apt-get --yes install gnupg &&\
+    sh -c 'wget -q -O - https://packages.blackfire.io/gpg.key |APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' &&\
+    sh -c 'echo "deb http://packages.blackfire.io/debian any main" >  /etc/apt/sources.list.d/blackfire.list' &&\
+    apt-get update && \
     apt-get --yes install \
         blackfire-agent \
         blackfire-php \


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**


Docker build failed for 4.0 PHP image

**Definition Of Done (for Core Developer only)**

Need to update ca certificate as soon as possible.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
