### PR TITLE
PIM-9783: decrease batch when calculate completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - PIM-9767: Fix minimum & maximum user password validation
 - PIM-9765: Fix missing translation key in bulk actions when adding attributes values for some product
 - PIM-9780: Fix completed import/export job notification broken link
+- PIM-9783: Optimize batch query when compute completeness
 - PIM-9715: Prevent the deletion of an attribute used as a label by a family
 
 ## New features

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -14,7 +14,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
  */
 class ComputeAndPersistProductCompletenesses
 {
-    private const CHUNK_SIZE = 10000;
+    private const CHUNK_SIZE = 1000;
 
     /** @var CompletenessCalculator */
     private $completenessCalculator;


### PR DESCRIPTION
Fix https://akeneo.atlassian.net/browse/PIM-9783

The query to calculate completeness fails with 8.084 product identifiers. The batch was 10.000, it is now 1.000.  

Tested on https://cora-prod-clone-sds-17727.dev.cloud.akeneo.com
FYI it works with a batch of 5.000. But as the query depends on the catalog structure (number of product models + number of product values), a  margin of error is considered and the batch is set to 1.000.