### PR TITLE
PIM-9774: Fix variant axis 'metric' validation on import

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9774: Fix variant axis 'metric' validation on import.
+
 # 4.0.101 (2021-03-29)
 
 # 4.0.100 (2021-03-26)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -97,10 +97,7 @@ abstract class AbstractMetric implements MetricInterface
             return $metric->getData() === $this->data;
         }
 
-        return 0 === strcmp(
-                preg_replace('/\.0*$/', '', $metric->getData()),
-                preg_replace('/\.0*$/', '', $this->data)
-            );
+        return 0 === bccomp($metric->getData(), $this->data, 100);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -31,7 +31,7 @@ abstract class AbstractMetric implements MetricInterface
      *
      * @param string $family
      * @param string $unit
-     * @param float  $data
+     * @param float  $data (TODO: should not be float becaause of precision issues)
      * @param string $baseUnit
      * @param float  $baseData
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -27,6 +27,8 @@ abstract class AbstractMetric implements MetricInterface
     protected $family;
 
     /**
+     * TODO master: add type hiting for more strict data
+     *
      * @param string $family
      * @param string $unit
      * @param float  $data

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -87,7 +87,7 @@ abstract class AbstractMetric implements MetricInterface
      */
     public function isEqual(MetricInterface $metric)
     {
-        return $metric->getData() === $this->data && $metric->getUnit() === $this->unit;
+        return (float) $metric->getData() === (float) $this->data && $metric->getUnit() === $this->unit;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -27,7 +27,7 @@ abstract class AbstractMetric implements MetricInterface
     protected $family;
 
     /**
-     * TODO master: add type hiting for more strict data
+     * TODO master: add string type hiting for more strict data type and to handle big numbers and/or decimals
      *
      * @param string $family
      * @param string $unit

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -97,7 +97,7 @@ abstract class AbstractMetric implements MetricInterface
             return $metric->getData() === $this->data;
         }
 
-        return 0 === bccomp($metric->getData(), $this->data, 100);
+        return 0 === bccomp($metric->getData(), $this->data, 50);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -31,7 +31,7 @@ abstract class AbstractMetric implements MetricInterface
      *
      * @param string $family
      * @param string $unit
-     * @param float  $data (TODO: should not be float becaause of precision issues)
+     * @param float  $data (TODO: should not be float because of precision issues)
      * @param string $baseUnit
      * @param float  $baseData
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -89,7 +89,18 @@ abstract class AbstractMetric implements MetricInterface
      */
     public function isEqual(MetricInterface $metric)
     {
-        return (float) $metric->getData() === (float) $this->data && $metric->getUnit() === $this->unit;
+        if ($metric->getUnit() !== $this->unit) {
+            return false;
+        }
+
+        if (!is_string($metric->getData()) || !is_string($this->data)) {
+            return $metric->getData() === $this->data;
+        }
+
+        return 0 === strcmp(
+                preg_replace('/\.0*$/', '', $metric->getData()),
+                preg_replace('/\.0*$/', '', $this->data)
+            );
     }
 
     /**
@@ -99,7 +110,7 @@ abstract class AbstractMetric implements MetricInterface
     {
         return join(' ', array_filter([
             $this->data !== null ? sprintf('%.4F', $this->data) : null,
-            $this->unit
+            $this->unit,
         ]));
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Model;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\MetricInterface;
+use PhpSpec\ObjectBehavior;
+
+class MetricSpec extends ObjectBehavior
+{
+    function it_is_equal_to_another_metric_with_float_value(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            666.11,
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn(666.11);
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(true);
+    }
+
+    function it_is_equal_to_another_metric_with_string_value(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            666.11,
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('666.11');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(true);
+    }
+
+    function it_is_equal_to_another_metric_with_trailing_zeroes(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            666,
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('666.00000');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(true);
+    }
+
+    function it_is_not_equal_to_another_metric_with_float_value(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            666.11,
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn(666);
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(false);
+    }
+
+    function it_is_not_equal_to_another_metric_with_string_value(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            666.11,
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('666');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(false);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
@@ -109,18 +109,35 @@ class MetricSpec extends ObjectBehavior
         $this->isEqual($anotherMetric)->shouldReturn(false);
     }
 
+    function it_is_equal_to_another_metric_with_string_value_for_currency(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            '666.00000000000000000000000000000000000000000000000001',
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('666.00000000000000000000000000000000000000000000000001');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(true);
+    }
+
     function it_is_not_equal_to_another_metric_with_string_value_for_currency(
         MetricInterface $anotherMetric
     ) {
         $this->beConstructedWith(
             'length_family',
             'centimeter',
-            '666.00000000000000000000000000000000000000000000000000000000000000000001',
+            '666.00000000000000000000000000000000000000000000000001',
             'meter',
             6.6611
         );
 
-        $anotherMetric->getData()->willReturn('666.00000000000000000000000000000000000000000000000000000000000000000002');
+        $anotherMetric->getData()->willReturn('666.00000000000000000000000000000000000000000000000002');
         $anotherMetric->getUnit()->willReturn('centimeter');
 
         $this->isEqual($anotherMetric)->shouldReturn(false);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
@@ -13,18 +13,18 @@ class MetricSpec extends ObjectBehavior
         $this->beConstructedWith(
             'length_family',
             'centimeter',
-            666.11,
+            1/3,
             'meter',
             6.6611
         );
 
-        $anotherMetric->getData()->willReturn(666.11);
+        $anotherMetric->getData()->willReturn(2/6);
         $anotherMetric->getUnit()->willReturn('centimeter');
 
         $this->isEqual($anotherMetric)->shouldReturn(true);
     }
 
-    function it_is_equal_to_another_metric_with_string_value(
+    function it_is_not_equal_to_another_metric_with_string_value(
         MetricInterface $anotherMetric
     ) {
         $this->beConstructedWith(
@@ -38,16 +38,50 @@ class MetricSpec extends ObjectBehavior
         $anotherMetric->getData()->willReturn('666.11');
         $anotherMetric->getUnit()->willReturn('centimeter');
 
-        $this->isEqual($anotherMetric)->shouldReturn(true);
+        $this->isEqual($anotherMetric)->shouldReturn(false);
     }
 
-    function it_is_equal_to_another_metric_with_trailing_zeroes(
+    function it_is_equal_to_another_metric_with_trailing_zero_decimal(
         MetricInterface $anotherMetric
     ) {
         $this->beConstructedWith(
             'length_family',
             'centimeter',
-            666,
+            '666',
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('666.00000');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(true);
+    }
+
+    function it_is_not_equal_to_another_metric_with_trailing_zero_non_decimal(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            '6',
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('600');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(false);
+    }
+
+    function it_is_equal_to_another_metric_with_trailing_zeroes_on_both_sides(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            '666.00',
             'meter',
             6.6611
         );
@@ -75,18 +109,35 @@ class MetricSpec extends ObjectBehavior
         $this->isEqual($anotherMetric)->shouldReturn(false);
     }
 
-    function it_is_not_equal_to_another_metric_with_string_value(
+    function it_is_not_equal_to_another_metric_with_string_value_for_currency(
         MetricInterface $anotherMetric
     ) {
         $this->beConstructedWith(
             'length_family',
             'centimeter',
-            666.11,
+            '666.00000000000000000000000000000000000000000000000000000000000000000001',
             'meter',
             6.6611
         );
 
-        $anotherMetric->getData()->willReturn('666');
+        $anotherMetric->getData()->willReturn('666.00000000000000000000000000000000000000000000000000000000000000000002');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(false);
+    }
+
+    function it_is_not_equal_to_another_metric_with_very_high_numbers(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            '61529519452809720693702583126814',
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('61529519452809720000000000000000');
         $anotherMetric->getUnit()->willReturn('centimeter');
 
         $this->isEqual($anotherMetric)->shouldReturn(false);


### PR DESCRIPTION
The MetricValue data type is not enforced by any type hinting.

I could have fix by a cast here: https://github.com/akeneo/pim-community-dev/blob/4.0/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php#L38 but the impacts could be important, so I chose to only fix the comparison in 4.0