### PR TITLE
PLG-240: Open node when a new category is created inside

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
@@ -9,7 +9,7 @@ import React, {
   useState,
 } from 'react';
 import styled, {css} from 'styled-components';
-import {AkeneoThemedProps, getColor, RowIcon, useBooleanState} from 'akeneo-design-system';
+import {AkeneoThemedProps, getColor, RowIcon} from 'akeneo-design-system';
 import {TreeNode} from '../../../models';
 import {
   ArrowButton,
@@ -69,6 +69,9 @@ type TreeProps<T> = {
   selected?: boolean;
   isLoading?: boolean;
   readOnly?: boolean;
+  isOpen?: boolean;
+  open?: () => void;
+  close?: () => void;
   onOpen?: (value: TreeNode<T>) => void;
   onClose?: (value: TreeNode<T>) => void;
   onChange?: (value: TreeNode<T>, checked: boolean, event: SyntheticEvent) => void;
@@ -93,6 +96,9 @@ const Tree = <T,>({
   selected = false,
   isLoading = false,
   readOnly = false,
+  isOpen = false,
+  open,
+  close,
   onChange,
   onOpen,
   onClose,
@@ -124,22 +130,27 @@ const Tree = <T,>({
 
   const dragRef = useRef<HTMLDivElement>(null);
   const treeRowRef = useRef<HTMLDivElement>(null);
-  const [isOpen, open, close] = useBooleanState(_isRoot);
   const [timer, setTimer] = useState<number | null>(null);
 
   const handleOpen = useCallback(() => {
+    if (open === undefined) {
+      return;
+    }
     open();
     if (onOpen) {
       onOpen(value);
     }
-  }, [onOpen, value]);
+  }, [open, onOpen, value]);
 
   const handleClose = useCallback(() => {
+    if (close === undefined) {
+      return;
+    }
     close();
     if (onClose) {
       onClose(value);
     }
-  }, [onClose, value]);
+  }, [close, onClose, value]);
 
   const handleArrowClick = useCallback(
     event => {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/tree/categories/Node.tsx
@@ -21,7 +21,6 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
     node,
     children,
     loadChildren,
-    forceReloadChildren,
     moveTo,
     draggedCategory,
     setDraggedCategory,
@@ -32,6 +31,10 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
     setMoveTarget,
     resetMove,
     onDeleteCategory,
+    onCreateCategory,
+    isOpen,
+    open,
+    close,
   } = useCategoryTreeNode(id);
 
   const translate = useTranslate();
@@ -68,6 +71,9 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
             : 'bottom'
           : undefined
       }
+      isOpen={node.type === 'root' ? true : isOpen}
+      open={open}
+      close={close}
       onOpen={async () => {
         if (node.childrenStatus !== 'idle') {
           return;
@@ -141,7 +147,7 @@ const Node: FC<Props> = ({id, label, followCategory, addCategory, deleteCategory
               size="small"
               onClick={event => {
                 event.stopPropagation();
-                addCategory(node.data.code, forceReloadChildren);
+                addCategory(node.data.code, onCreateCategory);
               }}
             >
               {translate('pim_enrich.entity.category.new_category')}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
@@ -10,6 +10,7 @@ import {
 import {findByIdentifiers, findLoadedDescendantsIdentifiers, findOneByIdentifier, update} from '../../helpers';
 import {useFetch, useRoute} from '@akeneo-pim-community/shared';
 import {moveCategory} from '../../infrastructure/savers';
+import {useBooleanState} from 'akeneo-design-system';
 
 type Move = {
   identifier: number;
@@ -23,6 +24,7 @@ const useCategoryTreeNode = (id: number) => {
   const [node, setNode] = useState<TreeNode<CategoryTreeModel> | undefined>(undefined);
   const [children, setChildren] = useState<TreeNode<CategoryTreeModel>[]>([]);
   const [move, setMove] = useState<Move | null>(null);
+  const [isOpen, open, close] = useBooleanState(false);
 
   const url = useRoute('pim_enrich_categorytree_children', {
     _format: 'json',
@@ -205,9 +207,11 @@ const useCategoryTreeNode = (id: number) => {
     setNodes(update(updatedNodes, updatedParent));
   };
 
-  const forceReloadChildren = useCallback(() => {
+  // When a category is created inside the node, force reload children and open it.
+  const onCreateCategory = useCallback(() => {
     if (node) {
       setNode({...node, childrenStatus: 'to-reload'});
+      open();
     }
   }, [node]);
 
@@ -291,10 +295,13 @@ const useCategoryTreeNode = (id: number) => {
     node,
     children,
     loadChildren,
-    forceReloadChildren,
     moveTo,
     getCategoryPosition,
     onDeleteCategory,
+    onCreateCategory,
+    isOpen,
+    open,
+    close,
     ...rest,
   };
 };


### PR DESCRIPTION
I moved the boolean state `isOpen` in the hook to be able to change it when a category is created.

![open-node-on-create-category](https://user-images.githubusercontent.com/26378046/117980322-25df6200-b334-11eb-9880-cede8223d9e8.gif)
