### PR TITLE
PIM-9820: Fix the Error 500 on the product grid with the date filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PIM-9807: Trigger warning when importing date as text attribute via XLSX files
 - PIM-9801: Fix jobs that are still stuck in STARTED and STOPPING and create a command to avoid this again
 - PIM-9771: Fix the image preview when exporting a product as pdf
+- PIM-9820: Fix the Error 500 on the product grid with the date filter
 
 ## New features
 

--- a/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/AbstractDateFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/ProductValue/AbstractDateFilter.php
@@ -49,8 +49,14 @@ abstract class AbstractDateFilter extends OroAbstractDateFilter
     protected function isValidData($data)
     {
         // Empty operator does not need any value
-        if (is_array($data) && isset($data['type']) && in_array($data['type'], [FilterType::TYPE_EMPTY, FilterType::TYPE_NOT_EMPTY])) {
-            return true;
+        if (is_array($data) && isset($data['type'])) {
+            if ($data['type'] === DateRangeFilterType::TYPE_MORE_THAN && null === $data['value']['start']
+                || $data['type'] === DateRangeFilterType::TYPE_LESS_THAN && null === $data['value']['end']) {
+                return false;
+            }
+            if (in_array($data['type'], [FilterType::TYPE_EMPTY, FilterType::TYPE_NOT_EMPTY])) {
+                return true;
+            }
         }
 
         return parent::isValidData($data);

--- a/src/Oro/Bundle/PimFilterBundle/spec/Filter/ProductValue/DateRangeFilterSpec.php
+++ b/src/Oro/Bundle/PimFilterBundle/spec/Filter/ProductValue/DateRangeFilterSpec.php
@@ -256,12 +256,12 @@ class DateRangeFilterSpec extends ObjectBehavior
 
     function it_does_not_parse_array_with_more_than_filter_and_no_start_date()
     {
-        $this->parseData(['value' => ['start' => null], 'type' => 3])->shouldReturn(false);
+        $this->parseData(['value' => ['start' => null], 'type' => DateRangeFilterType::TYPE_MORE_THAN])->shouldReturn(false);
     }
 
     function it_does_not_parse_array_with_less_than_filter_and_no_end_date()
     {
-        $this->parseData(['value' => ['end' => null], 'type' => 4])->shouldReturn(false);
+        $this->parseData(['value' => ['end' => null], 'type' => DateRangeFilterType::TYPE_LESS_THAN])->shouldReturn(false);
     }
 
     function it_applies_between_date_range_filter(

--- a/src/Oro/Bundle/PimFilterBundle/spec/Filter/ProductValue/DateRangeFilterSpec.php
+++ b/src/Oro/Bundle/PimFilterBundle/spec/Filter/ProductValue/DateRangeFilterSpec.php
@@ -254,6 +254,16 @@ class DateRangeFilterSpec extends ObjectBehavior
         $this->parseData(['value' => ['end' => 'tomorrow'], 'type' => 1])->shouldReturn(false);
     }
 
+    function it_does_not_parse_array_with_more_than_filter_and_no_start_date()
+    {
+        $this->parseData(['value' => ['start' => null], 'type' => 3])->shouldReturn(false);
+    }
+
+    function it_does_not_parse_array_with_less_than_filter_and_no_end_date()
+    {
+        $this->parseData(['value' => ['end' => null], 'type' => 4])->shouldReturn(false);
+    }
+
     function it_applies_between_date_range_filter(
         FilterDatasourceAdapterInterface $datasource,
         \DateTime $start,


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Here is the description of the error:
On the product grid, on the filter "Created at", select "less than", 
then set a date and save the filter.
Reopen the filter, select "more than" > the date "disappears".
If you don't input a new date and save the filter > error 500 

I tested this case, too:
On the product grid, on the filter "Created at", select "more than", 
then set a date and save the filter.
Reopen the filter, select "less than" > the date "disappears".
If you don't input a new date and save the filter > error 500, also.

So, I fixed the issue returning false in isValidData() function when 
-> $data['type'] is "more than" and if $data['value']['start'] is null
-> $data['type'] is "less than" and if $data['value']['end'] is null

<!--- (What does this Pull Request do? reference the related issue?) --->

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
