### PR TITLE
CXP-693: Remove AFTER column from category:updated migration

### DIFF
--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
@@ -31,6 +31,9 @@ class CategorySaverIntegration extends TestCase
         $persistedCategory = $this->getCategoryRepository()->findOneByIdentifier('foo');
         $persistedNormalizedCategory = $this->getCategoryNormalizer()->normalize($persistedCategory);
 
+        NormalizedCategoryCleaner::clean($createdNormalizedCategory);
+        NormalizedCategoryCleaner::clean($persistedNormalizedCategory);
+
         self::assertEquals($createdNormalizedCategory, $persistedNormalizedCategory);
     }
 

--- a/upgrades/schema/Version_6_0_20210505180000_add_updated_to_category.php
+++ b/upgrades/schema/Version_6_0_20210505180000_add_updated_to_category.php
@@ -15,7 +15,7 @@ final class Version_6_0_20210505180000_add_updated_to_category extends AbstractM
 {
     public function up(Schema $schema): void
     {
-        $this->addSql("ALTER TABLE pim_catalog_category ADD updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '(DC2Type:datetime)' AFTER created");
+        $this->addSql("ALTER TABLE pim_catalog_category ADD updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '(DC2Type:datetime)'");
         $this->addSql("UPDATE pim_catalog_category SET updated = created");
         $this->addSql("CREATE INDEX updated_idx ON pim_catalog_category (updated)");
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The migration introduced in https://github.com/akeneo/pim-community-dev/pull/14443 is taking too long for one customer, due to the `AFTER`.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
