### PR TITLE
API-1598: Fix random test not detected earlier

### DIFF
--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/CategorySaverIntegration.php
@@ -31,6 +31,9 @@ class CategorySaverIntegration extends TestCase
         $persistedCategory = $this->getCategoryRepository()->findOneByIdentifier('foo');
         $persistedNormalizedCategory = $this->getCategoryNormalizer()->normalize($persistedCategory);
 
+        NormalizedCategoryCleaner::clean($createdNormalizedCategory);
+        NormalizedCategoryCleaner::clean($persistedNormalizedCategory);
+
         self::assertEquals($createdNormalizedCategory, $persistedNormalizedCategory);
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The changes done on https://github.com/akeneo/pim-community-dev/pull/14466 made this test random, due to the randomness of the datetime used.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
