### PR TITLE
PIM-9766: Prevent letter usage in grid Number filters

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9766: Prevent letter usage in grid Number filters
+
 # 4.0.101 (2021-03-29)
 
 # 4.0.100 (2021-03-26)

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/number-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/number-filter.js
@@ -1,6 +1,4 @@
-/* global define */
-define(['underscore', 'oro/datafilter/choice-filter'],
-function(_, ChoiceFilter) {
+define(['oro/datafilter/choice-filter'], function(ChoiceFilter) {
     'use strict';
 
     /**
@@ -10,5 +8,20 @@ function(_, ChoiceFilter) {
      * @class   oro.datafilter.NumberFilter
      * @extends oro.datafilter.ChoiceFilter
      */
-    return ChoiceFilter.extend({});
+    return ChoiceFilter.extend({
+        /**
+         * {@inheritdoc}
+         */
+        _onClickUpdateCriteria: function() {
+            const numberValue = Number(this._getInputValue(this.criteriaValueSelectors.value));
+
+            if (isNaN(numberValue)) {
+                this._setInputValue(this.criteriaValueSelectors.value, '');
+                this._focusCriteria();
+            } else {
+                this._hideCriteria();
+                this.setValue(this._formatRawValue(this._readDOMValue()));
+            }
+        },
+    });
 });


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Adding frontend input validation on grid Number filters, this will allow only number-like inputs (5, -4, 3e5, 6.2, etc)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
