### PR TITLE
PIM-9864: Fix 500 error when using DateTime filter with invalid value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@
 - PIM-9857: Fix Microgram & Microliter conversion operations
 - PIM-9853: Make the word "product" translatable
 - PIM-9741: Fix choice filter mask not closing when selecting with keyboard
-- PIM-9806: Enable authentication temporary lock to protect against brute force attack 
+- PIM-9806: Enable authentication temporary lock to protect against brute force attack
+- PIM-9864: Fix 500 error when using DateTime filter with invalid value
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/DateTimeFilter.php
@@ -248,8 +248,8 @@ class DateTimeFilter extends AbstractFieldFilter implements FieldFilterInterface
 
                 break;
             case Operators::SINCE_LAST_N_DAYS:
-                if (!is_numeric($value)) {
-                    throw InvalidPropertyTypeException::numericExpected($field, static::class, $value);
+                if (!is_int($value)) {
+                    throw InvalidPropertyTypeException::integerExpected($field, static::class, $value);
                 }
 
                 break;

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/DateTimeFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/DateTimeFilterSpec.php
@@ -457,17 +457,25 @@ class DateTimeFilterSpec extends ObjectBehavior
         )->during('addFieldFilter', ['created', Operators::SINCE_LAST_JOB, false]);
     }
 
-    function it_throws_an_exception_when_the_given_value_is_not_a_numeric(SearchQueryBuilder $sqb)
+    function it_throws_an_exception_when_the_given_value_is_not_a_integer(SearchQueryBuilder $sqb)
     {
         $this->setQueryBuilder($sqb);
 
         $this->shouldThrow(
-            InvalidPropertyTypeException::numericExpected(
+            InvalidPropertyTypeException::integerExpected(
                 'created',
                 DateTimeFilter::class,
                 false
             )
         )->during('addFieldFilter', ['created', Operators::SINCE_LAST_N_DAYS, false]);
+
+        $this->shouldThrow(
+            InvalidPropertyTypeException::integerExpected(
+                'updated',
+                DateTimeFilter::class,
+                0.25
+            )
+        )->during('addFieldFilter', ['updated', Operators::SINCE_LAST_N_DAYS, 0.25]);
     }
 
     function it_throws_an_exception_when_it_filters_on_an_unsupported_operator(SearchQueryBuilder $sqb)


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Replacing the `is_numeric` by a `is_int` as the filter only accepts integers.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
