### PR TITLE
PIM-9800: Event not sent when creating products or product models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 
+
 # master
 
 ## Bug fixes
@@ -51,6 +52,7 @@
 - PIM-9739: Fix connection users, users, channels having a link to a sub-category
 - PIM-9763: Make sure that 2 users can each create a private view with the same name
 - PIM-9798: Refresh completeness on product grid after family import
+- PIM-9800: Fix event not sent issue when creating products or product models
 
 ## New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 
-
 # master
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -228,7 +228,6 @@ class ProductController
 
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
-            $this->productAndProductModelClient->refreshIndex();
 
             return new JsonResponse($this->normalizer->normalize(
                 $product,

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
@@ -49,8 +49,8 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::POST_SAVE => 'createAndDispatchProductEvents',
-            StorageEvents::POST_SAVE_ALL => 'dispatchBufferedProductEvents',
+            StorageEvents::POST_SAVE => ['createAndDispatchProductEvents', -10],
+            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductEvents', -10],
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
@@ -49,8 +49,8 @@ final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements Even
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::POST_SAVE => 'createAndDispatchProductModelEvents',
-            StorageEvents::POST_SAVE_ALL => 'dispatchBufferedProductModelEvents',
+            StorageEvents::POST_SAVE => ['createAndDispatchProductModelEvents', -10],
+            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductModelEvents', -10],
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
@@ -2,7 +2,6 @@ services:
     pim_catalog.webhook.event_data_builder.product_created_and_updated:
         class: Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductCreatedAndUpdatedEventDataBuilder
         arguments:
-            - '@pim_catalog.query.product_query_builder_from_size_factory_external_api'
             - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
             - '@pim_api.normalizer.connector_products'
         tags:
@@ -16,7 +15,6 @@ services:
     pim_catalog.webhook.event_data_builder.product_model_created_and_updated:
         class: Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductModelCreatedAndUpdatedEventDataBuilder
         arguments:
-            - '@pim_catalog.query.product_model_query_builder_from_size_factory_external_api'
             - '@akeneo.pim.enrichment.product.connector.get_product_models_from_codes'
             - '@pim_api.normalizer.connector_product_models'
         tags:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
@@ -88,13 +88,16 @@ final class SqlGetConnectorProductModels implements Query\GetConnectorProductMod
             iterator_to_array($result)
         );
 
-        return $this->fromProductModelCodes(
+        $productModels = $this->fromProductModelCodes(
             $productModelCodes,
             $userId,
             $attributesToFilterOn,
             $channelToFilterOn,
             $localesToFilterOn
         );
+
+        // We use the pqb result count in order to keep paginated research working
+        return new ConnectorProductModelList($result->count(), $productModels->connectorProductModels());
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
@@ -88,14 +88,13 @@ final class SqlGetConnectorProductModels implements Query\GetConnectorProductMod
             iterator_to_array($result)
         );
 
-        $connectorProductModels = $this->fromProductModelCodes(
+        return $this->fromProductModelCodes(
             $productModelCodes,
+            $userId,
             $attributesToFilterOn,
             $channelToFilterOn,
             $localesToFilterOn
         );
-
-        return new ConnectorProductModelList($result->count(), $connectorProductModels);
     }
 
     /**
@@ -103,21 +102,22 @@ final class SqlGetConnectorProductModels implements Query\GetConnectorProductMod
      */
     public function fromProductModelCode(string $productModelCode, int $userId): ConnectorProductModel
     {
-        $connectorProductModels = $this->fromProductModelCodes([$productModelCode], null, null, null);
+        $connectorProductModels = $this->fromProductModelCodes([$productModelCode], $userId, null, null, null);
 
-        if (empty($connectorProductModels)) {
+        if ($connectorProductModels->totalNumberOfProductModels() === 0) {
             throw new ObjectNotFoundException(sprintf('Product model "%s" was not found', $productModelCode));
         }
 
-        return $connectorProductModels[0];
+        return $connectorProductModels->connectorProductModels()[0];
     }
 
-    private function fromProductModelCodes(
+    public function fromProductModelCodes(
         array $productModelCodes,
+        int $userId,
         ?array $attributesToFilterOn,
         ?string $channelToFilterOn,
         ?array $localesToFilterOn
-    ): array {
+    ): ConnectorProductModelList {
         $rows = array_replace_recursive(
             $this->getValuesAndPropertiesFromProductModelCodes->fromProductModelCodes($productModelCodes),
             $this->fetchAssociationsIndexedByProductModelCode($productModelCodes),
@@ -173,7 +173,7 @@ final class SqlGetConnectorProductModels implements Query\GetConnectorProductMod
             );
         }
 
-        return $productModels;
+        return new ConnectorProductModelList(count($productModels), $productModels);
     }
 
     private function fetchCategoryCodesIndexedByProductModelCode(array $productModelCodes): array

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProducts.php
@@ -91,7 +91,10 @@ class SqlGetConnectorProducts implements Query\GetConnectorProducts
             return $identifier->getIdentifier();
         }, iterator_to_array($result));
 
-        return $this->fromProductIdentifiers($identifiers, $userId, $attributesToFilterOn, $channelToFilterOn, $localesToFilterOn);
+        $products = $this->fromProductIdentifiers($identifiers, $userId, $attributesToFilterOn, $channelToFilterOn, $localesToFilterOn);
+
+        // We use the pqb result count in order to keep paginated research working
+        return new ConnectorProductList($result->count(), $products->connectorProducts());
     }
 
     public function fromProductIdentifier(string $productIdentifier, int $userId): ConnectorProduct

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptions.php
@@ -55,6 +55,22 @@ class SqlGetConnectorProductsWithOptions implements Query\GetConnectorProducts
         return $this->getConnectorProductsWithLabels([$connectorProduct])[0];
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function fromProductIdentifiers(
+        array $productIdentifiers,
+        int $userId,
+        ?array $attributesToFilterOn,
+        ?string $channelToFilterOn,
+        ?array $localesToFilterOn
+    ): ConnectorProductList {
+        $connectorProductList = $this->getConnectorProducts->fromProductIdentifiers($productIdentifiers, $userId, $attributesToFilterOn, $channelToFilterOn, $localesToFilterOn);
+        $productsWithOptions = $this->getConnectorProductsWithLabels($connectorProductList->connectorProducts());
+
+        return new ConnectorProductList($connectorProductList->totalNumberOfProducts(), $productsWithOptions);
+    }
+
     private function getConnectorProductsWithLabels(array $connectorProducts): array
     {
         $optionCodes = $this->getOptionCodes($connectorProducts);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/GetConnectorProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/GetConnectorProductModels.php
@@ -32,4 +32,20 @@ interface GetConnectorProductModels
      * @throws ObjectNotFoundException if the product model was not found
      */
     public function fromProductModelCode(string $productModelCode, int $userId): ConnectorProductModel;
+
+    /**
+     * @param string[] $productModelCodes
+     * @param int $userId
+     * @param array|null $attributesToFilterOn
+     * @param string|null $channelToFilterOn
+     * @param array|null $localesToFilterOn
+     * @return ConnectorProductModelList
+     */
+    public function fromProductModelCodes(
+        array $productModelCodes,
+        int $userId,
+        ?array $attributesToFilterOn,
+        ?string $channelToFilterOn,
+        ?array $localesToFilterOn
+    ): ConnectorProductModelList;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetConnectorProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/GetConnectorProducts.php
@@ -39,4 +39,20 @@ interface GetConnectorProducts
      * @throws ObjectNotFoundException when the product does not exist
      */
     public function fromProductIdentifier(string $productIdentifier, int $userId): ConnectorProduct;
+
+    /**
+    * @param string[] $productIdentifiers
+    * @param int $userId
+    * @param array|null $attributesToFilterOn
+    * @param string|null $channelToFilterOn
+    * @param array|null $localesToFilterOn
+    * @return ConnectorProductList
+    */
+    public function fromProductIdentifiers(
+        array $productIdentifiers,
+        int $userId,
+        ?array $attributesToFilterOn,
+        ?string $channelToFilterOn,
+        ?array $localesToFilterOn
+    ): ConnectorProductList;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -24,16 +24,13 @@ use Akeneo\UserManagement\Component\Model\UserInterface;
  */
 class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterface
 {
-    private ProductQueryBuilderFactoryInterface $pqbFactory;
     private GetConnectorProducts $getConnectorProductsQuery;
     private ConnectorProductNormalizer $connectorProductNormalizer;
 
     public function __construct(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
         GetConnectorProducts $getConnectorProductsQuery,
         ConnectorProductNormalizer $connectorProductNormalizer
     ) {
-        $this->pqbFactory = $pqbFactory;
         $this->getConnectorProductsQuery = $getConnectorProductsQuery;
         $this->connectorProductNormalizer = $connectorProductNormalizer;
     }
@@ -102,12 +99,8 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
      */
     private function getConnectorProducts(array $identifiers, int $userId): array
     {
-        $pqb = $this->pqbFactory
-            ->create(['limit' => count($identifiers)])
-            ->addFilter('identifier', Operators::IN_LIST, $identifiers);
-
         $result = $this->getConnectorProductsQuery
-            ->fromProductQueryBuilder($pqb, $userId, null, null, null)
+            ->fromProductIdentifiers($identifiers, $userId, null, null, null)
             ->connectorProducts();
 
         $products = array_fill_keys($identifiers, null);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilder.php
@@ -24,16 +24,13 @@ use Akeneo\UserManagement\Component\Model\UserInterface;
  */
 class ProductModelCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterface
 {
-    private ProductQueryBuilderFactoryInterface $pqbFactory;
     private GetConnectorProductModels $getConnectorProductModelsQuery;
     private ConnectorProductModelNormalizer $connectorProductModelNormalizer;
 
     public function __construct(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
         GetConnectorProductModels $getConnectorProductModelsQuery,
         ConnectorProductModelNormalizer $connectorProductModelNormalizer
     ) {
-        $this->pqbFactory = $pqbFactory;
         $this->getConnectorProductModelsQuery = $getConnectorProductModelsQuery;
         $this->connectorProductModelNormalizer = $connectorProductModelNormalizer;
     }
@@ -102,12 +99,8 @@ class ProductModelCreatedAndUpdatedEventDataBuilder implements EventDataBuilderI
      */
     private function getConnectorProductModels(array $codes, int $userId): array
     {
-        $pqb = $this->pqbFactory
-            ->create(['limit' => count($codes)])
-            ->addFilter('identifier', Operators::IN_LIST, $codes);
-
         $result = $this->getConnectorProductModelsQuery
-            ->fromProductQueryBuilder($pqb, $userId, null, null, null)
+            ->fromProductModelCodes($codes, $userId, null, null, null)
             ->connectorProductModels();
 
         $products = array_fill_keys($codes, null);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
@@ -32,7 +32,7 @@ class ProductCreationEndToEnd extends InternalApiTestCase
         $admin = $this->getAdminUser();
 
         $createdProduct = $this->getConnectorProductsQuery
-            ->fromProductQueryBuilder([$identifier], $admin->getId(), null, null, null)
+            ->fromProductIdentifiers([$identifier], $admin->getId(), null, null, null)
             ->connectorProducts();
 
         $this->assertCount(1, $createdProduct);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
@@ -14,14 +14,12 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class ProductCreationEndToEnd extends InternalApiTestCase
 {
-    private ProductQueryBuilderFactoryInterface $pqbFactory;
     private GetConnectorProducts $getConnectorProductsQuery;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->pqbFactory = $this->get('pim_catalog.query.product_query_builder_from_size_factory_external_api');
         $this->getConnectorProductsQuery = $this->get('akeneo.pim.enrichment.product.connector.get_product_from_identifiers');
         $this->authenticate($this->getAdminUser());
     }
@@ -32,12 +30,9 @@ class ProductCreationEndToEnd extends InternalApiTestCase
         $this->createProductWithInternalApi($identifier);
 
         $admin = $this->getAdminUser();
-        $pqb = $this->pqbFactory
-            ->create(['limit' => 1])
-            ->addFilter('identifier', Operators::EQUALS, $identifier);
 
         $createdProduct = $this->getConnectorProductsQuery
-            ->fromProductQueryBuilder($pqb, $admin->getId(), null, null, null)
+            ->fromProductQueryBuilder([$identifier], $admin->getId(), null, null, null)
             ->connectorProducts();
 
         $this->assertCount(1, $createdProduct);

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
@@ -16,7 +16,6 @@ use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetConnectorProdu
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
-use Akeneo\Pim\Structure\Component\Model\AssociationType;
 use Akeneo\Test\Integration\TestCase;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use PHPUnit\Framework\Assert;
@@ -458,6 +457,190 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
         $actualProductModel = $this->getQuery()->fromProductModelCode('sub_pm_A', $this->getUserIdFromUsername('admin'));
 
         Assert::assertEquals($expectedProductModel, $actualProductModel);
+    }
+
+    /**
+     * @test
+     *
+     * @group ce
+     */
+    public function it_gets_several_connector_product_models_from_codes(): void
+    {
+        $actualProductModelList = $this->getQuery()->fromProductModelCodes(
+            ['simple_pm', 'root_pm', 'sub_pm_A'],
+            $this->getUserIdFromUsername('admin'),
+            null,
+            null,
+            null
+        );
+
+        $dataSimplePm = $this->getIdAndDatesFromProductModelCode('simple_pm');
+        $dataRootPm = $this->getIdAndDatesFromProductModelCode('root_pm');
+        $dataSubPm = $this->getIdAndDatesFromProductModelCode('sub_pm_A');
+
+        $expectedProductModelList = new ConnectorProductModelList(3, [
+            new ConnectorProductModel(
+                (int)$dataSimplePm['id'],
+                'simple_pm',
+                new \DateTimeImmutable($dataSimplePm['created']),
+                new \DateTimeImmutable($dataSimplePm['updated']),
+                null,
+                'familyA',
+                'familyVariantA2',
+                [],
+                [
+                    'PACK' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'SUBSTITUTION' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'UPSELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'X_SELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                ],
+                [],
+                [],
+                new ReadValueCollection([])
+            ),
+            new ConnectorProductModel(
+                (int)$dataRootPm['id'],
+                'root_pm',
+                new \DateTimeImmutable($dataRootPm['created']),
+                new \DateTimeImmutable($dataRootPm['updated']),
+                null,
+                'familyA',
+                'familyVariantA1',
+                [],
+                [
+                    'PACK' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'SUBSTITUTION' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'UPSELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'X_SELL' => [
+                        'products' => ['another_product'],
+                        'product_models' => ['simple_pm'],
+                        'groups' => ['groupB'],
+                    ],
+                ],
+                [
+                    'PRODUCT_SET' => [
+                        'products' => [],
+                        'product_models' => [['identifier' => 'simple_pm', 'quantity' => 2]],
+                    ],
+                    'ANOTHER_PRODUCT_SET' => [
+                        'products' => [['identifier' => 'a_simple_product', 'quantity' => 4]],
+                        'product_models' => [],
+                    ],
+                ],
+                ['categoryA2'],
+                new ReadValueCollection(
+                    [
+                        PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(number_format(50.00, 2), 'EUR')])),
+                        ScalarValue::value('a_number_float', '12.5000'),
+                        ScalarValue::scopableLocalizableValue(
+                            'a_localized_and_scopable_text_area',
+                            'mon tshirt rose',
+                            'tablet',
+                            'fr_FR'
+                        ),
+                        ScalarValue::scopableLocalizableValue(
+                            'a_localized_and_scopable_text_area',
+                            'my pink tshirt',
+                            'ecommerce',
+                            'en_US'
+                        ),
+                    ]
+                )
+            ),
+            new ConnectorProductModel(
+                (int)$dataSubPm['id'],
+                'sub_pm_A',
+                new \DateTimeImmutable($dataSubPm['created']),
+                new \DateTimeImmutable($dataSubPm['updated']),
+                'root_pm',
+                'familyA',
+                'familyVariantA1',
+                [],
+                [
+                    'PACK' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'SUBSTITUTION' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'UPSELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => [],
+                    ],
+                    'X_SELL' => [
+                        'products' => ['a_simple_product', 'another_product'],
+                        'product_models' => ['simple_pm'],
+                        'groups' => ['groupA', 'groupB'],
+                    ],
+                ],
+                [
+                    'PRODUCT_SET' => [
+                        'products' => [['identifier' => 'a_simple_product', 'quantity' => 1]],
+                        'product_models' => [['identifier' => 'simple_pm', 'quantity' => 9]],
+                    ],
+                    'ANOTHER_PRODUCT_SET' => [
+                        'products' => [['identifier' => 'a_simple_product', 'quantity' => 4]],
+                        'product_models' => [],
+                    ],
+                ],
+                ['categoryA1', 'categoryA2'],
+                new ReadValueCollection(
+                    [
+                        OptionValue::value('a_simple_select', 'optionA'),
+                        PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(number_format(50.00, 2), 'EUR')])),
+                        ScalarValue::value('a_number_float', '12.5000'),
+                        ScalarValue::scopableLocalizableValue(
+                            'a_localized_and_scopable_text_area',
+                            'mon tshirt rose',
+                            'tablet',
+                            'fr_FR'
+                        ),
+                        ScalarValue::scopableLocalizableValue(
+                            'a_localized_and_scopable_text_area',
+                            'my pink tshirt',
+                            'ecommerce',
+                            'en_US'
+                        ),
+                        ScalarValue::value('a_text', 'Lorem ipsum dolor sit amet'),
+                    ]
+                )
+            ),
+        ]);
+
+        Assert::assertEquals($expectedProductModelList, $actualProductModelList);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
@@ -445,6 +445,133 @@ class SqlGetConnectorProductsIntegration extends TestCase
         $this->assertEquals($expectedProduct, $product);
     }
 
+
+    /**
+     * @group ce
+     */
+    public function test_get_product_from_identifiers()
+    {
+        $query = $this->getQuery();
+
+        $userId = $this
+            ->get('database_connection')
+            ->fetchColumn('SELECT id FROM oro_user WHERE username = "admin"', [], 0);
+
+        $product = $query->fromProductIdentifiers(['apollon_A_false', 'apollon_B_false'], (int) $userId, null, null, null);
+
+        $productDataAppolonA = $this->get('database_connection')->executeQuery(
+            'SELECT id, created, updated FROM pim_catalog_product WHERE identifier = "apollon_A_false"'
+        )->fetch();
+        $productDataAppolonB = $this->get('database_connection')->executeQuery(
+            'SELECT id, created, updated FROM pim_catalog_product WHERE identifier = "apollon_B_false"'
+        )->fetch();
+
+        $expectedProducts = new ConnectorProductList(2, [
+            new ConnectorProduct(
+                (int) $productDataAppolonA['id'],
+                'apollon_A_false',
+                new \DateTimeImmutable($productDataAppolonA['created']),
+                new \DateTimeImmutable($productDataAppolonA['updated']),
+                true,
+                'familyA',
+                ['categoryA2', 'categoryB', 'categoryC'],
+                [],
+                'amor',
+                [
+                    'X_SELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => ['groupA'],
+                    ],
+                    'UPSELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ],
+                    'PACK' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ],
+                    'SUBSTITUTION' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ]
+                ],
+                [
+                    'PRODUCT_SET' => [
+                        'products' => [],
+                        'product_models' => [['identifier' => 'amor', 'quantity' => 4]],
+                    ],
+                ],
+                [],
+                new ReadValueCollection([
+                    OptionValue::value('a_simple_select', 'optionA'),
+                    PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
+                    ScalarValue::value('a_yes_no', false),
+                    ScalarValue::value('a_number_float', '12.5000'),
+                    ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
+                ]),
+                null
+            ),
+            new ConnectorProduct(
+                (int) $productDataAppolonB['id'],
+                'apollon_B_false',
+                new \DateTimeImmutable($productDataAppolonB['created']),
+                new \DateTimeImmutable($productDataAppolonB['updated']),
+                true,
+                'familyA',
+                ['categoryA1', 'categoryA2'],
+                ['groupA', 'groupB'],
+                'amor',
+                [
+                    'X_SELL' => [
+                        'products' => ['apollon_A_false'],
+                        'product_models' => ['amor'],
+                        'groups' => ['groupA', 'groupB'],
+                    ],
+                    'UPSELL' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ],
+                    'PACK' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ],
+                    'SUBSTITUTION' => [
+                        'products' => [],
+                        'product_models' => [],
+                        'groups' => []
+                    ]
+                ],
+                [
+                    'PRODUCT_SET' => [
+                        'products' => [['identifier' => 'apollon_A_false', 'quantity' => 6]],
+                        'product_models' => [],
+                    ],
+                    'ANOTHER_PRODUCT_SET' => [
+                        'products' => [],
+                        'product_models' => [['identifier' => 'amor', 'quantity' => 2]],
+                    ],
+                ],
+                [],
+                new ReadValueCollection([
+                    OptionValue::value('a_simple_select', 'optionB'),
+                    PriceCollectionValue::value('a_price', new PriceCollection([new ProductPrice(50, 'EUR')])),
+                    ScalarValue::value('a_yes_no', false),
+                    ScalarValue::value('a_number_float', '12.5000'),
+                    ScalarValue::scopableLocalizableValue('a_localized_and_scopable_text_area', 'my pink tshirt', 'ecommerce', 'en_US'),
+                ]),
+                null
+            ),
+        ]);
+
+        Assert::assertEquals($expectedProducts, $product);
+    }
+
     public function test_it_throws_an_exception_when_product_is_not_found()
     {
         $this->expectException(ObjectNotFoundException::class);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
@@ -40,8 +40,8 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_SAVE => 'createAndDispatchProductEvents',
-                StorageEvents::POST_SAVE_ALL => 'dispatchBufferedProductEvents',
+                StorageEvents::POST_SAVE => ['createAndDispatchProductEvents', -10],
+                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductEvents', -10],
             ]
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
@@ -39,8 +39,8 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_SAVE => 'createAndDispatchProductModelEvents',
-                StorageEvents::POST_SAVE_ALL => 'dispatchBufferedProductModelEvents',
+                StorageEvents::POST_SAVE => ['createAndDispatchProductModelEvents', -10],
+                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductModelEvents', -10],
             ]
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
@@ -33,7 +33,6 @@ use Symfony\Component\Routing\RouterInterface;
 class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
 {
     public function let(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
         GetConnectorProducts $getConnectorProductsQuery,
         ProductValueNormalizer $productValuesNormalizer,
         RouterInterface $router
@@ -44,7 +43,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         );
         $productValuesNormalizer->normalize(Argument::type(ReadValueCollection::class), 'standard')->willReturn([]);
 
-        $this->beConstructedWith($pqbFactory, $getConnectorProductsQuery, $connectorProductNormalizer);
+        $this->beConstructedWith($getConnectorProductsQuery, $connectorProductNormalizer);
     }
 
     public function it_is_initializable()
@@ -77,9 +76,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     }
 
     public function it_builds_a_bulk_event_of_product_created_and_updated_event(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        GetConnectorProducts $getConnectorProductsQuery,
-        ProductQueryBuilderInterface $pqb
+        GetConnectorProducts $getConnectorProductsQuery
     ): void {
         $user = new User();
         $user->setId(10);
@@ -97,9 +94,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
             $this->buildConnectorProduct(2, 'red_jean'),
         ]);
 
-        $pqbFactory->create(['limit' => 2])->willReturn($pqb);
-        $pqb->addFilter('identifier', Operators::IN_LIST, ['blue_jean', 'red_jean'])->willReturn($pqb);
-        $getConnectorProductsQuery->fromProductQueryBuilder($pqb, 10, null, null, null)->willReturn($productList);
+        $getConnectorProductsQuery->fromProductIdentifiers(['blue_jean', 'red_jean'], 10, null, null, null)->willReturn($productList);
 
         $expectedCollection = new EventDataCollection();
         $expectedCollection->setEventData(
@@ -147,18 +142,14 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     }
 
     public function it_builds_a_bulk_event_of_product_created_and_updated_event_if_a_product_as_been_removed(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        GetConnectorProducts $getConnectorProductsQuery,
-        ProductQueryBuilderInterface $pqb
+        GetConnectorProducts $getConnectorProductsQuery
     ): void {
         $user = new User();
         $user->setId(10);
 
         $productList = new ConnectorProductList(1, [$this->buildConnectorProduct(1, 'blue_jean')]);
 
-        $pqbFactory->create(['limit' => 2])->willReturn($pqb);
-        $pqb->addFilter('identifier', Operators::IN_LIST, ['blue_jean', 'red_jean'])->willReturn($pqb);
-        $getConnectorProductsQuery->fromProductQueryBuilder($pqb, 10, null, null, null)->willReturn($productList);
+        $getConnectorProductsQuery->fromProductIdentifiers(['blue_jean', 'red_jean'], 10, null, null, null)->willReturn($productList);
 
         $blueJeanEvent = new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
@@ -38,18 +38,18 @@ use Symfony\Component\Routing\RouterInterface;
 class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
 {
     function let(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
         GetConnectorProductModels $getConnectorProductModelsQuery,
         ProductValueNormalizer $productValuesNormalizer,
         RouterInterface $router
-    ) {
+    )
+    {
         $connectorProductModelNormalizer = new ConnectorProductModelNormalizer(
             new ValuesNormalizer($productValuesNormalizer->getWrappedObject(), $router->getWrappedObject()),
             new DateTimeNormalizer(),
         );
         $productValuesNormalizer->normalize(Argument::type(ReadValueCollection::class), 'standard')->willReturn([]);
 
-        $this->beConstructedWith($pqbFactory, $getConnectorProductModelsQuery, $connectorProductModelNormalizer);
+        $this->beConstructedWith($getConnectorProductModelsQuery, $connectorProductModelNormalizer);
     }
 
 
@@ -83,9 +83,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     }
 
     public function it_builds_a_bulk_event_of_product_created_and_updated_event(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        GetConnectorProductModels $getConnectorProductModelsQuery,
-        ProductQueryBuilderInterface $pqb
+        GetConnectorProductModels $getConnectorProductModelsQuery
     ): void {
         $user = new User();
         $user->setId(10);
@@ -103,9 +101,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
             $this->buildConnectorProductModel(2, 'shoes'),
         ]);
 
-        $pqbFactory->create(['limit' => 2])->willReturn($pqb);
-        $pqb->addFilter('identifier', Operators::IN_LIST, ['jean', 'shoes'])->willReturn($pqb);
-        $getConnectorProductModelsQuery->fromProductQueryBuilder($pqb, 10, null, null, null)
+        $getConnectorProductModelsQuery->fromProductModelCodes(['jean', 'shoes'], 10, null, null, null)
             ->willReturn($productModelList);
 
         $expectedCollection = new EventDataCollection();
@@ -152,18 +148,14 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     }
 
     public function it_builds_a_bulk_event_of_product_created_and_updated_event_if_a_product_as_been_removed(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        GetConnectorProductModels $getConnectorProductModelsQuery,
-        ProductQueryBuilderInterface $pqb
+        GetConnectorProductModels $getConnectorProductModelsQuery
     ): void {
         $user = new User();
         $user->setId(10);
 
         $productList = new ConnectorProductModelList(1, [$this->buildConnectorProductModel(1, 'jean')]);
 
-        $pqbFactory->create(['limit' => 2])->willReturn($pqb);
-        $pqb->addFilter('identifier', Operators::IN_LIST, ['jean', 'shoes'])->willReturn($pqb);
-        $getConnectorProductModelsQuery->fromProductQueryBuilder($pqb, 10, null, null, null)
+        $getConnectorProductModelsQuery->fromProductModelCodes(['jean', 'shoes'], 10, null, null, null)
             ->willReturn($productList);
 
         $jeanEvent = new ProductModelCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
@@ -41,8 +41,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         GetConnectorProductModels $getConnectorProductModelsQuery,
         ProductValueNormalizer $productValuesNormalizer,
         RouterInterface $router
-    )
-    {
+    ) {
         $connectorProductModelNormalizer = new ConnectorProductModelNormalizer(
             new ValuesNormalizer($productValuesNormalizer->getWrappedObject(), $router->getWrappedObject()),
             new DateTimeNormalizer(),


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

The webhooks workflow searches for products and indexes product models after they are created. Depending on the [refresh time of the Elasticsearch index](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html#refresh-api-desc), the resource might not be retrieved.

To solve this problem, we base the retrieval of products and product models only on SQL queries.


**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
