### PR TITLE
PLG-231: Fix to display number of categories of new trees

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/categories/CategoryTreeDataGrid.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/categories/CategoryTreeDataGrid.tsx
@@ -127,11 +127,11 @@ const CategoryTreesDataGrid: FC<Props> = ({trees, refreshCategoryTrees}) => {
                 >
                   <Table.Cell rowTitle>{tree.label}</Table.Cell>
                   <Table.Cell>
-                    {countTreesChildren.hasOwnProperty(tree.code) &&
+                    {countTreesChildren !== null &&
                     translate(
                       'pim_enrich.entity.category.content.tree_list.columns.count_categories',
-                      {count: countTreesChildren[tree.code]},
-                      countTreesChildren[tree.code]
+                      {count: countTreesChildren.hasOwnProperty(tree.code) ? countTreesChildren[tree.code] : 0},
+                      countTreesChildren.hasOwnProperty(tree.code) ? countTreesChildren[tree.code] : 0
                     )}
                   </Table.Cell>
                   <TableActionCell>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCountCategoryTreesChildren.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCountCategoryTreesChildren.ts
@@ -5,8 +5,8 @@ type CountCategoryTreesChildren = {
   [key: string]: number;
 };
 
-const useCountCategoryTreesChildren = (): CountCategoryTreesChildren => {
-  const [countChildren, setCountChildren] = useState<CountCategoryTreesChildren>({});
+const useCountCategoryTreesChildren = (): CountCategoryTreesChildren | null => {
+  const [countChildren, setCountChildren] = useState<CountCategoryTreesChildren>(null);
   const url = useRoute('pim_enrich_categorytree_count_children');
 
   useEffect(() => {


### PR DESCRIPTION
Make `countTreesChildren` nullable to to distinct when the number of children are loaded or not.
Display `0 category` by default to handle new created tree.