### PR TITLE
PIM-9829: Fix product grid crash when using a family filter on a deleted family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PIM-9807: Trigger warning when importing date as text attribute via XLSX files
 - PIM-9801: Fix jobs that are still stuck in STARTED and STOPPING and create a command to avoid this again
 - PIM-9771: Fix the image preview when exporting a product as pdf
+- PIM-9829: Fix product grid crash when using a family filter on a deleted family
 - PIM-9820: Fix the Error 500 on the product grid with the date filter
 
 ## New features

--- a/src/Oro/Bundle/PimFilterBundle/Filter/Product/FamilyFilter.php
+++ b/src/Oro/Bundle/PimFilterBundle/Filter/Product/FamilyFilter.php
@@ -1,7 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Oro\Bundle\PimFilterBundle\Filter\Product;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility;
@@ -22,13 +25,19 @@ class FamilyFilter extends AjaxChoiceFilter
     public function apply(FilterDatasourceAdapterInterface $dataSource, $data)
     {
         $data = $this->parseData($data);
+
         if (!$data) {
             return false;
         }
-        if (in_array(strtoupper($data['type']), [Operators::IS_EMPTY, Operators::IS_NOT_EMPTY])) {
-            $this->util->applyFilter($dataSource, 'family', strtoupper($data['type']), null);
-        } else {
-            $this->util->applyFilter($dataSource, 'family', Operators::IN_LIST, $data['value']);
+
+        try {
+            if (in_array(strtoupper($data['type']), [Operators::IS_EMPTY, Operators::IS_NOT_EMPTY])) {
+                $this->util->applyFilter($dataSource, 'family', strtoupper($data['type']), null);
+            } else {
+                $this->util->applyFilter($dataSource, 'family', Operators::IN_LIST, $data['value']);
+            }
+        } catch (ObjectNotFoundException $exception) {
+            return false;
         }
 
         return true;

--- a/src/Oro/Bundle/PimFilterBundle/spec/Filter/Product/FamilyFilterSpec.php
+++ b/src/Oro/Bundle/PimFilterBundle/spec/Filter/Product/FamilyFilterSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Oro\Bundle\PimFilterBundle\Filter\Product;
 
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Oro\Bundle\FilterBundle\Filter\ChoiceFilter;
 use PhpSpec\ObjectBehavior;
 use Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface;
@@ -26,6 +27,15 @@ class FamilyFilterSpec extends ObjectBehavior
     ) {
         $utility->applyFilter($datasource, 'family', 'IN', [2, 3])->shouldBeCalled();
 
-        $this->apply($datasource, ['type' => null, 'value' => [2, 3]]);
+        $this->apply($datasource, ['type' => 'IN', 'value' => [2, 3]])->shouldReturn(true);
+    }
+
+    function it_does_not_apply_filter_when_family_is_not_found(
+        FilterDatasourceAdapterInterface $datasource,
+        $utility
+    ) {
+        $utility->applyFilter($datasource, 'family', 'IN', ['deleted_family'])->willThrow(ObjectNotFoundException::class);
+
+        $this->apply($datasource, ['type' => 'IN', 'value' => ['deleted_family']])->shouldReturn(false);
     }
 }


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

PIM-9829: Fix product grid crash when using a family filter on a deleted family by ignoring the filter when the specified family is not found

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
