### PR TITLE
CPM-176: Fix DSM for drag and drop cell width

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Table/TableRow/TableRow.tsx
+++ b/front-packages/akeneo-design-system/src/components/Table/TableRow/TableRow.tsx
@@ -10,7 +10,12 @@ import {useBooleanState} from '../../../hooks';
 import {PlaceholderPosition, usePlaceholderPosition} from './usePlaceholderPosition';
 
 const RowContainer = styled.tr<
-  {isSelected: boolean; isClickable: boolean; placeholderPosition: PlaceholderPosition} & AkeneoThemedProps
+  {
+    isSelected: boolean;
+    isClickable: boolean;
+    isDragAndDroppable: boolean;
+    placeholderPosition: PlaceholderPosition;
+  } & AkeneoThemedProps
 >`
   ${({isSelected}) =>
     isSelected &&
@@ -25,6 +30,14 @@ const RowContainer = styled.tr<
     css`
       &:hover {
         cursor: pointer;
+      }
+    `}
+
+  ${({isDragAndDroppable}) =>
+    isDragAndDroppable &&
+    css`
+      & > *:first-child {
+        width: 44px;
       }
     `}
 
@@ -132,6 +145,7 @@ const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
         ref={forwardedRef}
         isClickable={undefined !== onClick}
         isSelected={!!isSelected}
+        isDragAndDroppable={isDragAndDroppable}
         onClick={onClick}
         placeholderPosition={placeholderPosition}
         draggable={isDragAndDroppable && isDragged}


### PR DESCRIPTION
https://github.com/akeneo/pim-enterprise-dev/pull/10890

When there is only 1 column, the drag and drop cell takes ~ 200px width.
This PR fixes it and hardcode the width of this cell.



![Selection_474](https://user-images.githubusercontent.com/1590933/119849503-fa03d500-bf0c-11eb-9378-8b011e0950e3.png)
![Selection_475](https://user-images.githubusercontent.com/1590933/119849510-fa9c6b80-bf0c-11eb-986b-937f7f3291a9.png)
