### PR TITLE
PLG-200: Fix states reset after moving a category

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
@@ -30,6 +30,7 @@ type CategoryTreeState = {
   setHoveredCategory: (data: HoveredCategory | null) => void;
   moveTarget: MoveTarget | null;
   setMoveTarget: (data: MoveTarget | null) => void;
+  onMove: () => void;
 };
 
 const CategoryTreeContext = createContext<CategoryTreeState>({
@@ -41,6 +42,7 @@ const CategoryTreeContext = createContext<CategoryTreeState>({
   setHoveredCategory: () => {},
   moveTarget: null,
   setMoveTarget: () => {},
+  onMove: () => {},
 });
 
 type Props = {
@@ -58,6 +60,12 @@ const CategoryTreeProvider: FC<Props> = ({children, root}) => {
   const [draggedCategory, setDraggedCategory] = useState<DraggedCategory | null>(null);
   const [hoveredCategory, setHoveredCategory] = useState<HoveredCategory | null>(null);
   const [moveTarget, setMoveTarget] = useState<MoveTarget | null>(null);
+
+  const onMove = () => {
+    setDraggedCategory(null);
+    setHoveredCategory(null);
+    setMoveTarget(null);
+  };
 
   useEffect(() => {
     if (draggedCategory === null || draggedCategory.status !== 'pending') {
@@ -87,6 +95,7 @@ const CategoryTreeProvider: FC<Props> = ({children, root}) => {
     setHoveredCategory,
     moveTarget,
     setMoveTarget,
+    onMove
   };
   return <CategoryTreeContext.Provider value={state}>{children}</CategoryTreeContext.Provider>;
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
@@ -7,7 +7,6 @@ import {Button} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
 import {useCountProductsBeforeDeleteCategory} from '../../../hooks';
 import {NodePreview} from './NodePreview';
-import {move} from 'formik';
 
 type Props = {
   id: number;
@@ -34,6 +33,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
     getCategoryPosition,
     moveTarget,
     setMoveTarget,
+    onMove,
     onDeleteCategory,
   } = useCategoryTreeNode(id);
 
@@ -152,7 +152,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
       // }}
       onDrop={async () => {
         if (draggedCategory && moveTarget && draggedCategory.identifier !== moveTarget.identifier) {
-          moveTo(draggedCategory.identifier, moveTarget);
+          moveTo(draggedCategory.identifier, moveTarget, onMove);
 
           /*
             @todo pass the moveCategory as a props in CategoryTree
@@ -165,17 +165,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
             // @todo what we have to do if the callback fails? keep original position
             console.log(moveSuccess);
            */
-
-          // @todo: why onDragEnd is not fired when moving "in"?
-          setDraggedCategory(null);
-          setHoveredCategory(null);
-          setMoveTarget(null);
         }
-      }}
-      onDragEnd={() => {
-        setDraggedCategory(null);
-        setHoveredCategory(null);
-        setMoveTarget(null);
       }}
     >
       {(addCategory || deleteCategory) && (

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/NodePreview.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/NodePreview.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const NodePreview: FC<Props> = ({id}) => {
-  const {node, draggedCategory, moveTarget, moveTo} = useCategoryTreeNode(id);
+  const {node, draggedCategory, moveTarget, moveTo, onMove} = useCategoryTreeNode(id);
 
   if (node === undefined) {
     return null;
@@ -21,8 +21,7 @@ const NodePreview: FC<Props> = ({id}) => {
       selected={true}
       onDrop={() => {
         if (draggedCategory && moveTarget && draggedCategory.identifier !== moveTarget.identifier) {
-          moveTo(draggedCategory.identifier, moveTarget);
-          // @todo persist in backend
+          moveTo(draggedCategory.identifier, moveTarget, onMove);
         }
       }}
     />

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
@@ -14,6 +14,7 @@ type Move = {
   identifier: number;
   target: MoveTarget;
   status: 'pending' | 'ready';
+  onMove: () => void;
 };
 
 const useCategoryTreeNode = (id: number) => {
@@ -43,7 +44,7 @@ const useCategoryTreeNode = (id: number) => {
   };
 
   const moveTo = useCallback(
-    (movedCategoryId: number, target: MoveTarget) => {
+    (movedCategoryId: number, target: MoveTarget, onMove: () => void) => {
       const targetParentNode = findOneByIdentifier(
         nodes,
         target.position === 'in' ? target.identifier : target.parentId
@@ -61,6 +62,7 @@ const useCategoryTreeNode = (id: number) => {
           target.position === 'in' && targetParentNode.type === 'node' && targetParentNode.childrenStatus === 'idle'
             ? 'pending'
             : 'ready',
+        onMove,
       });
     },
     [nodes]
@@ -146,6 +148,7 @@ const useCategoryTreeNode = (id: number) => {
       // call callback to save it in backend
       // what we have to do if the callback fails? keep original position
 
+      move.onMove();
       setMove(null);
     },
     [nodes]


### PR DESCRIPTION
Wrap the reset of the states `draggedCategory`, `hoveredCategory` and `moveTarget` to be sure that it will be called when a category has been moved.

They were called in `onDrop` and `onDragEnd` but because of the previews, they were not called for some cases.