### PR TITLE
Fix Version_5_0_20201112083948_add_lock_table migration

### DIFF
--- a/upgrades/schema/Version_5_0_20201112083948_add_lock_table.php
+++ b/upgrades/schema/Version_5_0_20201112083948_add_lock_table.php
@@ -10,7 +10,7 @@ final class Version_5_0_20201112083948_add_lock_table extends AbstractMigration
     public function up(Schema $schema) : void
     {
         $sql = <<<SQL
-CREATE TABLE lock_keys (
+CREATE TABLE IF NOT EXISTS lock_keys (
     key_id VARCHAR(64) NOT NULL PRIMARY KEY,
     key_token VARCHAR(44) NOT NULL,
     key_expiration INTEGER UNSIGNED NOT NULL


### PR DESCRIPTION
This is an ugly fix, but we have a conflict between this migration and the [InitLockDbSchemaSubscriber](https://github.com/akeneo/pim-community-dev/blob/5.0/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/InitLockDbSchemaSubscriber.php) backported from master. This migration can have been played and we can't delete it. That's why I chose to modify it by adding the "IF NOT EXISTS" clause.

If it has been played, nothing will change. If it has not been played, it will not crash because of the InitLockDB subscriber.

Not the smarter fix ever, but with no side effects.