### PR TITLE
API-1608: Update EventsApiRequestLimitSubscriber to use MessageProcessedEvent

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriber.php
@@ -6,11 +6,11 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\LimitOfEventsApiRequestsReachedLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\GetDelayUntilNextRequest;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\Sleep;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Messenger\Event\WorkerRunningEvent;
 
 /**
  * @author Pierre Jolly <pierre.jolly@akeneo.com>
@@ -45,7 +45,7 @@ final class EventsApiRequestsLimitEventSubscriber implements EventSubscriberInte
     public static function getSubscribedEvents(): array
     {
         return [
-            WorkerRunningEvent::class => 'checkWebhookRequestLimit',
+            MessageProcessedEvent::class => 'checkWebhookRequestLimit',
         ];
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/EventsApiRequestsLimitEventSubscriberSpec.php
@@ -6,6 +6,7 @@ namespace spec\Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber;
 
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\LimitOfEventsApiRequestsReachedLogger;
 use Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepository;
 use Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\EventsApiRequestsLimitEventSubscriber;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\GetDelayUntilNextRequest;
@@ -37,7 +38,7 @@ class EventsApiRequestsLimitEventSubscriberSpec extends ObjectBehavior
     public function it_provides_subscribed_events(): void
     {
         $this->getSubscribedEvents()->shouldReturn([
-            WorkerRunningEvent::class => 'checkWebhookRequestLimit',
+            MessageProcessedEvent::class => 'checkWebhookRequestLimit',
         ]);
     }
 


### PR DESCRIPTION
In `EventsApiRequestsLimitEventSubscriber.php`, replace `WorkerRunningEvent` by `MessageProcessedEvent` in `getSubscribedEvents()`