### PR TITLE
PIM-9777: Fix error message when trying to delete an attribute linked to an entity

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9777: Fix error message when trying to delete an attribute linked to an entity
+
 # 4.0.107 (2021-05-03)
 
 ## Bug fixes

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/delete-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/delete-action.js
@@ -102,7 +102,7 @@ define([
     showErrorFlashMessage: function(response) {
       let message = '';
 
-      if (typeof response === 'string') {
+      if (typeof response === 'string' && response !== "") {
         message = response;
       } else {
         try {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When trying to delete an attribute - linked to a specific entity - in the attribute grid, the message displayed in the flash message was `error.removing.attribute`
As decided with Charlélie and Steven, I made the message displayed to be the same as the one displayed when trying to remove an attribute directly from the attribute page.

I had to add a condition so that when `response = ""`, we don't pass in the `if` and the exception is thrown correctly.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
