### PR TITLE
PIM-9692: Standardize the thumbnail display on the product grid

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9692: Standardize the thumbnail display on the product grid
+
 # 4.0.111 (2021-05-21)
 
 ## Bug fixes

--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -29,7 +29,7 @@ liip_imagine:
             quality:          95
             format:           png
             filters:
-                thumbnail:    { size: [320, 320], mode: outbound }
+                thumbnail:    { size: [320, 320], mode: inset }
                 strip:        ~
                 auto_rotate: ~
 
@@ -38,7 +38,7 @@ liip_imagine:
             format:           png
             filters:
                 auto_rotate: ~
-                thumbnail:    { size: [280, 280], mode: outbound }
+                thumbnail:    { size: [280, 280], mode: inset }
                 strip:        ~
         dropdown_select_picture:
             quality:          95

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/row/product-thumbnail.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/row/product-thumbnail.html
@@ -1,4 +1,4 @@
-<div class="AknGrid-fullImage" style="background-image: url('<%- imagePath %>')"></div>
+<div class="AknGrid-fullImage" style="background-image: url('<%- imagePath %>');background-size: contain;background-repeat: no-repeat;"></div>
 <div class="AknGrid-title"><%- label %></div>
 <div class="AknGrid-subTitle"><%- identifier %></div>
 <% if (completenessText !== null) { %>


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When an asset attribute was defined as the main image of a product, the thumbnail display was broken in the product grid on gallery mode.
Adding `background-size` and `background-repeat` css properties fixes the issue.

The thumbnail display was broken too when adding an image as attribute "picture" (thumbnail broken in the product form, in the product grid - list and gallery mode).
So, I fixed the liip_imagine config by replacing outbound mode with inset mode for thumbnail and thumbnail small.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
