### PR TITLE
PIM-9741: Fix choice filter mask not closing when selecting with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PIM-9827: Fix HTTP 500 when using POST/PATCH with incorrect format
 - PIM-9857: Fix Microgram & Microliter conversion operations
 - PIM-9853: Make the word "product" translatable
+- PIM-9741: Fix choice filter mask not closing when selecting with keyboard
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
@@ -232,5 +232,13 @@ define([
 
       return formattedChoices;
     },
+
+    /**
+     * {@inheritdoc}
+     */
+    _hideCriteria: function () {
+      TextFilter.prototype._hideCriteria.apply(this, arguments);
+      this.$(this.criteriaValueSelectors.value).select2('close');
+    },
   });
 });


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Forcing the select2 container to be closed when hiding filter choice criteria

**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
