### PR TITLE
Fix container react router

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/bridge/react/reactController.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/bridge/react/reactController.ts
@@ -16,6 +16,13 @@ abstract class ReactController extends BaseController {
    */
   abstract routeGuardToUnmount(): RegExp;
 
+  /**
+   * Return a static reference to a HTMLElement
+   */
+  getContainerRef(): Element {
+    return this.$el.get(0);
+  }
+
   initialize() {
     mediator.on('route_start', this.handleRouteChange, this);
 
@@ -23,7 +30,7 @@ abstract class ReactController extends BaseController {
   }
 
   renderRoute() {
-    this.$el.append(mountReactElementRef(this.reactElementToMount(), this.$el.get(0)));
+    this.$el.append(mountReactElementRef(this.reactElementToMount(), this.getContainerRef()));
 
     return Deferred().resolve();
   }
@@ -44,7 +51,7 @@ abstract class ReactController extends BaseController {
       return;
     }
 
-    unmountReactElementRef(this.$el.get(0));
+    unmountReactElementRef(this.getContainerRef());
   }
 }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/bridge/controller/settings.tsx
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/public/bridge/controller/settings.tsx
@@ -11,6 +11,8 @@ const mediator = require('oro/mediator');
 const __ = require('oro/translator');
 
 class SettingsController extends ReactController {
+  private static container = document.createElement('div');
+
   reactElementToMount() {
     return (
       <ThemeProvider theme={pimTheme}>
@@ -34,6 +36,10 @@ class SettingsController extends ReactController {
     mediator.trigger('pim_menu:highlight:item', {extension: 'pim-menu-measurements-settings'});
 
     return super.renderRoute();
+  }
+
+  getContainerRef(): Element {
+    return SettingsController.container;
   }
 
   canLeave() {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
This PR goal is to provide a way to fix a kind of memory leak when a single controller is used for a react application that uses multiple internal routes, without breaking anything in the PIM. The current behavior of the react controller creates a new container each time a react route is rendered, without unmounted the previous one, so react apps keeps piling up.

Each backbone controller that renders a React routed app will have to provide a static reference to a HTML element wherein the app will be mounted. To demonstrate the fix, I applied this fix in a dedicated commit in the Measurements. For now, it's the only place where we have this issue in the CE.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
