### PR TITLE
PLG-64: Prevent pagination crash when empty search result

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AssociationTypesIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AssociationTypesIndex.tsx
@@ -142,7 +142,9 @@ const AssociationTypesIndex = () => {
                 onSearchChange={onSearch}
                 className={'association-type-grid-search'}
               />
-              <Pagination currentPage={currentPage} totalItems={associationTypes.total} followPage={followPage} />
+              {associationTypes.total > 0 && (
+                <Pagination currentPage={currentPage} totalItems={associationTypes.total} followPage={followPage} />
+              )}
               <AssociationTypesDataGrid
                 associationTypes={associationTypes.list}
                 sortDirection={sortDirection}


### PR DESCRIPTION
The Pagination component crash when the search returns no results because it's called with `currentPage=1` and `totalItems=0` 

As the current page is piloted by the search itself and always start at page 1 (no page 0) the simple solution is to not call the Pagination component if there are no results.