### PR TITLE
PIM-9873: Fix since last n day filter in product export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - PIM-9864: Fix 500 error when using DateTime filter with invalid value
 - PIM-9869: Fix download log in job tracker is only available when log is located in the fpm server
 - PIM-9777: Fix error message when trying to delete an attribute linked to an entity
+- PIM-9873: Fix since last n day filter in product export
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/updated.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/updated.js
@@ -135,7 +135,10 @@ define([
         value = DateFormatter.format(value, DateContext.get('date').format, this.modelDateFormat);
       } else if ('SINCE LAST JOB' === operator) {
         value = this.getParentForm().getFormData().code;
+      } else if ('SINCE LAST N DAYS' === operator) {
+        value = parseInt(value);
       }
+
       if (_.isUndefined(value)) {
         value = '';
       }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Since [PIM-9864](https://akeneo.atlassian.net/browse/PIM-9864), SINCE_LAST_N_DAYS operator is more restrictive on the value type given.  In this PR, given the right value in case of the filter operator is SINCE LAST N DAYS

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
