### PR TITLE
PLG-226: Settings entry should not be displayed when a user has no right on Settings items

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import {PageContent, PageHeader} from '@akeneo-pim-community/shared';
+import {
+  FullScreenError,
+  PageContent,
+  PageHeader,
+  useRouter,
+  useSecurity,
+  useTranslate,
+} from '@akeneo-pim-community/shared';
 import {
   AssociateIcon,
   AttributeFileIcon,
@@ -19,7 +26,6 @@ import {
   ValueIcon,
 } from 'akeneo-design-system';
 import {PimView} from '@akeneo-pim-community/legacy-bridge';
-import {useRouter, useSecurity, useTranslate} from '@akeneo-pim-community/shared';
 import styled from 'styled-components';
 
 const SectionContent = styled.div`
@@ -61,6 +67,16 @@ const SettingsIndex = () => {
   const redirectToRoute = (route: string) => {
     router.redirect(router.generate(route));
   };
+
+  if (!canAccessCatalogSettings && !canAccessProductSettings) {
+    return (
+      <FullScreenError
+        title={translate('error.exception', {status_code: 403})}
+        message={translate('error.forbidden')}
+        code={403}
+      />
+    );
+  }
 
   return (
     <>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/common/menu.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/common/menu.yml
@@ -102,6 +102,7 @@ extensions:
             title: pim_menu.tab.settings
             iconModifier: iconSettings
             to: pim_settings_index
+            isLandingSection: true
 
     pim-menu-settings-column:
         module: pim/menu/column

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/menu.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/menu.js
@@ -27,7 +27,7 @@ define(['underscore', 'pim/form', 'pim/template/menu/menu'], function (_, BaseFo
     renderExtension: function (extension) {
       if (
         !_.isEmpty(extension.options.config) &&
-        !extension.options.config.to &&
+        (!extension.options.config.to || extension.options.config.isLandingSectionPage) &&
         _.isFunction(extension.hasChildren) &&
         !extension.hasChildren()
       ) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/tab.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/menu/tab.js
@@ -30,7 +30,11 @@ define([
      * {@inheritdoc}
      */
     initialize: function (config) {
-      this.config = config.config;
+      this.config = {
+        // Define the page url (config.to) as the landing page for the section of menu (ex: pim_settings_index)
+        isLandingSectionPage: false,
+        ...config.config,
+      };
       this.items = [];
 
       mediator.on('pim_menu:highlight:tab', this.highlight, this);
@@ -54,7 +58,7 @@ define([
     render: function () {
       this.$el.empty();
 
-      if (!this.config.to && !this.hasChildren()) {
+      if ((!this.config.to || this.config.isLandingSectionPage) && !this.hasChildren()) {
         return this;
       }
 


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
