### PR TITLE
PIM-9792: Use mb_strlen to handle special chars

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -471,9 +471,9 @@ class UserController
                 $propertyPath,
                 ''
             ));
-            // We have to use `strlen` here because Symfony's BasePasswordEncoder will check
-            // the actual character count when trying to encode it with salt.
-            // See: Symfony\Component\Security\Core\Encoder\BasePasswordEncoder
+        // We have to use `strlen` here because Symfony's BasePasswordEncoder will check
+        // the actual byte count when trying to encode it with salt.
+        // See: Symfony\Component\Security\Core\Encoder\BasePasswordEncoder
         } elseif (self::PASSWORD_MAXIMUM_LENGTH < strlen($password)) {
             $violations->add(new ConstraintViolation(
                 $this->translator->trans('pim_user.user.fields_errors.new_password.maximum_length'),

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -462,7 +462,7 @@ class UserController
     {
         $violations = new ConstraintViolationList();
 
-        if (self::PASSWORD_MINIMUM_LENGTH > strlen($password)) {
+        if (self::PASSWORD_MINIMUM_LENGTH > mb_strlen($password)) {
             $violations->add(new ConstraintViolation(
                 $this->translator->trans('pim_user.user.fields_errors.new_password.minimum_length'),
                 '',
@@ -471,6 +471,9 @@ class UserController
                 $propertyPath,
                 ''
             ));
+            // We have to use `strlen` here because Symfony's BasePasswordEncoder will check
+            // the actual character count when trying to encode it with salt.
+            // See: Symfony\Component\Security\Core\Encoder\BasePasswordEncoder
         } elseif (self::PASSWORD_MAXIMUM_LENGTH < strlen($password)) {
             $violations->add(new ConstraintViolation(
                 $this->translator->trans('pim_user.user.fields_errors.new_password.maximum_length'),

--- a/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/UserPasswordIntegration.php
@@ -48,6 +48,43 @@ JSON;
         self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
+    public function test_it_can_not_create_a_user_with_password_less_than_8_special_characters(): void
+    {
+        $params = [
+            'username' => 'test2',
+            'password' => 'ééééééé',
+            'password_repeat' => 'ééééééé',
+            'first_name' => 'first',
+            'last_name' => 'last',
+            'email' => 'new@example.com',
+        ];
+
+        $this->logIn('admin');
+        $response = $this->callRoute(
+            'pim_user_user_rest_create',
+            [],
+            Request::METHOD_POST,
+            ['HTTP_X-Requested-With' => 'XMLHttpRequest', 'CONTENT_TYPE' => 'application/json'],
+            [],
+            \json_encode($params)
+        );
+
+        $expectedResponse = <<<JSON
+{
+    "values": [
+        {
+            "path": "password",
+            "message": "Password must contain at least 8 characters",
+            "global": false
+        }
+    ]
+}
+JSON;
+
+        $this->assertStatusCode($response, Response::HTTP_BAD_REQUEST);
+        self::assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
     public function test_it_can_not_create_a_user_with_password_more_than_4096_characters(): void
     {
         $params = [


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Uses `mb_strlen` to handle special characters correctly in password length computation. However, we still need to use `strlen` on the max length check because Symfony's BasePasswordEncore will compare its strict length when trying to encode it with salt.
See: https://github.com/symfony/symfony/blob/5.x/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php#L100

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
