### PR TITLE
PLG-248: Fix move category in another ones

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
@@ -199,7 +199,7 @@ const Tree = <T,>({
         }}
         onDragEnter={() => {
           // @fixme does not work when the user enter in a sub element of the row
-          if (!isLeaf) {
+          if (!isLeaf && !disabled) {
             if (timer) {
               return;
             }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
@@ -280,7 +280,7 @@ const Tree = <T,>({
           <TreeIcon isLoading={isLoading} isLeaf={isLeaf && !selected} selected={selected} />
           {label}
         </RowInnerContainer>
-        {actions && <RowActionsContainer>{actions}</RowActionsContainer>}
+        {actions && !disabled && <RowActionsContainer>{actions}</RowActionsContainer>}
       </TreeRow>
       {isOpen && !isLeaf && subTrees.length > 0 && (
         <SubTreesContainer role="group">

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/shared/tree/Tree.tsx
@@ -274,10 +274,10 @@ const Tree = <T,>({
               <RowIcon size={16} shapeRendering="crispEdges" />
             </DragInitiator>
           )}
-          <ArrowButton disabled={isLeaf} role="button" onClick={handleArrowClick}>
-            {!isLeaf && <TreeArrowIcon $isFolderOpen={isOpen} size={14} />}
+          <ArrowButton disabled={isLeaf && !selected} role="button" onClick={handleArrowClick}>
+            {(!isLeaf || selected) && <TreeArrowIcon $isFolderOpen={isOpen} size={14} />}
           </ArrowButton>
-          <TreeIcon isLoading={isLoading} isLeaf={isLeaf} selected={selected} />
+          <TreeIcon isLoading={isLoading} isLeaf={isLeaf && !selected} selected={selected} />
           {label}
         </RowInnerContainer>
         {actions && <RowActionsContainer>{actions}</RowActionsContainer>}


### PR DESCRIPTION
1. Display a leaf as a node when another category is over (to be dropped in)
![Drop-category-in-leaf](https://user-images.githubusercontent.com/26378046/118499109-eb583980-b726-11eb-806e-f329a55f7ae4.gif)

2. Hide the actions (`Create` and `Delete`) when a category is dragged
![Hide-action-on-drag](https://user-images.githubusercontent.com/26378046/118499404-307c6b80-b727-11eb-89ff-761f42c75113.gif)

3. Do not open a node when it's dragged
![Drag-node-over-itself](https://user-images.githubusercontent.com/26378046/118499825-923cd580-b727-11eb-9e69-89920819e31b.gif)
