### PR TITLE
API: allow the use of the 'parent' filter in product models endpoint

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -87,14 +87,20 @@ final class ApplyProductSearchQueryParametersToPQB
                 }
 
                 /**
-                 * Today, external API uses the "product_index" to search the products. This index indexes parent data
-                 * with help of 'ancestors.codes' and 'ancestors.ids'.
-                 * To avoid a big refactoring (i.e. use the product_and_product_model_index, TIP-1150), we consider to change the
-                 * parent filter to a dedicated one `AncestorCodeFilter`.
+                 * In v3.2, the 'parent' filter was internally replaced by 'ancestor.code' filter, because
+                 * the parent property was not indexed in the products index (which does not exist anymore).
+                 * The 'ancestor.code' filter:
+                 * - only concerned products
+                 * - only accepted the '=' operator
+                 *
+                 * In order to avoid a functional BC break, we keep this behavior when filter is 'parent' and
+                 * operator is '=', but we now allow the use of the other operators for the 'parent' filter:
+                 * - 'IN', 'EMPTY' and 'NOT EMPTY' operators can now be used
+                 * - the 'parent' filter can now be used with product models as well as with products
                  *
                  * @see src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/AncestorCodeFilter.php
                  */
-                if ($propertyCode === 'parent') {
+                if ('parent' === $propertyCode && Operators::EQUALS === ($filter['operator'] ?? null)) {
                     $pqb->addfilter('ancestor.code', $filter['operator'], $value, $context);
                 } else {
                     $pqb->addFilter($propertyCode, $filter['operator'], $value, $context);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
@@ -25,11 +25,11 @@ class ListOffsetProductModelEndToEnd extends AbstractProductModelTestCase
     "current_page" : 1,
     "items_count"  : 6,
     "_embedded"    : {
-		"items": [
+        "items": [
             {$standardizedProducts['sweat']},
             {$standardizedProducts['shoes']},
             {$standardizedProducts['tshirt']}
-		]
+        ]
     }
 }
 JSON;
@@ -57,11 +57,11 @@ JSON;
     "current_page" : 2,
     "items_count"  : 6,
     "_embedded"    : {
-		"items": [
+        "items": [
             {$standardizedProducts['trousers']},
             {$standardizedProducts['hat']},
             {$standardizedProducts['handbag']}
-		]
+        ]
     }
 }
 JSON;
@@ -84,7 +84,7 @@ JSON;
     "current_page" : 2,
     "items_count"  : 6,
     "_embedded"    : {
-		"items": []
+        "items": []
     }
 }
 JSON;
@@ -128,5 +128,63 @@ JSON;
 
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
         $this->assertJsonStringEqualsJsonString($expected, $client->getResponse()->getContent());
+    }
+
+    public function testListSubProductModels()
+    {
+        $client = $this->createAuthenticatedClient();
+        $search = '{"parent":[{"operator":"NOT EMPTY","value":null}]}';
+        $client->request('GET', 'api/rest/v1/product-models?page=1&with_count=true&limit=10&search=' . $search);
+        $encodedSearch = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10&search=${encodedSearch}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10&search=${encodedSearch}"}
+    },
+    "current_page" : 1,
+    "items_count"  : 0,
+    "_embedded"    : {
+        "items": []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * @group ce
+     */
+    public function testListRootProductModels()
+    {
+        $standardizedProductModels = $this->getStandardizedProductModels();
+
+        $client = $this->createAuthenticatedClient();
+        $search = '{"parent":[{"operator":"EMPTY","value":null}]}';
+        $client->request('GET', 'api/rest/v1/product-models?page=1&with_count=true&limit=10&search=' . $search);
+        $encodedSearch = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10&search=${encodedSearch}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/product-models?page=1&with_count=true&pagination_type=page&limit=10&search=${encodedSearch}"}
+    },
+    "current_page" : 1,
+    "items_count"  : 6,
+    "_embedded"    : {
+        "items": [
+            {$standardizedProductModels['sweat']},
+            {$standardizedProductModels['shoes']},
+            {$standardizedProductModels['tshirt']},
+            {$standardizedProductModels['trousers']},
+            {$standardizedProductModels['hat']},
+            {$standardizedProductModels['handbag']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Prior to this PR, in the API, the use of the `parent` filter was restricted to the products endpoint (where it was internally replaced by the 'ancestor.code' filter), and only accepted the '=' operator, which was inconsistent with the rest of the PIM (where `parent` can be used to filter on both products and models, and accepts the `IN`, `EMPTY` and `NOT EMPTY` operators)
This PR allows the use of the `parent` filter for both the product and product model endpoints, while keeping the former behavior when filter is 'parent' and operator is '=', in order to avoid a functional BC break

Note: this feature is implemented on 5.0, but will only be documented (and supported) as of v6.0/Saas editions

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
