### PR TITLE
PIM-9856: Fix children completeness query being too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - PIM-9850: Fix broken section title in DQI dashboard
 - PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format
 - PIM-9857: Fix Microgram & Microliter conversion operations
+- PIM-9856: Fix children completeness query being too long
 - PIM-9853: Make the word "product" translatable
 
 ## New features

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodes.php
@@ -168,25 +168,38 @@ SQL;
         }
 
         $sql = <<<SQL
-            SELECT 
+            SELECT
                 pm.code,
                 COUNT(p_child.id) AS nb_children,
                 SUM(IF(completeness.missing_count = 0, 1, 0)) AS nb_children_complete
-            FROM 
+            FROM
                 pim_catalog_product_model pm
                 LEFT JOIN pim_catalog_product_model pm_child ON pm_child.parent_id = pm.id
-                LEFT JOIN pim_catalog_product p_child ON (
-                    p_child.product_model_id = pm_child.id
-                    OR
-                    p_child.product_model_id = pm.id
-                )
+                LEFT JOIN pim_catalog_product p_child ON p_child.product_model_id = pm_child.id
                 LEFT JOIN pim_catalog_completeness completeness ON completeness.product_id = p_child.id
                 LEFT JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
                 LEFT JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id
             WHERE pm.code IN (:codes)
                 AND channel.code = :channel
                 AND locale.code = :locale
-            GROUP BY 
+            GROUP BY
+                pm.code
+            UNION
+            SELECT
+                pm.code,
+                COUNT(p_child.id) AS nb_children,
+                SUM(IF(completeness.missing_count = 0, 1, 0)) AS nb_children_complete
+            FROM
+                pim_catalog_product_model pm
+                LEFT JOIN pim_catalog_product_model pm_child ON pm_child.parent_id = pm.id
+                LEFT JOIN pim_catalog_product p_child ON p_child.product_model_id = pm.id
+                LEFT JOIN pim_catalog_completeness completeness ON completeness.product_id = p_child.id
+                LEFT JOIN pim_catalog_channel channel ON channel.id = completeness.channel_id
+                LEFT JOIN pim_catalog_locale locale ON locale.id = completeness.locale_id
+            WHERE pm.code IN (:codes)
+                AND channel.code = :channel
+                AND locale.code = :locale
+            GROUP BY
                 pm.code
 SQL;
         $rows = $this->connection->executeQuery(


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Splitting the `OR` in `JOIN` predicate into two queries with a `UNION` to be able to perform an index seek

**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
