### PR TITLE
API-1564: Add tests & reduce amount of re-render in useInfiniteScroll

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/scroll/hooks/useInfiniteScroll.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/scroll/hooks/useInfiniteScroll.ts
@@ -32,7 +32,7 @@ const useInfiniteScroll = <T>(
     }>({
         lastPage: null,
         isStopped: false,
-        isLoading: false,
+        isLoading: true,
         isInitialized: false,
         shouldFetch: true,
     });
@@ -43,14 +43,16 @@ const useInfiniteScroll = <T>(
 
     useEffect(() => {
         (async () => {
-            if (!shouldFetch || isLoading || isStopped) {
+            if (!shouldFetch || (isLoading && isInitialized) || isStopped) {
                 return;
             }
 
-            setState(state => ({
-                ...state,
-                isLoading: true,
-            }));
+            if (!isLoading) {
+                setState(state => ({
+                    ...state,
+                    isLoading: true,
+                }));
+            }
 
             const page = await loadNextPage(lastPage);
 

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/hooks/api/use-infinite-event-subscription-logs.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/hooks/api/use-infinite-event-subscription-logs.test.ts
@@ -1,0 +1,83 @@
+import {renderHook} from '@testing-library/react-hooks';
+import useInfiniteEventSubscriptionLogs from '@src/webhook/hooks/api/use-infinite-event-subscription-logs';
+import {EventSubscriptionLogLevel} from '@src/webhook/model/EventSubscriptionLogLevel';
+import {mockFetchResponses} from '../../../../test-utils';
+
+beforeEach(() => {
+    document.body.innerHTML = `
+    <div>
+        <div id='content'></div>
+    </div>
+    `;
+});
+
+test('The first logs are fetched on mount', async () => {
+    const ref = {current: document.getElementById('content')};
+
+    mockFetchResponses({
+        'akeneo_connectivity_connection_events_api_debug_rest_search_event_subscription_logs?connection_code=alkemics': {
+            json: {
+                results: [
+                    {
+                        level: EventSubscriptionLogLevel.INFO,
+                        timestamp: 1615741520,
+                        connection_code: null,
+                        message: 'a log message',
+                        context: {
+                            foo: 'bar',
+                        },
+                    },
+                ],
+                total: 1,
+                search_after: 'search_after_1',
+            },
+        },
+    });
+
+    const filters = {
+        levels: [
+            EventSubscriptionLogLevel.INFO,
+            EventSubscriptionLogLevel.NOTICE,
+            EventSubscriptionLogLevel.WARNING,
+            EventSubscriptionLogLevel.ERROR,
+        ],
+        text: '',
+        dateTime: {},
+    };
+
+    const {waitForNextUpdate, result, unmount} = renderHook(() => useInfiniteEventSubscriptionLogs('alkemics', filters, ref));
+
+    expect(result.current).toEqual({
+        logs: [],
+        total: undefined,
+        page: 0,
+        maxScrollReached: false,
+        endScrollReached: false,
+        isLoading: true,
+        isInitialized: false
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current).toEqual({
+        logs: [
+            {
+                level: EventSubscriptionLogLevel.INFO,
+                timestamp: 1615741520,
+                connection_code: null,
+                message: 'a log message',
+                context: {
+                    foo: 'bar',
+                },
+            },
+        ],
+        total: 1,
+        page: 1,
+        maxScrollReached: false,
+        endScrollReached: false,
+        isLoading: false,
+        isInitialized: true
+    });
+
+    unmount();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/hooks/api/use-infinite-event-subscription-logs.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/hooks/api/use-infinite-event-subscription-logs.test.ts
@@ -45,7 +45,9 @@ test('The first logs are fetched on mount', async () => {
         dateTime: {},
     };
 
-    const {waitForNextUpdate, result, unmount} = renderHook(() => useInfiniteEventSubscriptionLogs('alkemics', filters, ref));
+    const {waitForNextUpdate, result, unmount} = renderHook(() =>
+        useInfiniteEventSubscriptionLogs('alkemics', filters, ref)
+    );
 
     expect(result.current).toEqual({
         logs: [],
@@ -54,7 +56,7 @@ test('The first logs are fetched on mount', async () => {
         maxScrollReached: false,
         endScrollReached: false,
         isLoading: true,
-        isInitialized: false
+        isInitialized: false,
     });
 
     await waitForNextUpdate();
@@ -76,7 +78,7 @@ test('The first logs are fetched on mount', async () => {
         maxScrollReached: false,
         endScrollReached: false,
         isLoading: false,
-        isInitialized: true
+        isInitialized: true,
     });
 
     unmount();

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/scroll/hooks/useInfiniteScroll.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/webhook/scroll/hooks/useInfiniteScroll.test.ts
@@ -88,3 +88,26 @@ test('Reset the scroll should fetch the first page', async () => {
 
     unmount();
 });
+
+test('The hook does not render more times than necessary', async () => {
+    const ref = {
+        current: document.getElementById('content'),
+    };
+
+    const loadNextPage = jest.fn().mockImplementation(() => {
+        return Promise.resolve(null);
+    });
+
+    let renderCount = 0;
+
+    const {waitForNextUpdate, unmount} = renderHook(() => {
+        renderCount++;
+        useInfiniteScroll(loadNextPage, ref);
+    });
+
+    expect(renderCount).toBe(1);
+    await waitForNextUpdate();
+    expect(renderCount).toBe(2);
+
+    unmount();
+});


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

2 parts:
- new generic test on `use-infinite-event-subscription-logs.ts`
- new test about amount of re-renders of `useInfiniteScroll.ts`

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | -
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -
