### PR TITLE
PLG-250: Apply permission on delete category tree

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/categories/CategoryTreeDataGrid.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/categories/CategoryTreeDataGrid.tsx
@@ -142,15 +142,17 @@ const CategoryTreesDataGrid: FC<Props> = ({trees, refreshCategoryTrees}) => {
                       )}
                   </Table.Cell>
                   <TableActionCell>
-                    <Button
-                      ghost
-                      level="danger"
-                      size={'small'}
-                      onClick={() => onDeleteCategoryTree(tree)}
-                      disabled={!tree.hasOwnProperty('productsNumber')}
-                    >
-                      {translate('pim_common.delete')}
-                    </Button>
+                    {isGranted('pim_enrich_product_category_remove') && (
+                      <Button
+                        ghost
+                        level="danger"
+                        size={'small'}
+                        onClick={() => onDeleteCategoryTree(tree)}
+                        disabled={!tree.hasOwnProperty('productsNumber')}
+                      >
+                        {translate('pim_common.delete')}
+                      </Button>
+                    )}
                   </TableActionCell>
                 </Table.Row>
               ))}


### PR DESCRIPTION
Hide the button `Delete` on the new category trees data-grid when the user hasn't the permission to remove a category.