### PR TITLE
Fix Events API logs output on dev env

### DIFF
--- a/config/packages/dev/monolog.yml
+++ b/config/packages/dev/monolog.yml
@@ -4,7 +4,7 @@ monolog:
             type:     stream
             path:     "%kernel.logs_dir%/%kernel.environment%.log"
             level:    '%env(LOGGING_LEVEL)%'
-            channels: ['!event', '!event_api', '!business_event']
+            channels: ['!event']
         console:
             type:     console
-            channels: ['!event', '!doctrine', '!event_api', '!business_event']
+            channels: ['!event', '!doctrine']


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Currently all the logs output in the monolog channel `event_api` or `business_event` are silenced and not visible.
- Not in the log file
- Not in the `messenger:consume` command output (even with `--verbose` flag)

This make it really difficult to debug the Events API.

This is because the configuration is setup to ignore those logs for the `main` output (log file) and the `console` output.

The goal of this PR is to stop ignoring these monolog channels and use the default behaviors like other channels.
- For the `main` configuration, all the logs at the level `debug` and above will be sent to the log file
- For the `console` configuration (for the `messenger:consume` command) all the logs will be output directly according to  verbosity level (See https://symfony.com/doc/current/logging/monolog_console.html)
  It means that the command launched with the most verbose option`-vvv` will display all the `event_api` logs directly, but if it launched without verbosity option it will only display logs at a `warning` level and above.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [x] Tech Doc
