### PR TITLE
API-1544: Validate url length in event subscription form

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validation/WriteConnectionWebhook.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validation/WriteConnectionWebhook.yml
@@ -12,3 +12,5 @@ Akeneo\Connectivity\Connection\Domain\Webhook\Model\Write\ConnectionWebhook:
         url:
             - Url:
                 message: 'akeneo_connectivity.connection.webhook.error.wrong_url'
+            - Length:
+                max: 255

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Validation/WriteConnectionWebhookValidationIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Validation/WriteConnectionWebhookValidationIntegration.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Validation;
+
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Model\Write\ConnectionWebhook;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class WriteConnectionWebhookValidationIntegration extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = $this->get('validator');
+
+        /** @var ConnectionLoader $connectionLoader */
+        $connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+        $connectionLoader->createConnection('magento', 'Magento Connector', FlowType::DATA_DESTINATION, false);
+    }
+
+    public function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_the_url_is_valid_when_has_255_characters()
+    {
+        $url = $this->createValidUrlOfLength(255);
+
+        $value = new ConnectionWebhook('magento', true, $url);
+        $errors = $this->validator->validate($value);
+
+        $this->assertCount(0, $errors);
+    }
+
+    public function test_the_url_is_invalid_when_more_than_255_characters()
+    {
+        $url = $this->createValidUrlOfLength(256);
+
+        $value = new ConnectionWebhook('magento', true, $url);
+        $errors = $this->validator->validate($value);
+
+        $this->assertCount(1, $errors);
+        $this->assertInstanceOf(Length::class, $errors[0]->getConstraint());
+    }
+
+    private function createValidUrlOfLength(int $length): string
+    {
+        $baseUrl = 'http://foo.com/';
+        $url = sprintf('%s%s', $baseUrl, str_repeat('a', $length - strlen($baseUrl)));
+
+        if (strlen($url) !== $length) {
+            throw new \LogicException(sprintf('The url should have %d characters but has %d instead.', $length, strlen($url)));
+        }
+
+        return $url;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Validation/WriteConnectionWebhookValidationIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Validation/WriteConnectionWebhookValidationIntegration.php
@@ -52,8 +52,7 @@ class WriteConnectionWebhookValidationIntegration extends TestCase
 
     private function createValidUrlOfLength(int $length): string
     {
-        $baseUrl = 'http://foo.com/';
-        $url = sprintf('%s%s', $baseUrl, str_repeat('a', $length - strlen($baseUrl)));
+        $url = str_pad('http://foo.com/', $length, 'a');
 
         if (strlen($url) !== $length) {
             throw new \LogicException(sprintf('The url should have %d characters but has %d instead.', $length, strlen($url)));


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Since the validation configuration is not something that can be spec'ed, I've added an integration test for it.

![Screenshot_2021-04-15_13-29-19](https://user-images.githubusercontent.com/1421130/114862265-999e5580-9dee-11eb-98a2-b56da92e0087.png)

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
