### PR TITLE
BH-518: Upgrade docker-compose format to 3.7

### DIFF
--- a/.circleci/docker-compose.override.yml.dist
+++ b/.circleci/docker-compose.override.yml.dist
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.7'
 
 services:
   mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.7'
 
 services:
   php:


### PR DESCRIPTION
3.7 format is the latest compatible with our current requirements:

Akeneo doc: https://docs.akeneo.com/master/install_pim/docker/installation_docker.html

docker-compose compatibility table: https://docs.docker.com/compose/compose-file/compose-file-v3/