### PR TITLE
PIM-9838: fix project completeness selection filter on product grid's bulk edit and quick export

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9838: fix project completeness selection filter on product grid's bulk edit and quick export
+
 # 4.0.108 (2021-05-10)
 
 # 4.0.107 (2021-05-03)

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-action.js
@@ -124,7 +124,8 @@ function(_, messenger, __, Dialog, AbstractAction) {
 
             if (state.parameters !== undefined && state.parameters.view !== undefined) {
                 result.view = {
-                    columns: state.parameters.view.columns
+                    columns: state.parameters.view.columns,
+                    id: state.parameters.view.id,
                 };
             }
 


### PR DESCRIPTION
Required change for : 
https://github.com/akeneo/pim-enterprise-dev/pull/10802

**Description (for Contributor and Core Developer)**

- Added view id as query parameter in mass action front side request
- Updated changelog

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
