### PR TITLE
PIM-9804: Add an interface to Pim events dispatchers

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchBufferedPimEventSubscriberInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchBufferedPimEventSubscriberInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+interface DispatchBufferedPimEventSubscriberInterface extends EventSubscriberInterface
+{
+    public function createAndDispatchPimEvents(GenericEvent $postSaveEvent): void;
+    public function dispatchBufferedPimEvents(): void;
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
@@ -11,7 +11,6 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -21,7 +20,7 @@ use Symfony\Component\Security\Core\Security;
  * @copyright 202O Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubscriberInterface
+final class DispatchProductCreatedAndUpdatedEventSubscriber implements DispatchBufferedPimEventSubscriberInterface
 {
     private Security $security;
     private MessageBusInterface $messageBus;
@@ -49,12 +48,12 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::POST_SAVE => ['createAndDispatchProductEvents', -10],
-            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductEvents', -10],
+            StorageEvents::POST_SAVE => ['createAndDispatchPimEvents', -10],
+            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedPimEvents', -10],
         ];
     }
 
-    public function createAndDispatchProductEvents(GenericEvent $postSaveEvent): void
+    public function createAndDispatchPimEvents(GenericEvent $postSaveEvent): void
     {
         if ($postSaveEvent->hasArgument('force_save') && true === $postSaveEvent->getArgument('force_save')) {
             return;
@@ -82,13 +81,13 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements EventSubs
         }
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->dispatchBufferedProductEvents();
+            $this->dispatchBufferedPimEvents();
         } elseif (count($this->events) >= $this->maxBulkSize) {
-            $this->dispatchBufferedProductEvents();
+            $this->dispatchBufferedPimEvents();
         }
     }
 
-    public function dispatchBufferedProductEvents(): void
+    public function dispatchBufferedPimEvents(): void
     {
         if (count($this->events) === 0) {
             return;

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriber.php
@@ -11,7 +11,6 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -21,7 +20,7 @@ use Symfony\Component\Security\Core\Security;
  * @copyright 202O Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements EventSubscriberInterface
+final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements DispatchBufferedPimEventSubscriberInterface
 {
     private Security $security;
     private MessageBusInterface $messageBus;
@@ -49,12 +48,12 @@ final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements Even
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::POST_SAVE => ['createAndDispatchProductModelEvents', -10],
-            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductModelEvents', -10],
+            StorageEvents::POST_SAVE => ['createAndDispatchPimEvents', -10],
+            StorageEvents::POST_SAVE_ALL => ['dispatchBufferedPimEvents', -10],
         ];
     }
 
-    public function createAndDispatchProductModelEvents(GenericEvent $postSaveEvent): void
+    public function createAndDispatchPimEvents(GenericEvent $postSaveEvent): void
     {
         if ($postSaveEvent->hasArgument('force_save') && true === $postSaveEvent->getArgument('force_save')) {
             return;
@@ -82,13 +81,13 @@ final class DispatchProductModelCreatedAndUpdatedEventSubscriber implements Even
         }
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->dispatchBufferedProductModelEvents();
+            $this->dispatchBufferedPimEvents();
         } elseif (count($this->events) >= $this->maxBulkSize) {
-            $this->dispatchBufferedProductModelEvents();
+            $this->dispatchBufferedPimEvents();
         }
     }
 
-    public function dispatchBufferedProductModelEvents(): void
+    public function dispatchBufferedPimEvents(): void
     {
         if (count($this->events) === 0) {
             return;

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
@@ -10,7 +10,6 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Messenger\Exception\TransportException;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -20,7 +19,7 @@ use Symfony\Component\Security\Core\Security;
  * @copyright 202O Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class DispatchProductRemovedEventSubscriber implements EventSubscriberInterface
+final class DispatchProductRemovedEventSubscriber implements DispatchBufferedPimEventSubscriberInterface
 {
     private Security $security;
     private MessageBusInterface $messageBus;
@@ -48,12 +47,12 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::POST_REMOVE => 'createAndDispatchProductEvents',
-            StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedProductEvents',
+            StorageEvents::POST_REMOVE => 'createAndDispatchPimEvents',
+            StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedPimEvents',
         ];
     }
 
-    public function createAndDispatchProductEvents(GenericEvent $postSaveEvent): void
+    public function createAndDispatchPimEvents(GenericEvent $postSaveEvent): void
     {
         /** @var ProductInterface */
         $product = $postSaveEvent->getSubject();
@@ -74,13 +73,13 @@ final class DispatchProductRemovedEventSubscriber implements EventSubscriberInte
         $this->events[] = new ProductRemoved($author, $data);
 
         if ($postSaveEvent->hasArgument('unitary') && true === $postSaveEvent->getArgument('unitary')) {
-            $this->dispatchBufferedProductEvents();
+            $this->dispatchBufferedPimEvents();
         } elseif (count($this->events) >= $this->maxBulkSize) {
-            $this->dispatchBufferedProductEvents();
+            $this->dispatchBufferedPimEvents();
         }
     }
 
-    public function dispatchBufferedProductEvents(): void
+    public function dispatchBufferedPimEvents(): void
     {
         if (count($this->events) === 0) {
             return;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductCreatedAndUpdatedEventSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
@@ -15,7 +16,6 @@ use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
-use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -34,14 +34,15 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
     function it_is_initializable(): void
     {
         $this->shouldHaveType(DispatchProductCreatedAndUpdatedEventSubscriber::class);
+        $this->shouldImplement(DispatchBufferedPimEventSubscriberInterface::class);
     }
 
     function it_returns_subscribed_tech_events(): void
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_SAVE => ['createAndDispatchProductEvents', -10],
-                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductEvents', -10],
+                StorageEvents::POST_SAVE => ['createAndDispatchPimEvents', -10],
+                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedPimEvents', -10],
             ]
         );
     }
@@ -59,7 +60,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product, ['is_new' => true, 'unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product, ['is_new' => true, 'unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -87,7 +88,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product, ['is_new' => false, 'unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product, ['is_new' => false, 'unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -117,9 +118,9 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product2 = new Product();
         $product2->setIdentifier('product_identifier_2');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
-        $this->createAndDispatchProductEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
-        $this->dispatchBufferedProductEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -156,10 +157,10 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product3 = new Product();
         $product3->setIdentifier('product_identifier_3');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
-        $this->createAndDispatchProductEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
-        $this->createAndDispatchProductEvents(new GenericEvent($product3, ['is_new' => true, 'unitary' => false]));
-        $this->dispatchBufferedProductEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($product1, ['is_new' => true, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product2, ['is_new' => false, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product3, ['is_new' => true, 'unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(2, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -193,7 +194,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             new \stdClass(),
             ['is_new' => false, 'unitary' => true]
         ));
@@ -211,7 +212,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
             ['is_new' => false, 'unitary' => true]
         ));
@@ -227,7 +228,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
             ['is_new' => false, 'force_save' => true]
         ));
@@ -252,7 +253,7 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
             ['is_new' => false, 'unitary' => true]
         ));

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelCreatedAndUpdatedEventSubscriberSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelCreatedAndUpdatedEventSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;
@@ -33,14 +34,15 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
     function it_is_initializable(): void
     {
         $this->shouldHaveType(DispatchProductModelCreatedAndUpdatedEventSubscriber::class);
+        $this->shouldImplement(DispatchBufferedPimEventSubscriberInterface::class);
     }
 
     function it_returns_subscribed_tech_events(): void
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_SAVE => ['createAndDispatchProductModelEvents', -10],
-                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedProductModelEvents', -10],
+                StorageEvents::POST_SAVE => ['createAndDispatchPimEvents', -10],
+                StorageEvents::POST_SAVE_ALL => ['dispatchBufferedPimEvents', -10],
             ]
         );
     }
@@ -58,7 +60,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel = new ProductModel();
         $productModel->setCode('polo_col_mao');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel, ['is_new' => true, 'unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel, ['is_new' => true, 'unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -86,7 +88,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel = new ProductModel();
         $productModel->setCode('polo_col_mao');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel, ['is_new' => false, 'unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel, ['is_new' => false, 'unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -116,9 +118,9 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel2 = new ProductModel();
         $productModel2->setCode('product_model_code_2');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel1, ['is_new' => true, 'unitary' => false]));
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel2, ['is_new' => false, 'unitary' => false]));
-        $this->dispatchBufferedProductModelEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel1, ['is_new' => true, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel2, ['is_new' => false, 'unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -155,10 +157,10 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel3 = new ProductModel();
         $productModel3->setCode('product_model_code_3');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel1, ['is_new' => true, 'unitary' => false]));
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel2, ['is_new' => false, 'unitary' => false]));
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel3, ['is_new' => true, 'unitary' => false]));
-        $this->dispatchBufferedProductModelEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel1, ['is_new' => true, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel2, ['is_new' => false, 'unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel3, ['is_new' => true, 'unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(2, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -192,7 +194,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             new \stdClass(),
             ['is_new' => false, 'unitary' => true]
         ));
@@ -210,7 +212,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel, ['is_new' => false, 'unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel, ['is_new' => false, 'unitary' => true]));
 
         Assert::assertCount(0, $messageBus->messages);
     }
@@ -223,7 +225,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel = new ProductModel();
         $productModel->setCode('product_model_code');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $productModel,
             ['is_new' => false, 'force_save' => true]
         ));
@@ -248,7 +250,7 @@ class DispatchProductModelCreatedAndUpdatedEventSubscriberSpec extends ObjectBeh
         $productModel = new ProductModel();
         $productModel->setCode('product_model_code');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $productModel,
             ['is_new' => false, 'unitary' => true]
         ));

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelRemovedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductModelRemovedEventSubscriberSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelRemovedEventSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
@@ -35,14 +36,15 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
     function it_is_initializable(): void
     {
         $this->shouldHaveType(DispatchProductModelRemovedEventSubscriber::class);
+        $this->shouldImplement(DispatchBufferedPimEventSubscriberInterface::class);
     }
 
     function it_returns_subscribed_events(): void
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_REMOVE => 'createAndDispatchProductModelEvents',
-                StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedProductModelEvents',
+                StorageEvents::POST_REMOVE => 'createAndDispatchPimEvents',
+                StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedPimEvents',
             ]
         );
     }
@@ -62,7 +64,7 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
         $productModel = new ProductModel();
         $productModel->setCode('jean');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($productModel, ['unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($productModel, ['unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -98,9 +100,9 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
         $product2 = new ProductModel();
         $product2->setCode('jean');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent($product1, ['unitary' => false]));
-        $this->createAndDispatchProductModelEvents(new GenericEvent($product2, ['unitary' => false]));
-        $this->dispatchBufferedProductModelEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($product1, ['unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product2, ['unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -138,7 +140,7 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             new \stdClass(),
             ['unitary' => true]
         ));
@@ -157,7 +159,7 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $productModel,
             ['unitary' => true]
         ));
@@ -182,7 +184,7 @@ class DispatchProductModelRemovedEventSubscriberSpec extends ObjectBehavior
         $productModel = new ProductModel();
         $productModel->setCode('product_model_code');
 
-        $this->createAndDispatchProductModelEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $productModel,
             ['unitary' => true]
         ));

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent;
 
+use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductRemovedEventSubscriber;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
@@ -34,14 +35,15 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
     function it_is_initializable(): void
     {
         $this->shouldHaveType(DispatchProductRemovedEventSubscriber::class);
+        $this->shouldImplement(DispatchBufferedPimEventSubscriberInterface::class);
     }
 
     function it_returns_subscribed_events(): void
     {
         $this->getSubscribedEvents()->shouldReturn(
             [
-                StorageEvents::POST_REMOVE => 'createAndDispatchProductEvents',
-                StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedProductEvents',
+                StorageEvents::POST_REMOVE => 'createAndDispatchPimEvents',
+                StorageEvents::POST_REMOVE_ALL => 'dispatchBufferedPimEvents',
             ]
         );
     }
@@ -59,7 +61,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('blue_jean');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product, ['unitary' => true]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product, ['unitary' => true]));
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -95,9 +97,9 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $product2 = new Product();
         $product2->setIdentifier('product_identifier_2');
 
-        $this->createAndDispatchProductEvents(new GenericEvent($product1, ['unitary' => false]));
-        $this->createAndDispatchProductEvents(new GenericEvent($product2, ['unitary' => false]));
-        $this->dispatchBufferedProductEvents(new GenericEvent());
+        $this->createAndDispatchPimEvents(new GenericEvent($product1, ['unitary' => false]));
+        $this->createAndDispatchPimEvents(new GenericEvent($product2, ['unitary' => false]));
+        $this->dispatchBufferedPimEvents(new GenericEvent());
 
         Assert::assertCount(1, $messageBus->messages);
         Assert::assertContainsOnlyInstancesOf(BulkEventInterface::class, $messageBus->messages);
@@ -134,7 +136,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $messageBus = $this->getMessageBus();
         $this->beConstructedWith($security, $messageBus, 10, new NullLogger(), new NullLogger());
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             new \stdClass(),
             ['unitary' => true]
         ));
@@ -152,7 +154,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
 
         $security->getUser()->willReturn(null);
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
             ['unitary' => true]
         ));
@@ -178,7 +180,7 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('product_identifier');
 
-        $this->createAndDispatchProductEvents(new GenericEvent(
+        $this->createAndDispatchPimEvents(new GenericEvent(
             $product,
             ['unitary' => true]
         ));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Currently, published products produce PIM events (which are sent to webhooks) but they mustn't.
This PR aims to change this behavior by decorating the subscribers and stopping the propagation of events from a published product.

In the CE PR, I add an interface to the subscribers in order to create a contract and be able to mock those final classes in EE spec.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
