### PR TITLE
FixturesLoader cache fixtures with column names

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -401,6 +401,7 @@ class FixturesLoader implements FixturesLoaderInterface
             '--quick',
             '--skip-add-locks',
             '--skip-disable-keys',
+            '--complete-insert',
             $this->databaseName,
             '> '.$filepath,
         ]);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

**TL;DR** mysqldump bad; always specify the columns when inserting data.

**What happened ?**

While working on #14443,

first, we added a new column to the entity `Category`.
see https://github.com/akeneo/pim-community-dev/pull/14443/commits/1e879a806abfe50c9c5e9d2ed565ebcbe3d9ddfb#diff-8d43e73c3b47b8dbbf8f530d66a4a8c96790f2f3bae7396afe36b7bfa1c8934aR33-R41

then, we added the corresponding migration.
see https://github.com/akeneo/pim-community-dev/pull/14443/commits/1e879a806abfe50c9c5e9d2ed565ebcbe3d9ddfb#diff-47b029001315fb1029e5bd63811e76285fe629ff49ea622e7be77382cbca9fccR16-R20

Everything was working as expected, the CI was green.
Then, another unrelated migration has been merged earlier today, and after rebasing, this migration was now failing in our PR's CI with a new error.

```
TypeError: Typed property Akeneo\Pim\Enrichment\Component\Category\Model\Category::$updated must be an instance of DateTime, null used
```
It was theoretically impossible, this new column has a default value configured in mysql and in the code, and we writed enough tests to be sure of it.

It was only happening when using the FixturesLoader for the integration tests...

**Why ?**

When running integration tests and loading a catalog, a SQL dump is cached after the first import.
In the following tests, the SQL dump is then directly imported instead of loading the fixtures from csv files. (it's faster)

In the produced dump, our table is like this:
```
INSERT INTO `pim_catalog_category` VALUES (3,NULL,'master','2021-05-11 16:53:53','2021-05-11 16:53:53',3,0,1,12),(4,3,'categoryA','2021-05-11 16:53:53','2021-05-11 16:53:53',3,1,2,7),(5,4,'categoryA1','2021-05-11 16:53:53','2021-05-11 16:53:53',3,2,3,4),(6,4,'categoryA2','2021-05-11 16:53:53','2021-05-11 16:53:53',3,2,5,6),(7,3,'categoryB','2021-05-11 16:53:53','2021-05-11 16:53:53',3,1,8,9),(8,3,'categoryC','2021-05-11 16:53:53','2021-05-11 16:53:53',3,1,10,11),(9,NULL,'master_china','2021-05-11 16:53:53','2021-05-11 16:53:53',9,0,1,2);
```

But the database is like this:
![Screenshot_2021-05-11_19-06-55](https://user-images.githubusercontent.com/1421130/117864463-1e1cb080-b295-11eb-8b8b-2284c9108652.png)

As you can guess with `2021` in the `root` column and the actual `updated` column, the rows are inserted with an incorrect order of columns !

**What really happened ?**

By updating the doctrine entity schema, the new column was inserted after `created`.
The migration was inserting it at the end of the table.
Depending of which code was creating the column, it was not the same position and the SQL dump was not guarantee to work.

We fixed our migration to insert the column at the correct position.

To avoid such cryptic issues in the future, I'm proposing the option `--complete-insert` with `mysqldump` so the columns are specified in the SQL dump.

It look like this now:
```
INSERT INTO `pim_catalog_category` (`id`, `parent_id`, `code`, `created`, `updated`, `root`, `lvl`, `lft`, `rgt`) VALUES (2,NULL,'master','2021-05-11 17:45:54','2021-05-11 17:45:54',2,0,1,12),(3,2,'categoryA','2021-05-11 17:45:54','2021-05-11 17:45:54',2,1,2,7),(4,3,'categoryA1','2021-05-11 17:45:54','2021-05-11 17:45:54',2,2,3,4),(5,3,'categoryA2','2021-05-11 17:45:54','2021-05-11 17:45:54',2,2,5,6),(6,2,'categoryB','2021-05-11 17:45:54','2021-05-11 17:45:54',2,1,8,9),(7,2,'categoryC','2021-05-11 17:45:54','2021-05-11 17:45:54',2,1,10,11),(8,NULL,'master_china','2021-05-11 17:45:54','2021-05-11 17:45:54',8,0,1,2);
```
Same but safer.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
