### PR TITLE
API-1545: Adds isInitialized to useInfiniteScroll

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
@@ -48,7 +48,16 @@ export const EventLogList: FC<{connectionCode: string}> = ({connectionCode}) => 
     }>({filters: getDefaultFilters()});
     const isSearchActive = !isSameAsDefaultFiltersValues(filters);
 
-    const {logs, total, isLoading} = useInfiniteEventSubscriptionLogs(connectionCode, filters, scrollContainer);
+    const {
+        logs,
+        total,
+        isLoading,
+        isInitialized
+    } = useInfiniteEventSubscriptionLogs(connectionCode, filters, scrollContainer);
+
+    if (!isInitialized) {
+        return null;
+    }
 
     if (!isSearchActive && !isLoading && total === 0) {
         return <NoEventLogs />;

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EventLogList.tsx
@@ -48,12 +48,11 @@ export const EventLogList: FC<{connectionCode: string}> = ({connectionCode}) => 
     }>({filters: getDefaultFilters()});
     const isSearchActive = !isSameAsDefaultFiltersValues(filters);
 
-    const {
-        logs,
-        total,
-        isLoading,
-        isInitialized
-    } = useInfiniteEventSubscriptionLogs(connectionCode, filters, scrollContainer);
+    const {logs, total, isLoading, isInitialized} = useInfiniteEventSubscriptionLogs(
+        connectionCode,
+        filters,
+        scrollContainer
+    );
 
     if (!isInitialized) {
         return null;

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-infinite-event-subscription-logs.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-infinite-event-subscription-logs.ts
@@ -31,6 +31,7 @@ const useInfiniteEventSubscriptionLogs = (
     container: RefObject<HTMLElement>
 ): EventSubscriptionLogs & {
     isLoading: boolean;
+    isInitialized: boolean;
 } => {
     const [state, setState] = useState<EventSubscriptionLogs>({
         logs: [],
@@ -89,7 +90,11 @@ const useInfiniteEventSubscriptionLogs = (
         return payload;
     };
 
-    const {reset, isLoading} = useInfiniteScroll<SearchEventSubscriptionLogsResponse>(fetchNextResponse, container);
+    const {
+        reset,
+        isLoading,
+        isInitialized
+    } = useInfiniteScroll<SearchEventSubscriptionLogsResponse>(fetchNextResponse, container);
 
     const resetState = useCallback(() => {
         setState({
@@ -117,6 +122,7 @@ const useInfiniteEventSubscriptionLogs = (
     return {
         ...state,
         isLoading: isLoading,
+        isInitialized: isInitialized,
     };
 };
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-infinite-event-subscription-logs.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-infinite-event-subscription-logs.ts
@@ -90,11 +90,10 @@ const useInfiniteEventSubscriptionLogs = (
         return payload;
     };
 
-    const {
-        reset,
-        isLoading,
-        isInitialized
-    } = useInfiniteScroll<SearchEventSubscriptionLogsResponse>(fetchNextResponse, container);
+    const {reset, isLoading, isInitialized} = useInfiniteScroll<SearchEventSubscriptionLogsResponse>(
+        fetchNextResponse,
+        container
+    );
 
     const resetState = useCallback(() => {
         setState({

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/scroll/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/scroll/hooks/useInfiniteScroll.ts
@@ -4,6 +4,7 @@ import useIsMounted from './useIsMounted';
 
 type InfiniteScrollStatus = {
     isLoading: boolean;
+    isInitialized: boolean;
     reset: () => void;
 };
 
@@ -26,15 +27,17 @@ const useInfiniteScroll = <T>(
         lastPage: T | null;
         isStopped: boolean;
         isLoading: boolean;
+        isInitialized: boolean;
         shouldFetch: boolean;
     }>({
         lastPage: null,
         isStopped: false,
         isLoading: false,
+        isInitialized: false,
         shouldFetch: true,
     });
 
-    const {lastPage, isStopped, isLoading, shouldFetch} = state;
+    const {lastPage, isStopped, isLoading, isInitialized, shouldFetch} = state;
 
     const isMounted = useIsMounted();
 
@@ -63,6 +66,7 @@ const useInfiniteScroll = <T>(
                 lastPage: page,
                 isStopped: null === page,
                 isLoading: false,
+                isInitialized: true,
                 shouldFetch: false,
             }));
         })();
@@ -103,12 +107,13 @@ const useInfiniteScroll = <T>(
     useScrollPosition(containerRef, handleScrollPosition, [lastPage], 100);
 
     const reset = useCallback(() => {
-        setState({
+        setState(state => ({
+            ...state,
             lastPage: null,
             isStopped: false,
             isLoading: false,
             shouldFetch: false,
-        });
+        }));
         setState(state => ({
             ...state,
             shouldFetch: true,
@@ -117,6 +122,7 @@ const useInfiniteScroll = <T>(
 
     return {
         isLoading: isLoading,
+        isInitialized: isInitialized,
         reset: reset,
     };
 };


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

In the current version, there is no "initial" loading screen, it jump directly to the table of logs.
Then, when the fetch is done, and there is no logs, the page is replaced by `<NoEventLogs />`.
This create a "flash" of the page content.

By adding isInitialized, we display nothing until the first fetch is done.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
