### PR TITLE
CXP-711: fix sub navigation link css

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/Column.less
@@ -155,13 +155,15 @@
   }
 
   &-navigationLink {
-    display: block;
+    display: flex;
     font-size: @AknFontSizeBig;
-    margin: 0 0 20px 0;
+    margin: 0 0 13px 0;
     color: @AknDarkBlue;
     cursor: pointer;
     opacity: 0.85;
     transition: opacity 0.2s ease-in;
+    line-height: 21px;
+    align-items: baseline;
 
     &:hover {
       opacity: 1;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The small line-height was incompatible with the label included recently, creating differences in the height of the sub navigation elements, see:

![Capture d’écran 2021-05-25 à 10 27 24](https://user-images.githubusercontent.com/1421130/120201607-ec5c9100-c225-11eb-8b96-4b887fc63787.png)
![Capture d’écran 2021-05-25 à 10 27 17](https://user-images.githubusercontent.com/1421130/120201604-ebc3fa80-c225-11eb-8daf-77d08406dee7.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
