### PR TITLE
PIM-9834: Fix "MySQL server has gone away" error when importing a lot of attribute options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - PIM-9820: Fix the Error 500 on the product grid with the date filter
 - PIM-9833: Fix null pointer exception on Product::getVariationLevel (CE contribution)
 - PIM-9826: Display the system attribute filters with the UI locale on the user account settings
+- PIM-9834: Fix MySQL error when trying to import new attribute options to attributes with a lot of options already
 - PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format
 
 ## New features

--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeOption/SqlGetAttributeOptionCodes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/AttributeOption/SqlGetAttributeOptionCodes.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeOption;
+
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetAttributeOptionCodes;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class SqlGetAttributeOptionCodes implements GetAttributeOptionCodes
+{
+    private const BATCH_QUERY_SIZE = 1000;
+
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function forAttributeCode(string $attributeCode): \Iterator
+    {
+        $sql = <<<SQL
+        SELECT ao.id, ao.code
+        FROM pim_catalog_attribute_option ao
+            JOIN pim_catalog_attribute a ON a.id = ao.attribute_id
+        WHERE a.code = :attributeCode AND ao.id > :searchAfterId
+        ORDER BY ao.id
+        LIMIT :limit
+        SQL;
+
+        $searchAfterId = 0;
+        do {
+            $results = $this->connection->executeQuery(
+                $sql,
+                [
+                    'attributeCode' => $attributeCode,
+                    'searchAfterId' => $searchAfterId,
+                    'limit' => self::BATCH_QUERY_SIZE,
+                ],
+                ['limit' => \PDO::PARAM_INT]
+            )->fetchAll();
+            foreach ($results as $result) {
+                yield $result['code'];
+                $searchAfterId = $result['id'];
+            }
+        } while (count($results) === self::BATCH_QUERY_SIZE);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/normalizers.yml
@@ -31,6 +31,7 @@ services:
         arguments:
             - '@pim_catalog.normalizer.standard.attribute'
             - '@pim_versioning.serializer.normalizer.flat.label_translation'
+            - '@akeneo.pim.structure.query.get_attribute_option_codes'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -121,3 +121,8 @@ services:
         class: Akeneo\Pim\Structure\Bundle\Query\InternalApi\Attribute\GetAllBlacklistedAttributeCodes
         arguments:
             - '@database_connection'
+
+    akeneo.pim.structure.query.get_attribute_option_codes:
+        class: Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeOption\SqlGetAttributeOptionCodes
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetAttributeOptionCodes.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/InternalApi/GetAttributeOptionCodes.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Component\Query\InternalApi;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface GetAttributeOptionCodes
+{
+    public function forAttributeCode(string $attributeCode): \Iterator;
+}

--- a/tests/back/Pim/Structure/Integration/AttributeOption/SqlGetAttributeOptionCodesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeOption/SqlGetAttributeOptionCodesIntegration.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\AttributeOption;
+
+use Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeOption\SqlGetAttributeOptionCodes;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
+
+final class SqlGetAttributeOptionCodesIntegration extends TestCase
+{
+    private SqlGetAttributeOptionCodes $sqlGetAttributeOptionCodes;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->sqlGetAttributeOptionCodes = $this->get('akeneo.pim.structure.query.get_attribute_option_codes');
+
+        $this->createAttributes(['attribute_1', 'attribute_2', 'attribute_3']);
+        $this->createAttributeOptions('attribute_1', 'option_A', ['fr_FR' => 'option A', 'en_US' => 'A option']);
+        $this->createAttributeOptions('attribute_1', 'option_B', ['fr_FR' => 'option B', 'en_US' => 'B option']);
+        $this->createAttributeOptions('attribute_1', 'option_C', []);
+        $this->createAttributeOptions('attribute_2', 'option_D', ['fr_FR' => 'option D']);
+    }
+
+    public function test_it_returns_all_attribute_option_codes_for_a_given_attribute_code(): void
+    {
+        $attributeOptionCodes = \iterator_to_array($this->sqlGetAttributeOptionCodes->forAttributeCode('attribute_1'));
+        self::assertSame(['option_A', 'option_B', 'option_C'], $attributeOptionCodes);
+
+        $attributeOptionCodes = \iterator_to_array($this->sqlGetAttributeOptionCodes->forAttributeCode('attribute_2'));
+        self::assertSame(['option_D'], $attributeOptionCodes);
+
+        $attributeOptionCodes = \iterator_to_array($this->sqlGetAttributeOptionCodes->forAttributeCode('attribute_3'));
+        self::assertSame([], $attributeOptionCodes);
+
+        $attributeOptionCodes = \iterator_to_array($this->sqlGetAttributeOptionCodes->forAttributeCode('unknown'));
+        self::assertSame([], $attributeOptionCodes);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createAttributes(array $codes): void
+    {
+        $attributes = [];
+        foreach ($codes as $code) {
+            $data = [
+                'code' => $code,
+                'type' => AttributeTypes::OPTION_SIMPLE_SELECT,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other'
+            ];
+
+            $attribute = $this->get('pim_catalog.factory.attribute')->create();
+            $this->get('pim_catalog.updater.attribute')->update($attribute, $data);
+            $violations = $this->get('validator')->validate($attribute);
+
+            Assert::count($violations, 0);
+            $attributes[] = $attribute;
+        }
+
+        $this->get('pim_catalog.saver.attribute')->saveAll($attributes);
+    }
+
+    private function createAttributeOptions(string $attributeCode, string $optionCode, array $labels): void
+    {
+        $attributeOption = $this->get('pim_catalog.factory.attribute_option')->create();
+
+        $this->get('pim_catalog.updater.attribute_option')->update($attributeOption, [
+            'code' => $optionCode,
+            'attribute' => $attributeCode,
+            'labels' => $labels,
+        ]);
+        $constraints = $this->get('validator')->validate($attributeOption);
+        Assert::count($constraints, 0);
+        $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
+    }
+}

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Versioning/AttributeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Versioning/AttributeNormalizerSpec.php
@@ -2,22 +2,21 @@
 
 namespace Specification\Akeneo\Pim\Structure\Component\Normalizer\Versioning;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\Model\AttributeOption;
-use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\TranslationNormalizer;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Normalizer\Versioning\AttributeNormalizer;
+use Akeneo\Pim\Structure\Component\Query\InternalApi\GetAttributeOptionCodes;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
 class AttributeNormalizerSpec extends ObjectBehavior
 {
     function let(
         AttributeNormalizer $attributeNormalizerStandard,
-        TranslationNormalizer $translationNormalizer
+        TranslationNormalizer $translationNormalizer,
+        GetAttributeOptionCodes $getAttributeOptionCodes
     ) {
-        $this->beConstructedWith($attributeNormalizerStandard, $translationNormalizer);
+        $this->beConstructedWith($attributeNormalizerStandard, $translationNormalizer, $getAttributeOptionCodes);
     }
 
     function it_is_initializable()
@@ -41,19 +40,13 @@ class AttributeNormalizerSpec extends ObjectBehavior
     function it_normalizes_attribute(
         AttributeNormalizer $attributeNormalizerStandard,
         TranslationNormalizer $translationNormalizer,
-        AttributeInterface $attribute
+        AttributeInterface $attribute,
+        GetAttributeOptionCodes $getAttributeOptionCodes
     ) {
-        $size = new AttributeOption();
-        $size->setCode('size');
-        $en = new AttributeOptionValue();
-        $fr =new AttributeOptionValue();
-        $en->setLocale('en_US');
-        $en->setValue('big');
-        $fr->setLocale('fr_FR');
-        $fr->setValue('grand');
-        $size->addOptionValue($en);
-        $size->addOptionValue($fr);
-        $attribute->getOptions()->willReturn(new ArrayCollection([$size]));
+        $attribute->getCode()->willReturn('attribute_size');
+        $getAttributeOptionCodes->forAttributeCode('attribute_size')->willReturn(
+            new \ArrayIterator(['size'])
+        );
         $attribute->isRequired()->willReturn(false);
         $attribute->isLocaleSpecific()->willReturn(false);
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-9834

When importing new options to an attribute that already have a lot of options, a "MySQL server has gone away" could happen. 
When we save and flush the attribute options in the database:
- Doctrine's unit of work detect the attribute has changed, save the new attribute and send events.
- A listener catches this event to create a new version of the attribute
-  To build the new version we normalized the attribute and its options. The `getOptions()` method on attribute model fetches all options in a single query without limit => MySQL crashes when too many options are in DB.  

Now a new query is added to fetch the option codes with a search after method. It avoid MySQL to crash.


<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
