### PR TITLE
BH-477 Remove deprecated parameter

### DIFF
--- a/config/packages/twig.yml
+++ b/config/packages/twig.yml
@@ -1,7 +1,7 @@
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
-    exception_controller: FOS\RestBundle\Controller\ExceptionController::showAction
+    exception_controller: null
     form_theme: ['PimUIBundle:Form:pim-fields.html.twig']
     globals:
         ws:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As described in:
 - https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.4.md#twigbundle
 - https://github.com/FriendsOfSymfony/FOSRestBundle/blob/2.8.6/UPGRADING-2.8.md

This parameter is deprecated. This change disable Twig ErrorHandler to use the HTTP Kernel one.

This will help have a better control over logging.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
