### PR TITLE
API-1534: Fix log context width

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/ExpandableTableRow.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/ExpandableTableRow.tsx
@@ -7,9 +7,9 @@ const LargeCell = styled.td.attrs(({colSpan}) => ({colSpan: colSpan}))`
 `;
 const ShowContextContainer = styled.div`
     display: block;
-    margin: 0 auto 20px auto;
+    margin: 0 auto 20px;
     padding-left: 10px;
-    width: 70%;
+    width: 756px;
     overflow-x: scroll;
     border: 1px solid ${getColor('grey', 80)};
     background-color: ${getColor('white')};


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->
There is no `max-width: 100%` on the `<pre>` element, the behavior with max-width in % does not work as expected.
Without a width, `overflow: scroll` does not work.
Without wrapping of the content, the `<pre>` will take the width on its content, overflowing the table.
Hence the following:
![Screenshot 2021-03-29 at 10 33 57](https://user-images.githubusercontent.com/1421130/113334464-006a3c00-9324-11eb-9563-379842e68f22.png)
(you can see that the row is wider than the table header)

The only solution I found, which will work on all browsers and most screen is to set a width to it.
The width is not random, it's the exact same one as the initial design.

![Screenshot_2021-04-01_19-55-59](https://user-images.githubusercontent.com/1421130/113334714-517a3000-9324-11eb-9a1d-b19fcfbaabce.png)


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
