### PR TITLE
RAC-575: Add Measurement family domain events + Fix CI configuration

### DIFF
--- a/config/services/test_fake/services.yml
+++ b/config/services/test_fake/services.yml
@@ -25,3 +25,9 @@ services:
         decoration_inner_name: messenger.default_bus.inner
         arguments:
             - '@messenger.default_bus.inner'
+
+    akeneo_integration_tests.event_dispatcher:
+        class: 'Akeneo\Test\Acceptance\EventDispatcher\EventDispatcherMock'
+        decorates: event_dispatcher
+        arguments:
+            - '@akeneo_integration_tests.event_dispatcher.inner'

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -58,6 +58,7 @@ unit-front:
 acceptance-back:
 	APP_ENV=behat ${PHP_RUN} vendor/bin/behat -p acceptance --format pim --out var/tests/behat --format progress --out std --colors
 	$(MAKE) connectivity-connection-acceptance-back
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php Acceptance
 
 .PHONY: acceptance-front
 acceptance-front:

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -58,7 +58,7 @@ unit-front:
 acceptance-back:
 	APP_ENV=behat ${PHP_RUN} vendor/bin/behat -p acceptance --format pim --out var/tests/behat --format progress --out std --colors
 	$(MAKE) connectivity-connection-acceptance-back
-	.circleci/run_phpunit.sh . .circleci/find_phpunit.php Acceptance
+	.circleci/run_phpunit.sh . .circleci/find_phpunit.php Akeneo_Measurement_Acceptance
 
 .PHONY: acceptance-front
 acceptance-front:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,6 +44,13 @@
             <directory suffix="Integration.php">src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration</directory>
         </testsuite>
 
+        <testsuite name="Akeneo_Measurement_Acceptance">
+            <directory suffix="Test.php">src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance</directory>
+        </testsuite>
+        <testsuite name="Akeneo_Measurement_EndToEnd">
+            <directory suffix="EndToEnd.php">src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd</directory>
+        </testsuite>
+
         <testsuite name="Akeneo_Connectivity_Connection_EndToEnd">
             <directory suffix="EndToEnd.php">src/Akeneo/Connectivity/Connection/back/tests/EndToEnd</directory>
         </testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -47,6 +47,7 @@
         <testsuite name="Akeneo_Measurement_Acceptance">
             <directory suffix="Test.php">src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance</directory>
         </testsuite>
+
         <testsuite name="Akeneo_Measurement_EndToEnd">
             <directory suffix="EndToEnd.php">src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd</directory>
         </testsuite>

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/CreateMeasurementFamily/CreateMeasurementFamilyHandler.php
@@ -46,7 +46,9 @@ class CreateMeasurementFamilyHandler
         );
 
         $this->measurementFamilyRepository->save($measurementFamily);
-        $this->eventDispatcher->dispatch(new MeasurementFamilyCreated($measurementFamilyCode));
+        if (null !== $this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(new MeasurementFamilyCreated($measurementFamilyCode));
+        }
     }
 
     private function units(CreateMeasurementFamilyCommand $saveMeasurementFamilyCommand): array

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyDeleted;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (https://www.akeneo.com)
@@ -17,9 +19,15 @@ class DeleteMeasurementFamilyHandler
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;
 
-    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
-    {
+    private ?EventDispatcherInterface $eventDispatcher;
+
+    /** TODO: @pullup Remove = null */
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        EventDispatcherInterface $eventDispatcher = null
+    ) {
         $this->measurementFamilyRepository = $measurementFamilyRepository;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -27,6 +35,8 @@ class DeleteMeasurementFamilyHandler
      */
     public function handle(DeleteMeasurementFamilyCommand $deleteMeasurementFamilyCommand): void
     {
-        $this->measurementFamilyRepository->deleteByCode(MeasurementFamilyCode::fromString($deleteMeasurementFamilyCommand->code));
+        $measurementFamilyCode = MeasurementFamilyCode::fromString($deleteMeasurementFamilyCommand->code);
+        $this->measurementFamilyRepository->deleteByCode($measurementFamilyCode);
+        $this->eventDispatcher->dispatch(new MeasurementFamilyDeleted($measurementFamilyCode));
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/DeleteMeasurementFamily/DeleteMeasurementFamilyHandler.php
@@ -37,6 +37,8 @@ class DeleteMeasurementFamilyHandler
     {
         $measurementFamilyCode = MeasurementFamilyCode::fromString($deleteMeasurementFamilyCommand->code);
         $this->measurementFamilyRepository->deleteByCode($measurementFamilyCode);
-        $this->eventDispatcher->dispatch(new MeasurementFamilyDeleted($measurementFamilyCode));
+        if (null !== $this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(new MeasurementFamilyDeleted($measurementFamilyCode));
+        }
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyUpdated;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
@@ -11,6 +12,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
@@ -22,22 +24,30 @@ class SaveMeasurementFamilyHandler
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;
 
-    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
-    {
+    private ?EventDispatcherInterface $eventDispatcher;
+
+    /** TODO: @pullup Remove = null */
+    public function __construct(
+        MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        EventDispatcherInterface $eventDispatcher = null
+    ) {
         $this->measurementFamilyRepository = $measurementFamilyRepository;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function handle(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand): void
     {
         $units = $this->units($saveMeasurementFamilyCommand);
+        $measurementFamilyCode = MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code);
         $measurementFamily = MeasurementFamily::create(
-            MeasurementFamilyCode::fromString($saveMeasurementFamilyCommand->code),
+            $measurementFamilyCode,
             LabelCollection::fromArray($saveMeasurementFamilyCommand->labels),
             UnitCode::fromString($saveMeasurementFamilyCommand->standardUnitCode),
             $units
         );
 
         $this->measurementFamilyRepository->save($measurementFamily);
+        $this->eventDispatcher->dispatch(new MeasurementFamilyUpdated($measurementFamilyCode));
     }
 
     private function units(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand): array

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Application/SaveMeasurementFamily/SaveMeasurementFamilyHandler.php
@@ -47,7 +47,9 @@ class SaveMeasurementFamilyHandler
         );
 
         $this->measurementFamilyRepository->save($measurementFamily);
-        $this->eventDispatcher->dispatch(new MeasurementFamilyUpdated($measurementFamilyCode));
+        if (null !== $this->eventDispatcher) {
+            $this->eventDispatcher->dispatch(new MeasurementFamilyUpdated($measurementFamilyCode));
+        }
     }
 
     private function units(SaveMeasurementFamilyCommand $saveMeasurementFamilyCommand): array

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyCreated.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyCreated.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamilyCreated extends Event
+{
+    private MeasurementFamilyCode $measurementFamilyCode;
+
+    public function __construct(MeasurementFamilyCode $measurementFamilyCode)
+    {
+        $this->measurementFamilyCode = $measurementFamilyCode;
+    }
+
+    public function getMeasurementFamilyCode(): MeasurementFamilyCode
+    {
+        return $this->measurementFamilyCode;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyDeleted.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyDeleted.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamilyDeleted extends Event
+{
+    private MeasurementFamilyCode $measurementFamilyCode;
+
+    public function __construct(MeasurementFamilyCode $measurementFamilyCode)
+    {
+        $this->measurementFamilyCode = $measurementFamilyCode;
+    }
+
+    public function getMeasurementFamilyCode(): MeasurementFamilyCode
+    {
+        return $this->measurementFamilyCode;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyUpdated.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Event/MeasurementFamilyUpdated.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamilyUpdated extends Event
+{
+    private MeasurementFamilyCode $measurementFamilyCode;
+
+    public function __construct(MeasurementFamilyCode $measurementFamilyCode)
+    {
+        $this->measurementFamilyCode = $measurementFamilyCode;
+    }
+
+    public function getMeasurementFamilyCode(): MeasurementFamilyCode
+    {
+        return $this->measurementFamilyCode;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamily.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Model/MeasurementFamily.php
@@ -87,11 +87,6 @@ class MeasurementFamily
         return $unit->getLabel($localeIdentifier);
     }
 
-    public function getRecordedEvents(): array
-    {
-        return $this->recordedEvents;
-    }
-
     private function assertStandardUnitExists(UnitCode $standardUnitCode, array $units): void
     {
         $isStandardUnitCodePresentInUnits = !empty($this->getUnit($standardUnitCode, $units));

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
-use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
-use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyUpdated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -30,8 +28,6 @@ class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterfac
 
     /** @var MeasurementFamily[] */
     private array $measurementFamilyCache = [];
-
-    private ?EventDispatcher $eventDispatcher;
 
     public function __construct(Connection $sqlConnection)
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyUpdated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -21,14 +23,15 @@ use Doctrine\DBAL\Types\Type;
  */
 class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterface
 {
-    /** @var Connection */
-    private $sqlConnection;
+    private Connection $sqlConnection;
 
     /** @var MeasurementFamily[] */
-    private $allMeasurementFamiliesCache = [];
+    private array $allMeasurementFamiliesCache = [];
 
     /** @var MeasurementFamily[] */
-    private $measurementFamilyCache = [];
+    private array $measurementFamilyCache = [];
+
+    private ?EventDispatcher $eventDispatcher;
 
     public function __construct(Connection $sqlConnection)
     {
@@ -46,11 +49,12 @@ class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterfac
 
     public function getByCode(MeasurementFamilyCode $measurementFamilyCode): MeasurementFamily
     {
-        if (!isset($this->measurementFamilyCache[$measurementFamilyCode->normalize()])) {
-            $this->measurementFamilyCache[$measurementFamilyCode->normalize()] = $this->loadAssetFamily($measurementFamilyCode);
+        $normalizedMeasurementFamilyCode = $measurementFamilyCode->normalize();
+        if (!isset($this->measurementFamilyCache[$normalizedMeasurementFamilyCode])) {
+            $this->measurementFamilyCache[$normalizedMeasurementFamilyCode] = $this->loadAssetFamily($measurementFamilyCode);
         }
 
-        return $this->measurementFamilyCache[$measurementFamilyCode->normalize()];
+        return $this->measurementFamilyCache[$normalizedMeasurementFamilyCode];
     }
 
     public function save(MeasurementFamily $measurementFamily)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/services.yml
@@ -42,16 +42,19 @@ services:
         class: Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@event_dispatcher'
 
     akeneo_measure.application.create_measurement_family_handler:
         class: Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyHandler
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@event_dispatcher'
 
     akeneo_measure.application.delete_measurement_family_handler:
         class: Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyHandler
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@event_dispatcher'
 
     akeneo_measure.validation.measurement_family.code_must_be_unique:
         class: Akeneo\Tool\Bundle\MeasureBundle\Validation\MeasurementFamily\CodeMustBeUniqueValidator

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollectionValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/LabelCollectionValidator.php
@@ -52,7 +52,7 @@ class LabelCollectionValidator extends ConstraintValidator
         }
     }
 
-    private function validateLabelForLocale(ValidatorInterface $validator, string $label, string $localeCode): void
+    private function validateLabelForLocale(ValidatorInterface $validator, $label, $localeCode): void
     {
         $violations = $validator->validate($label, [
             new Constraints\NotNull(),

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyCreatedSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyCreatedSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use PhpSpec\ObjectBehavior;
+
+class MeasurementFamilyCreatedSpec extends ObjectBehavior
+{
+    public function it_is_created_with_a_measurement_family_code()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('weight');
+
+        $this->beConstructedWith($measurementFamilyCode);
+
+        $this->getMeasurementFamilyCode()->shouldReturn($measurementFamilyCode);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyDeletedSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyDeletedSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use PhpSpec\ObjectBehavior;
+
+class MeasurementFamilyDeletedSpec extends ObjectBehavior
+{
+    public function it_is_created_with_a_measurement_family_code()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('weight');
+
+        $this->beConstructedWith($measurementFamilyCode);
+
+        $this->getMeasurementFamilyCode()->shouldReturn($measurementFamilyCode);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyUpdatedSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Event/MeasurementFamilyUpdatedSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Event;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use PhpSpec\ObjectBehavior;
+
+class MeasurementFamilyUpdatedSpec extends ObjectBehavior
+{
+    public function it_is_created_with_a_measurement_family_code()
+    {
+        $measurementFamilyCode = MeasurementFamilyCode::fromString('weight');
+
+        $this->beConstructedWith($measurementFamilyCode);
+
+        $this->getMeasurementFamilyCode()->shouldReturn($measurementFamilyCode);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/MeasurementFamilySpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/MeasurementFamilySpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Model;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\UnitNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LocaleIdentifier;
@@ -51,34 +52,38 @@ class MeasurementFamilySpec extends ObjectBehavior
         );
     }
 
-    function it_is_initializable()
+    function it_is_initializable_and_records_a_measurement_family_created_event_on_creation()
     {
         $this->shouldHaveType(MeasurementFamily::class);
+        $this->getRecordedEvents()->shouldBeEqualTo(
+            [new MeasurementFamilyCreated(MeasurementFamilyCode::fromString(self::MEASUREMENT_FAMILY_CODE))]
+        );
     }
 
-    function it_should_be_able_to_normalize_itself()
+    function it_can_be_created_from_its_normalized_form_and_should_be_able_to_normalize_itself()
     {
-        $this->normalize()->shouldReturn(
-            [
-                'code'               => self::MEASUREMENT_FAMILY_CODE,
-                'labels'             => self::MEASUREMENT_FAMILY_LABEL,
-                'standard_unit_code' => self::METER_UNIT_CODE,
-                'units'              => [
-                    [
-                        'code'                  => self::METER_UNIT_CODE,
-                        'labels'                => self::METER_LABELS,
-                        'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
-                        'symbol'                => self::METER_SYMBOL,
-                    ],
-                    [
-                        'code'                  => self::CENTIMETER_UNIT_CODE,
-                        'labels'                => self::CENTIMETER_LABELS,
-                        'convert_from_standard' => [['operator' => 'mul', 'value' => '5']],
-                        'symbol'                => self::CENTIMETER_SYMBOL,
-                    ]
+        $normalizedVersion = [
+            'code' => self::MEASUREMENT_FAMILY_CODE,
+            'labels' => self::MEASUREMENT_FAMILY_LABEL,
+            'standard_unit_code' => self::METER_UNIT_CODE,
+            'units' => [
+                [
+                    'code' => self::METER_UNIT_CODE,
+                    'labels' => self::METER_LABELS,
+                    'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                    'symbol' => self::METER_SYMBOL,
+                ],
+                [
+                    'code' => self::CENTIMETER_UNIT_CODE,
+                    'labels' => self::CENTIMETER_LABELS,
+                    'convert_from_standard' => [['operator' => 'mul', 'value' => '5']],
+                    'symbol' => self::CENTIMETER_SYMBOL,
                 ]
             ]
-        );
+        ];
+        $this->beConstructedThrough('fromNormalized', [$normalizedVersion]);
+        $this->normalize()->shouldReturn($normalizedVersion);
+        $this->getRecordedEvents()->shouldBe([]);
     }
 
     function it_should_not_be_able_create_a_measurement_family_having_no_units()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/MeasurementFamilySpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Model/MeasurementFamilySpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Model;
 
-use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\UnitNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LocaleIdentifier;
@@ -52,38 +51,34 @@ class MeasurementFamilySpec extends ObjectBehavior
         );
     }
 
-    function it_is_initializable_and_records_a_measurement_family_created_event_on_creation()
+    function it_is_initializable()
     {
         $this->shouldHaveType(MeasurementFamily::class);
-        $this->getRecordedEvents()->shouldBeEqualTo(
-            [new MeasurementFamilyCreated(MeasurementFamilyCode::fromString(self::MEASUREMENT_FAMILY_CODE))]
-        );
     }
 
-    function it_can_be_created_from_its_normalized_form_and_should_be_able_to_normalize_itself()
+    function it_should_be_able_to_normalize_itself()
     {
-        $normalizedVersion = [
-            'code' => self::MEASUREMENT_FAMILY_CODE,
-            'labels' => self::MEASUREMENT_FAMILY_LABEL,
-            'standard_unit_code' => self::METER_UNIT_CODE,
-            'units' => [
-                [
-                    'code' => self::METER_UNIT_CODE,
-                    'labels' => self::METER_LABELS,
-                    'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
-                    'symbol' => self::METER_SYMBOL,
-                ],
-                [
-                    'code' => self::CENTIMETER_UNIT_CODE,
-                    'labels' => self::CENTIMETER_LABELS,
-                    'convert_from_standard' => [['operator' => 'mul', 'value' => '5']],
-                    'symbol' => self::CENTIMETER_SYMBOL,
+        $this->normalize()->shouldReturn(
+            [
+                'code'               => self::MEASUREMENT_FAMILY_CODE,
+                'labels'             => self::MEASUREMENT_FAMILY_LABEL,
+                'standard_unit_code' => self::METER_UNIT_CODE,
+                'units'              => [
+                    [
+                        'code'                  => self::METER_UNIT_CODE,
+                        'labels'                => self::METER_LABELS,
+                        'convert_from_standard' => [['operator' => 'mul', 'value' => '1']],
+                        'symbol'                => self::METER_SYMBOL,
+                    ],
+                    [
+                        'code'                  => self::CENTIMETER_UNIT_CODE,
+                        'labels'                => self::CENTIMETER_LABELS,
+                        'convert_from_standard' => [['operator' => 'mul', 'value' => '5']],
+                        'symbol'                => self::CENTIMETER_SYMBOL,
+                    ]
                 ]
             ]
-        ];
-        $this->beConstructedThrough('fromNormalized', [$normalizedVersion]);
-        $this->normalize()->shouldReturn($normalizedVersion);
-        $this->getRecordedEvents()->shouldBe([]);
+        );
     }
 
     function it_should_not_be_able_create_a_measurement_family_having_no_units()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
@@ -17,23 +17,14 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
-use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CreateMeasurementFamilyTest extends AcceptanceTestCase
 {
-    /** * @var ValidatorInterface */
-    private $validator;
-
-    /** @var InMemoryMeasurementFamilyRepository */
-    private $measurementFamilyRepository;
-
-    /** @var CreateMeasurementFamilyHandler */
-    private $createMeasurementFamilyHandler;
-
-    /** @var InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub */
-    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
-
+    private ValidatorInterface $validator;
+    private InMemoryMeasurementFamilyRepository $measurementFamilyRepository;
+    private CreateMeasurementFamilyHandler $createMeasurementFamilyHandler;
+    private InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
     private EventDispatcherMock $eventDispatcherMock;
 
     public function setUp(): void

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Acceptance;
 
 use Akeneo\Test\Acceptance\Attribute\InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub;
+use Akeneo\Test\Acceptance\EventDispatcher\EventDispatcherMock;
 use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
 use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Application\CreateMeasurementFamily\CreateMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -15,6 +17,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CreateMeasurementFamilyTest extends AcceptanceTestCase
@@ -31,6 +34,8 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
     /** @var InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub */
     private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
 
+    private EventDispatcherMock $eventDispatcherMock;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -39,6 +44,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
         $this->measurementFamilyRepository->clear();
         $this->createMeasurementFamilyHandler = $this->get('akeneo_measure.application.create_measurement_family_handler');
         $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $this->get('akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family');
+        $this->eventDispatcherMock = $this->get('event_dispatcher');
     }
 
     /**
@@ -106,6 +112,11 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
             MeasurementFamilyCode::fromString($measurementFamilyCode)
         );
         $this->assertEquals($expectedMeasurementFamily, $actualMeasurementFamily);
+        $events = $this->eventDispatcherMock->getEvents();
+        $this->assertCount(1, $events);
+        $event = current($events)['event'];
+        $this->assertInstanceOf(MeasurementFamilyCreated::class, $event);
+        $this->assertEquals($measurementFamilyCode, $event->getMeasurementFamilyCode()->normalize());
     }
 
     /**
@@ -176,6 +187,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
         $violation = $violations->get(0);
         self::assertEquals('The standard unit code of the "WEIGHT" measurement family should be a multiply-by-1 operation', $violation->getMessage());
         self::assertEquals('units[0].convert_from_standard', $violation->getPropertyPath());
+        self::assertEmpty($this->eventDispatcherMock->getEvents());
     }
 
     /**
@@ -208,7 +220,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
      * @test
      * @dataProvider invalidLabels
      */
-    public function it_has_an_invalid_label($invalidLabels, string $expectedErrorMessage): void
+    public function it_has_an_invalid_label($invalidLabels, string $expectedErrorMessage, string $propertyPath): void
     {
         $saveFamilyCommand = new CreateMeasurementFamilyCommand();
         $saveFamilyCommand->code = 'WEIGHT';
@@ -228,7 +240,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
         self::assertEquals(1, $violations->count());
         $violation = $violations->get(0);
         self::assertEquals($expectedErrorMessage, $violation->getMessage());
-        self::assertEquals('labels', $violation->getPropertyPath());
+        self::assertEquals($propertyPath, $violation->getPropertyPath());
     }
 
     /**
@@ -322,9 +334,9 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
 
     /**
      * @test
-     * @dataProvider invalidLabels
+     * @dataProvider invalidUnitLabels
      */
-    public function it_has_a_unit_with_an_invalid_label($invalidLabels, string $expectedErrorMessage): void
+    public function it_has_a_unit_with_an_invalid_label($invalidLabels, string $expectedErrorMessage, string $propertyPath): void
     {
         $saveFamilyCommand = new CreateMeasurementFamilyCommand();
         $saveFamilyCommand->code = 'WEIGHT';
@@ -344,7 +356,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
         self::assertEquals(1, $violations->count());
         $violation = $violations->get(0);
         self::assertEquals($expectedErrorMessage, $violation->getMessage());
-        self::assertEquals('units[0][labels]', $violation->getPropertyPath());
+        self::assertEquals($propertyPath, $violation->getPropertyPath());
     }
 
     /**
@@ -496,7 +508,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
      */
     public function it_cannot_create_too_many_measurement_families(): void
     {
-        for ($i = 0; $i < 100; $i++) {
+        for ($i = 0; $i < 400; $i++) {
             $measurementFamily = MeasurementFamily::create(
                 MeasurementFamilyCode::fromString(sprintf('unit_%d', $i)),
                 LabelCollection::fromArray(['en_US' => 'Custom measurement']),
@@ -531,7 +543,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
 
         self::assertEquals(1, $violations->count());
         $violation = $violations->get(0);
-        self::assertEquals('You’ve reached the limit of 100 measurement families.', $violation->getMessage());
+        self::assertEquals('You’ve reached the limit of 300 measurement families.', $violation->getMessage());
         self::assertEquals('', $violation->getPropertyPath());
     }
 
@@ -581,11 +593,25 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
 
     public function invalidLabels(): array
     {
+        $as = str_repeat('a', 101);
+
         return [
-            'Locale code should be a string' => [[123 => 'my label'], 'This value should be of type string.'],
-            'Locale code cannot be too long' => [[str_repeat('a', 101) => 'my label'], 'This value is too long. It should have 100 characters or less.'],
-            'Label should be a string' => [['fr_FR' => 12], 'This value should be of type string.'],
-            'Label cannot be too long' => [['fr_FR' => str_repeat('a', 101)], 'This value is too long. It should have 100 characters or less.']
+            'Locale code should be a string' => [[123 => 'my label'], 'This value should be of type string.', 'labels[123]'],
+            'Locale code cannot be too long' => [[$as => 'my label'], 'This value is too long. It should have 100 characters or less.', sprintf('labels[%s]', $as)],
+            'Label should be a string' => [['fr_FR' => 12], 'This value should be of type string.', 'labels[fr_FR]'],
+            'Label cannot be too long' => [['fr_FR' => $as], 'This value is too long. It should have 100 characters or less.', 'labels[fr_FR]']
+        ];
+    }
+
+    public function invalidUnitLabels(): array
+    {
+        $as = str_repeat('a', 101);
+
+        return [
+            'Locale code should be a string' => [[123 => 'my label'], 'This value should be of type string.', 'units[0][labels][123]'],
+            'Locale code cannot be too long' => [[$as => 'my label'], 'This value is too long. It should have 100 characters or less.', sprintf('units[0][labels][%s]', $as)],
+            'Label should be a string' => [['fr_FR' => 12], 'This value should be of type string.', 'units[0][labels][fr_FR]'],
+            'Label cannot be too long' => [['fr_FR' => $as], 'This value is too long. It should have 100 characters or less.', 'units[0][labels][fr_FR]']
         ];
     }
 
@@ -600,7 +626,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
     public function invalidConvertValue(): array
     {
         return [
-            'The convert value is not a valid number represented as a string' => ['1.24adv', 'The conversion value should be a number represented in a string (example: "0.2561")']
+            'The convert value is not a valid number represented as a string' => ['1.24adv', 'The operation value should be a valid number']
         ];
     }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
@@ -55,6 +55,7 @@ class DeleteMeasurementFamilyTest extends AcceptanceTestCase
         $this->assertEquals(0, $violations->count());
         $this->assertMeasurementFamilyEventDispatched($measurementFamilyCode);
         $this->assertMeasurementFamilyDoesNotExists($measurementFamilyCode);
+        $this->assertTrue(false);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
@@ -54,7 +54,6 @@ class DeleteMeasurementFamilyTest extends AcceptanceTestCase
         $this->assertEquals(0, $violations->count());
         $this->assertMeasurementFamilyDeletedEventDispatched($measurementFamilyCode);
         $this->assertMeasurementFamilyDoesNotExists($measurementFamilyCode);
-        $this->assertTrue(false);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Acceptance;
+
+use Akeneo\Test\Acceptance\Attribute\InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub;
+use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\DeleteMeasurementFamily\DeleteMeasurementFamilyHandler;
+use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
+use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyDeleted;
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class DeleteMeasurementFamilyTest extends AcceptanceTestCase
+{
+    private ValidatorInterface $validator;
+    private InMemoryMeasurementFamilyRepository $measurementFamilyRepository;
+    private DeleteMeasurementFamilyHandler $deleteMeasurementFamilyHandler;
+    private InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = $this->get('validator');
+        $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+        $this->measurementFamilyRepository->clear();
+        $this->deleteMeasurementFamilyHandler = $this->get('akeneo_measure.application.delete_measurement_family_handler');
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily = $this->get('akeneo.pim.structure.query.is_there_at_least_one_attribute_configured_with_measurement_family');
+        $this->eventDispatcherMock = $this->get('event_dispatcher');
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_an_existing_measurement_family(): void
+    {
+        $measurementFamilyCode = 'weight';
+        $this->createMeasurementFamilyWithUnitsAndStandardUnit($measurementFamilyCode, ['KILOGRAM'], 'KILOGRAM');
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily->setStub(false);
+
+        $deleteCommand = new DeleteMeasurementFamilyCommand();
+        $deleteCommand->code = $measurementFamilyCode;
+
+        $violations = $this->validator->validate($deleteCommand);
+        $this->deleteMeasurementFamilyHandler->handle($deleteCommand);
+
+        $this->assertEquals(0, $violations->count());
+        $this->assertMeasurementFamilyEventDispatched($measurementFamilyCode);
+        $this->assertMeasurementFamilyDoesNotExists($measurementFamilyCode);
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_delete_an_existing_measurement_family_linked_to_a_product_attribute(): void
+    {
+        $measurementFamilyCode = 'weight';
+        $this->createMeasurementFamilyWithUnitsAndStandardUnit($measurementFamilyCode, ['KILOGRAM'], 'KILOGRAM');
+        $this->isThereAtLeastOneAttributeConfiguredWithMeasurementFamily->setStub(true);
+
+        $deleteCommand = new DeleteMeasurementFamilyCommand();
+        $deleteCommand->code = $measurementFamilyCode;
+
+        $violations = $this->validator->validate($deleteCommand);
+        $this->deleteMeasurementFamilyHandler->handle($deleteCommand);
+
+        $this->assertCannotRemoveTheMeasurementFamily($violations);
+        $this->assertMeasurementFamilyEventDispatched($measurementFamilyCode);
+        $this->assertMeasurementFamilyDoesNotExists($measurementFamilyCode);
+    }
+
+    private function assertMeasurementFamilyEventDispatched(string $measurementFamilyCode): void
+    {
+        $events = $this->eventDispatcherMock->getEvents();
+        $this->assertCount(1, $events);
+        $event = current($events)['event'];
+        $this->assertInstanceOf(MeasurementFamilyDeleted::class, $event);
+        $this->assertEquals($measurementFamilyCode, $event->getMeasurementFamilyCode()->normalize());
+    }
+
+    private function assertMeasurementFamilyDoesNotExists(string $measurementFamilyCode): void
+    {
+        try {
+            $this->measurementFamilyRepository->getByCode(MeasurementFamilyCode::fromString($measurementFamilyCode));
+        } catch (MeasurementFamilyNotFoundException $e) {
+            return;
+        }
+
+        self::assertTrue(
+            false,
+            sprintf('Measurement family "%s" exists, expected not to exist', $measurementFamilyCode)
+        );
+    }
+
+    private function createMeasurementFamilyWithUnitsAndStandardUnit(string $measurementFamilyCode, array $unitCodes, string $standardUnitCode): void
+    {
+        $this->measurementFamilyRepository->save(
+            MeasurementFamily::create(
+                MeasurementFamilyCode::fromString($measurementFamilyCode),
+                LabelCollection::fromArray([]),
+                UnitCode::fromString($standardUnitCode),
+                array_map(function (string $unitCode) {
+                    return Unit::create(
+                        UnitCode::fromString($unitCode),
+                        LabelCollection::fromArray([]),
+                        [
+                            Operation::create("mul", "1"),
+                        ],
+                        "km",
+                    );
+                }, $unitCodes)
+            )
+        );
+    }
+
+    /**
+     * @param \Symfony\Component\Validator\ConstraintViolationListInterface $violations
+     *
+     */
+    private function assertCannotRemoveTheMeasurementFamily(
+        \Symfony\Component\Validator\ConstraintViolationListInterface $violations
+    ): void {
+        $this->assertEquals(1, $violations->count());
+        $violation = $violations->get(0);
+        $this->assertEquals(
+            'pim_measurements.validation.measurement_family.measurement_family_cannot_be_removed',
+            $violation->getMessage()
+        );
+        $this->assertEquals('', $violation->getPropertyPath());
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -108,7 +108,6 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
         $event = current($events)['event'];
         $this->assertInstanceOf(MeasurementFamilyUpdated::class, $event);
         $this->assertEquals($measurementFamilyCode, $event->getMeasurementFamilyCode()->normalize());
-
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SaveMeasurementFamilyTest extends AcceptanceTestCase
 {
-    private ValidatorInterface$validator;
+    private ValidatorInterface $validator;
     private InMemoryMeasurementFamilyRepository $measurementFamilyRepository;
     private SaveMeasurementFamilyHandler $saveMeasurementFamilyHandler;
     private InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -8,7 +8,6 @@ use Akeneo\Test\Acceptance\Attribute\InMemoryIsThereAtLeastOneAttributeConfigure
 use Akeneo\Test\Acceptance\MeasurementFamily\InMemoryMeasurementFamilyRepository;
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyCommand;
 use Akeneo\Tool\Bundle\MeasureBundle\Application\SaveMeasurementFamily\SaveMeasurementFamilyHandler;
-use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyCreated;
 use Akeneo\Tool\Bundle\MeasureBundle\Event\MeasurementFamilyUpdated;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
@@ -21,17 +20,10 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class SaveMeasurementFamilyTest extends AcceptanceTestCase
 {
-    /** * @var ValidatorInterface */
-    private $validator;
-
-    /** @var InMemoryMeasurementFamilyRepository */
-    private $measurementFamilyRepository;
-
-    /** @var SaveMeasurementFamilyHandler */
-    private $saveMeasurementFamilyHandler;
-
-    /** @var InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub */
-    private $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
+    private ValidatorInterface$validator;
+    private InMemoryMeasurementFamilyRepository $measurementFamilyRepository;
+    private SaveMeasurementFamilyHandler $saveMeasurementFamilyHandler;
+    private InMemoryIsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyStub $isThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
 
     public function setUp(): void
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyActionEndToEnd.php
@@ -12,7 +12,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInte
 use Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\WebTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class CreateMeasurementFamilyActionTest extends WebTestCase
+class CreateMeasurementFamilyActionEndToEnd extends WebTestCase
 {
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/CreateMeasurementFamilyActionEndToEnd.php
@@ -79,12 +79,11 @@ class CreateMeasurementFamilyActionEndToEnd extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $responseBody = json_decode($response->getContent(), true);
-        $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $responseBody['code']);
         $this->assertEquals(
-            'The measurement family has data that does not comply with the business rules.',
-            $responseBody['message']
+            'This field can only contain letters, numbers, and underscores.',
+            $responseBody[0]['message']
         );
     }
 
@@ -123,7 +122,7 @@ class CreateMeasurementFamilyActionEndToEnd extends WebTestCase
         );
 
         $response = $this->client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
     }
 
     private function measurementFamilyWithCode(string $code): MeasurementFamily

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/SaveMeasurementFamilyActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/SaveMeasurementFamilyActionEndToEnd.php
@@ -173,12 +173,10 @@ class SaveMeasurementFamilyActionEndToEnd extends WebTestCase
 
     private function assertMeasurementFamilyCannotBeSavedBecauseLabelWasTooLong(Response $response): void
     {
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
         $responseBody = json_decode($response->getContent(), true);
-        $this->assertEquals(422, $responseBody['code']);
-        $this->assertEquals('The measurement family has data that does not comply with the business rules.', $responseBody['message']);
-        $this->assertEquals('labels', $responseBody['errors'][0]['property']);
-        $this->assertEquals('This value is too long. It should have 100 characters or less.', $responseBody['errors'][0]['message']);
+        $this->assertEquals('labels[fr_FR]', $responseBody[0]['propertyPath']);
+        $this->assertEquals('This value is too long. It should have 100 characters or less.', $responseBody[0]['message']);
     }
 
     private function saveWithMeasurementFamilyCodeDifferentFromRouteAndBody(

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/SaveMeasurementFamilyActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/InternalApi/SaveMeasurementFamilyActionEndToEnd.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class SaveMeasurementFamilyActionTest extends WebTestCase
+class SaveMeasurementFamilyActionEndToEnd extends WebTestCase
 {
     /** @var MeasurementFamilyRepositoryInterface */
     private $measurementFamilyRepository;

--- a/tests/back/Acceptance/EventDispatcher/EventDispatcherMock.php
+++ b/tests/back/Acceptance/EventDispatcher/EventDispatcherMock.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2020 Akeneo SAS (http://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Test\Acceptance\EventDispatcher;
+
+use Behat\Behat\Context\Context;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ */
+final class EventDispatcherMock implements Context, EventDispatcherInterface
+{
+    private EventDispatcherInterface $eventDispatcher;
+    private array $events = [];
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function getEvents(): array
+    {
+        return $this->events;
+    }
+
+    public function getEventsByName(string $eventName): array
+    {
+        return array_map(
+            fn (array $event) => $event['event'],
+            array_filter(
+                $this->events,
+                fn (array $event): bool => $eventName === $event['name']
+            )
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dispatch($event)
+    {
+        $eventName = null;
+        if (1 < \func_num_args()) {
+            $eventName = func_get_arg(1);
+            $this->eventDispatcher->dispatch($event, $eventName);
+        } else {
+            $this->eventDispatcher->dispatch($event);
+        }
+
+        if (\is_object($event)) {
+            $eventName = $eventName ?? \get_class($event);
+        } elseif (\is_string($event) && (null === $eventName || \is_object($eventName))) {
+            // Deprecated since symfony 4.3
+            // See https://github.com/symfony/event-dispatcher/blob/v4.3.11/EventDispatcher.php#L58
+            $swap = $event;
+            $event = $eventName;
+            $eventName = $swap;
+        }
+
+        $this->events[] = ['name' => $eventName, 'event' => $event];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addListener($eventName, $listener, $priority = 0)
+    {
+        $this->eventDispatcher->addListener($eventName, $listener, $priority);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addSubscriber(EventSubscriberInterface $subscriber)
+    {
+        $this->eventDispatcher->addSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeListener($eventName, $listener)
+    {
+        $this->eventDispatcher->removeListener($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeSubscriber(EventSubscriberInterface $subscriber)
+    {
+        $this->eventDispatcher->removeSubscriber($subscriber);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListeners($eventName = null)
+    {
+        return $this->eventDispatcher->getListeners($eventName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->eventDispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasListeners($eventName = null)
+    {
+        return $this->eventDispatcher->hasListeners($eventName);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Introduces Domain events for measurement families
   - MeasurementFamilyCreated
   - MeasurementFamilyUpdated
   - MeasurementFamilyDeleted

Events are created & dispatched by the dedicated application services (ideally, they would have been created by the aggregate and dispatched by the repository, that was too much work).

⚠️ Acceptance & EndToEnd tests were not run by the CI, hence I added them in the phpunit config.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [x] Tech Doc
