### PR TITLE
Fix measurement glitch

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/pages/create-unit/CreateUnit.tsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useContext, useRef, useState} from 'react';
+import styled from 'styled-components';
 import {
   Helper,
   MeasurementIllustration,
@@ -39,6 +40,10 @@ type CreateUnitProps = {
   onClose: () => void;
   onNewUnit: (unit: Unit) => void;
 };
+
+const FormGroup = styled(Section)`
+  max-width: 400px;
+`;
 
 const CreateUnit = ({onClose, onNewUnit, measurementFamily}: CreateUnitProps) => {
   const translate = useTranslate();
@@ -113,39 +118,41 @@ const CreateUnit = ({onClose, onNewUnit, measurementFamily}: CreateUnitProps) =>
         {measurementFamily.is_locked && (
           <Helper level="warning">{translate('measurements.unit.will_be_read_only')}</Helper>
         )}
-        <TextField
-          ref={firstFieldRef}
-          label={translate('pim_common.code')}
-          value={form.code}
-          onChange={value => setFormValue('code', value)}
-          required={true}
-          errors={getErrorsForPath(errors, 'code')}
-        />
-        <TextField
-          label={translate('pim_common.label')}
-          value={form.label}
-          onChange={value => setFormValue('label', value)}
-          locale={locale}
-          errors={getErrorsForPath(errors, `labels[${locale}]`)}
-        />
-        <TextField
-          label={translate('measurements.form.input.symbol')}
-          value={form.symbol}
-          onChange={value => setFormValue('symbol', value)}
-          errors={getErrorsForPath(errors, 'symbol')}
-        />
-        <OperationCollection
-          operations={form.operations}
-          onOperationsChange={(operations: Operation[]) => setFormValue('operations', operations)}
-          errors={filterErrors(errors, `convert_from_standard`)}
-        />
-        <Checkbox
-          id="measurements.unit.create_another"
-          checked={createAnotherUnit}
-          onChange={(checked: boolean) => setCreateAnotherUnit(checked)}
-        >
-          {translate('measurements.unit.create_another')}
-        </Checkbox>
+        <FormGroup>
+          <TextField
+            ref={firstFieldRef}
+            label={translate('pim_common.code')}
+            value={form.code}
+            onChange={value => setFormValue('code', value)}
+            required={true}
+            errors={getErrorsForPath(errors, 'code')}
+          />
+          <TextField
+            label={translate('pim_common.label')}
+            value={form.label}
+            onChange={value => setFormValue('label', value)}
+            locale={locale}
+            errors={getErrorsForPath(errors, `labels[${locale}]`)}
+          />
+          <TextField
+            label={translate('measurements.form.input.symbol')}
+            value={form.symbol}
+            onChange={value => setFormValue('symbol', value)}
+            errors={getErrorsForPath(errors, 'symbol')}
+          />
+          <OperationCollection
+            operations={form.operations}
+            onOperationsChange={(operations: Operation[]) => setFormValue('operations', operations)}
+            errors={filterErrors(errors, `convert_from_standard`)}
+          />
+          <Checkbox
+            id="measurements.unit.create_another"
+            checked={createAnotherUnit}
+            onChange={(checked: boolean) => setCreateAnotherUnit(checked)}
+          >
+            {translate('measurements.unit.create_another')}
+          </Checkbox>
+        </FormGroup>
       </Section>
       <Modal.BottomButtons>
         <Button onClick={handleAdd} disabled={config.units_max <= measurementFamily.units.length}>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This PR fix a glitch introduced when we use DSM component. It only append when user create unit on measurement family already used by an attribute

Before:
![Capture d’écran du 2021-05-06 13-58-32](https://user-images.githubusercontent.com/7239572/117294855-6b52e980-ae73-11eb-870b-76ea6b4faf42.png)

After:
![Capture d’écran du 2021-05-06 13-57-59](https://user-images.githubusercontent.com/7239572/117294845-6a21bc80-ae73-11eb-8f7f-9f7160fbf251.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
