### PR TITLE
PIM-9780: Fix completed import/export job notification broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PIM-9773: Fix unique variant axis validator considering 01 and 1 as equal
 - PIM-9767: Fix minimum & maximum user password validation
 - PIM-9765: Fix missing translation key in bulk actions when adding attributes values for some product
+- PIM-9780: Fix completed import/export job notification broken link
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Factory/NotificationFactory.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Factory/NotificationFactory.php
@@ -54,7 +54,7 @@ class NotificationFactory extends AbstractNotificationFactory implements Notific
             ->setType($status)
             ->setMessage(sprintf('pim_import_export.notification.%s.%s', $type, $status))
             ->setMessageParams(['%label%' => $jobExecution->getJobInstance()->getLabel()])
-            ->setRoute(sprintf('pim_importexport_%s_execution_show', $type))
+            ->setRoute('pim_enrich_job_tracker_show')
             ->setRouteParams(['id' => $jobExecution->getId()])
             ->setContext(['actionType' => $type]);
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Fix completed import/export job notification broken link, now leading to the new job tracker

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
