### PR TITLE
PIM-9772: Fix V5 standard build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,3 +161,13 @@ up:
 .PHONY: down
 down:
 	$(DOCKER_COMPOSE) down -v
+
+.PHONY: upgrade-front
+upgrade-front:
+	$(MAKE) node_modules
+	$(MAKE) cache
+	$(MAKE) assets
+	$(MAKE) dsm
+	$(MAKE) javascript-prod
+	$(MAKE) css
+	$(MAKE) javascript-extensions

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -120,6 +120,7 @@ upgrade-front:
 	$(MAKE) node_modules
 	$(MAKE) cache
 	$(MAKE) assets
+	$(MAKE) dsm
 	$(MAKE) javascript-prod
 	$(MAKE) css
 	$(MAKE) javascript-extensions

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -114,3 +114,13 @@ up:
 .PHONY: down
 down:
 	docker-compose down -v
+
+.PHONY: upgrade-front
+upgrade-front:
+	$(MAKE) node_modules
+	$(MAKE) cache
+	$(MAKE) assets
+	$(MAKE) javascript-prod
+	$(MAKE) css
+	$(MAKE) javascript-extensions
+

--- a/std-build/install-required-files.sh
+++ b/std-build/install-required-files.sh
@@ -68,6 +68,8 @@ cp $DEV_DISTRIB_DIR/std-build/Makefile $STANDARD_DISTRIB_DIR/Makefile
 cp $DEV_DISTRIB_DIR/std-build/package.json $STANDARD_DISTRIB_DIR/package.json
 cp $DEV_DISTRIB_DIR/yarn.lock $STANDARD_DISTRIB_DIR/yarn.lock
 
+cp $DEV_DISTRIB_DIR/std-build/Kernel.php $STANDARD_DISTRIB_DIR/src
+
 # Needed to define the loader path to target the CE-dev
 cp $DEV_DISTRIB_DIR/std-build/tsconfig.json $STANDARD_DISTRIB_DIR/tsconfig.json
 

--- a/std-build/migration/prepare_40_to_50.sh
+++ b/std-build/migration/prepare_40_to_50.sh
@@ -43,8 +43,8 @@ cp $DEV_DISTRIB_DIR/.env $STANDARD_DISTRIB_DIR/
 
 # Prepare database upgrades to run
 mkdir -p $STANDARD_DISTRIB_DIR/upgrades/
-cp -R $DEV_DISTRIB_DIR/upgrades/* $STANDARD_DISTRIB_DIR/upgrades/
+cp -r $DEV_DISTRIB_DIR/upgrades/* $STANDARD_DISTRIB_DIR/upgrades/
 
-cp $DEV_DISTRIB_DIR/std-build/migration/40_to_50/* $STANDARD_DISTRIB_DIR/
+cp -r $DEV_DISTRIB_DIR/std-build/migration/40_to_50/* $STANDARD_DISTRIB_DIR/
 
 printf "Done. \n"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Kernel was not updated during the standard edition update

**Definition Of Done (for Core Developer only)**
 - Fix Kernel update
 - Add upgrade-front in the makefile according to the documentation
 - Fix copy statement in the prepare script

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
