### PR TITLE
PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PIM-9820: Fix the Error 500 on the product grid with the date filter
 - PIM-9833: Fix null pointer exception on Product::getVariationLevel (CE contribution)
 - PIM-9826: Display the system attribute filters with the UI locale on the user account settings
+- PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Updater/ProductUpdater.php
@@ -15,6 +15,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\PropertySetterInterface;
 use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 /**
  * Updates a product
@@ -164,6 +165,9 @@ class ProductUpdater implements ObjectUpdaterInterface
         }
 
         foreach ($data as $code => $value) {
+            if (!is_string($code)) {
+                throw new BadRequestHttpException('Invalid json message received');
+            }
             $filteredValue = $this->filterData($product, $code, $value, $data);
             $this->setData($product, $code, $filteredValue, $options);
         }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

Copy of Thomas' PR.

His description: _Throw BadRequestHttpException when bad parameters are passed to ProductUpdater->filterData()_

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
