### PR TITLE
RAC-717: Fix dsm deployment in https://akeneo.github.io/akeneo-design-system/

### DIFF
--- a/front-packages/akeneo-design-system/.github/workflows/deploy.yml
+++ b/front-packages/akeneo-design-system/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           node-version: 13.13
 
+      - name: Install peer dependencies
+        # TODO RAC-594 Do not used fixed peer dependencies
+        run: yarn add --dev react@^16.14.0 react-dom@^16.9.12 styled-components@^5.1.1
+
       - name: Install node modules
         run: yarn install
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Since we moved react to peer dependencies the dsm is not deployed on github.io after merge cf: https://github.com/akeneo/akeneo-design-system/runs/2611873575.

This PR fix this by adding fixed peer dependencies while we found a better way to do this
<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
