### PR TITLE
Allows ctrl-c for stopping the php process in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - '${HOST_COMPOSER_HOME:-~/.composer}:/var/www/.composer'
     working_dir: '/srv/pim'
     command: 'php'
+    init: true
     networks:
       - 'pim'
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Do you hate when you start a consumer with docker-compose and you cannot stop it ?

![Screenshot_2021-04-13_17-19-41](https://user-images.githubusercontent.com/1421130/114578094-e4985b80-9c7c-11eb-84c2-2ad3cf391f5c.png)

~Have you tried turning your computer off and on again?~

---

Now, with this PR, it will work.

![Screenshot_2021-04-13_17-18-43](https://user-images.githubusercontent.com/1421130/114578207-fd087600-9c7c-11eb-8a9f-2634b20d5d95.png)

**How**

I'm simply proposing to use the option `init: true` see https://docs.docker.com/compose/compose-file/compose-file-v3/#init
It's only possible since https://github.com/akeneo/pim-community-dev/pull/14303, thanks to our dear @jmleroux 

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
