### PR TITLE
PIM-9881: Do not update a value which was not modified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - PIM-9777: Fix error message when trying to delete an attribute linked to an entity
 - PIM-9873: Fix since last n day filter in product export
 - PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation
+- PIM-9881: Do not update a product value which was not modified
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Builder/EntityWithValuesBuilder.php
@@ -131,7 +131,9 @@ class EntityWithValuesBuilder implements EntityWithValuesBuilderInterface
     ): ValueInterface {
         $formerValue = $entityWithValues->getValue($attribute->code(), $localeCode, $channelCode);
         $updatedValue = $this->productValueFactory->createByCheckingData($attribute, $channelCode, $localeCode, $data);
-        $entityWithValues->removeValue($formerValue)->addValue($updatedValue);
+        if (!$formerValue->isEqual($updatedValue)) {
+            $entityWithValues->removeValue($formerValue)->addValue($updatedValue);
+        }
         $this->updateProductIdentiferIfNeeded($attribute, $entityWithValues, $data);
 
         return $updatedValue;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Since https://github.com/akeneo/pim-community-dev/pull/13338 we do not save products or product models that were not actually updated anymore. One thing we missed is, when trying to update a value with the same data, we successively call `$entity->removeValue()` then `$entity->addValue()`, which makes the entity *believe* it was updated, whereas the data is the same. This leads to saving the entity and possibly triggering an "Entity update" webhook event, which we do not want.
For most use cases it's not an issue, as identical data is filtered _a priori_ (External API, UI, Mass actions), but the behavior still happens when 
- executing a rule
- running an import with the "Compare values" flag disabled


**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
