### PR TITLE
API-1552: Add a min-height to the breadcrumb to avoid jump of the DOM

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
@@ -15,6 +15,10 @@ const ButtonCollection = styled.div.attrs(() => ({className: 'AknTitleContainer-
     }
 `;
 
+const AknTitleContainerBreadcrumbs = styled.div.attrs(() => ({className: 'AknTitleContainer-breadcrumbs'}))`
+    min-height: 32px;
+`;
+
 export const PageHeader = ({children: title, breadcrumb, buttons, userButtons, state, imageSrc}: Props) => (
     <Header>
         <div className='AknTitleContainer-line'>
@@ -27,7 +31,7 @@ export const PageHeader = ({children: title, breadcrumb, buttons, userButtons, s
             <div className='AknTitleContainer-mainContainer'>
                 <div>
                     <div className='AknTitleContainer-line'>
-                        <div className='AknTitleContainer-breadcrumbs'>{breadcrumb}</div>
+                        <AknTitleContainerBreadcrumbs>{breadcrumb}</AknTitleContainerBreadcrumbs>
                         <div className='AknTitleContainer-buttonsContainer'>
                             {userButtons}
                             {buttons && (


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When loading the page, there was a css jump when the DOM appears.
With a simple min-height, we can anticipate this element expected height.

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
