### PR TITLE
PIM-9779: fix ACE orders after finding ACLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PIM-9783: Optimize batch query when compute completeness
 - PIM-9715: Prevent the deletion of an attribute used as a label by a family
 - PIM-9781: Fix Category tree not refreshing when switching locale
+- PIM-9779: Fix ACE order when loading ACLs
 - PIM-9739: Fix connection users, users, channels having a link to a sub-category
 
 ## New features

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -61,5 +61,8 @@
             <directory suffix="EndToEnd.php">src</directory>
         </testsuite>
 
+        <testsuite name="OroSecurityBundle">
+            <file>src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php</file>
+        </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
@@ -2,32 +2,27 @@
 
 namespace Oro\Bundle\SecurityBundle\Tests\Unit\Acl\Dbal;
 
+use Doctrine\DBAL\Statement;
 use Oro\Bundle\SecurityBundle\Acl\Dbal\MutableAclProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Acl\Domain\Acl;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 
-class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
+class MutableAclProviderTest extends TestCase
 {
     /** @var MutableAclProvider */
     private $provider;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    /** @var MockObject */
     private $connection;
 
     protected function setUp(): void
     {
         $platform = $this->getMockForAbstractClass('Doctrine\DBAL\Platforms\AbstractPlatform');
-        $platform->expects($this->any())
-            ->method('convertBooleans')
-            ->will(
-                $this->returnValueMap(
-                    [
-                        [false, '0'],
-                        [true, '1'],
-                    ]
-                )
-            );
         $this->connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
             ->disableOriginalConstructor()
             ->getMock();
@@ -49,7 +44,13 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         $this->provider = new MutableAclProvider(
             $this->connection,
             $strategy,
-            ['sid_table_name' => 'acl_security_identities']
+            [
+                'sid_table_name' => 'acl_security_identities',
+                'oid_table_name' => 'acl_object_identities',
+                'class_table_name' => 'acl_object_identities',
+                'oid_ancestors_table_name' => 'acl_object_identity_ancestors',
+                'entry_table_name' => 'acl_entries',
+            ]
         );
     }
 
@@ -142,8 +143,57 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
     public static function updateSecurityIdentityNoChangesProvider()
     {
         return [
-            [new UserSecurityIdentity('test', 'Acme\User'), 'test'],
-            [new RoleSecurityIdentity('ROLE_TEST'), 'ROLE_TEST'],
+            [new UserSecurityIdentity('test_new', 'Acme\User'), 'test'],
+            [new RoleSecurityIdentity('ROLE_TEST_NEW'), 'ROLE_TEST'],
         ];
+    }
+
+    public function testReorderAcesWhenLoadAcls(): void
+    {
+        $statement = new class() extends Statement {
+            public function __construct()
+            {
+            }
+            public function fetchAll($fetchMode = null, $fetchArgument = null, $ctorArgs = null)
+            {
+                return [
+                    [
+                        'acl_id' => 1,
+                        'object_identifier' => 'id1',
+                        'parent_object_identity_id' => null,
+                        'entries_inheriting' => '',
+                        'class_type' => 'type1',
+                        'ace_id' => 4,
+                        'object_identity_id' => null,
+                        'field_name' => null,
+                        'ace_order' => 2, // Here the ace_order is important for the test.
+                        'mask' => 0,
+                        'granting' => 1,
+                        'granting_strategy' => 'all',
+                        'audit_success' => 0,
+                        'audit_failure' => 0,
+                        'username' => 'ROLE',
+                        'security_identifier' => 'ROLE-ROLE',
+                    ],
+                ];
+            }
+        };
+
+        $this->connection->expects($this->any())
+            ->method('executeQuery')->willReturn($statement);
+
+        $oids = [new ObjectIdentity('id1', 'type1')];
+        $sids = [new RoleSecurityIdentity('ROLE')];
+
+        $results = $this->provider->findAcls($oids, $sids);
+        self::assertInstanceOf(\SplObjectStorage::class, $results);
+        $acl = $results->offsetGet($oids[0]);
+        self::assertInstanceOf(Acl::class, $acl);
+        $classAces = $acl->getClassAces();
+        self::assertIsArray($classAces);
+
+        // the ace_order is 2 but the key must be 0 because of the re-order
+        self::assertArrayHasKey(0, $classAces);
+        self::assertArrayNotHasKey(2, $classAces);
     }
 }


### PR DESCRIPTION
Fix https://akeneo.atlassian.net/browse/PIM-9779  

On a very specific environment, we cannot add a specific ACL for a specific role. This behaviour is very strange, but we are not the only one to observe the problem. It's in the `symfony/security-acl` bundle, it's exactly the same as:  
https://github.com/symfony/security-acl/issues/5 
https://github.com/symfony/security-acl/issues/23 
https://github.com/symfony/security-acl/issues/24 
https://github.com/symfony/security-acl/issues/28 

To fix it a PR was opened https://github.com/symfony/security-acl/pull/29, approved by one person, but never merged.  

We had 2 choices:
- fix the problem by code by applying the patch described by the PR (or equivalent)
- fix by SQL query

We think the fix by SQL query is too risky to be executed on all customers. Because we don't understand all the usecases/features of the security-acl bundle, and it's difficult to go back in case of errors/side effects/whatever
Plus there is a internal cache for ACLs that complicates the operation.

**The fix**

The fix is an adaptation of the PR: after fetching the ACLs we re-order the ACEs. My first idea was to applied strictly the PR modification, but the `hydrateObjectIdentities` method is private and can't be override easily (too many private things + too many inheritence).  
So we fix the ACE order after loading the ACLs.  

**Bonus**

For information here is a query to return the "bad" entries in the database. The `ace_order` should begin by 0 and should be incremental by `class_id`

```sql
WITH acl_entries_with_expected_ace_order AS (
    SELECT id,
           class_id,
           security_identity_id,
           ace_order,
           ROW_NUMBER() over (PARTITION BY class_id ORDER BY ace_order) - 1 AS expected_ace_order
    FROM acl_entries
    WHERE object_identity_id IS NULL -- if we remove this condition, we have a lot of additional entries. Is it normal?
    ORDER BY class_id, ace_order
)
SELECT * FROM acl_entries_with_expected_ace_order WHERE ace_order != expected_ace_order;
```
