### PR TITLE
API-1565: rest api search category without parent

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ExternalApi/CategoryRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ExternalApi/CategoryRepository.php
@@ -118,6 +118,12 @@ class CategoryRepository extends EntityRepository implements ApiResourceReposito
                             $qb->andWhere($qb->expr()->gt('r.left', $parentCategory->getLeft()));
                             $qb->andWhere($qb->expr()->lt('r.right', $parentCategory->getRight()));
                             $qb->andWhere($qb->expr()->eq('r.root', $parentCategory->getRoot()));
+                        } elseif ('is_root' === $property) {
+                            if (true === (bool)$criterion['value']) {
+                                $qb->andWhere($qb->expr()->isNull('r.parent'));
+                            } else {
+                                $qb->andWhere($qb->expr()->isNotNull('r.parent'));
+                            }
                         } else {
                             $qb->andWhere($qb->expr()->eq($field, $parameter));
                             $qb->setParameter($parameter, $criterion['value']);
@@ -171,6 +177,20 @@ class CategoryRepository extends EntityRepository implements ApiResourceReposito
                         new Assert\Type([
                             'type' => 'string',
                             'message' => 'In order to search on category parent you must send a parent code category as value, {{ type }} given.'
+                        ]),
+                    ],
+                ])
+            ]),
+            'is_root' => new Assert\All([
+                new Assert\Collection([
+                    'operator' => new Assert\IdenticalTo([
+                        'value' => '=',
+                        'message' => 'In order to search on category is_root you must use "=" operator, {{ value }} given.',
+                    ]),
+                    'value' => [
+                        new Assert\Type([
+                            'type' => 'bool',
+                            'message' => 'In order to search on category is_root you must send a {{ type }} value, {{ value }} given.'
                         ]),
                     ],
                 ])

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/Repository/ExternalApi/CategoryRepositoryApiResourceIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/ORM/Repository/ExternalApi/CategoryRepositoryApiResourceIntegration.php
@@ -117,6 +117,38 @@ class CategoryRepositoryApiResourceIntegration extends TestCase
         Assert::assertEquals('ring', $categories[4]->getCode());
     }
 
+    public function test_to_search_root_categories_only(): void
+    {
+        $this->initFixtures();
+
+        $categories = $this->getRepository()->searchAfterOffset(
+            ['is_root' => [['operator' => '=', 'value' => true]]],
+            ['code' => 'ASC'],
+            10,
+            0
+        );
+        Assert::assertCount(3, $categories);
+        Assert::assertEquals('accessories', $categories[0]->getCode());
+        Assert::assertEquals('clothes', $categories[1]->getCode());
+        Assert::assertEquals('master', $categories[2]->getCode());
+    }
+
+    public function test_to_search_non_root_categories_only(): void
+    {
+        $this->initFixtures();
+
+        $categories = $this->getRepository()->searchAfterOffset(
+            ['is_root' => [['operator' => '=', 'value' => false]]],
+            ['code' => 'ASC'],
+            10,
+            0
+        );
+
+        Assert::assertCount(9, $categories);
+        Assert::assertEquals('bob', $categories[0]->getCode());
+        Assert::assertEquals('women', $categories[8]->getCode());
+    }
+
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();


### PR DESCRIPTION
Add a "is_root" search filter to the Rest API for get categories.

Supports searching for root categories only or non-root categories only.
