### PR TITLE
PIM-9726: mitigate deadlock on categories (backport PIM-9548)

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9726: Mitigate deadlock issues on category API (backport PIM-9548)
+
 # 4.0.102 (2021-03-31)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/DependencyInjection/AkeneoPimEnrichmentExtension.php
@@ -106,6 +106,7 @@ class AkeneoPimEnrichmentExtension extends Extension
         $loader->load('view_elements/category.yml');
         $loader->load('command.yml');
         $loader->load('cli_command.yml');
+        $loader->load('lock.yml');
 
         if (!$container->hasParameter('pim_pdf_generator_font')) {
             $container->setParameter('pim_pdf_generator_font', null);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/CategorySaver.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/Common/Saver/CategorySaver.php
@@ -1,0 +1,166 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Pim\Enrichment\Component\Lock\Query\EnsureLockTableExistsInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+class CategorySaver implements SaverInterface, BulkSaverInterface
+{
+    private const LOCK_TTL_IN_SECONDS = 10;
+
+    /** @var ObjectManager */
+    private $objectManager;
+
+    /** @var EventDispatcherInterface */
+    private $eventDispatcher;
+
+    /** @var LockFactory */
+    private $lockFactory;
+
+    /** @var ?EnsureLockTableExistsInterface */
+    private $ensureLockTableExistsQuery;
+
+    public function __construct(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        LockFactory $lockFactory,
+        ?EnsureLockTableExistsInterface $ensureLockTableExistsQuery = null
+    ) {
+        $this->objectManager = $objectManager;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->lockFactory = $lockFactory;
+        // Pull up 5.0 remove this.
+        $this->ensureLockTableExistsQuery = $ensureLockTableExistsQuery;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save($object, array $options = [])
+    {
+        $this->validateObject($object);
+
+        $lock = $this->lockUnitarySave($object);
+
+        try {
+            $options['unitary'] = true;
+            $options['is_new'] = null === $object->getId();
+
+            $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE, new GenericEvent($object, $options));
+
+            $this->objectManager->persist($object);
+
+            $this->objectManager->flush();
+
+            $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE, new GenericEvent($object, $options));
+        } finally {
+            $lock->release();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveAll(array $objects, array $options = [])
+    {
+        if (empty($objects)) {
+            return;
+        }
+
+        $options['unitary'] = false;
+
+        $this->eventDispatcher->dispatch(StorageEvents::PRE_SAVE_ALL, new GenericEvent($objects, $options));
+
+        $areObjectsNew = array_map(function ($object) {
+            return null === $object->getId();
+        }, $objects);
+
+        foreach ($objects as $i => $object) {
+            $this->validateObject($object);
+
+            $this->eventDispatcher->dispatch(
+                StorageEvents::PRE_SAVE,
+                new GenericEvent($object, array_merge($options, ['is_new' => $areObjectsNew[$i]]))
+            );
+
+            $this->objectManager->persist($object);
+        }
+
+        $this->objectManager->flush();
+
+        foreach ($objects as $i => $object) {
+            $this->eventDispatcher->dispatch(
+                StorageEvents::POST_SAVE,
+                new GenericEvent($object, array_merge($options, ['is_new' => $areObjectsNew[$i]]))
+            );
+        }
+
+        $this->eventDispatcher->dispatch(StorageEvents::POST_SAVE_ALL, new GenericEvent($objects, $options));
+    }
+
+    protected function validateObject($object)
+    {
+        if (!$object instanceof CategoryInterface) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expects a "%s", "%s" provided.',
+                    CategoryInterface::class,
+                    ClassUtils::getClass($object)
+                )
+            );
+        }
+    }
+
+    /**
+     * There is a possible deadlock when creating several new categories at the same time.
+     * Gedmo/Tree execute queries like `UPDATE pim_catalog_category SET lft = lft + 2 WHERE lft >= 2 AND root = ?`
+     * producing GAP Lock issues.
+     *
+     * The entity manager is not capable to recover from such error and is automatically closed.
+     * A new entity manager could be created but when a new one is created using the ManagerRegistry, there is a lot of
+     * issues because the reference to the previous entity manager is kept in many places.
+     *
+     * By locking with an external lock beforehand, we can mitigate this deadlock issue.
+     *
+     * This lock is restricted to the category root, since only rows belonging to this root are affected by the
+     * current queries.
+     */
+    private function lockUnitarySave(CategoryInterface $object): LockInterface
+    {
+        if (null !== $this->ensureLockTableExistsQuery) {
+            $this->ensureLockTableExistsQuery->execute();
+        }
+        $lockIdentifier = sprintf('create_category_in_root_%d', $object->getRoot());
+        $lock = $this->lockFactory->createLock($lockIdentifier, self::LOCK_TTL_IN_SECONDS);
+
+        $errors = 0;
+        $acquired = false;
+
+        while (!$acquired && $errors < 3) {
+            try {
+                $acquired = $lock->acquire(true);
+            } catch (LockConflictedException $ex) {
+                $errors++;
+                continue;
+            }
+        }
+
+        if (!$acquired) {
+            throw new \ErrorException('The lock for creating new categories cannot be acquired.');
+        }
+
+        return $lock;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/EnsureLockTableExistsQuery.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Query/EnsureLockTableExistsQuery.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query;
+
+use Akeneo\Pim\Enrichment\Component\Lock\Query\EnsureLockTableExistsInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * TODO pull up remove this
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class EnsureLockTableExistsQuery implements EnsureLockTableExistsInterface
+{
+    /** @var Connection */
+    private $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(): void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS lock_keys (
+    key_id VARCHAR(64) NOT NULL PRIMARY KEY,
+    key_token VARCHAR(44) NOT NULL,
+    key_expiration INTEGER UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+        $this->connection->exec($sql);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/InitLockDbSchemaSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/InitLockDbSchemaSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Db;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * The table used by the PDOStore of Symfony/Lock is not attached to Doctrine.
+ *
+ * We need to manually create the table.
+ */
+class InitLockDbSchemaSubscriber implements EventSubscriberInterface
+{
+    private $connection;
+
+    public function __construct(Connection $dbalConnection)
+    {
+        $this->connection = $dbalConnection;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            InstallerEvents::POST_DB_CREATE => 'initDbSchema'
+        ];
+    }
+
+    public function initDbSchema(InstallerEvent $event): void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS lock_keys (
+    key_id VARCHAR(64) NOT NULL PRIMARY KEY,
+    key_token VARCHAR(44) NOT NULL,
+    key_expiration INTEGER UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+        $this->connection->exec($sql);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -100,6 +100,13 @@ services:
         tags:
             - { name: 'kernel.event_subscriber' }
 
+    pim_catalog.event_subscriber.init_lock_db_schema:
+        class: 'Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Db\InitLockDbSchemaSubscriber'
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'kernel.event_subscriber' }
+
     pim_catalog.event_subscriber.attribute_option_set_sort_order:
         class: 'Akeneo\Pim\Enrichment\Bundle\EventSubscriber\AttributeOption\SetAttributeOptionSortOrderSubscriber'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/lock.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/lock.yml
@@ -1,0 +1,15 @@
+services:
+    akeneo.enrichment.lock.store:
+        class: Symfony\Component\Lock\Store\PdoStore
+        arguments:
+          - '@database_connection'
+
+    akeneo.enrichment.lock.store.retry_till_save:
+        class: Symfony\Component\Lock\Store\RetryTillSaveStore
+        decorates: akeneo.enrichment.lock.store
+        arguments: ['@akeneo.enrichment.lock.store.retry_till_save.inner', 100, 50]
+
+    akeneo.enrichment.lock.factory:
+        class: Symfony\Component\Lock\LockFactory
+        arguments:
+          - '@akeneo.enrichment.lock.store'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -272,6 +272,11 @@ services:
         arguments:
             - '@database_connection'
 
+    akeneo.pim.enrichment.query.ensure_lock_table_exists:
+        class: Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Query\EnsureLockTableExistsQuery
+        arguments:
+            - '@database_connection'
+
     akeneo.pim.enrichment.product.query.get_product_and_product_model_identifiers_with_values_ignoring_locale_and_scope:
         class: Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\ESGetProductAndProductModelIdentifiersWithValuesIgnoringLocaleAndScope
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/savers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/savers.yml
@@ -53,11 +53,12 @@ services:
             - '%pim_catalog.model.association_type.interface%'
 
     pim_catalog.saver.category:
-        class: '%pim_catalog.saver.base.class%'
+        class: Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\CategorySaver
         arguments:
             - '@doctrine.orm.entity_manager'
             - '@event_dispatcher'
-            - '%pim_catalog.model.category.interface%'
+            - '@akeneo.enrichment.lock.factory'
+            - '@akeneo.pim.enrichment.query.ensure_lock_table_exists'
 
     pim_catalog.saver.group_options_resolver:
         class: '%pim_catalog.saver.group_options_resolver.class%'

--- a/src/Akeneo/Pim/Enrichment/Component/Lock/Query/EnsureLockTableExistsInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Lock/Query/EnsureLockTableExistsInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Lock\Query;
+
+/**
+ * TODO pull up remove this interface
+ *
+ * @author    Willy Mesnage <willy.mesnage@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface EnsureLockTableExistsInterface
+{
+    public function execute(): void;
+}

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\Common\Saver;
+
+use Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\CategorySaver;
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Pim\Enrichment\Component\Category\Normalizer\Standard\CategoryNormalizer;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
+
+class CategorySaverIntegration extends TestCase
+{
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_that_it_saves_a_new_category(): void
+    {
+        $category = $this->createCategoryWithoutSaving([
+            'code' => 'foo',
+        ]);
+        $createdNormalizedCategory = $this->getCategoryNormalizer()->normalize($category);
+
+        $this->getCategorySaver()->save($category);
+
+        $persistedCategory = $this->getCategoryRepository()->findOneByIdentifier('foo');
+        $persistedNormalizedCategory = $this->getCategoryNormalizer()->normalize($persistedCategory);
+
+        self::assertEquals($createdNormalizedCategory, $persistedNormalizedCategory);
+    }
+
+    public function test_that_it_saves_a_new_sub_category(): void
+    {
+        $parent = $this->createCategoryWithoutSaving([
+            'code' => 'foo',
+        ]);
+        $this->getCategorySaver()->save($parent);
+
+        $category = $this->createCategoryWithoutSaving([
+            'code' => 'bar',
+            'parent' => 'foo',
+        ]);
+        $createdNormalizedCategory = $this->getCategoryNormalizer()->normalize($category);
+
+        $this->getCategorySaver()->save($category);
+
+        $persistedCategory = $this->getCategoryRepository()->findOneByIdentifier('bar');
+        $persistedNormalizedCategory = $this->getCategoryNormalizer()->normalize($persistedCategory);
+
+        self::assertEquals($createdNormalizedCategory, $persistedNormalizedCategory);
+    }
+
+    private function createCategoryWithoutSaving(array $data = []): CategoryInterface
+    {
+        $category = $this->get('pim_catalog.factory.category')->create();
+        $this->get('pim_catalog.updater.category')->update($category, $data);
+        $this->get('validator')->validate($category);
+
+        return $category;
+    }
+
+    private function getCategorySaver(): CategorySaver
+    {
+        return $this->get('pim_catalog.saver.category');
+    }
+
+    private function getCategoryNormalizer(): CategoryNormalizer
+    {
+        return $this->get('pim_catalog.normalizer.standard.category');
+    }
+
+    private function getCategoryRepository(): CategoryRepositoryInterface
+    {
+        return $this->get('pim_catalog.repository.category');
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/EnsureLockTableExistsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/EnsureLockTableExistsIntegration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\ORM;
+
+use Akeneo\Pim\Enrichment\Component\Lock\Query\EnsureLockTableExistsInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+class EnsureLockTableExistsIntegration extends TestCase
+{
+    /** @var EnsureLockTableExistsInterface */
+    private $query;
+
+    /** @var Connection */
+    private $connection;
+
+    public function testItCreatesTheLockTableIfNotExists(): void
+    {
+        $this->dropTable();
+        $this->query->execute();
+
+        $sql = <<<SQL
+    SELECT *
+    FROM information_schema.tables
+    WHERE table_name = 'lock_keys';
+SQL;
+        $result = $this->connection->executeQuery($sql);
+
+        Assert::assertNotEmpty($result->fetch());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = $this->get('akeneo.pim.enrichment.query.ensure_lock_table_exists');
+        $this->connection = $this->get('database_connection');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function dropTable(): void
+    {
+        $sql = <<<SQL
+DROP TABLE IF EXISTS lock_keys;
+SQL;
+        $this->connection->exec($sql);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/CategorySaverSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Doctrine/Common/Saver/CategorySaverSpec.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver;
+
+use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
+use Akeneo\Pim\Enrichment\Component\Lock\Query\EnsureLockTableExistsInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Persistence\ObjectManager;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Lock\Exception\LockConflictedException;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\LockInterface;
+
+class CategorySaverSpec extends ObjectBehavior
+{
+    public function let(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        LockFactory $lockFactory,
+        EnsureLockTableExistsInterface $ensureLockTableExists
+    ): void {
+        $this->beConstructedWith($objectManager, $eventDispatcher, $lockFactory, $ensureLockTableExists);
+    }
+
+    public function it_is_a_saver(): void
+    {
+        $this->shouldHaveType(SaverInterface::class);
+    }
+
+    public function it_saves_a_category(
+        ObjectManager $objectManager,
+        EventDispatcherInterface $eventDispatcher,
+        LockFactory $lockFactory,
+        LockInterface $lock,
+        CategoryInterface $category,
+        EnsureLockTableExistsInterface $ensureLockTableExists
+    ): void {
+        $category->getId()->willReturn(null);
+        $category->getRoot()->willReturn(1);
+
+        $ensureLockTableExists->execute()->shouldBeCalled();
+        $lockFactory
+            ->createLock('create_category_in_root_1', 10)
+            ->willReturn($lock);
+
+        $lock->acquire(true)->willReturn(true);
+
+        $eventDispatcher->dispatch(
+            Argument::exact(StorageEvents::PRE_SAVE),
+            Argument::that(
+                function (GenericEvent $event) {
+                    return $event->getSubject() instanceof CategoryInterface
+                        && $event->getArgument('unitary') === true;
+                }
+            )
+        )->shouldBeCalled();
+
+        $objectManager->persist($category)->shouldBeCalled();
+        $objectManager->flush()->shouldBeCalled();
+
+        $eventDispatcher->dispatch(
+            Argument::exact(StorageEvents::POST_SAVE),
+            Argument::that(
+                function (GenericEvent $event) {
+                    return $event->getSubject() instanceof CategoryInterface
+                        && $event->getArgument('unitary') === true;
+                }
+            )
+        )->shouldBeCalled();
+
+        $lock->release()->shouldBeCalled();
+
+        $this->save($category);
+    }
+
+    public function it_throws_if_the_lock_cannot_be_acquired(
+        LockFactory $lockFactory,
+        LockInterface $lock,
+        CategoryInterface $category,
+        EnsureLockTableExistsInterface $ensureLockTableExists
+    ) {
+        $category->getId()->willReturn(null);
+        $category->getRoot()->willReturn(1);
+
+        $ensureLockTableExists->execute()->shouldBeCalled();
+        $lockFactory
+            ->createLock('create_category_in_root_1', 10)
+            ->willReturn($lock);
+
+        $lock->acquire(true)->willThrow(LockConflictedException::class);
+
+        $this->shouldThrow(\ErrorException::class)
+            ->during('save', [$category]);
+    }
+}


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | OK
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | OK
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
