### PR TITLE
PIM-9886: Fix display of completeness in the PEF when the selected locale is deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation
 - PIM-9881: Do not update a product value which was not modified
 - PIM-9863: Remove temporisation and add unit tests for product model reindexation.
+- PIM-9886: Fix display of completeness in the PEF when the selected locale is deactivated
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/workspaces/enrichment/src/components/completeness/ProductCurrentCompleteness.tsx
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/workspaces/enrichment/src/components/completeness/ProductCurrentCompleteness.tsx
@@ -77,6 +77,10 @@ const ProductCurrentCompleteness: FC<Props> = ({
     router.redirect(router.generate('pim_enrich_product_model_edit', {id: modelId}));
   };
 
+  if (false === currentCompleteness.localesCompleteness.hasOwnProperty(userContext.get('catalogLocale'))) {
+    return null;
+  }
+
   return (
     <StyledDropdown>
       <SwitcherButton


### PR DESCRIPTION
This fix prevent a javascript error that block the display of the PEF when the selected locale has been deactivated. 

As on 5.0, the completeness badge and selector will not be displayed at all.
![no-completeness](https://user-images.githubusercontent.com/26378046/120334472-f39ca100-c2f0-11eb-81af-395bf723556b.png)
