### PR TITLE
Fixed: Typo

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save-form.js
@@ -79,7 +79,7 @@ define([
         if (this.config.identifierParamName === 'undefined') {
           identifierProperty = undefined;
         } else {
-          identifierProperty = this.configure.identifierParamName;
+          identifierProperty = this.config.identifierParamName;
         }
       }
       const entityId = propertyAccessor.accessProperty(this.getFormData(), entityIdProperty, '');


### PR DESCRIPTION
Fixed a typo causing `identifierProperty` always be `identifier`, even when `identifierParamName: code` specified at `config`.