### PR TITLE
Fixed a wrongly formatted placeholder in a message for quantified associations

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.fr_FR.yml
@@ -97,7 +97,7 @@ pim_enrich.entity.product:
       show_products: Afficher les produits
       show_groups: Afficher les groupes
       number_of_associations: "{{ productCount }} produit(s), {{ productModelCount }} modèle(s) de produit et {{ groupCount }} groupe(s)"
-      number_of_quantified_associations: "{ productCount }} produit(s) and {{ productModelCount }} modèle(s) de produit"
+      number_of_quantified_associations: "{{ productCount }} produit(s) and {{ productModelCount }} modèle(s) de produit"
       association_type_selector: Type d'association
       target: Destination
       manage: Ajouter des associations {{ associationType }}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

A small wording fix, on quantified association page : 

![image](https://user-images.githubusercontent.com/2323369/118990905-91a07b00-b983-11eb-9754-18d10e95036e.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
