### PR TITLE
PIM-9832: Fix variant product images query by extracting image values before sorting

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9832: Fix variant product images query by extracting image values before sorting
+
 # 4.0.105 (2021-04-27)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -312,34 +312,46 @@ SQL;
         }
 
         $sql = <<<SQL
-            WITH product_child as (
-                SELECT root.code as root_code, product.family_id, product.raw_values, product.created
+            WITH product_child AS (
+                SELECT root.code AS root_code, product.family_id, product.raw_values, product.created
                 FROM pim_catalog_product_model root
                     INNER JOIN pim_catalog_product_model sub ON sub.parent_id = root.id
                     INNER JOIN pim_catalog_product product ON product.product_model_id = sub.id
                 WHERE root.code = :code
                 UNION ALL
-                SELECT root.code as root_code, product.family_id, product.raw_values, product.created
+                SELECT root.code AS root_code, product.family_id, product.raw_values, product.created
                 FROM pim_catalog_product_model root
                     INNER JOIN pim_catalog_product product ON product.product_model_id = root.id
                 WHERE root.code = :code
+            ),
+            product_child_extracted_image_code AS (
+                SELECT DISTINCT
+                    product_child.root_code AS root_code,
+                    product_child.family_id,
+                    product_child.created,
+                    a_image.code AS attribute_code,
+                    a_image.is_localizable,
+                    a_image.is_scopable,
+                    JSON_EXTRACT(product_child.raw_values, CONCAT('$.', a_image.code)) AS image_values,
+                    JSON_EXTRACT(
+                        product_child.raw_values,
+                        CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
+                    ) AS image_value
+                FROM product_child
+                    JOIN pim_catalog_family f ON f.id = product_child.family_id
+                    JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
             )
-            SELECT product_child.root_code as code,
-                   a_image.code as attribute_code,
-                   a_image.is_localizable,
-                   a_image.is_scopable,
-                   JSON_EXTRACT(product_child.raw_values, CONCAT('$.', a_image.code)) as image_values,
-                   JSON_EXTRACT(
-                       product_child.raw_values,
-                       CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))
-                   ) as image_value
-            FROM product_child
-                JOIN pim_catalog_family f ON f.id = product_child.family_id
-                JOIN pim_catalog_attribute a_image ON a_image.id = f.image_attribute_id
+            SELECT root_code AS code,
+                   attribute_code,
+                   is_localizable,
+                   is_scopable,
+                   image_values,
+                   image_value
+            FROM product_child_extracted_image_code
             HAVING
                 image_value IS NOT NULL AND JSON_TYPE(image_value) != 'NULL'
             ORDER BY 
-                product_child.created ASC
+                created ASC
             LIMIT 1
 SQL;
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Extracting the `JSON_EXTRACT` part of the query in a dedicated CTE to avoid sorting on all JSON raw values, thanks @ahocquard for the tips
Tested on the ref env with the problematic dataset and it creates no Out of sort memory errors.

**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)

