### PR TITLE
PIM-9890: Creating Channels with numeric code breaks the PIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # master
 
 ## Bug fixes
-
+- PIM-9890: Creating Channels with numeric code breaks the PIM
 - PIM-9748: Upgrade JQuery for security reasons
 - PIM-9678: The time counter is still running despite the job failed
 - PIM-9672: Error 500 on the API when inputing [null] on an array

--- a/src/Akeneo/Channel/Bundle/Resources/config/validation/channel.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/validation/channel.yml
@@ -8,8 +8,8 @@ Akeneo\Channel\Component\Model\Channel:
         code:
             - NotBlank: ~
             - Regex:
-                pattern: /^[a-zA-Z0-9_]+$/
-                message: Channel code may contain only letters, numbers and underscores
+                pattern: /^[a-zA-Z0-9_]*[a-zA-Z]+[a-zA-Z0-9_]*$/
+                message: Channel code may contain only letters, numbers and underscores and should contain at least one letter
             - Length:
                 max: 100
         category:

--- a/tests/back/Channel/EndToEnd/Channel/ExternalApi/PartialUpdateListChannelEndToEnd.php
+++ b/tests/back/Channel/EndToEnd/Channel/ExternalApi/PartialUpdateListChannelEndToEnd.php
@@ -72,7 +72,7 @@ JSON;
         $expectedContent =
 <<<JSON
 {"line":1,"code":"foo","status_code":422,"message":"Property \"type\" does not exist. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_channels__code_"}}}
-{"line":2,"code":"baz,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Channel code may contain only letters, numbers and underscores"}]}
+{"line":2,"code":"baz,","status_code":422,"message":"Validation failed.","errors":[{"property":"code","message":"Channel code may contain only letters, numbers and underscores and should contain at least one letter"}]}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/channels', [], [], [], $data);

--- a/tests/back/Channel/Integration/Channel/Validation/ChannelValidationIntegration.php
+++ b/tests/back/Channel/Integration/Channel/Validation/ChannelValidationIntegration.php
@@ -117,7 +117,31 @@ class ChannelValidationIntegration extends TestCase
 
         $this->assertCount(1, $violations);
         $this->assertSame(
-            'Channel code may contain only letters, numbers and underscores',
+            'Channel code may contain only letters, numbers and underscores and should contain at least one letter',
+            $violation->getMessage()
+        );
+        $this->assertSame('code', $violation->getPropertyPath());
+    }
+
+    public function testChannelCodeContainsAtLeastOneLetter()
+    {
+        $channel = $this->createChannel();
+        $this->getUpdater()->update(
+            $channel,
+            [
+                'code'          => '1234567890',
+                'category_tree' => 'master',
+                'currencies'    => ['EUR'],
+                'locales'       => ['fr_FR'],
+            ]
+        );
+
+        $violations = $this->getValidator()->validate($channel);
+        $violation = current($violations)[0];
+
+        $this->assertCount(1, $violations);
+        $this->assertSame(
+            'Channel code may contain only letters, numbers and underscores and should contain at least one letter',
             $violation->getMessage()
         );
         $this->assertSame('code', $violation->getPropertyPath());


### PR DESCRIPTION
For solving the issue, it has been decided that the channel should contain at least one letter.
