### PR TITLE
[WIP] Octolab: Fix performance issue from event logs page

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EventLogs.tsx
@@ -1,5 +1,5 @@
 import {Breadcrumb} from 'akeneo-design-system';
-import React, {FC, useEffect} from 'react';
+import React, {FC, useEffect, useState} from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 import {Loading, PageContent, PageHeader} from '../../common';
 import {useRoute} from '../../shared/router';
@@ -7,18 +7,43 @@ import {Translate} from '../../shared/translate';
 import {UserButtons} from '../../shared/user';
 import {EventSubscriptionDisabled} from '../components/EventSubscriptionDisabled';
 import {EventLogList} from '../components/EventLogList';
-import {useFetchConnection} from '../hooks/api/use-fetch-connection';
-import {useFetchEventSubscription} from '../hooks/api/use-fetch-event-subscription';
+import {EventSubscription} from '../hooks/api/use-fetch-event-subscription';
 import {DownloadLogsButton} from '../components/DownloadLogsButton';
+import {useRouter} from '../../shared/router/use-router';
+import {Connection} from '../../model/connection';
+
+type EventSubscriptionResponse = {
+    connection?: Connection;
+    eventSubscription?: EventSubscription;
+};
+
+const useEventSubscription = (connectionCode: string): EventSubscriptionResponse => {
+    const [state, setState] = useState<EventSubscriptionResponse>({});
+    const generateUrl = useRouter();
+    const urlGetConnection = generateUrl(
+        'akeneo_connectivity_connection_rest_get',
+        {code: connectionCode}
+    );
+    const urlGetEventSubscription = generateUrl(
+        'akeneo_connectivity_connection_webhook_rest_get',
+        {code: connectionCode}
+    );
+
+    useEffect(() => {
+        (async () => {
+            const connection = await (await fetch(urlGetConnection)).json();
+            const eventSubscription = await (await fetch(urlGetEventSubscription)).json();
+
+            setState({connection, eventSubscription});
+        })();
+    }, [connectionCode]);
+
+    return state;
+};
 
 export const EventLogs: FC = () => {
     const {connectionCode} = useParams<{connectionCode: string}>();
-    const {connection} = useFetchConnection(connectionCode);
-    const {eventSubscription, fetchEventSubscription} = useFetchEventSubscription(connectionCode);
-
-    useEffect(() => {
-        fetchEventSubscription();
-    }, [fetchEventSubscription]);
+    const {connection, eventSubscription} = useEventSubscription(connectionCode);
 
     if (undefined === connection || undefined === eventSubscription) {
         return (


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Reduce the number of custom hooks and avoid rendering too many times the event logs page.
This improvement divide by two the number of renderings (from 8 to 4).

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
