### PR TITLE
PIM-9818: Handle SVG image show action in file input

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9818: Handle SVG image show action in file input
+
 # 4.0.104 (2021-04-22)
 
 # 4.0.103 (2021-04-02)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
@@ -6,13 +6,13 @@ use Akeneo\Pim\Enrichment\Bundle\File\DefaultImageProviderInterface;
 use Akeneo\Pim\Enrichment\Bundle\File\FileTypeGuesserInterface;
 use Akeneo\Pim\Enrichment\Bundle\File\FileTypes;
 use Akeneo\Tool\Component\FileStorage\FilesystemProvider;
-use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use Akeneo\Tool\Component\FileStorage\Repository\FileInfoRepositoryInterface;
 use Akeneo\Tool\Component\FileStorage\StreamedFileResponse;
 use Liip\ImagineBundle\Controller\ImagineController;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -82,23 +82,41 @@ class FileController
             return $this->renderDefaultImage(FileTypes::MISC, $filter);
         }
 
-        $fileType = $this->fileTypeGuesser->guess($fileInfo->getMimeType());
+        $mimeType = $this->getMimeType($filename);
+        $fileType = $this->fileTypeGuesser->guess($mimeType);
         $result = $this->renderDefaultImage($fileType, $filter);
 
         if (self::DEFAULT_IMAGE_KEY !== $filename) {
-            $fileType = $this->fileTypeGuesser->guess($this->getMimeType($filename));
-
-            $result = $this->renderDefaultImage($fileType, $filter);
             if (FileTypes::IMAGE === $fileType) {
                 try {
                     $result = $this->imagineController->filterAction($request, $filename, $filter);
-                } catch (NotFoundHttpException|\RuntimeException $exception) {
+
+                    if ('image/svg' === $mimeType) {
+                        return $this->getFileResponse($filename, 'image/svg+xml');
+                    }
+                } catch (NotFoundHttpException | \RuntimeException $exception) {
                     $result = $this->renderDefaultImage(FileTypes::IMAGE, $filter);
                 }
             }
         }
 
         return $result;
+    }
+
+    private function getFileResponse(string $filename, string $mimeType): Response
+    {
+        foreach ($this->filesystemAliases as $alias) {
+            $fs = $this->filesystemProvider->getFilesystem($alias);
+
+            $response = new Response($fs->read($filename));
+            $response->headers->set('Content-Type', $mimeType);
+
+            return $response;
+        }
+
+        throw new NotFoundHttpException(
+            sprintf('File with key "%s" could not be found.', $filename)
+        );
     }
 
     /**


### PR DESCRIPTION
<!--- (<3 Thanks for taking the time to contribute! You're awesome! <3) --->

<!--- (If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md) --->

**Description (for Contributor and Core Developer)**

Adding a special case for SVG images to return them as file response in the File controller in order to display them correctly as thumbnails, refactoring the whole image caching process for Ref entities would be a bit much for a released version patch

**Definition Of Done (for Core Developer only)**

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | Todo
| Added legacy Behats               | Todo
| Added acceptance tests            | Todo
| Added integration tests           | Todo
| Changelog updated                 | Todo
| Review and 2 GTM                  | Todo
| Micro Demo to the PO (Story only) | Todo
| Migration script                  | -
| Tech Doc                          | -

`Todo`: Pending / Work in progress
`OK`: Done / Validated
`-`: Not needed
