### PR TITLE
CXP-628: decouple events api limit increment

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestFailedEvent.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestFailedEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Akeneo\Connectivity\Connection\Domain\Webhook\Event;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EventsApiRequestFailedEvent
+{
+}

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestFailedEvent.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestFailedEvent.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Connectivity\Connection\Domain\Webhook\Event;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class EventsApiRequestFailedEvent
+final class EventsApiRequestFailedEvent
 {
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
@@ -1,11 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Connectivity\Connection\Domain\Webhook\Event;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class EventsApiRequestSucceededEvent
+final class EventsApiRequestSucceededEvent
 {
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Akeneo\Connectivity\Connection\Domain\Webhook\Event;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EventsApiRequestSucceededEvent
+{
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriber.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
+
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\EventsApiRequestFailedEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\EventsApiRequestSucceededEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiRequestCountRepository;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class EventsApiRequestsLimitIncrementSubscriber implements EventSubscriberInterface
+{
+    private EventsApiRequestCountRepository $repository;
+    private int $count;
+
+    public function __construct(EventsApiRequestCountRepository $repository)
+    {
+        $this->repository = $repository;
+        $this->count = 0;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            EventsApiRequestSucceededEvent::class => 'incrementRequestCount',
+            EventsApiRequestFailedEvent::class => 'incrementRequestCount',
+            MessageProcessedEvent::class => 'saveRequestCount',
+        ];
+    }
+
+    public function incrementRequestCount(): int
+    {
+        return ++$this->count;
+    }
+
+    public function saveRequestCount(): void
+    {
+        if (0 === $this->count) {
+            return;
+        }
+
+        $this->repository->upsert(new \DateTimeImmutable('now', new \DateTimeZone('UTC')), $this->count);
+        $this->count = 0;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/event_subscribers.yml
@@ -29,6 +29,12 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitIncrementSubscriber:
+        arguments:
+            - '@akeneo_connectivity.connection.persistence.repository.events_api_request_count'
+        tags:
+            - { name: kernel.event_subscriber }
+
     Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiClearCacheSubscriber:
         arguments:
             - '@akeneo_connectivity.connection.webhook.cache_clearer'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -102,7 +102,6 @@ services:
             - '@akeneo_connectivity.connection.webhook.webhook_event_builder'
             - '@monolog.logger.event_api'
             - '@akeneo_connectivity.connection.webhook.events_api_debug_logger'
-            - '@akeneo_connectivity.connection.persistence.repository.events_api_request_count'
             - '%env(AKENEO_PIM_URL)%'
 
     akeneo_connectivity.connection.application.webhook.handler.update_connection_webhook:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/webhook.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/webhook.yml
@@ -18,6 +18,7 @@ services:
             - '@akeneo_connectivity.connection.webhook.serializer.json_encoder'
             - '@akeneo_connectivity.connection.webhook.send_api_event_request_logger'
             - '@akeneo_connectivity.connection.webhook.events_api_debug_logger'
+            - '@event_dispatcher'
             -
                 concurrency: '%webhook_concurrency%'
                 timeout: '%webhook_timeout%'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -39,7 +39,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         WebhookClient $client,
         WebhookEventBuilder $builder,
         LoggerInterface $logger,
-        DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger
     ): void {
         $this->beConstructedWith(
@@ -49,7 +48,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $builder,
             $logger,
             $eventSubscriptionSkippedOwnEventLogger,
-            $eventsApiRequestRepository,
             'staging.akeneo.com'
         );
     }
@@ -63,8 +61,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder,
-        $eventsApiRequestRepository
+        $builder
     ): void {
         $juliaUser = new User();
         $juliaUser->setId(0);
@@ -111,8 +108,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 ]
             );
 
-        $eventsApiRequestRepository->upsert(Argument::any(), Argument::any())->shouldBeCalled();
-
         $client
             ->bulkSend(
                 Argument::that(
@@ -154,8 +149,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder,
-        $eventsApiRequestRepository
+        $builder
     ): void {
         $erpUser = new User();
         $erpUser->setId(42);
@@ -205,8 +199,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                 ]
             );
 
-        $eventsApiRequestRepository->upsert(Argument::any(), Argument::any())->shouldBeCalled();
-
         $client
             ->bulkSend(
                 Argument::that(
@@ -249,8 +241,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $selectActiveWebhooksQuery,
         $webhookUserAuthenticator,
         $client,
-        $builder,
-        $eventsApiRequestRepository
+        $builder
     ): void {
         $user = new User();
         $user->setId(0);
@@ -278,8 +269,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             )
             ->willThrow(\Exception::class);
 
-        $eventsApiRequestRepository->upsert(Argument::any(), Argument::any())->shouldBeCalled();
-
         $client
             ->bulkSend(
                 Argument::that(
@@ -301,7 +290,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         SelectActiveWebhooksQuery $selectActiveWebhooksQuery,
         WebhookUserAuthenticator $webhookUserAuthenticator,
         EventSubscriptionSkippedOwnEventLogger $eventSubscriptionSkippedOwnEventLogger,
-        DbalEventsApiRequestCountRepository $eventsApiRequestRepository,
         WebhookClient $client
     ): void {
         $user = new User();
@@ -322,9 +310,6 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
 
         $eventSubscriptionSkippedOwnEventLogger->logEventSubscriptionSkippedOwnEvent('erp', $pimEvent)
             ->shouldBeCalled();
-
-        $eventsApiRequestRepository->upsert(Argument::cetera())
-            ->willReturn(0);
 
         $client->bulkSend(
             Argument::that(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriberSpec.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
+
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\EventsApiRequestFailedEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\EventsApiRequestSucceededEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiRequestCountRepository;
+use Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitIncrementSubscriber;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EventsApiRequestsLimitIncrementSubscriberSpec extends ObjectBehavior
+{
+    public function let(EventsApiRequestCountRepository $repository): void
+    {
+        $this->beConstructedWith($repository);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(EventsApiRequestsLimitIncrementSubscriber::class);
+    }
+
+    public function it_subscribes_to_message_processed_event_and_events_api_request_status_events(): void
+    {
+        $this->getSubscribedEvents()
+            ->shouldReturn([
+                EventsApiRequestSucceededEvent::class => 'incrementRequestCount',
+                EventsApiRequestFailedEvent::class => 'incrementRequestCount',
+                MessageProcessedEvent::class => 'saveRequestCount',
+            ]);
+    }
+
+    public function it_increments_request_count(): void
+    {
+        $this->incrementRequestCount()
+            ->shouldReturn(1);
+
+        $this->incrementRequestCount()
+            ->shouldReturn(2);
+    }
+
+    public function it_saves_request_count($repository): void
+    {
+        $repository->upsert(Argument::type(\DateTimeImmutable::class), 1)
+            ->shouldBeCalled();
+
+        $this->incrementRequestCount();
+        $this->saveRequestCount();
+    }
+
+    public function it_resets_the_request_count_to_zero_after_saving_it($repository): void
+    {
+        $repository->upsert(Argument::cetera())
+            ->shouldBeCalled();
+
+        $this->incrementRequestCount();
+        $this->saveRequestCount();
+
+        $this->incrementRequestCount()
+            ->shouldReturn(1);
+    }
+
+    public function it_doesnt_save_request_count_of_zero($repository): void
+    {
+        $repository->upsert(Argument::cetera())
+            ->shouldNotBeCalled();
+
+        $this->saveRequestCount();
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitIncrementSubscriberSpec.php
@@ -11,6 +11,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsA
 use Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitIncrementSubscriber;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -26,6 +27,7 @@ class EventsApiRequestsLimitIncrementSubscriberSpec extends ObjectBehavior
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(EventsApiRequestsLimitIncrementSubscriber::class);
+        $this->shouldImplement(EventSubscriberInterface::class);
     }
 
     public function it_subscribes_to_message_processed_event_and_events_api_request_status_events(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
@@ -24,6 +24,7 @@ use GuzzleHttp\Psr7\Response;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
 use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 /**
@@ -35,13 +36,15 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 {
     public function let(
         SendApiEventRequestLogger $sendApiEventRequestLogger,
-        EventsApiRequestLogger $eventsApiRequestLogger
+        EventsApiRequestLogger $eventsApiRequestLogger,
+        EventDispatcherInterface $eventDispatcher
     ): void {
         $this->beConstructedWith(
             new Client(),
             new JsonEncoder(),
             $sendApiEventRequestLogger,
             $eventsApiRequestLogger,
+            $eventDispatcher,
             ['timeout' => 0.5, 'concurrency' => 1]
         );
     }
@@ -53,7 +56,8 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
     public function it_sends_webhook_requests_in_bulk(
         SendApiEventRequestLogger $sendApiEventRequestLogger,
-        EventsApiRequestLogger $eventsApiRequestLogger
+        EventsApiRequestLogger $eventsApiRequestLogger,
+        $eventDispatcher
     ): void {
         $mock = new MockHandler(
             [
@@ -72,6 +76,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
             new JsonEncoder(),
             $sendApiEventRequestLogger,
             $eventsApiRequestLogger,
+            $eventDispatcher,
             ['timeout' => 0.5, 'concurrency' => 1]
         );
 
@@ -154,7 +159,8 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
     public function it_logs_a_failed_events_api_request(
         SendApiEventRequestLogger $sendApiEventRequestLogger,
-        EventsApiRequestLogger $eventsApiRequestLogger
+        EventsApiRequestLogger $eventsApiRequestLogger,
+        $eventDispatcher
     ): void {
         $mock = new MockHandler(
             [
@@ -172,6 +178,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
             new JsonEncoder(),
             $sendApiEventRequestLogger,
             $eventsApiRequestLogger,
+            $eventDispatcher,
             ['timeout' => 0.5, 'concurrency' => 1]
         );
 
@@ -207,7 +214,8 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
     public function it_does_not_send_webhook_request_because_of_timeout(
         SendApiEventRequestLogger $sendApiEventRequestLogger,
-        EventsApiRequestLogger $debugLogger
+        EventsApiRequestLogger $debugLogger,
+        $eventDispatcher
     ): void {
 
         $container = [];
@@ -221,6 +229,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
             new JsonEncoder(),
             $sendApiEventRequestLogger,
             $debugLogger,
+            $eventDispatcher,
             ['timeout' => 0.5, 'concurrency' => 1]
         );
 
@@ -276,7 +285,8 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
     private function createEvent(Author $author, array $data, int $timestamp, string $uuid): EventInterface
     {
-        return new class($author, $data, $timestamp, $uuid) extends Event {
+        return new class($author, $data, $timestamp, $uuid) extends Event
+        {
             public function getName(): string
             {
                 return 'product.created';


### PR DESCRIPTION
Decouple the incrementation of the Events API rate limit from the main command handler.