### PR TITLE
PIM-9853: Make the word "product" translatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - PIM-9833: Fix null pointer exception on Product::getVariationLevel (CE contribution)
 - PIM-9826: Display the system attribute filters with the UI locale on the user account settings
 - PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format
+- PIM-9853: Make the word "product" translatable
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
@@ -368,6 +368,7 @@ pim_enrich.mass_edit.product:
       description: Le parent des produits variants et des sous modèles de produits sélectionnés dans la grille va être modifié avec ce modèle de produit.
 pim_datagrid:
   no_entities: "Aucune {{ entityHint }} trouvée"
+  no_results: "Désolé, il n’y a aucun(e) {{ entityHint }} pour votre recherche."
   mass_action_group:
     bulk_actions:
       label: Actions de masse


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

On the product grid, searching with a term that does not exist returns a message saying there is no result for the search.
The word "product" is not translatable therefore in French we have 
"Désolé, il n’y a aucun(e) product pour votre recherche."

I added the translation key in a jsmessages.fr_FR.yml file so that Crowdin can translate the variable.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
