### PR TITLE
Api 1341 - Updated API error output format

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ExternalApi/CategoryRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ExternalApi/CategoryRepository.php
@@ -178,7 +178,7 @@ class CategoryRepository extends EntityRepository implements ApiResourceReposito
         ];
         $availableSearchFilters = array_keys($constraints);
 
-        $exceptionMessage = '';
+        $exceptionMessages = [];
         foreach ($searchFilters as $property => $searchFilter) {
             if (!in_array($property, $availableSearchFilters)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -188,14 +188,13 @@ class CategoryRepository extends EntityRepository implements ApiResourceReposito
                 ));
             }
             $violations = $validator->validate($searchFilter, $constraints[$property]);
-            if (0 !== $violations->count()) {
-                foreach ($violations as $violation) {
-                    $exceptionMessage .= $violation->getMessage();
-                }
+            foreach ($violations as $violation) {
+                $exceptionMessages[] = $violation->getMessage();
             }
         }
-        if ('' !== $exceptionMessage) {
-            throw new \InvalidArgumentException($exceptionMessage);
+
+        if (!empty($exceptionMessages)) {
+            throw new \InvalidArgumentException(implode(' ', $exceptionMessages));
         }
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeGroupRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeGroupRepository.php
@@ -131,7 +131,7 @@ class AttributeGroupRepository extends EntityRepository implements ApiResourceRe
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ compared_value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
                 ])
             ]),
         ];

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeGroupRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeGroupRepository.php
@@ -131,13 +131,13 @@ class AttributeGroupRepository extends EntityRepository implements ApiResourceRe
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ compared_value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
                 ])
             ]),
         ];
         $availableSearchFilters = array_keys($constraints);
 
-        $exceptionMessage = '';
+        $exceptionMessages = [];
         foreach ($searchFilters as $property => $searchFilter) {
             if (!in_array($property, $availableSearchFilters)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -147,14 +147,12 @@ class AttributeGroupRepository extends EntityRepository implements ApiResourceRe
                 ));
             }
             $violations = $validator->validate($searchFilter, $constraints[$property]);
-            if (0 !== $violations->count()) {
-                foreach ($violations as $violation) {
-                    $exceptionMessage .= $violation->getMessage();
-                }
+            foreach ($violations as $violation) {
+                $exceptionMessages[] = $violation->getMessage();
             }
         }
-        if ('' !== $exceptionMessage) {
-            throw new \InvalidArgumentException($exceptionMessage);
+        if (!empty($exceptionMessages)) {
+            throw new \InvalidArgumentException(implode(' ', $exceptionMessages));
         }
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
@@ -172,7 +172,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ compared_value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
                 ])
             ]),
             'type' => new Assert\All(
@@ -195,7 +195,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
         ];
         $availableSearchFilters = array_keys($constraints);
 
-        $exceptionMessage = '';
+        $exceptionMessages = [];
         foreach ($searchFilters as $property => $searchFilter) {
             if (!in_array($property, $availableSearchFilters)) {
                 throw new \InvalidArgumentException(sprintf(
@@ -205,14 +205,12 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
                 ));
             }
             $violations = $validator->validate($searchFilter, $constraints[$property]);
-            if (0 !== $violations->count()) {
-                foreach ($violations as $violation) {
-                    $exceptionMessage .= $violation->getMessage();
-                }
+            foreach ($violations as $violation) {
+                $exceptionMessages[] = $violation->getMessage();
             }
         }
-        if ('' !== $exceptionMessage) {
-            throw new \InvalidArgumentException($exceptionMessage);
+        if (!empty($exceptionMessages)) {
+            throw new \InvalidArgumentException(implode(' ', $exceptionMessages));
         }
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/AttributeRepository.php
@@ -172,7 +172,7 @@ class AttributeRepository extends EntityRepository implements AttributeRepositor
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ compared_value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
                 ])
             ]),
             'type' => new Assert\All(

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/FamilyRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/FamilyRepository.php
@@ -146,7 +146,7 @@ class FamilyRepository extends EntityRepository implements ApiResourceRepository
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
                 ])
             ]),
         ];

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/FamilyRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/ExternalApi/FamilyRepository.php
@@ -146,7 +146,7 @@ class FamilyRepository extends EntityRepository implements ApiResourceRepository
                         'value' => '>',
                         'message' => 'Searching on the "updated" property require the ">" (greater than) operator, {{ value }} given.',
                     ]),
-                    'value' => new Assert\DateTime(['format' => \DateTime::ATOM]),
+                    'value' => new Assert\DateTime(['format' => \DateTimeInterface::ATOM]),
                 ])
             ]),
         ];
@@ -162,10 +162,8 @@ class FamilyRepository extends EntityRepository implements ApiResourceRepository
                 ));
             }
             $violations = $validator->validate($searchFilter, $constraints[$property]);
-            if (0 !== $violations->count()) {
-                foreach ($violations as $violation) {
-                    $exceptionMessages[] = $violation->getMessage();
-                }
+            foreach ($violations as $violation) {
+                $exceptionMessages[] = $violation->getMessage();
             }
         }
         if (!empty($exceptionMessages)) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
API concatenates error messages together without leaving a space character in between
This pull request threats only errors done by search filters validation for the following endpoints:
- family (is already fixed on master)
- category
- attribute
- attributeGroup

~~Updated namespaces from DateTime to DateTimeInterface as the former was removed since PHP 7.2~~

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | -
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
