### PR TITLE
Fix DSM extraction by not ignoring the lib folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ coverage/*
 cypress/videos
 cypress/screenshots
 
+# The "lib/" folder must be ignored here to not be taken into account when the DSM is extracted to its own repository.
+# See ".github/actions/extract/entrypoint.sh"
+front-packages/akeneo-design-system/lib
+
 ###> symfony/framework-bundle ###
 /.env.local
 /.env.local.php

--- a/front-packages/akeneo-design-system/.gitignore
+++ b/front-packages/akeneo-design-system/.gitignore
@@ -5,4 +5,3 @@ __diff_output__
 /stories.json
 /public/*.png
 tsconfig.build.tsbuildinfo
-lib/


### PR DESCRIPTION
Fix DSM extraction. The lib folder was not sent to the library private repository.