### PR TITLE
CXP-687: remove Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface coupling

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/ErrorManagement/Service/CollectApiError.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/ErrorManagement/Service/CollectApiError.php
@@ -16,7 +16,6 @@ use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Persistence\Repository
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
 use Akeneo\Pim\Enrichment\Component\Error\DomainErrorInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Serializer\Serializer;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -53,13 +52,11 @@ class CollectApiError
 
     public function collectFromProductDomainError(
         DomainErrorInterface $error,
-        ?ProductInterface $product
+        ?Context $context
     ): void {
         if (false === $this->isConnectionCollectable()) {
             return;
         }
-
-        $context = (new Context())->setAttribute('product', $product);
         $json = $this->serializer->serialize($error, 'json', $context);
         $this->errors->add(new BusinessError($json));
     }
@@ -69,13 +66,12 @@ class CollectApiError
      */
     public function collectFromProductValidationError(
         ConstraintViolationListInterface $constraintViolationList,
-        ProductInterface $product
+        Context $context
     ): void {
         if (false === $this->isConnectionCollectable()) {
             return;
         }
 
-        $context = (new Context())->setAttribute('product', $product);
         foreach ($constraintViolationList as $constraintViolation) {
             $json = $this->serializer->serialize($constraintViolation, 'json', $context);
             $this->errors->add(new BusinessError($json));

--- a/src/Akeneo/Connectivity/Connection/back/Application/ErrorManagement/Service/CollectApiError.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/ErrorManagement/Service/CollectApiError.php
@@ -52,7 +52,7 @@ class CollectApiError
 
     public function collectFromProductDomainError(
         DomainErrorInterface $error,
-        ?Context $context
+        Context $context
     ): void {
         if (false === $this->isConnectionCollectable()) {
             return;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
@@ -42,13 +42,10 @@ final class ApiErrorEventSubscriber implements EventSubscriberInterface
 
     public function collectProductDomainError(ProductDomainErrorEvent $event): void
     {
-        $context = new Context();
-
-        if ($event->getProduct() instanceof ProductInterface) {
-            $context->setAttribute('product', $event->getProduct());
-        }
-
-        $this->collectApiError->collectFromProductDomainError($event->getError(), $context);
+        $this->collectApiError->collectFromProductDomainError(
+            $event->getError(),
+            (new Context())->setAttribute('product', $event->getProduct())
+        );
     }
 
     public function collectProductValidationError(ProductValidationErrorEvent $event): void

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
@@ -8,6 +8,7 @@ use Akeneo\Connectivity\Connection\Application\ErrorManagement\Service\CollectAp
 use Akeneo\Pim\Enrichment\Bundle\Event\ProductValidationErrorEvent;
 use Akeneo\Pim\Enrichment\Bundle\Event\TechnicalErrorEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Event\ProductDomainErrorEvent;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use FOS\RestBundle\Context\Context;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -41,7 +42,12 @@ final class ApiErrorEventSubscriber implements EventSubscriberInterface
 
     public function collectProductDomainError(ProductDomainErrorEvent $event): void
     {
-        $context = (new Context())->setAttribute('product', $event->getProduct());
+        $context = new Context();
+
+        if ($event->getProduct() instanceof ProductInterface) {
+            $context->setAttribute('product', $event->getProduct());
+        }
+
         $this->collectApiError->collectFromProductDomainError($event->getError(), $context);
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/EventSubscriber/ApiErrorEventSubscriber.php
@@ -8,6 +8,7 @@ use Akeneo\Connectivity\Connection\Application\ErrorManagement\Service\CollectAp
 use Akeneo\Pim\Enrichment\Bundle\Event\ProductValidationErrorEvent;
 use Akeneo\Pim\Enrichment\Bundle\Event\TechnicalErrorEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Event\ProductDomainErrorEvent;
+use FOS\RestBundle\Context\Context;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -40,14 +41,16 @@ final class ApiErrorEventSubscriber implements EventSubscriberInterface
 
     public function collectProductDomainError(ProductDomainErrorEvent $event): void
     {
-        $this->collectApiError->collectFromProductDomainError($event->getError(), $event->getProduct());
+        $context = (new Context())->setAttribute('product', $event->getProduct());
+        $this->collectApiError->collectFromProductDomainError($event->getError(), $context);
     }
 
     public function collectProductValidationError(ProductValidationErrorEvent $event): void
     {
+        $context = (new Context())->setAttribute('product', $event->getProduct());
         $this->collectApiError->collectFromProductValidationError(
             $event->getConstraintViolationList(),
-            $event->getProduct()
+            $context
         );
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -42,7 +42,6 @@ $rules = [
 
             // Not ok
             'Akeneo\Pim\Enrichment\Component\Error\DomainErrorInterface',
-            'Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface',
         ]
     )->in('Akeneo\Connectivity\Connection\Application\ErrorManagement'),
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/ErrorManagement/Service/CollectApiErrorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/ErrorManagement/Service/CollectApiErrorSpec.php
@@ -16,6 +16,7 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection;
 use Akeneo\Pim\Enrichment\Component\Error\DomainErrorInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Serializer\Serializer;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
@@ -51,6 +52,8 @@ class CollectApiErrorSpec extends ObjectBehavior
         $connectionContext->getConnection()->willReturn($connection);
         $connectionContext->isCollectable()->willReturn(true);
 
+        $context = (new Context())->setAttribute('product', $product);
+
         $connection->code()->willReturn(new ConnectionCode('erp'));
         $connection->flowType()->willReturn(new FlowType(FlowType::DATA_SOURCE));
 
@@ -85,7 +88,7 @@ class CollectApiErrorSpec extends ObjectBehavior
         }))
             ->shouldBeCalled();
 
-        $this->collectFromProductDomainError($error, $product);
+        $this->collectFromProductDomainError($error, $context);
         $this->flush();
     }
 
@@ -103,6 +106,8 @@ class CollectApiErrorSpec extends ObjectBehavior
             $violation1->getWrappedObject(),
             $violation2->getWrappedObject()
         ]);
+
+        $context = (new Context())->setAttribute('product', $product);
 
         $connectionContext->getConnection()->willReturn($connection);
         $connectionContext->isCollectable()->willReturn(true);
@@ -147,7 +152,7 @@ class CollectApiErrorSpec extends ObjectBehavior
         }))
             ->shouldBeCalled();
 
-        $this->collectFromProductValidationError($violationList, $product);
+        $this->collectFromProductValidationError($violationList, $context);
         $this->flush();
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
@@ -47,7 +47,7 @@ class ApiErrorEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $event = new ProductDomainErrorEvent($error, $product);
         $context = (new Context())->setAttribute('product', $event->getProduct());
-        
+
         $collectApiError->collectFromProductDomainError($error, $context)->shouldBeCalled();
 
         $this->collectProductDomainError($event);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
@@ -11,6 +11,7 @@ use Akeneo\Pim\Enrichment\Bundle\Event\TechnicalErrorEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Event\ProductDomainErrorEvent;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnknownAttributeException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use FOS\RestBundle\Context\Context;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\TerminateEvent;
@@ -45,8 +46,10 @@ class ApiErrorEventSubscriberSpec extends ObjectBehavior
         $error = new UnknownAttributeException('attribute_code');
         $product = new Product();
         $event = new ProductDomainErrorEvent($error, $product);
+        $context = (new Context())->setAttribute('product', $event->getProduct());
 
-        $collectApiError->collectFromProductDomainError($error, $product)->shouldBeCalled();
+
+        $collectApiError->collectFromProductDomainError($error, $context)->shouldBeCalled();
 
         $this->collectProductDomainError($event);
     }
@@ -56,8 +59,9 @@ class ApiErrorEventSubscriberSpec extends ObjectBehavior
         $constraintViolationList = new ConstraintViolationList();
         $product = new Product();
         $event = new ProductValidationErrorEvent($constraintViolationList, $product);
+        $context = (new Context())->setAttribute('product', $event->getProduct());
 
-        $collectApiError->collectFromProductValidationError($constraintViolationList, $product)->shouldBeCalled();
+        $collectApiError->collectFromProductValidationError($constraintViolationList, $context)->shouldBeCalled();
 
         $this->collectProductValidationError($event);
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/EventSubscriber/ApiErrorEventSubscriberSpec.php
@@ -47,8 +47,7 @@ class ApiErrorEventSubscriberSpec extends ObjectBehavior
         $product = new Product();
         $event = new ProductDomainErrorEvent($error, $product);
         $context = (new Context())->setAttribute('product', $event->getProduct());
-
-
+        
         $collectApiError->collectFromProductDomainError($error, $context)->shouldBeCalled();
 
         $this->collectProductDomainError($event);


### PR DESCRIPTION
Pass Context instead of Product in `Akeneo\Connectivity\Connection\Application\ErrorManagement\Service\CollectApiError::collectFromProductDomainError:collectFromProductDomainError() `and `Akeneo\Connectivity\Connection\Application\ErrorManagement\Service\CollectApiError::collectFromProductDomainError:collectFromProductValidationError()`