### PR TITLE
PLG-200: Reset states when invalid move

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
@@ -30,7 +30,7 @@ type CategoryTreeState = {
   setHoveredCategory: (data: HoveredCategory | null) => void;
   moveTarget: MoveTarget | null;
   setMoveTarget: (data: MoveTarget | null) => void;
-  onMove: () => void;
+  resetMove: () => void;
 };
 
 const CategoryTreeContext = createContext<CategoryTreeState>({
@@ -42,7 +42,7 @@ const CategoryTreeContext = createContext<CategoryTreeState>({
   setHoveredCategory: () => {},
   moveTarget: null,
   setMoveTarget: () => {},
-  onMove: () => {},
+  resetMove: () => {},
 });
 
 type Props = {
@@ -61,7 +61,7 @@ const CategoryTreeProvider: FC<Props> = ({children, root}) => {
   const [hoveredCategory, setHoveredCategory] = useState<HoveredCategory | null>(null);
   const [moveTarget, setMoveTarget] = useState<MoveTarget | null>(null);
 
-  const onMove = () => {
+  const resetMove = () => {
     setDraggedCategory(null);
     setHoveredCategory(null);
     setMoveTarget(null);
@@ -95,7 +95,7 @@ const CategoryTreeProvider: FC<Props> = ({children, root}) => {
     setHoveredCategory,
     moveTarget,
     setMoveTarget,
-    onMove
+    resetMove
   };
   return <CategoryTreeContext.Provider value={state}>{children}</CategoryTreeContext.Provider>;
 };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
@@ -33,7 +33,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
     getCategoryPosition,
     moveTarget,
     setMoveTarget,
-    onMove,
+    resetMove,
     onDeleteCategory,
   } = useCategoryTreeNode(id);
 
@@ -151,8 +151,8 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
       // so that we can handle the
       // }}
       onDrop={async () => {
-        if (draggedCategory && moveTarget && draggedCategory.identifier !== moveTarget.identifier) {
-          moveTo(draggedCategory.identifier, moveTarget, onMove);
+        if (draggedCategory && moveTarget) {
+          moveTo(draggedCategory.identifier, moveTarget, resetMove);
 
           /*
             @todo pass the moveCategory as a props in CategoryTree
@@ -167,6 +167,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
            */
         }
       }}
+      onDragEnd={() => resetMove()}
     >
       {(addCategory || deleteCategory) && (
         <Tree.Actions key={`category-actions-${id}`}>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/NodePreview.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/NodePreview.tsx
@@ -7,7 +7,7 @@ type Props = {
 };
 
 const NodePreview: FC<Props> = ({id}) => {
-  const {node, draggedCategory, moveTarget, moveTo, onMove} = useCategoryTreeNode(id);
+  const {node, draggedCategory, moveTarget, moveTo, resetMove} = useCategoryTreeNode(id);
 
   if (node === undefined) {
     return null;
@@ -20,8 +20,8 @@ const NodePreview: FC<Props> = ({id}) => {
       isLeaf={node.type === 'leaf'}
       selected={true}
       onDrop={() => {
-        if (draggedCategory && moveTarget && draggedCategory.identifier !== moveTarget.identifier) {
-          moveTo(draggedCategory.identifier, moveTarget, onMove);
+        if (draggedCategory && moveTarget) {
+          moveTo(draggedCategory.identifier, moveTarget, resetMove);
         }
       }}
     />

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
@@ -75,6 +75,10 @@ const useCategoryTreeNode = (id: number) => {
         return;
       }
 
+      if (identifier === target.identifier) {
+        return;
+      }
+
       const movedNode = findOneByIdentifier(nodes, identifier);
       if (!movedNode) {
         console.error(`Node ${identifier} not found`);
@@ -147,9 +151,6 @@ const useCategoryTreeNode = (id: number) => {
 
       // call callback to save it in backend
       // what we have to do if the callback fails? keep original position
-
-      move.onMove();
-      setMove(null);
     },
     [nodes]
   );
@@ -242,6 +243,9 @@ const useCategoryTreeNode = (id: number) => {
 
     if (move.status === 'ready') {
       doMove(move);
+      move.onMove();
+      setMove(null);
+
       return;
     }
   }, [move]);


### PR DESCRIPTION
The reset of the "drag" states must also be done when a move is invalid (in itself, outside the tree, etc...) or when an error occurred during the move.