### PR TITLE
PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - PIM-9869: Fix download log in job tracker is only available when log is located in the fpm server
 - PIM-9777: Fix error message when trying to delete an attribute linked to an entity
 - PIM-9873: Fix since last n day filter in product export
+- PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Component/Remover/FamilyRemover.php
+++ b/src/Akeneo/Pim/Structure/Component/Remover/FamilyRemover.php
@@ -56,12 +56,13 @@ class FamilyRemover implements RemoverInterface
         $this->ensureFamilyHasNoVariants($family);
         $this->ensureFamilyHasNoProducts($family);
 
-        $this->sendEvent($family, StorageEvents::PRE_REMOVE);
+        $familyId = $family->getId();
+        $this->sendEvent($family, $familyId, StorageEvents::PRE_REMOVE);
 
         $this->objectManager->remove($family);
         $this->objectManager->flush();
 
-        $this->sendEvent($family, StorageEvents::POST_REMOVE);
+        $this->sendEvent($family, $familyId, StorageEvents::POST_REMOVE);
     }
 
     private function ensureIsFamily($family): void
@@ -104,16 +105,10 @@ class FamilyRemover implements RemoverInterface
         }
     }
 
-    /**
-     * @param FamilyInterface $family
-     * @param string $event
-     *
-     * @return void
-     */
-    private function sendEvent(FamilyInterface $family, string $event): void
+    private function sendEvent(FamilyInterface $family, int $familyId, string $event): void
     {
         $this->eventDispatcher->dispatch(
-            new RemoveEvent($family, $family->getId(), ['unitary' => true]),
+            new RemoveEvent($family, $familyId, ['unitary' => true]),
             $event
         );
     }

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
@@ -75,12 +75,15 @@ class BaseRemover implements RemoverInterface, BulkRemoverInterface
 
         $this->eventDispatcher->dispatch(new RemoveEvent($objects, null), StorageEvents::PRE_REMOVE_ALL);
 
-        $removedObjects = [];
         foreach ($objects as $object) {
             $this->validateObject($object);
-            $removedObjects[$object->getId()] = $object;
 
             $this->eventDispatcher->dispatch(new RemoveEvent($object, $object->getId(), $options), StorageEvents::PRE_REMOVE);
+        }
+
+        $removedObjects = [];
+        foreach ($objects as $object) {
+            $removedObjects[$object->getId()] = $object;
 
             $this->objectManager->remove($object);
         }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
@@ -64,7 +64,7 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            StorageEvents::PRE_REMOVE => 'addRemoveVersion',
+            StorageEvents::POST_REMOVE => 'addRemoveVersion',
         ];
     }
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddRemoveVersionSubscriberSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddRemoveVersionSubscriberSpec.php
@@ -37,7 +37,7 @@ class AddRemoveVersionSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_post_remove_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::PRE_REMOVE => 'addRemoveVersion',
+            StorageEvents::POST_REMOVE => 'addRemoveVersion',
         ]);
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When we remove multiple objects we dispatch event PRE_REMOVE, handlers can throw exception in this case the remove process is stopped but the entity are always in the the unit of work so when we flushed the unit of work (for example when we save the JobExecution) the product are remove but the POST_REMOVE is not triggered.

In this PR, I also changed the event listened by the AddRemoveVersionSubscriber because it create a version while the product is not really removed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
