### PR TITLE
PIM-9882: Fix display of grid selector secondary actions dropdown

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes:
+
+- PIM-9882: Fix the display of the grid selector secondary action dropdown
+
 # 5.0.28 (2021-05-28)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/grid/grid_view_selector.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/grid/grid_view_selector.yml
@@ -7,7 +7,7 @@ extensions:
                 view: 'datagrid-view'
 
     pim-grid-view-selector-secondary-actions:
-        module: pim/form/common/secondary-actions
+        module: pim/grid/view-selector/view-selector-secondary-actions
         parent: pim-grid-view-selector
         targetZone: buttons
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -984,6 +984,7 @@ config:
     # Grid view selector
     pim/grid/view-selector: pimui/js/product/grid/view-selector
     pim/grid/view-selector/selector: pimui/js/grid/view-selector
+    pim/grid/view-selector/view-selector-secondary-actions: pimui/js/grid/view-selector-secondary-actions.ts
     pim/grid/view-selector/line: pimui/js/grid/view-selector-line
     pim/grid/view-selector/create-view: pimui/js/grid/view-selector-create-view
     pim/grid/view-selector/save-view: pimui/js/grid/view-selector-save-view

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector-secondary-actions.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/view-selector-secondary-actions.ts
@@ -1,0 +1,25 @@
+import {EventsHash} from 'backbone';
+
+const BaseView = require('pim/form/common/secondary-actions');
+
+class ViewSelectorSecondaryActions extends BaseView {
+  /*
+    @see Oro/datafilter/filter/abstract-filter.js::_updateCriteriaSelectorPosition()
+    The current css position cannot be used in a column, we have to manually set it as fixed on open
+   */
+  public events(): EventsHash {
+    return {
+      'click .dropdown-button': () => {
+        this.$el.find('.AknDropdown-menu').css({
+          position: 'fixed',
+          left: this.$el.offset().left,
+          minWidth: 'auto',
+          right: 'auto',
+          top: this.$el.offset().top,
+        });
+      },
+    };
+  }
+}
+
+export = ViewSelectorSecondaryActions;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Under certain circumstances (Italian, German or Dutch UI locale, a selected grid view with a short label, ..), the "secondary actions" dropdown of the grid view selector is partially hidden, and no horizontal scrollbar appears, making it hardly readable:
![before](https://user-images.githubusercontent.com/5301298/120160719-d84d6b00-c1f6-11eb-8f0d-1966baa7b42b.png)

This PR fixes this behavior:
![after](https://user-images.githubusercontent.com/5301298/120160830-fca94780-c1f6-11eb-8557-9e08c88b4ad1.png)

Due to the column layout I wasn't able to fix it in pure CSS, I had to manually set the position: fixed in js


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
