### PR TITLE
PIM-9891: Fix missing sanity checks when computing enrichment status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation
 - PIM-9881: Do not update a product value which was not modified
 - PIM-9863: Remove temporisation and add unit tests for product model reindexation.
+- PIM-9891: Fix missing sanity checks when computing enrichment status
 - PIM-9886: Fix display of completeness in the PEF when the selected locale is deactivated
 
 ## New features


### PR DESCRIPTION
`$this->channels->getIdByCode($channel);` and `$localeId = $this->locales->getIdByCode($locale);` can return `null`, but this case was not handled and it can cause a fatal error.

Because we're loading channels/locales codes and ids in two distinct queries. And because we put the results in cache to avoid to repeat those queries. It can happen that the id of a channel or locale cannot be found from its code.

I added sanity checks to avoid any error, and rework the code for more readability.