### PR TITLE
API-1602: dns lookup for event subscription url

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/DnsLookupInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/DnsLookupInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface DnsLookupInterface
+{
+    public function ip(string $host): ?string;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/IpMatcherInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/IpMatcherInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
 
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 interface IpMatcherInterface
 {
     /**

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/IpMatcherInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/IpMatcherInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Service;
+
+interface IpMatcherInterface
+{
+    /**
+     * @param string[] $whitelist
+     */
+    public function match(string $ip, array $whitelist): bool;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrl.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrl.php
@@ -12,5 +12,5 @@ use Symfony\Component\Validator\Constraint;
  */
 class ExternalUrl extends Constraint
 {
-    public string $message = 'The address {{ address }} is not allowed.';
+    public string $message = 'akeneo_connectivity.connection.webhook.error.not_allowed_url';
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrl.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrl.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Validation;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ExternalUrl extends Constraint
+{
+    public string $message = 'The address {{ address }} is not allowed.';
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
@@ -20,6 +20,8 @@ class ExternalUrlValidator extends ConstraintValidator
         'localhost',
         'elasticsearch',
         'memcached',
+        'object-storage',
+        'mysql',
     ];
 
     private DnsLookupInterface $dnsLookup;

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Webhook\Validation;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\DnsLookupInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ExternalUrlValidator extends ConstraintValidator
+{
+    private DnsLookupInterface $dnsLookup;
+
+    public function __construct(
+        DnsLookupInterface $dnsLookup
+    ) {
+        $this->dnsLookup = $dnsLookup;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof ExternalUrl) {
+            throw new UnexpectedTypeException($constraint, ExternalUrl::class);
+        }
+
+        $value = $this->valueToString($value);
+
+        if (empty($value)) {
+            return;
+        }
+
+        $host = parse_url($value, \PHP_URL_HOST);
+
+        if (empty($host) || !is_string($host)) {
+            return;
+        }
+
+        $ip = $this->dnsLookup->ip($host);
+
+        if (null === $ip) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ address }}', $this->formatValue($value))
+                ->addViolation();
+
+            return;
+        }
+
+        $flag = \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE;
+        if (!filter_var($ip, \FILTER_VALIDATE_IP, $flag)) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ address }}', $this->formatValue($value))
+                ->addViolation();
+
+            return;
+        }
+    }
+
+    private function valueToString($value): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+
+        if (\is_object($value) && method_exists($value, '__toString')) {
+            return $value->__toString();
+        }
+
+        return '';
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
@@ -23,6 +23,10 @@ class ExternalUrlValidator extends ConstraintValidator
     ];
 
     private DnsLookupInterface $dnsLookup;
+
+    /**
+     * @var string[]
+     */
     private array $networkWhitelist;
 
     public function __construct(

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Validation/ExternalUrlValidator.php
@@ -23,7 +23,7 @@ class ExternalUrlValidator extends ConstraintValidator
         $this->dnsLookup = $dnsLookup;
     }
 
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof ExternalUrl) {
             throw new UnexpectedTypeException($constraint, ExternalUrl::class);
@@ -44,23 +44,22 @@ class ExternalUrlValidator extends ConstraintValidator
         $ip = $this->dnsLookup->ip($host);
 
         if (null === $ip) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ address }}', $this->formatValue($value))
-                ->addViolation();
+            $this->context->buildViolation($constraint->message)->addViolation();
 
             return;
         }
 
         $flag = \FILTER_FLAG_NO_PRIV_RANGE | \FILTER_FLAG_NO_RES_RANGE;
         if (!filter_var($ip, \FILTER_VALIDATE_IP, $flag)) {
-            $this->context->buildViolation($constraint->message)
-                ->setParameter('{{ address }}', $this->formatValue($value))
-                ->addViolation();
+            $this->context->buildViolation($constraint->message)->addViolation();
 
             return;
         }
     }
 
+    /**
+     * @param mixed $value
+     */
     private function valueToString($value): string
     {
         if (\is_string($value)) {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/DnsLookup.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/DnsLookup.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Service;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\DnsLookupInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class DnsLookup implements DnsLookupInterface
+{
+    /**
+     * The ip returned by gethostbyname must be validated because when an error occurs in this function,
+     * the host is returned.
+     */
+    public function ip(string $host): ?string
+    {
+        $ip = gethostbyname($host);
+
+        $flag = \FILTER_FLAG_IPV4 | \FILTER_FLAG_IPV6;
+        if (!filter_var($ip, \FILTER_VALIDATE_IP, $flag)) {
+            return null;
+        }
+
+        return $ip;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/IpMatcher.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/IpMatcher.php
@@ -7,6 +7,10 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Service;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\IpMatcherInterface;
 use Symfony\Component\HttpFoundation\IpUtils;
 
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class IpMatcher implements IpMatcherInterface
 {
     /**

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/IpMatcher.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Service/IpMatcher.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Service;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\IpMatcherInterface;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+class IpMatcher implements IpMatcherInterface
+{
+    /**
+     * @param string[] $whitelist
+     */
+    public function match(string $ip, array $whitelist): bool
+    {
+        return IpUtils::checkIp($ip, $whitelist);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -98,3 +98,6 @@ services:
 
     akeneo_connectivity.connection.dns_lookup:
         class: Akeneo\Connectivity\Connection\Infrastructure\Service\DnsLookup
+
+    akeneo_connectivity.connection.ip_matcher:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Service\IpMatcher

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -95,3 +95,6 @@ services:
             - 'AES-256-OFB'
             - '%env(APP_SECRET)%'
             - '%env(APP_SECRET)%'
+
+    akeneo_connectivity.connection.dns_lookup:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Service\DnsLookup

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validation/WriteConnectionWebhook.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validation/WriteConnectionWebhook.yml
@@ -14,3 +14,4 @@ Akeneo\Connectivity\Connection\Domain\Webhook\Model\Write\ConnectionWebhook:
                 message: 'akeneo_connectivity.connection.webhook.error.wrong_url'
             - Length:
                 max: 255
+            - Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrl: ~

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -32,5 +32,6 @@ services:
         class: Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrlValidator
         arguments:
             - '@akeneo_connectivity.connection.dns_lookup'
+            - '%env(string:ALLOWED_NETWORK_WHITELIST)%'
         tags:
             - { name: validator.constraint_validator }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -1,3 +1,6 @@
+parameters:
+    env(ALLOWED_NETWORK_WHITELIST): ''
+
 services:
     akeneo_connectivity.connection.validators.connection.code_must_be_unique:
         class: Akeneo\Connectivity\Connection\Application\Settings\Validation\Connection\CodeMustBeUniqueValidator

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -35,6 +35,7 @@ services:
         class: Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrlValidator
         arguments:
             - '@akeneo_connectivity.connection.dns_lookup'
+            - '@akeneo_connectivity.connection.ip_matcher'
             - '%env(string:ALLOWED_NETWORK_WHITELIST)%'
         tags:
             - { name: validator.constraint_validator }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -27,3 +27,10 @@ services:
             - '%webhook_active_event_subscriptions_limit%'
         tags:
             - { name: validator.constraint_validator }
+
+    akeneo_connectivity.connection.validators.webhook.external_url:
+        class: Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrlValidator
+        arguments:
+            - '@akeneo_connectivity.connection.dns_lookup'
+        tags:
+            - { name: validator.constraint_validator }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -236,6 +236,7 @@ akeneo_connectivity.connection:
             required: This field is required.
             not_found: You are trying to update a connection that does not exist.
             limit_reached: You have reached the limit of active event subscriptions.
+            not_allowed_url: This url is not allowed.
         flash:
             success: Event subscription successfully updated.
             error: Sorry, an error occurred while editing the event subscription.

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/WebhookReachabilityChecker.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Service/WebhookReachabilityChecker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\UrlReachabilityCheckerInterface;
+use Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrl;
 use Akeneo\Connectivity\Connection\Domain\Webhook\DTO\UrlReachabilityStatus;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Client\Signature;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\RequestHeaders;
@@ -40,7 +41,11 @@ class WebhookReachabilityChecker implements UrlReachabilityCheckerInterface
 
     public function check(string $url, string $secret): UrlReachabilityStatus
     {
-        $violations = $this->validator->validate($url, [new Assert\Url(), new Assert\NotBlank(),]);
+        $violations = $this->validator->validate($url, [
+            new Assert\Url(),
+            new Assert\NotBlank(),
+            new ExternalUrl(),
+        ]);
 
         if (0 !== count($violations)) {
             return new UrlReachabilityStatus(

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
@@ -44,7 +44,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $connection->code(),
             'enabled' => true,
-            'url' => 'http://localhost',
+            'url' => 'http://example.com',
         ];
 
         $this->authenticateAsAdmin();
@@ -151,7 +151,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => 'shopify',
             'enabled' => true,
-            'url' => 'http://localhost',
+            'url' => 'http://example.com',
         ];
 
         $this->authenticateAsAdmin();
@@ -218,7 +218,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $translationConnection->code(),
             'enabled' => true,
-            'url' => 'http://localhost',
+            'url' => 'http://example.com',
         ];
 
         $this->authenticateAsAdmin();

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
@@ -250,6 +250,37 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         );
     }
 
+    public function test_it_fails_to_update_a_webhook_with_a_forbidden_url(): void
+    {
+        $connection = $this->connectionLoader->createConnection(
+            'magento',
+            'Magento',
+            FlowType::DATA_SOURCE,
+            false,
+        );
+
+        $data = [
+            'code' => $connection->code(),
+            'enabled' => true,
+            'url' => 'http://localhost',
+        ];
+
+        $this->authenticateAsAdmin();
+        $this->client->request(
+            'POST',
+            sprintf('/rest/connections/%s/webhook', $connection->code()),
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            json_encode($data),
+        );
+
+        Assert::assertEquals(
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            $this->client->getResponse()->getStatusCode(),
+        );
+    }
+
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/UpdateEventSubscriptionEndToEnd.php
@@ -44,7 +44,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $connection->code(),
             'enabled' => true,
-            'url' => 'http://example.com',
+            'url' => 'http://example.test',
         ];
 
         $this->authenticateAsAdmin();
@@ -151,7 +151,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => 'shopify',
             'enabled' => true,
-            'url' => 'http://example.com',
+            'url' => 'http://example.test',
         ];
 
         $this->authenticateAsAdmin();
@@ -218,7 +218,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $translationConnection->code(),
             'enabled' => true,
-            'url' => 'http://example.com',
+            'url' => 'http://example.test',
         ];
 
         $this->authenticateAsAdmin();

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeDnsLookup.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeDnsLookup.php
@@ -6,6 +6,10 @@ namespace Akeneo\Connectivity\Connection\Tests\Integration\Mock;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\DnsLookupInterface;
 
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 class FakeDnsLookup implements DnsLookupInterface
 {
     public function ip(string $host): ?string

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeDnsLookup.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeDnsLookup.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Mock;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\DnsLookupInterface;
+
+class FakeDnsLookup implements DnsLookupInterface
+{
+    public function ip(string $host): ?string
+    {
+        return '168.212.226.204';
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Resources/config/services.yml
@@ -1,3 +1,5 @@
 services:
     akeneo_connectivity.connection.clock:
         class: Akeneo\Connectivity\Connection\Infrastructure\Service\Clock\FakeClock
+    akeneo_connectivity.connection.dns_lookup:
+        class: Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeDnsLookup

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/ExternalUrlValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/ExternalUrlValidatorSpec.php
@@ -18,11 +18,9 @@ use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 class ExternalUrlValidatorSpec extends ObjectBehavior
 {
     public function let(
-        ExecutionContextInterface $context,
         DnsLookupInterface $dnsLookup
     ): void {
         $this->beConstructedWith($dnsLookup);
-        $this->initialize($context);
     }
 
     public function it_is_initializable(): void
@@ -38,67 +36,136 @@ class ExternalUrlValidatorSpec extends ObjectBehavior
             ->during('validate', ['', $constraint]);
     }
 
-    public function it_does_not_add_violations_if_the_value_is_empty(
+    public function it_ignores_the_value_if_empty(
         ExecutionContextInterface $context,
         ExternalUrl $constraint
     ): void {
+        $this->initialize($context);
+        $value = '';
+
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
-        $this->validate('', $constraint);
+        $this->validate($value, $constraint);
     }
 
-    public function it_does_not_add_violations_if_the_value_is_not_an_url(
+    public function it_ignores_the_value_if_not_an_url(
         ExecutionContextInterface $context,
         ExternalUrl $constraint
     ): void {
+        $this->initialize($context);
+        $value = 'not_an_url';
+
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
-        $this->validate('not_an_url', $constraint);
+        $this->validate($value, $constraint);
     }
 
-    public function it_adds_a_violation_if_the_dns_lookup_fails(
+    public function it_ignores_the_value_if_url_cannot_be_resolved(
         ExecutionContextInterface $context,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder,
         DnsLookupInterface $dnsLookup,
         ExternalUrl $constraint
     ): void {
+        $this->initialize($context);
         $value = 'http://akeneo.com/foo';
 
         $dnsLookup->ip('akeneo.com')->willReturn(null);
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_adds_a_violation_if_the_url_is_localhost(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        ExternalUrl $constraint
+    ): void {
+        $this->initialize($context);
+
+        $value = 'http://localhost/foo';
+
         $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->setParameter('{{ address }}', '"'.$value.'"')
-            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter(Argument::cetera())->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);
     }
 
-    public function it_adds_a_violation_if_the_ip_belong_to_private_range(
+    public function it_adds_a_violation_if_the_url_is_elasticsearch(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        ExternalUrl $constraint
+    ): void {
+        $this->initialize($context);
+
+        $value = 'http://elasticsearch/foo';
+
+        $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter(Argument::cetera())->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_adds_a_violation_if_the_url_is_memcached(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        ExternalUrl $constraint
+    ): void {
+        $this->initialize($context);
+
+        $value = 'http://memcached/foo';
+
+        $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter(Argument::cetera())->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_adds_a_violation_if_the_ip_is_in_private_range(
         ExecutionContextInterface $context,
         ConstraintViolationBuilderInterface $constraintViolationBuilder,
         DnsLookupInterface $dnsLookup,
         ExternalUrl $constraint
     ): void {
+        $this->initialize($context);
+
         $value = 'http://akeneo.com/foo';
 
         $dnsLookup->ip('akeneo.com')->willReturn('172.16.0.1');
         $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
-        $constraintViolationBuilder->setParameter('{{ address }}', '"'.$value.'"')
-            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter(Argument::cetera())->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($value, $constraint);
     }
 
-    public function it_does_not_add_violations_if_the_ip_is_external(
+    public function it_allows_the_ip_if_in_private_range_and_in_whitelist(
         ExecutionContextInterface $context,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder,
         DnsLookupInterface $dnsLookup,
         ExternalUrl $constraint
     ): void {
+        $this->beConstructedWith($dnsLookup, '172.16.0.0/24');
+        $this->initialize($context);
+
         $value = 'http://akeneo.com/foo';
 
-        $dnsLookup->ip('akeneo.com')->willReturn('205.205.205.1');
+        $dnsLookup->ip('akeneo.com')->willReturn('172.16.0.1');
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_allows_the_ip_if_external(
+        ExecutionContextInterface $context,
+        DnsLookupInterface $dnsLookup,
+        ExternalUrl $constraint
+    ): void {
+        $this->initialize($context);
+
+        $value = 'http://akeneo.com/foo';
+
+        $dnsLookup->ip('akeneo.com')->willReturn('168.212.226.204');
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
         $this->validate($value, $constraint);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/ExternalUrlValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/ExternalUrlValidatorSpec.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Application\Webhook\Validation;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Service\DnsLookupInterface;
+use Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrl;
+use Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrlValidator;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+class ExternalUrlValidatorSpec extends ObjectBehavior
+{
+    public function let(
+        ExecutionContextInterface $context,
+        DnsLookupInterface $dnsLookup
+    ): void {
+        $this->beConstructedWith($dnsLookup);
+        $this->initialize($context);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldBeAnInstanceOf(ExternalUrlValidator::class);
+        $this->shouldImplement(ConstraintValidatorInterface::class);
+    }
+
+    public function it_does_not_support_other_constraints(Constraint $constraint): void
+    {
+        $this
+            ->shouldThrow(new UnexpectedTypeException($constraint->getWrappedObject(), ExternalUrl::class))
+            ->during('validate', ['', $constraint]);
+    }
+
+    public function it_does_not_add_violations_if_the_value_is_empty(
+        ExecutionContextInterface $context,
+        ExternalUrl $constraint
+    ): void {
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('', $constraint);
+    }
+
+    public function it_does_not_add_violations_if_the_value_is_not_an_url(
+        ExecutionContextInterface $context,
+        ExternalUrl $constraint
+    ): void {
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate('not_an_url', $constraint);
+    }
+
+    public function it_adds_a_violation_if_the_dns_lookup_fails(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        DnsLookupInterface $dnsLookup,
+        ExternalUrl $constraint
+    ): void {
+        $value = 'http://akeneo.com/foo';
+
+        $dnsLookup->ip('akeneo.com')->willReturn(null);
+        $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter('{{ address }}', '"'.$value.'"')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_adds_a_violation_if_the_ip_belong_to_private_range(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        DnsLookupInterface $dnsLookup,
+        ExternalUrl $constraint
+    ): void {
+        $value = 'http://akeneo.com/foo';
+
+        $dnsLookup->ip('akeneo.com')->willReturn('172.16.0.1');
+        $context->buildViolation($constraint->message)->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->setParameter('{{ address }}', '"'.$value.'"')
+            ->willReturn($constraintViolationBuilder);
+        $constraintViolationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
+    public function it_does_not_add_violations_if_the_ip_is_external(
+        ExecutionContextInterface $context,
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
+        DnsLookupInterface $dnsLookup,
+        ExternalUrl $constraint
+    ): void {
+        $value = 'http://akeneo.com/foo';
+
+        $dnsLookup->ip('akeneo.com')->willReturn('205.205.205.1');
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Service/IpMatcherSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Service/IpMatcherSpec.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Service;
+
+use PhpSpec\ObjectBehavior;
+
+class IpMatcherSpec extends ObjectBehavior
+{
+    function it_does_not_match_if_the_whitelist_is_empty()
+    {
+        $this->match('168.212.226.204', [])->shouldReturn(false);
+    }
+
+    function it_does_not_match_if_not_in_the_whitelist()
+    {
+        $this->match('168.212.226.204', ['10.0.0.0'])->shouldReturn(false);
+    }
+
+    function it_match_if_in_the_whitelist()
+    {
+        $this->match('168.212.226.204', ['168.212.226.0/24'])->shouldReturn(true);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/WebhookReachabilityCheckerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Service/WebhookReachabilityCheckerSpec.php
@@ -52,7 +52,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
                 $this->getWrappedObject()::POST === $object->getMethod() &&
                 $validUrl === (string) $object->getUri();
         }))->willReturn(new Response(200, [], null, '1.1', 'OK'));
-        $validator->validate($validUrl, [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),])->willReturn([]);
+        $validator->validate($validUrl, Argument::any())->willReturn([]);
 
         $resultUrlReachabilityStatus = $this->check($validUrl, $secret);
 
@@ -74,7 +74,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
 
         $validator->validate(
             $notValidUrl,
-            [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),]
+            Argument::any()
         )->willReturn($violationList);
 
         $resultUrlReachabilityStatus = $this->check($notValidUrl, $secret);
@@ -97,7 +97,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
 
         $validator->validate(
             $emptyUrl,
-            [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),]
+            Argument::any()
         )->willReturn($violationList);
 
         $resultUrlReachabilityStatus = $this->check($emptyUrl, $secret);
@@ -125,7 +125,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
                 $this->getWrappedObject()::POST === $object->getMethod() &&
                 $validUrl === (string) $object->getUri();
         }))->willThrow($requestException);
-        $validator->validate($validUrl, [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),])->willReturn([]);
+        $validator->validate($validUrl, Argument::any())->willReturn([]);
 
         $resultUrlReachabilityStatus = $this->check($validUrl, $secret);
 
@@ -150,7 +150,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
                 $this->getWrappedObject()::POST === $object->getMethod() &&
                 $validUrl === (string) $object->getUri();
         }))->willThrow($connectException);
-        $validator->validate($validUrl, [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),])->willReturn([]);
+        $validator->validate($validUrl, Argument::any())->willReturn([]);
 
         $resultUrlReachabilityStatus = $this->check($validUrl, $secret);
 
@@ -174,7 +174,7 @@ class WebhookReachabilityCheckerSpec extends ObjectBehavior
                 $this->getWrappedObject()::POST === $object->getMethod() &&
                 $validUrl === (string) $object->getUri();
         }))->willThrow($transferException);
-        $validator->validate($validUrl, [new ValidatorAssert\Url(), new ValidatorAssert\NotBlank(),])->willReturn([]);
+        $validator->validate($validUrl, Argument::any())->willReturn([]);
 
         $resultUrlReachabilityStatus = $this->check($validUrl, $secret);
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Rules**

Blacklist of the domains:
- localhost
- elasticsearch
- memcached 

Check URL for use of IP addresses instead of FQDN's and blacklist all RFC 1918 IPs

Set a new env variable to allow a coma separated list of specific network. For example: `ALLOWED_NETWORK_WHITELIST=10.0.2.0/24,172.19.8`

**Description (for Contributor and Core Developer)**

In the Event Subscription endpoint field, we want to check 2 things:
First, only urls are allowed (http & https), not other protocols.
![Screenshot_2021-06-09_17-10-30](https://user-images.githubusercontent.com/1421130/121381305-e5303400-c945-11eb-8dc7-0f2017abb05d.png)
Second, urls resolving to internal ips are forbidden.
![Screenshot_2021-06-09_17-09-49](https://user-images.githubusercontent.com/1421130/121381402-fbd68b00-c945-11eb-9a5d-a63d2e0d0ace.png)


**Documentation's PR:** https://github.com/akeneo/pim-docs/pull/1643

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [x] Tech Doc
