### PR TITLE
OB-759: Fix missing measurements in cache

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -37,7 +37,7 @@ class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterfac
     public function all(): array
     {
         if (empty($this->allMeasurementFamiliesCache)) {
-            $this->allMeasurementFamiliesCache = $this->loadAssetFamiliesIndexByCodes();
+            $this->allMeasurementFamiliesCache = $this->loadMeasurementFamiliesIndexByCodes();
         }
 
         return array_values($this->allMeasurementFamiliesCache);
@@ -47,7 +47,7 @@ class MeasurementFamilyRepository implements MeasurementFamilyRepositoryInterfac
     {
         $normalizedMeasurementFamilyCode = $measurementFamilyCode->normalize();
         if (!isset($this->measurementFamilyCache[$normalizedMeasurementFamilyCode])) {
-            $this->measurementFamilyCache[$normalizedMeasurementFamilyCode] = $this->loadAssetFamily($measurementFamilyCode);
+            $this->measurementFamilyCache[$normalizedMeasurementFamilyCode] = $this->loadMeasurementFamily($measurementFamilyCode);
         }
 
         return $this->measurementFamilyCache[$normalizedMeasurementFamilyCode];
@@ -84,6 +84,7 @@ SQL;
             );
         }
 
+        $this->allMeasurementFamiliesCache = $this->all();
         $this->allMeasurementFamiliesCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
         $this->measurementFamilyCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
     }
@@ -189,7 +190,7 @@ SQL;
      *
      * @throws \Doctrine\DBAL\DBALException
      */
-    private function loadAssetFamiliesIndexByCodes(): array
+    private function loadMeasurementFamiliesIndexByCodes(): array
     {
         $selectAllQuery = <<<SQL
     SELECT
@@ -215,7 +216,7 @@ SQL;
         return $measurementFamiliesIndexByCodes;
     }
 
-    private function loadAssetFamily(MeasurementFamilyCode $measurementFamilyCode): ?MeasurementFamily
+    private function loadMeasurementFamily(MeasurementFamilyCode $measurementFamilyCode): ?MeasurementFamily
     {
         $sql = <<<SQL
     SELECT

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidatorSpec.php
@@ -25,12 +25,12 @@ class MeasurementFamilyCommonStructureValidatorSpec extends ObjectBehavior
 
     function it_returns_all_the_errors_of_invalid_measurement_family_properties()
     {
-        $asset = [
+        $measurement = [
             'values' => null,
             'foo' => 'bar',
         ];
 
-        $errors = $this->validate($asset);
+        $errors = $this->validate($measurement);
         $errors->shouldBeArray();
         $errors->shouldHaveCount(1);
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
@@ -16,12 +16,12 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
 
     function it_returns_all_the_errors_of_invalid_measurement_family_properties()
     {
-        $asset = [
+        $measurement = [
             'values' => null,
             'foo' => 'bar',
         ];
 
-        $errors = $this->validate($asset);
+        $errors = $this->validate($measurement);
         $errors->shouldBeArray();
         $errors->shouldHaveCount(5);
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/Persistence/MeasurementFamilyRepositoryIntegration.php
@@ -24,7 +24,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         parent::setUp();
 
         $this->repository = $this->get('akeneo_measure.persistence.measurement_family_repository');
-        $this->loadSomeMetrics();
+        $this->loadSomeMeasurements();
     }
 
     /**
@@ -128,6 +128,21 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         );
     }
 
+    /** @test */
+    public function it_refreshes_the_cache_after_creating_a_measurement_family(): void
+    {
+        $this->assertCount(2, $this->repository->all());
+
+        $this->repository->save(
+            $this->createMeasurementFamily(
+                'NewFamily',
+                ["en_US" => "New family label", "fr_FR" => "Nouveau famille label"]
+            )
+        );
+
+        $this->assertCount(3, $this->repository->all());
+    }
+
     /**
      * @test
      */
@@ -161,7 +176,7 @@ class MeasurementFamilyRepositoryIntegration extends SqlIntegrationTestCase
         );
     }
 
-    private function loadSomeMetrics(): void
+    private function loadSomeMeasurements(): void
     {
         $sql = <<<SQL
 TRUNCATE TABLE `akeneo_measurement`;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

After creating a measurement, the cache contains only one measurement so the `FindAllMeasurementFamilies` query returns only one measurements instead of all. 
I also found some forgotten copy/paste from asset context and fixed them.
