### PR TITLE
OB-752: Fix php-memcached version

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- OB-752: Fix 5.0 memcached package issue
+
 # 5.0.18 (2021-04-15)
 
 # 5.0.17 (2021-04-15)

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -34,7 +34,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         php7.4-apcu \
         php7.4-exif \
         openssh-client \
-        php-memcached \
+        php7.4-memcached \
         aspell \
         aspell-en aspell-es aspell-de aspell-fr && \
     apt-get clean && \


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

PIM 5.0 deployments are failing with the following error `Memcached not found`. It has been fixed in master [here](https://github.com/akeneo/pim-community-dev/pull/13979/files) but not in 5.0 The Onboarder team is using these branch to build the docker image with the bundle for PIM 5.0 deployment.
In this PR, we are just backporting the fix made in the master branch.

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | -
| Added legacy Behats               | -
| Added acceptance tests            | -
| Added integration tests           | -
| Changelog updated                 | OK
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | -
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
