### PR TITLE
OB-806: Add missing migration on `pim_catalog_completeness` table

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,7 @@
 # 5.0.x
 
+- OB-806: Add missing migration on `pim_catalog_completeness` table
+
 # 5.0.24 (2021-05-07)
 
 # 5.0.23 (2021-05-05)

--- a/upgrades/schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id.php
+++ b/upgrades/schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 

--- a/upgrades/schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id.php
+++ b/upgrades/schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_5_0_20210507154610_update_pim_catalog_completeness_id extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql("ALTER TABLE pim_catalog_completeness MODIFY id bigint AUTO_INCREMENT");
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20210507154610_update_pim_catalog_completeness_id_Integration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+
+class Version_5_0_20210507154610_update_pim_catalog_completeness_id_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_5_0_20210507154610_update_pim_catalog_completeness_id';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_completeness_id_has_changed_to_bigint(): void
+    {
+        $this->ensureCompletenessUsesNormalInt();
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $sql = <<<SQL
+select data_type
+from information_schema.COLUMNS
+where
+  TABLE_NAME='pim_catalog_completeness'
+  and COLUMN_NAME='id';
+SQL;
+        $result = $this->get('database_connection')
+            ->executeQuery($sql)
+            ->fetchColumn();
+
+        $this->assertEquals('bigint', $result);
+    }
+
+    private function ensureCompletenessUsesNormalInt(): void
+    {
+        $this->get('database_connection')->executeQuery(
+            "ALTER TABLE pim_catalog_completeness MODIFY id int AUTO_INCREMENT"
+        );
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

A migration has been forgot in this [PR ](https://github.com/akeneo/pim-community-dev/pull/14115) , it make the Onboarder test on migration failing, this PR add the missing migration on `pim_catalog_completeness` table

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
