### PR TITLE
PIM-9826: Display the system attribute filters with the UI locale on …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PIM-9829: Fix product grid crash when using a family filter on a deleted family
 - PIM-9820: Fix the Error 500 on the product grid with the date filter
 - PIM-9833: Fix null pointer exception on Product::getVariationLevel (CE contribution)
+- PIM-9826: Display the system attribute filters with the UI locale on the user account settings
 
 ## New features
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -51,10 +51,10 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   protected convertBackendItem(item: NormalizedAttribute): Object {
     return {
       id: item.code,
-      text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code),
+      text: i18n.getLabel(item.labels, UserContext.get('uiLocale'), item.code),
       group: {
         text: item.group
-          ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('catalogLocale'), item.group)
+          ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('uiLocale'), item.group)
           : '',
       },
     };
@@ -94,7 +94,7 @@ class ProductGridFilters extends BaseMultiSelectAsync {
    */
   private static getSystemAttributeGroup(): NormalizedAttributeGroup {
     const result: NormalizedAttributeGroup = {labels: {}};
-    result['labels'][UserContext.get('catalogLocale')] = __('pim_datagrid.filters.system');
+    result['labels'][UserContext.get('uiLocale')] = __('pim_datagrid.filters.system');
 
     return result;
   }

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -49,26 +49,17 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   }
 
   protected convertBackendItem(item: NormalizedAttribute): Object {
-    if (item.group === "system") {
+      const uiLocale = UserContext.get('uiLocale');
+      const catalogLocale = UserContext.get('catalogLocale');
       return {
         id: item.code,
-        text: i18n.getLabel(item.labels, UserContext.get('uiLocale'), item.code),
+        text: i18n.getLabel(item.labels, item.group === "system" ? uiLocale : catalogLocale, item.code),
         group: {
           text: item.group
-              ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('uiLocale'), item.group)
+              ? i18n.getLabel(this.attributeGroups[item.group].labels, item.group === "system" ? uiLocale : catalogLocale, item.group)
               : '',
         },
       };
-    }
-    return {
-      id: item.code,
-      text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code),
-      group: {
-        text: item.group
-          ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('catalogLocale'), item.group)
-          : '',
-      },
-    };
   }
 
   /**

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -49,12 +49,23 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   }
 
   protected convertBackendItem(item: NormalizedAttribute): Object {
+    if (item.group === "system") {
+      return {
+        id: item.code,
+        text: i18n.getLabel(item.labels, UserContext.get('uiLocale'), item.code),
+        group: {
+          text: item.group
+              ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('uiLocale'), item.group)
+              : '',
+        },
+      };
+    }
     return {
       id: item.code,
-      text: i18n.getLabel(item.labels, UserContext.get('uiLocale'), item.code),
+      text: i18n.getLabel(item.labels, UserContext.get('catalogLocale'), item.code),
       group: {
         text: item.group
-          ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('uiLocale'), item.group)
+          ? i18n.getLabel(this.attributeGroups[item.group].labels, UserContext.get('catalogLocale'), item.group)
           : '',
       },
     };

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -49,17 +49,16 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   }
 
   protected convertBackendItem(item: NormalizedAttribute): Object {
-      const uiLocale = UserContext.get('uiLocale');
-      const catalogLocale = UserContext.get('catalogLocale');
-      return {
-        id: item.code,
-        text: i18n.getLabel(item.labels, item.group === "system" ? uiLocale : catalogLocale, item.code),
-        group: {
-          text: item.group
-              ? i18n.getLabel(this.attributeGroups[item.group].labels, item.group === "system" ? uiLocale : catalogLocale, item.group)
-              : '',
-        },
-      };
+    const locale = 'system' === item.group ? UserContext.get('uiLocale') : UserContext.get('catalogLocale');
+    return {
+      id: item.code,
+      text: i18n.getLabel(item.labels, locale, item.code),
+      group: {
+        text: item.group
+            ? i18n.getLabel(this.attributeGroups[item.group].labels, locale, item.group)
+            : '',
+      },
+    };
   }
 
   /**

--- a/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
+++ b/src/Akeneo/UserManagement/Bundle/Resources/public/js/fields/product-grid-filters.ts
@@ -49,14 +49,12 @@ class ProductGridFilters extends BaseMultiSelectAsync {
   }
 
   protected convertBackendItem(item: NormalizedAttribute): Object {
-    const locale = 'system' === item.group ? UserContext.get('uiLocale') : UserContext.get('catalogLocale');
+    const locale = UserContext.get('system' === item.group ? 'uiLocale' : 'catalogLocale');
     return {
       id: item.code,
       text: i18n.getLabel(item.labels, locale, item.code),
       group: {
-        text: item.group
-            ? i18n.getLabel(this.attributeGroups[item.group].labels, locale, item.group)
-            : '',
+        text: item.group ? i18n.getLabel(this.attributeGroups[item.group].labels, locale, item.group) : '',
       },
     };
   }


### PR DESCRIPTION
…the user account settings

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When using a UI locale different from the catalog locale, the system attribute were displayed with their codes.
In the product-grid-filters.ts, I replaced the `UserContext.get('catalogLocale')` by `UserContext.get('uiLocale')` for the system attributes. The other attributes have to be displayed with catalogLocale.



<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
