### PR TITLE
PIM-9809: Fix missing filters in the product grid for few UI locales with Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - PIM-9763: Make sure that 2 users can each create a private view with the same name
 - PIM-9798: Refresh completeness on product grid after family import
 - PIM-9800: Fix event not sent issue when creating products or product models
+- PIM-9809: Fix missing filters in the product grid for few UI locales with Firefox
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/select-filter.js
@@ -156,7 +156,7 @@ define(['underscore', 'oro/translator', 'oro/datafilter/abstract-filter', 'oro/m
         return option;
       });
       options.sort((a, b) => {
-        return a.__translation.localeCompare(b.__translation);
+        return a.__translation.toString().localeCompare(b.__translation);
       });
 
       this.$el.empty();


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

With Firefox and for some UI locale, filters in the product grid disappeared + the filter 'Product image' had a different behavior from the others. 
Video before fixing the bug => https://www.screencast.com/t/G05lxhii1

In the console, I got this message `jQuery.Deferred exception: a.__translation.localeCompare is not a function`
Addind the toString() function resolves the issue.

Here is a gif, after adding the fix:
![filtersok](https://user-images.githubusercontent.com/57708349/114731452-0dceef80-9d42-11eb-9545-e96aa4d5c27b.gif)


<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
