### PR TITLE
PIM-9869: Fix download log in job tracker is only available when log is located in the fpm server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PIM-9741: Fix choice filter mask not closing when selecting with keyboard
 - PIM-9806: Enable authentication temporary lock to protect against brute force attack
 - PIM-9864: Fix 500 error when using DateTime filter with invalid value
+- PIM-9869: Fix download log in job tracker is only available when log is located in the fpm server
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -56,6 +56,7 @@ services:
             - '@pim_enrich.repository.job_execution'
             - '@pim_internal_api_serializer'
             - '@oro_security.security_facade'
+            - '@oneup_flysystem.archivist_filesystem'
             - {'import': 'pim_importexport_import_execution_show', 'export': 'pim_importexport_export_execution_show'}
 
     pim_enrich.controller.job_tracker:

--- a/src/Akeneo/Tool/Component/Connector/LogKey.php
+++ b/src/Akeneo/Tool/Component/Connector/LogKey.php
@@ -23,10 +23,6 @@ final class LogKey
         if (empty($jobExecution->getLogFile())) {
             throw new \InvalidArgumentException('The log file should not be empty');
         }
-
-        if (!is_file($jobExecution->getLogFile())) {
-            throw new \InvalidArgumentException('The log should exists.');
-        }
     }
 
     public function __toString(): string

--- a/src/Akeneo/Tool/Component/Connector/spec/LogKeySpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/LogKeySpec.php
@@ -15,12 +15,6 @@ class LogKeySpec extends ObjectBehavior
         $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
     }
 
-    function it_fails_when_log_file_does_not_exist()
-    {
-        $this->beConstructedWith((new JobExecution())->setLogFile('/does/not/exist'));
-        $this->shouldThrow(InvalidArgumentException::class)->duringInstantiation();
-    }
-
     function it_is_a_key_built_from_a_job_execution()
     {
         $importInstance = new JobInstance(null, JobInstance::TYPE_IMPORT, 'csv_import');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
The download log is not present in cloud version because we called file_exist function. 

The file does not exist because the file generated is present in the pim-daemon-server not in the fpm-server. Now we use the filesystem dedicated to the log and check if the file exist.

We only check if there is a logFile related to the JobExecution because when the job is not started the jobFile is empty.
I remove the `is_file($jobExecution->getLogFile()` statement because it required that the file is located in the same server. The \Akeneo\Tool\Component\Connector\LogArchiver already check this.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
