### PR TITLE
RAC: Add DeleteModal in shared

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -1,19 +1,8 @@
 import React, {useEffect, useState} from 'react';
 import styled from 'styled-components';
-import {
-  Button,
-  DeleteIllustration,
-  Field,
-  getColor,
-  Helper,
-  Key,
-  Link,
-  Modal,
-  TextInput,
-  useShortcut,
-} from 'akeneo-design-system';
+import {Field, getColor, Helper, Link, TextInput} from 'akeneo-design-system';
 import {NotificationLevel, useNotify, useTranslate, useRoute} from '@akeneo-pim-community/legacy-bridge';
-import {useIsMounted} from '@akeneo-pim-community/shared';
+import {useIsMounted, DeleteModal as BaseDeleteModal} from '@akeneo-pim-community/shared';
 
 const SpacedHelper = styled(Helper)`
   margin: 10px 0 20px;
@@ -92,8 +81,6 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
     }
   };
 
-  useShortcut(Key.Enter, handleConfirm);
-
   const productText =
     0 < productCount
       ? translate(
@@ -115,9 +102,12 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
   }${productModelText}`;
 
   return (
-    <Modal onClose={onCancel} closeTitle={translate('pim_common.close')} illustration={<DeleteIllustration />}>
-      <Modal.SectionTitle color="brand">{translate('pim_enrich.entity.attribute.plural_label')}</Modal.SectionTitle>
-      <Modal.Title>{translate('pim_common.confirm_deletion')}</Modal.Title>
+    <BaseDeleteModal
+      title={translate('pim_enrich.entity.attribute.plural_label')}
+      onConfirm={handleConfirm}
+      onCancel={onCancel}
+      canConfirmDelete={isValid}
+    >
       {translate('pim_enrich.entity.attribute.module.delete.confirm')}
       {(0 < productCount || 0 < productModelCount) && (
         <p>
@@ -133,17 +123,14 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
         </Link>
       </SpacedHelper>
       <Field label={translate('pim_enrich.entity.attribute.module.delete.type', {attributeCode})}>
-        <TextInput readOnly={isLoading} value={attributeCodeConfirm} onChange={setAttributeCodeConfirm} />
+        <TextInput
+          readOnly={isLoading}
+          value={attributeCodeConfirm}
+          onChange={setAttributeCodeConfirm}
+          onSubmit={handleConfirm}
+        />
       </Field>
-      <Modal.BottomButtons>
-        <Button level="tertiary" onClick={onCancel}>
-          {translate('pim_common.cancel')}
-        </Button>
-        <Button disabled={!isValid} level="danger" onClick={handleConfirm}>
-          {translate('pim_common.delete')}
-        </Button>
-      </Modal.BottomButtons>
-    </Modal>
+    </BaseDeleteModal>
   );
 };
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
@@ -1,34 +1,32 @@
-import React from 'react';
-import {DeleteIllustration, Button, Modal} from 'akeneo-design-system';
+import React, {ReactNode} from 'react';
+import {Button, DeleteIllustration, Modal} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
 
-type ConfirmModalProps = {
-  isOpen: boolean;
-  description: string;
+type DeleteModalProps = {
+  title: string;
+  children: ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
 };
 
-const ConfirmDeleteModal = ({isOpen, description, onConfirm, onCancel}: ConfirmModalProps) => {
+const DeleteModal = ({children, title, onConfirm, onCancel}: DeleteModalProps) => {
   const translate = useTranslate();
-
-  if (!isOpen) return null;
 
   return (
     <Modal closeTitle={translate('pim_common.close')} onClose={onCancel} illustration={<DeleteIllustration />}>
-      <Modal.SectionTitle color="brand">{translate('measurements.title.measurement')}</Modal.SectionTitle>
+      <Modal.SectionTitle color="brand">{title}</Modal.SectionTitle>
       <Modal.Title>{translate('pim_common.confirm_deletion')}</Modal.Title>
-      {description}
+      {children}
       <Modal.BottomButtons>
         <Button level="tertiary" onClick={onCancel}>
           {translate('pim_common.cancel')}
         </Button>
         <Button level="danger" onClick={onConfirm}>
-          {translate('pim_common.delete')}
+          {translate('pim_common.confirm')}
         </Button>
       </Modal.BottomButtons>
     </Modal>
   );
 };
 
-export {ConfirmDeleteModal};
+export {DeleteModal};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
@@ -5,11 +5,12 @@ import {useTranslate} from '@akeneo-pim-community/legacy-bridge';
 type DeleteModalProps = {
   title: string;
   children: ReactNode;
+  canConfirmDelete?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 };
 
-const DeleteModal = ({children, title, onConfirm, onCancel}: DeleteModalProps) => {
+const DeleteModal = ({children, title, canConfirmDelete = true, onConfirm, onCancel}: DeleteModalProps) => {
   const translate = useTranslate();
 
   return (
@@ -21,7 +22,7 @@ const DeleteModal = ({children, title, onConfirm, onCancel}: DeleteModalProps) =
         <Button level="tertiary" onClick={onCancel}>
           {translate('pim_common.cancel')}
         </Button>
-        <Button level="danger" onClick={onConfirm}>
+        <Button level="danger" disabled={!canConfirmDelete} onClick={onConfirm}>
           {translate('pim_common.delete')}
         </Button>
       </Modal.BottomButtons>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/DeleteModal.tsx
@@ -22,7 +22,7 @@ const DeleteModal = ({children, title, onConfirm, onCancel}: DeleteModalProps) =
           {translate('pim_common.cancel')}
         </Button>
         <Button level="danger" onClick={onConfirm}>
-          {translate('pim_common.confirm')}
+          {translate('pim_common.delete')}
         </Button>
       </Modal.BottomButtons>
     </Modal>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/index.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/shared/src/components/index.ts
@@ -1,3 +1,5 @@
+export * from './CategoryTree';
+export * from './DeleteModal';
 export * from './FullScreenError';
 export * from './LoadingPlaceholder';
 export * from './LocaleSelector';
@@ -5,4 +7,3 @@ export * from './NoData';
 export * from './page';
 export * from './SearchBar';
 export * from './TextField';
-export * from './CategoryTree';

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/Edit.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/Edit.tsx
@@ -21,7 +21,6 @@ import {
   useMeasurementFamilyRemover,
   MeasurementFamilyRemoverResult,
 } from 'akeneomeasure/hooks/use-measurement-family-remover';
-import {ConfirmDeleteModal} from 'akeneomeasure/shared/components/ConfirmDeleteModal';
 import {ConfigContext} from 'akeneomeasure/context/config-context';
 import {
   useTranslate,
@@ -39,6 +38,7 @@ import {
   useToggleState,
   FullScreenError,
   PageContent,
+  DeleteModal,
 } from '@akeneo-pim-community/shared';
 import {Helper, Button, Breadcrumb} from 'akeneo-design-system';
 
@@ -96,7 +96,7 @@ const Errors = ({errors}: {errors: ValidationError[]}) => {
 };
 
 const Edit = () => {
-  const __ = useTranslate();
+  const translate = useTranslate();
   const notify = useNotify();
   const history = useHistory();
   const locale = useUserContext().get('uiLocale');
@@ -118,7 +118,7 @@ const Edit = () => {
   const {setHasUnsavedChanges} = useContext(UnsavedChangesContext);
   const [isModified, resetState] = useUnsavedChanges<MeasurementFamily | null>(
     measurementFamily,
-    __('pim_ui.flash.unsaved_changes')
+    translate('pim_ui.flash.unsaved_changes')
   );
   useEffect(() => setHasUnsavedChanges(isModified), [isModified]);
 
@@ -145,7 +145,7 @@ const Edit = () => {
       switch (response.success) {
         case true:
           resetState();
-          notify(NotificationLevel.SUCCESS, __('measurements.family.save.flash.success'));
+          notify(NotificationLevel.SUCCESS, translate('measurements.family.save.flash.success'));
           break;
 
         case false:
@@ -154,9 +154,9 @@ const Edit = () => {
       }
     } catch (error) {
       console.error(error);
-      notify(NotificationLevel.ERROR, __('measurements.family.save.flash.error'));
+      notify(NotificationLevel.ERROR, translate('measurements.family.save.flash.error'));
     }
-  }, [measurementFamily, locale, saveMeasurementFamily, notify, __, setErrors, resetState]);
+  }, [measurementFamily, locale, saveMeasurementFamily, notify, translate, setErrors, resetState]);
 
   const removeMeasurementFamily = useMeasurementFamilyRemover();
   const handleRemoveMeasurementFamily = useCallback(async () => {
@@ -165,7 +165,7 @@ const Edit = () => {
 
       switch (response) {
         case MeasurementFamilyRemoverResult.Success:
-          notify(NotificationLevel.SUCCESS, __('measurements.family.delete.flash.success'));
+          notify(NotificationLevel.SUCCESS, translate('measurements.family.delete.flash.success'));
           history.push('/');
           break;
         case MeasurementFamilyRemoverResult.NotFound:
@@ -174,9 +174,9 @@ const Edit = () => {
       }
     } catch (error) {
       console.error(error);
-      notify(NotificationLevel.ERROR, __('measurements.family.delete.flash.error'));
+      notify(NotificationLevel.ERROR, translate('measurements.family.delete.flash.error'));
     }
-  }, [measurementFamilyCode, removeMeasurementFamily, history, notify, __]);
+  }, [measurementFamilyCode, removeMeasurementFamily, history, notify, translate]);
 
   const handleNewUnit = useCallback(
     (unit: Unit) => {
@@ -197,8 +197,8 @@ const Edit = () => {
   if (undefined === measurementFamily) {
     return (
       <FullScreenError
-        title={__('error.exception', {status_code: '404'})}
-        message={__('measurements.family.not_found')}
+        title={translate('error.exception', {status_code: '404'})}
+        message={translate('measurements.family.not_found')}
         code={404}
       />
     );
@@ -207,9 +207,9 @@ const Edit = () => {
   const buttons = [];
   if (isGranted('akeneo_measurements_measurement_family_delete') && !measurementFamily.is_locked) {
     buttons.push(
-      <SecondaryActionsDropdownButton title={__('pim_common.other_actions')} key={0}>
+      <SecondaryActionsDropdownButton title={translate('pim_common.other_actions')} key={0}>
         <DropdownLink onClick={openConfirmDeleteMeasurementFamilyModal}>
-          {__('measurements.family.delete.button')}
+          {translate('measurements.family.delete.button')}
         </DropdownLink>
       </SecondaryActionsDropdownButton>
     );
@@ -223,7 +223,7 @@ const Edit = () => {
         onClick={openAddUnitModal}
         disabled={config.units_max <= measurementFamily.units.length}
       >
-        {__('measurements.unit.add')}
+        {translate('measurements.unit.add')}
       </Button>
     );
   }
@@ -232,7 +232,7 @@ const Edit = () => {
     isGranted('akeneo_measurements_measurement_unit_edit') ||
     isGranted('akeneo_measurements_measurement_family_edit_properties')
   ) {
-    buttons.push(<Button onClick={handleSaveMeasurementFamily}>{__('pim_common.save')}</Button>);
+    buttons.push(<Button onClick={handleSaveMeasurementFamily}>{translate('pim_common.save')}</Button>);
   }
 
   const [unitsErrors, propertiesErrors, otherErrors] = partitionErrors(errors, [
@@ -244,16 +244,19 @@ const Edit = () => {
 
   return (
     <>
-      <Prompt when={isModified} message={() => __('pim_ui.flash.unsaved_changes')} />
+      <Prompt when={isModified} message={() => translate('pim_ui.flash.unsaved_changes')} />
       {isAddUnitModalOpen && (
         <CreateUnit measurementFamily={measurementFamily} onClose={closeAddUnitModal} onNewUnit={handleNewUnit} />
       )}
-      <ConfirmDeleteModal
-        isOpen={isConfirmDeleteMeasurementFamilyModalOpen}
-        description={__('measurements.family.delete.confirm')}
-        onConfirm={handleRemoveMeasurementFamily}
-        onCancel={closeConfirmDeleteMeasurementFamilyModal}
-      />
+      {isConfirmDeleteMeasurementFamilyModalOpen && (
+        <DeleteModal
+          title={translate('measurements.title.measurement')}
+          onConfirm={handleRemoveMeasurementFamily}
+          onCancel={closeConfirmDeleteMeasurementFamilyModal}
+        >
+          {translate('measurements.family.delete.confirm')}
+        </DeleteModal>
+      )}
       <PageHeader
         userButtons={
           <PimView
@@ -264,9 +267,9 @@ const Edit = () => {
         buttons={buttons}
         breadcrumb={
           <Breadcrumb>
-            <Breadcrumb.Step href={settingsHref}>{__('pim_menu.tab.settings')}</Breadcrumb.Step>
+            <Breadcrumb.Step href={settingsHref}>{translate('pim_menu.tab.settings')}</Breadcrumb.Step>
             <Breadcrumb.Step href={history.createHref({pathname: '/'})}>
-              {__('pim_menu.item.measurements')}
+              {translate('pim_menu.item.measurements')}
             </Breadcrumb.Step>
             <Breadcrumb.Step>{measurementFamilyLabel}</Breadcrumb.Step>
           </Breadcrumb>
@@ -281,20 +284,19 @@ const Edit = () => {
           <div>{measurementFamilyLabel}</div>
         )}
       </PageHeader>
-
       <PageContent>
         <TabsContainer>
           <Tabs>
             {Object.values(Tab).map((tab: Tab) => (
               <TabSelector key={tab} onClick={() => setCurrentTab(tab)} isActive={currentTab === tab}>
-                {__(`measurements.family.tab.${tab}`)}
+                {translate(`measurements.family.tab.${tab}`)}
                 {tab === Tab.Units && 0 < unitsErrors.length && <ErrorBadge />}
                 {tab === Tab.Properties && 0 < propertiesErrors.length && <ErrorBadge />}
               </TabSelector>
             ))}
           </Tabs>
           <Errors errors={[...unitsErrors.filter(error => error.propertyPath === 'units'), ...otherErrors]} />
-          {measurementFamily.is_locked && <Helper level="warning">{__('measurements.family.is_locked')}</Helper>}
+          {measurementFamily.is_locked && <Helper level="warning">{translate('measurements.family.is_locked')}</Helper>}
         </TabsContainer>
         <Container>
           {currentTab === Tab.Units && null !== selectedUnitCode && (

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/unit-tab/UnitDetails.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/edit/unit-tab/UnitDetails.tsx
@@ -12,9 +12,15 @@ import {
 import {Operation} from 'akeneomeasure/model/operation';
 import {useUiLocales} from 'akeneomeasure/shared/hooks/use-ui-locales';
 import {UnitCode, getUnitLabel} from 'akeneomeasure/model/unit';
-import {ConfirmDeleteModal} from 'akeneomeasure/shared/components/ConfirmDeleteModal';
 import {useTranslate, useUserContext, useSecurity} from '@akeneo-pim-community/legacy-bridge';
-import {filterErrors, ValidationError, useToggleState, TextField, Section} from '@akeneo-pim-community/shared';
+import {
+  filterErrors,
+  ValidationError,
+  useToggleState,
+  TextField,
+  Section,
+  DeleteModal,
+} from '@akeneo-pim-community/shared';
 import {Button, getColor, SectionTitle} from 'akeneo-design-system';
 
 const Container = styled.div`
@@ -66,12 +72,15 @@ const UnitDetails = ({
 
   return (
     <>
-      <ConfirmDeleteModal
-        isOpen={isConfirmDeleteUnitModalOpen}
-        description={translate('measurements.unit.delete.confirm')}
-        onConfirm={handleRemoveUnit}
-        onCancel={closeConfirmDeleteUnitModal}
-      />
+      {isConfirmDeleteUnitModalOpen && (
+        <DeleteModal
+          title={translate('measurements.title.measurement')}
+          onConfirm={handleRemoveUnit}
+          onCancel={closeConfirmDeleteUnitModal}
+        >
+          {translate('measurements.unit.delete.confirm')}
+        </DeleteModal>
+      )}
       <Container>
         <Section>
           <SectionTitle sticky={0}>


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Unifying modal usage with a simple DeleteModal, currently used in Measurements and in RefEntities/Asset Manager here akeneo/pim-enterprise-dev#10622

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
