### PR TITLE
PIM-9771: Fix the image preview when exporting a product as pdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - PIM-9809: Fix missing filters in the product grid for few UI locales with Firefox
 - PIM-9807: Trigger warning when importing date as text attribute via XLSX files
 - PIM-9801: Fix jobs that are still stuck in STARTED and STOPPING and create a command to avoid this again
+- PIM-9771: Fix the image preview when exporting a product as pdf
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Builder/DompdfBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Builder/DompdfBuilder.php
@@ -24,16 +24,12 @@ class DompdfBuilder implements PdfBuilderInterface
      */
     protected $dompdf;
 
-    private $publicDir;
+    private string $publicDir;
 
-    /**
-     * @param string $rootDir
-     */
-    public function __construct(string $rootDir, string $publicDir)
+    public function __construct(string $rootDir, $publicDir)
     {
         $this->rootDir = $rootDir;
         $this->publicDir = $publicDir;
-
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Builder/DompdfBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/PdfGeneration/Builder/DompdfBuilder.php
@@ -24,12 +24,16 @@ class DompdfBuilder implements PdfBuilderInterface
      */
     protected $dompdf;
 
+    private $publicDir;
+
     /**
      * @param string $rootDir
      */
-    public function __construct($rootDir)
+    public function __construct(string $rootDir, string $publicDir)
     {
         $this->rootDir = $rootDir;
+        $this->publicDir = $publicDir;
+
     }
 
     /**
@@ -54,6 +58,7 @@ class DompdfBuilder implements PdfBuilderInterface
         $options = new Options([
             'fontDir' => $this->rootDir . '/Akeneo/Pim/Enrichment/Bundle/Resources/fonts',
             'isRemoteEnabled' => true,
+            'chroot' => $this->publicDir
         ]);
         $this->dompdf = new Dompdf($options);
         $this->dompdf->loadHtml($html);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/builders.yml
@@ -22,6 +22,7 @@ services:
     pim_pdf_generator.builder.dompdf:
         class: 'Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Builder\DompdfBuilder'
         arguments:
+            - '%kernel.root_dir%'
             - '%kernel.project_dir%/public'
 
     pim_comment.builder.comment:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/builders.yml
@@ -22,7 +22,7 @@ services:
     pim_pdf_generator.builder.dompdf:
         class: 'Akeneo\Pim\Enrichment\Bundle\PdfGeneration\Builder\DompdfBuilder'
         arguments:
-            - '%kernel.root_dir%'
+            - '%kernel.project_dir%/public'
 
     pim_comment.builder.comment:
         class: 'Akeneo\Pim\Enrichment\Component\Comment\Builder\CommentBuilder'


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

When exporting to PDF, no image was exported.
I added the chroot option to point to the correct directory.

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
