### PR TITLE
POC: ack job message after pull in all cases

### DIFF
--- a/config/packages/behat/messenger.yml
+++ b/config/packages/behat/messenger.yml
@@ -31,7 +31,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_UI)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_UI)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0
@@ -42,7 +41,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_IMPORT_EXPORT)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_IMPORT_EXPORT)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0
@@ -53,7 +51,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_DATA_MAINTENANCE)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_DATA_MAINTENANCE)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0

--- a/config/packages/test/messenger.yml
+++ b/config/packages/test/messenger.yml
@@ -31,7 +31,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_UI)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_UI)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0
@@ -42,7 +41,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_IMPORT_EXPORT)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_IMPORT_EXPORT)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0
@@ -53,7 +51,6 @@ framework:
                     project_id: '%env(GOOGLE_CLOUD_PROJECT)%'
                     topic_name: '%env(PUBSUB_TOPIC_JOB_QUEUE_DATA_MAINTENANCE)%'
                     subscription_name: '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_DATA_MAINTENANCE)%'
-                    ack_message_right_after_pull: true
                     auto_setup: '%env(bool:PUBSUB_AUTO_SETUP)%'
                 retry_strategy:
                     max_retries: 0

--- a/config/packages/test_fake/messenger.yml
+++ b/config/packages/test_fake/messenger.yml
@@ -2,7 +2,7 @@ framework:
     messenger:
         transports:
             business_event: 'in-memory://'
-            job: 'in-memory://'
+            job: 'in-memory-spy://'
         routing:
             'Akeneo\Platform\Component\EventQueue\Event': business_event
             'Akeneo\Platform\Component\EventQueue\BulkEvent': business_event

--- a/config/services/test_fake/services.yml
+++ b/config/services/test_fake/services.yml
@@ -2,6 +2,7 @@ imports:
     - { resource: ../../../tests/back/Acceptance/Resources/config/pim/repositories.yml }
     - { resource: ../../../tests/back/Acceptance/Resources/config/pim/queries.yml }
     - { resource: ../../../tests/back/Acceptance/Resources/config/pim/file_storage.yml }
+    - { resource: ../../../tests/back/Acceptance/Resources/config/pim/messenger.yml }
     - { resource: ../../../tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Resources/config/pim/queries.yml }
     - { resource: ../../../tests/back/Acceptance/Resources/config/behat/services.yml }
     - { resource: ../../../tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Resources/config/behat/services.yml }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -64,6 +64,10 @@
             <directory suffix="Integration.php">src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration</directory>
         </testsuite>
 
+        <testsuite name="Batch_Queue_Acceptance">
+            <directory suffix="Test.php">src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/Acceptance</directory>
+        </testsuite>
+
         <testsuite name="End_to_End">
             <directory suffix="EndToEnd.php">tests/back</directory>
             <directory suffix="EndToEnd.php">src</directory>

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchQueueBundle\EventListener;
+
+use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessageInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+/**
+ * Using Google Pub/Sub we should ack the message within the next 10 seconds after pulling it (it can be configured
+ * to 10 minutes maximum). After that the message is re-dispatched. As the job execution can be longer, we
+ * take the decision to ack the message just after pulling it. The aim to this subscriber is to ack all job messages
+ * before the job execution.
+ *
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class AckMessageEventListener implements EventSubscriberInterface
+{
+    private ContainerInterface $receiverLocator;
+
+    public function __construct(ContainerInterface $receiverLocator)
+    {
+        $this->receiverLocator = $receiverLocator;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            WorkerMessageReceivedEvent::class => 'ackMessage',
+        ];
+    }
+
+    public function ackMessage(WorkerMessageReceivedEvent $event): void
+    {
+        $envelope = $event->getEnvelope();
+        if (!$envelope->getMessage() instanceof JobExecutionMessageInterface) {
+            return;
+        }
+
+        try {
+            $receiver = $this->receiverLocator->get($event->getReceiverName());
+        } catch (NotFoundExceptionInterface $e) {
+            return;
+        }
+
+        $receiver->ack($envelope);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
@@ -12,7 +12,7 @@ use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
 
 /**
  * Using Google Pub/Sub we should ack the message within the next 10 seconds after pulling it (it can be configured
- * to 10 minutes maximum). After that the message is re-dispatched. As the job execution can be longer, we
+ * to 10 minutes maximum). After that the message is deliver again. As the job execution can be longer, we
  * take the decision to ack the message just after pulling it. The aim to this subscriber is to ack all job messages
  * before the job execution.
  *

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/EventListener/AckMessageEventListener.php
@@ -42,12 +42,7 @@ final class AckMessageEventListener implements EventSubscriberInterface
             return;
         }
 
-        try {
-            $receiver = $this->receiverLocator->get($event->getReceiverName());
-        } catch (NotFoundExceptionInterface $e) {
-            return;
-        }
-
+        $receiver = $this->receiverLocator->get($event->getReceiverName());
         $receiver->ack($envelope);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/README.md
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/README.md
@@ -40,7 +40,6 @@ bash command        Symfony Messenger          / Doctrine / ...)    JobExecution
 |                         | <------------------------ |                      |                          |
 |                         |                           |                      |                          |
 |                         | Acknowledge message       |                      |                          |
-|                         | (GooglePubSub only)       |                      |                          |
 |                         | ------------------------> |                      |                          |
 |                         |                           |                      |                          |
 |                         | Spread message to handler |                      |                          |
@@ -61,10 +60,6 @@ bash command        Symfony Messenger          / Doctrine / ...)    JobExecution
 |                         |                   Message handling is terminated |                          |
 |                         | <-------------------------+--------------------- |                          |
 |                         |                           |                      |                          |
-|                         | Acknowledge message       |                      |                          |
-|                         | (except GooglePubSub)     |                      |                          |
-|                         | ------------------------> |                      |                          |
-|                         |                           |                      |                          |
 |  The message is handled |                           |                      |                          |
 | <---------------------- |                           |                      |                          |
 |                         |                           |                      |                          |
@@ -74,9 +69,11 @@ bash command        Symfony Messenger          / Doctrine / ...)    JobExecution
 |                         |                           |                      |                          |
 | ...                     |                           |                      |                          |
 ```
-### Why do we ackowledge the message differently with Google PubSub?
 
-Google PubSub has a maximum time to acknowledge a message. By default it's 10 seconds and it can be configured
+### Why do we acknowledge the message just after pulling it?
+
+The normal usage in the Symfony Messenger's workflow is to ack the message after handling it.
+But Google PubSub has a maximum time to acknowledge a message. By default it's 10 seconds and it can be configured
 with the `ackDeadlineSeconds` option (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create).
 The maximum that can be configured is 10 minutes. If the the message is not acknowledged in that interval, it can be delivered again.  
 But it's not rare a job execution exceeds 10 minutes, and we don't want to receive the same message twice. We thought about 2 solutions:

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -109,3 +109,9 @@ services:
             - 'job_key'
         tags:
             - { name: 'akeneo_messenger.ordering_key_candidate' }
+
+    Akeneo\Tool\Bundle\BatchQueueBundle\EventListener\AckMessageEventListener:
+        arguments:
+            - '@messenger.receiver_locator'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/EventListener/AckMessageEventListenerSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/EventListener/AckMessageEventListenerSpec.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\BatchQueueBundle\EventListener;
+
+use Akeneo\Tool\Bundle\BatchQueueBundle\EventListener\AckMessageEventListener;
+use Akeneo\Tool\Component\BatchQueue\Queue\UiJobExecutionMessage;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
+
+class AckMessageEventListenerSpec extends ObjectBehavior
+{
+    function let(ContainerInterface $receiverLocator)
+    {
+        $this->beConstructedWith($receiverLocator);
+    }
+
+    function it_is_an_event_subscriber()
+    {
+        $this->shouldHaveType(AckMessageEventListener::class);
+        $this->shouldImplement(EventSubscriberInterface::class);
+    }
+
+    function it_does_nothing_when_message_is_not_a_job_message(ContainerInterface $receiverLocator)
+    {
+        $envelope = new Envelope(new \stdClass());
+        $event = new WorkerMessageReceivedEvent($envelope, 'receiver');
+
+        $receiverLocator->get(Argument::any())->shouldNotBeCalled();
+
+        $this->ackMessage($event);
+    }
+
+    function it_acks_the_message_for_a_job_message(
+        ContainerInterface $receiverLocator,
+        ReceiverInterface $receiver
+    ) {
+        $envelope = new Envelope(UiJobExecutionMessage::createJobExecutionMessage(1, []));
+        $event = new WorkerMessageReceivedEvent($envelope, 'receiver_name');
+
+        $receiverLocator->get('receiver_name')->shouldBeCalledOnce()->willReturn($receiver);
+        $receiver->ack($envelope)->shouldBeCalledOnce();
+
+        $this->ackMessage($event);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/Acceptance/AckMessageEventListenerTest.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/Acceptance/AckMessageEventListenerTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchQueueBundle\tests\Acceptance;
+
+use Akeneo\Tool\Component\BatchQueue\Queue\UiJobExecutionMessage;
+use AkeneoTest\Acceptance\Messenger\InMemorySpyTransport;
+use AkeneoTest\Acceptance\Messenger\InMemorySpyTransportFactory;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Event\WorkerMessageReceivedEvent;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class AckMessageEventListenerTest extends KernelTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        static::bootKernel(['debug' => false, 'environment' => 'test_fake']);
+    }
+
+    protected function get(string $service)
+    {
+        return self::$container->get($service);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        $this->ensureKernelShutdown();
+    }
+
+    /** @test */
+    public function it_acks_the_message(): void
+    {
+        $message = UiJobExecutionMessage::createJobExecutionMessage(1, []);
+        $envelope = new Envelope($message);
+        $this->get('messenger.default_bus')->dispatch($message);
+
+        $event = new WorkerMessageReceivedEvent($envelope, 'job');
+        $this->get('event_dispatcher')->dispatch($event);
+
+        $transportFactory = $this->get(InMemorySpyTransportFactory::class);
+        $transports = $transportFactory->getCreatedTransports();
+        self::assertCount(1, $transports);
+        $transport = current($transports);
+
+        $events = $transport->releaseEvents();
+        self::assertCount(2, $events);
+        self::assertSame(InMemorySpyTransport::SEND_EVENT, $events[0]);
+        self::assertSame(InMemorySpyTransport::ACK_EVENT, $events[1]);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/README.md
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/README.md
@@ -87,15 +87,6 @@ From the Symfony Messenger point of view, these are three independent queues. Bu
   that will lead to degraded performance. Plus be aware for Google PubSub the checks perform some administrator operations
   which are limited by quotas (c.f. https://cloud.google.com/pubsub/quotas).
 
-- `ack_message_right_after_pull: ?bool`
-
-  Default to `false`, it allows to ack the message right after pulling it.  
-  By default Google Pub/Sub waits for an acknowledgement during the next 10 seconds after the message is pulled. After that the message is available once again for another subscriber using the same subscription.  
-  It can be a problem because in Symfony Messenger the message is acknowledged after the message is handled. For long processes the message will not be acknowledged in time.  
-  The maximum custom deadline you can specify is 600 seconds (10 minutes). If this limit is not high enough, consider setting this option to `true`.  
-  (See the `ackDeadlineSeconds` option in https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/create)    
-  Note: with a doctrine transport, the `redeliver_timeout` is the equivalent of `ackDeadlineSeconds`
-
 - `subscription_filter: ?string`
 
   Default to `null`, it allows to filter messages. See https://cloud.google.com/pubsub/docs/filtering for the syntax.  

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/Client.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/Client.php
@@ -111,14 +111,12 @@ class Client
             'subscription_name' => null,
             'auto_setup' => false,
             'subscription_filter' => null,
-            'ack_message_right_after_pull' => false,
         ]);
         $resolver->setAllowedTypes('project_id', 'string');
         $resolver->setAllowedTypes('topic_name', 'string');
         $resolver->setAllowedTypes('subscription_name', ['null', 'string']);
         $resolver->setAllowedTypes('auto_setup', 'bool');
         $resolver->setAllowedTypes('subscription_filter', ['null', 'string']);
-        $resolver->setAllowedTypes('ack_message_right_after_pull', 'bool');
 
         return $resolver;
     }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsReceiver.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsReceiver.php
@@ -20,18 +20,13 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  */
 final class GpsReceiver implements ReceiverInterface
 {
-    private const ACK_MESSAGE_RIGHT_AFTER_PULL_OPTION = 'ack_message_right_after_pull';
-    public const AVAILABLE_OPTIONS = [self::ACK_MESSAGE_RIGHT_AFTER_PULL_OPTION];
-
     private SerializerInterface $serializer;
     private Subscription $subscription;
-    private array $options;
 
-    public function __construct(Subscription $subscription, SerializerInterface $serializer, array $options = [])
+    public function __construct(Subscription $subscription, SerializerInterface $serializer)
     {
         $this->subscription = $subscription;
         $this->serializer = $serializer;
-        $this->options = $options;
     }
 
     public function get(): iterable
@@ -50,10 +45,6 @@ final class GpsReceiver implements ReceiverInterface
         }
 
         $message = $messages[0];
-        if ($this->ackMessageRightAfterPullMode()) {
-            $this->ackMessage($message);
-        }
-
         $envelope = $this->serializer->decode([
             'body' => $message->data(),
             'headers' => $message->attributes(),
@@ -68,17 +59,8 @@ final class GpsReceiver implements ReceiverInterface
 
     public function ack(Envelope $envelope): void
     {
-        if ($this->ackMessageRightAfterPullMode()) {
-            return;
-        }
-
-        $this->ackMessage($this->getNativeMessage($envelope));
-    }
-
-    private function ackMessage(Message $message): void
-    {
         try {
-            $this->subscription->acknowledge($message);
+            $this->subscription->acknowledge($this->getNativeMessage($envelope));
         } catch (GoogleException $e) {
             throw new TransportException($e->getMessage(), 0, $e);
         }
@@ -101,10 +83,5 @@ final class GpsReceiver implements ReceiverInterface
         }
 
         return $nativeMessageStamp->getNativeMessage();
-    }
-
-    private function ackMessageRightAfterPullMode(): bool
-    {
-        return $this->options[static::ACK_MESSAGE_RIGHT_AFTER_PULL_OPTION] ?? false;
     }
 }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsTransportFactory.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/GpsTransportFactory.php
@@ -32,12 +32,7 @@ final class GpsTransportFactory implements TransportFactoryInterface
 
         $receiver = null;
         if (null !== $subscription = $client->getSubscription()) {
-            $receiverOptions = array_filter(
-                $options,
-                fn (string $key): bool => in_array($key, GpsReceiver::AVAILABLE_OPTIONS),
-                ARRAY_FILTER_USE_KEY
-            );
-            $receiver = new GpsReceiver($subscription, $serializer, $receiverOptions);
+            $receiver = new GpsReceiver($subscription, $serializer);
         }
 
         return new GpsTransport($client, $sender, $receiver);

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsReceiverSpec.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/GpsReceiverSpec.php
@@ -64,41 +64,6 @@ class GpsReceiverSpec extends ObjectBehavior
             ]);
     }
 
-    public function it_gets_and_acks_message_when_mode_is_activated(Subscription $subscription, $serializer): void
-    {
-        $this->beConstructedWith($subscription, $serializer, ['ack_message_right_after_pull' => true]);
-
-        $gpsMessage = new Message(
-            [
-                'data' => 'My message!',
-                'messageId' => '123',
-                'attributes' => ['my_attribute' => 'My attribute!']
-            ]
-        );
-        $envelope = new Envelope((object)['message' => 'My message!']);
-
-        $subscription->pull([
-            'maxMessages' => 1,
-            'returnImmediately' => true,
-        ])
-            ->willReturn([$gpsMessage]);
-
-        $serializer->decode([
-            'body' => 'My message!',
-            'headers' => ['my_attribute' => 'My attribute!']
-        ])
-            ->willReturn($envelope);
-
-        $subscription->acknowledge($gpsMessage)->shouldBeCalledOnce();
-
-        $this->get()
-            ->shouldBeLike([
-                $envelope
-                    ->with(new TransportMessageIdStamp('123'))
-                    ->with(new NativeMessageStamp($gpsMessage))
-            ]);
-    }
-
     public function it_acknowledges_a_message(Subscription $subscription): void
     {
         $gpsMessage = new Message(
@@ -111,20 +76,6 @@ class GpsReceiverSpec extends ObjectBehavior
 
         $subscription->acknowledge($gpsMessage)
             ->shouldBeCalled();
-
-        $this->ack($envelope);
-    }
-
-    public function it_does_not_acknowledges_a_message_when_it_was_acknowledged_after_pull(
-        Subscription $subscription,
-        SerializerInterface $serializer
-    ): void {
-        $this->beConstructedWith($subscription, $serializer, ['ack_message_right_after_pull' => true]);
-
-        $gpsMessage = new Message(['data' => 'My message!']);
-        $envelope = new Envelope((object)['message' => 'My message!'], [new NativeMessageStamp($gpsMessage)]);
-
-        $subscription->acknowledge($gpsMessage)->shouldNotBeCalled();
 
         $this->ack($envelope);
     }

--- a/tests/back/Acceptance/Messenger/InMemorySpyTransport.php
+++ b/tests/back/Acceptance/Messenger/InMemorySpyTransport.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace AkeneoTest\Acceptance\Messenger;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\InMemoryTransport;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class InMemorySpyTransport extends InMemoryTransport
+{
+    public const GET_EVENT = 'get_event';
+    public const ACK_EVENT = 'ack_event';
+    public const SEND_EVENT = 'send_event';
+
+    private array $events = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(): iterable
+    {
+        $this->events[] = self::GET_EVENT;
+        return parent::get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ack(Envelope $envelope): void
+    {
+        $this->events[] = self::ACK_EVENT;
+        parent::ack($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function send(Envelope $envelope): Envelope
+    {
+        $this->events[] = self::SEND_EVENT;
+        return parent::send($envelope);
+    }
+
+    public function releaseEvents(): array
+    {
+        $events = $this->events;
+        $this->events = [];
+
+        return $events;
+    }
+}

--- a/tests/back/Acceptance/Messenger/InMemorySpyTransportFactory.php
+++ b/tests/back/Acceptance/Messenger/InMemorySpyTransportFactory.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace AkeneoTest\Acceptance\Messenger;
+
+use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
+use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class InMemorySpyTransportFactory implements TransportFactoryInterface, ResetInterface
+{
+    /** @var InMemorySpyTransport[] */
+    private array $createdTransports = [];
+
+    public function createTransport(string $dsn, array $options, SerializerInterface $serializer): TransportInterface
+    {
+        return $this->createdTransports[] = new InMemorySpyTransport();
+    }
+
+    public function supports(string $dsn, array $options): bool
+    {
+        return 0 === strpos($dsn, 'in-memory-spy://');
+    }
+
+    public function reset()
+    {
+        foreach ($this->createdTransports as $transport) {
+            $transport->reset();
+        }
+    }
+
+    /**
+     * @return InMemorySpyTransport[]
+     */
+    public function getCreatedTransports(): array
+    {
+        return $this->createdTransports;
+    }
+}

--- a/tests/back/Acceptance/Resources/config/pim/messenger.yml
+++ b/tests/back/Acceptance/Resources/config/pim/messenger.yml
@@ -1,0 +1,5 @@
+services:
+    AkeneoTest\Acceptance\Messenger\InMemorySpyTransportFactory:
+        tags:
+            - { name: messenger.transport_factory }
+            - { name: kernel.reset, method: reset }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Previously we set a machanism to ack the message after pulling it only if the transport was pubsub (please see the ADR to know the reason).  
Now we ack the message in all cases thanks to an event subscriber.


Issue:
The event subscriber allows to ack the message before handling it. But after handling it, a new ack is requested. I don't figure out how to disable this second ack: it's hardcoded in the Worker https://github.com/symfony/messenger/blob/4.4/Worker.php#L150  
It seems there is no problem to ack the same message twice, but it would be better to ack once.  

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
