### PR TITLE
PIM-9783: optimize query for completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - PIM-9765: Fix missing translation key in bulk actions when adding attributes values for some product
 - PIM-9780: Fix completed import/export job notification broken link
 - PIM-9783: Optimize batch query when compute completeness
+- PIM-9783: Optimize SQL query when compute completeness
 - PIM-9715: Prevent the deletion of an attribute used as a label by a family
 - PIM-9781: Fix Category tree not refreshing when switching locale
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -51,6 +51,10 @@ final class SqlGetCompletenessProductMasks implements GetCompletenessProductMask
     {
         // TODO - TIP-1212: Replace the first LEFT JOIN (to pim_catalog_family) by an INNER JOIN
         $sql = <<<SQL
+WITH
+filtered_product AS (
+    SELECT id FROM pim_catalog_product WHERE identifier IN (:productIdentifiers)
+)
 SELECT
     product.id AS id,
     product.identifier AS identifier,
@@ -60,11 +64,11 @@ SELECT
            COALESCE(pm2.raw_values, '{}'),
            product.raw_values
     ) AS rawValues
-FROM pim_catalog_product product
+FROM filtered_product
+    INNER JOIN pim_catalog_product product ON filtered_product.id = product.id
     LEFT JOIN pim_catalog_family family ON product.family_id = family.id
     LEFT JOIN pim_catalog_product_model pm1 ON product.product_model_id = pm1.id
     LEFT JOIN pim_catalog_product_model pm2 ON pm1.parent_id = pm2.id
-WHERE product.identifier IN (:productIdentifiers)
 GROUP BY product.identifier
 SQL;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -117,9 +117,9 @@ SQL;
     {
         $attributeCodes = [];
         foreach ($rows as $row) {
-            $attributeCodes = array_merge($attributeCodes, array_keys($row['cleanedRawValues']));
+            $attributeCodes = array_unique(array_merge($attributeCodes, array_keys($row['cleanedRawValues'])));
         }
-        $attributes = $this->getAttributes->forCodes(array_unique($attributeCodes));
+        $attributes = $this->getAttributes->forCodes($attributeCodes);
 
         $result = [];
         foreach ($rows as $row) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -117,6 +117,9 @@ SQL;
     {
         $attributeCodes = [];
         foreach ($rows as $row) {
+            // array_unique is important for big catalog (see PIM-9783), because for a very high number of rows the array_merge takes too much time.
+            // For instance for 1.000 rows it can take 1 second, for 10.000 rows more than 1 minute.
+            // With array_unique it's less than 1 second in both cases.
             $attributeCodes = array_unique(array_merge($attributeCodes, array_keys($row['cleanedRawValues'])));
         }
         $attributes = $this->getAttributes->forCodes($attributeCodes);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -50,6 +50,9 @@ final class SqlGetCompletenessProductMasks implements GetCompletenessProductMask
     public function fromProductIdentifiers(array $productIdentifiers): array
     {
         // TODO - TIP-1212: Replace the first LEFT JOIN (to pim_catalog_family) by an INNER JOIN
+        // PIM-9783: the initial query didn't use the CTE, we filtered directly the product in the main SELECT. There
+        // was some performance issues with a big number of productIdentifier. The CTE allows to fix it (please check
+        // the issue for further information).
         $sql = <<<SQL
 WITH
 filtered_product AS (


### PR DESCRIPTION
See https://akeneo.atlassian.net/browse/PIM-9783

With the old version, MySQL don't use index range scan if a lot of product identifiers are given (+6000 in our tests).  
Old version: 1min12 for the query with 8084 idnetifiers
New version: less than 2s

Thanks @ahocquard