### PR TITLE
RAC-576: Introduce MF read model & public API for onboarder

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder;
 
-use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
 use \Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily as MeasurementFamilyAggregate;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -28,7 +29,7 @@ class FindAllMeasurementFamilies
         $allMeasurementFamilies = $this->measurementFamilyRepository->all();
 
         return array_map(
-            static fn(MeasurementFamilyAggregate $measurementFamily) => MeasurementFamily::fromAggregate($measurementFamily),
+            static fn (MeasurementFamilyAggregate $measurementFamily) => MeasurementFamily::fromAggregate($measurementFamily),
             $allMeasurementFamilies
         );
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
+use \Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily as MeasurementFamilyAggregate;
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FindAllMeasurementFamilies
+{
+    private MeasurementFamilyRepositoryInterface $measurementFamilyRepository;
+
+    public function __construct(MeasurementFamilyRepositoryInterface  $measurementFamilyRepository)
+    {
+        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    }
+
+    /**
+     * @return MeasurementFamily[]
+     */
+    public function execute(): array
+    {
+        $allMeasurementFamilies = $this->measurementFamilyRepository->all();
+
+        return array_map(
+            static fn(MeasurementFamilyAggregate $measurementFamily) => MeasurementFamily::fromAggregate($measurementFamily),
+            $allMeasurementFamilies
+        );
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/FindAllMeasurementFamilies.php
@@ -16,7 +16,7 @@ class FindAllMeasurementFamilies
 {
     private MeasurementFamilyRepositoryInterface $measurementFamilyRepository;
 
-    public function __construct(MeasurementFamilyRepositoryInterface  $measurementFamilyRepository)
+    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
     {
         $this->measurementFamilyRepository = $measurementFamilyRepository;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/MeasurementFamily.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/MeasurementFamily.php
@@ -7,7 +7,7 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder;
 use \Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily as MeasurementFamilyAggregate;
 
 /**
- * Read model dedicated to onboarded synchronization
+ * Read model dedicated to onboarder synchronization
  *
  * @author    Samir Boulil <samir.boulil@akeneo.com>
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/MeasurementFamily.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/Onboarder/MeasurementFamily.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder;
+
+use \Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily as MeasurementFamilyAggregate;
+
+/**
+ * Read model dedicated to onboarded synchronization
+ *
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class MeasurementFamily
+{
+    public string $code;
+    public array $labels;
+    public string $standardUnitCode;
+    public array $units;
+
+    public static function fromAggregate(MeasurementFamilyAggregate $measurementFamily): self
+    {
+        $normalizedMeasurementFamily = $measurementFamily->normalize();
+        $readModel = new self();
+        $readModel->code = $normalizedMeasurementFamily['code'];
+        $readModel->labels = $normalizedMeasurementFamily['labels'];
+        $readModel->standardUnitCode = $normalizedMeasurementFamily['standard_unit_code'];
+        $readModel->units = $normalizedMeasurementFamily['units'];
+
+        return $readModel;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/public_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/public_api.yml
@@ -3,3 +3,8 @@ services:
         class: 'Akeneo\Tool\Bundle\MeasureBundle\PublicApi\SqlGetUnitTranslations'
         arguments:
             - '@database_connection'
+            -
+    akeneo_measurement.public_api.onboarder.find_all_measurement_families:
+        class: 'Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder\FindAllMeasurementFamilies'
+        arguments:
+            - '@akeneo_measure.persistence.measurement_family_repository'

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/Onboarder/FindAllMeasurementFamiliesIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/Onboarder/FindAllMeasurementFamiliesIntegration.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @author    Samir Boulil <samir.boulil@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class FindAllMeasurementFamiliesIntegration extends TestCase
+{
+    private FindAllMeasurementFamilies $findAllMeasurementFamilies;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->findAllMeasurementFamilies = $this->get(
+            'akeneo_measurement.public_api.onboarder.find_all_measurement_families'
+        );
+    }
+
+    /** @test */
+    public function it_finds_all_measurements_families_for_onboarder()
+    {
+        $result = $this->findAllMeasurementFamilies->execute();
+        $actualMeasurementFamily = current($result);
+
+        self::assertNotEmpty($result, 'Expect to find at least the standard measurement families');
+        self::assertEquals('Angle', $actualMeasurementFamily->code);
+        self::assertEquals($this->expectedAngleLabels(), $actualMeasurementFamily->labels);
+        self::assertEquals('RADIAN', $actualMeasurementFamily->standardUnitCode);
+        self::assertEqualsCanonicalizing($this->expectedAngleUnits(), $actualMeasurementFamily->units);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function expectedAngleUnits(): array
+    {
+        return [
+            [
+                'code' => 'RADIAN',
+                'labels' => [
+                    'en_US' => 'Radian',
+                    'fr_FR' => 'Radian',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '1',
+                    ],
+                ],
+                'symbol' => 'rad',
+            ],
+            [
+                'code' => 'MILLIRADIAN',
+                'labels' => [
+                    'en_US' => 'Milliradian',
+                    'fr_FR' => 'Milliradian',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.001',
+                    ],
+                ],
+                'symbol' => 'mrad',
+            ],
+            [
+                'code' => 'MICRORADIAN',
+                'labels' => [
+                    'en_US' => 'Microradian',
+                    'fr_FR' => 'Microradian',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.000001',
+                    ],
+                ],
+                'symbol' => 'µrad',
+            ],
+            [
+                'code' => 'DEGREE',
+                'labels' => [
+                    'en_US' => 'Degree',
+                    'fr_FR' => 'Degré',
+                ],
+                'convert_from_standard' => [
+                     [
+                        'operator' => 'mul',
+                        'value' => '0.01745329',
+                    ],
+                ],
+                'symbol' => '°',
+            ],
+            [
+                'code' => 'MINUTE',
+                'labels' => [
+                    'en_US' => 'Minute',
+                    'fr_FR' => 'Minute',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.0002908882',
+                    ],
+                ],
+                'symbol' => '\'',
+            ],
+            [
+                'code' => 'SECOND',
+                'labels' => [
+                    'en_US' => 'Second',
+                    'fr_FR' => 'Seconde',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.000004848137',
+                    ],
+                ],
+                'symbol' => '"',
+            ],
+            [
+                'code' => 'GON',
+                'labels' => [
+                    'en_US' => 'Gon',
+                    'fr_FR' => 'Gon',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.01570796',
+                    ],
+                ],
+                'symbol' => 'gon',
+            ],
+            [
+                'code' => 'MIL',
+                'labels' => [
+                    'en_US' => 'Mil',
+                    'fr_FR' => 'Mil',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '0.0009817477',
+                    ],
+                ],
+                'symbol' => 'mil',
+            ],
+            [
+                'code' => 'REVOLUTION',
+                'labels' => [
+                    'en_US' => 'Revolution',
+                    'fr_FR' => 'Révolution',
+                ],
+                'convert_from_standard' => [
+                    [
+                        'operator' => 'mul',
+                        'value' => '6.283185',
+                    ],
+                ],
+                'symbol' => 'rev',
+            ],
+        ];
+    }
+
+    /**
+     * @return string[]
+     *
+     */
+    private function expectedAngleLabels(): array
+    {
+        return [
+            'de_DE' => 'Winkel',
+            'en_US' => 'Angle',
+            'fr_FR' => 'Angle',
+        ];
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/Onboarder/FindAllMeasurementFamiliesIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/Onboarder/FindAllMeasurementFamiliesIntegration.php
@@ -176,7 +176,6 @@ final class FindAllMeasurementFamiliesIntegration extends TestCase
 
     /**
      * @return string[]
-     *
      */
     private function expectedAngleLabels(): array
     {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- New read model dedicated to onboarder representing the measurement family (lives in PHP publicAPI)
- New query dedicated to onboarder to fetch all measurement families in the form of the onboarder read model

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer
- [x] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [x] Tech Doc
