### PR TITLE
PIM-9719: add entity updated info in indexation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 
 - PIM-9648: Mitigate DDoS risk on API auth endpoint by rejecting too large content
 - PIM-9697: Exported files streamer
+- PIM-9719: Add the real "updated" values in ES for product and product models
 
 ## Classes
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Model/ElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Model/ElasticsearchProductModelProjection.php
@@ -15,65 +15,37 @@ final class ElasticsearchProductModelProjection
 {
     private const INDEX_DATE_FORMAT = 'c';
 
-    /** @var int */
-    private $id;
-
-    /** @var string */
-    private $code;
-
-    /** @var \DateTimeImmutable */
-    private $createdDate;
-
-    /** @var \DateTimeImmutable */
-    private $updatedDate;
-
-    /** @var string */
-    private $familyCode;
-
+    private int $id;
+    private string $code;
+    private \DateTimeImmutable $createdDate;
+    private \DateTimeImmutable $updatedDate;
+    private \DateTimeImmutable $entityUpdatedDate;
+    private string $familyCode;
     /** @var string[] */
-    private $familyLabels;
-
-    /** @var string */
-    private $familyVariantCode;
-
+    private array $familyLabels;
+    private string $familyVariantCode;
     /** @var string[] */
-    private $categoryCodes;
-
+    private array $categoryCodes;
     /** @var string[] */
-    private $ancestorCategoryCodes;
-
-    /** @var string|null */
-    private $parentCode;
-
-    /** @var array */
-    private $values;
-
-    /** @var array */
-    private $allComplete;
-
-    /** @var array */
-    private $allIncomplete;
-
-    /** @var int|null */
-    private $parentId;
-
-    /** @var array */
-    private $labels;
-
+    private array $ancestorCategoryCodes;
+    private ?string $parentCode;
+    private array $values;
+    private array $allComplete;
+    private array $allIncomplete;
+    private ?int $parentId;
+    private array $labels;
     /** @var string[] */
-    private $ancestorAttributeCodes;
-
+    private array $ancestorAttributeCodes;
     /** @var string[] */
-    private $attributesForThisLevel;
-
-    /** @var array */
-    private $additionalData = [];
+    private array $attributesForThisLevel;
+    private array $additionalData = [];
 
     public function __construct(
         int $id,
         string $code,
         \DateTimeImmutable $createdDate,
         \DateTimeImmutable $updatedDate,
+        \DateTimeImmutable $entityUpdatedDate,
         string $familyCode,
         array $familyLabels,
         string $familyVariantCode,
@@ -93,6 +65,7 @@ final class ElasticsearchProductModelProjection
         $this->code = $code;
         $this->createdDate = $createdDate;
         $this->updatedDate = $updatedDate;
+        $this->entityUpdatedDate = $entityUpdatedDate;
         $this->familyCode = $familyCode;
         $this->familyLabels = $familyLabels;
         $this->familyVariantCode = $familyVariantCode;
@@ -118,6 +91,7 @@ final class ElasticsearchProductModelProjection
             $this->code,
             $this->createdDate,
             $this->updatedDate,
+            $this->entityUpdatedDate,
             $this->familyCode,
             $this->familyLabels,
             $this->familyVariantCode,
@@ -142,6 +116,7 @@ final class ElasticsearchProductModelProjection
             'identifier' => $this->code,
             'created' => $this->createdDate->format(self::INDEX_DATE_FORMAT),
             'updated' => $this->updatedDate->format(self::INDEX_DATE_FORMAT),
+            'entity_updated' => $this->entityUpdatedDate->format(self::INDEX_DATE_FORMAT),
             'family' => [
                 'code' => $this->familyCode,
                 'labels' => $this->familyLabels,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Model/ElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Model/ElasticsearchProductProjection.php
@@ -16,71 +16,34 @@ final class ElasticsearchProductProjection
     private const INDEX_PREFIX_ID   = 'product_';
     private const INDEX_DATE_FORMAT = 'c';
 
-    /** @var string */
-    private $id;
-
-    /** @var string */
-    private $identifier;
-
-    /** @var \DateTimeImmutable */
-    private $createdDate;
-
-    /** @var \DateTimeImmutable */
-    private $updatedDate;
-
-    /** @var bool */
-    private $isEnabled;
-
-    /** @var null|string */
-    private $familyCode;
-
-    /** @var null|array */
-    private $familyLabels;
-
-    /** @var null|string */
-    private $familyVariantCode;
-
-    /** @var array */
-    private $categoryCodes;
-
-    /** @var array */
-    private $categoryCodesOfAncestors;
-
-    /** @var array */
-    private $groupCodes;
-
-    /** @var array */
-    private $completeness;
-
-    /** @var null|string */
-    private $parentProductModelCode;
-
-    /** @var array */
-    private $values;
-
-    /** @var array */
-    private $ancestorsIds;
-
-    /** @var array */
-    private $ancestorsCodes;
-
-    /** @var null|array */
-    private $label;
-
-    /** @var array */
-    private $attributeCodesForAncestor;
-
-    /** @var array */
-    private $attributeCodesForThisLevel;
-
-    /** @var array */
-    private $additionalData = [];
+    private string $id;
+    private string $identifier;
+    private \DateTimeImmutable $createdDate;
+    private \DateTimeImmutable $updatedDate;
+    private \DateTimeImmutable $entityUpdatedDate;
+    private bool $isEnabled;
+    private ?string $familyCode;
+    private ?array $familyLabels;
+    private ?string $familyVariantCode;
+    private array $categoryCodes;
+    private array $categoryCodesOfAncestors;
+    private array $groupCodes;
+    private array $completeness;
+    private ?string $parentProductModelCode;
+    private array $values;
+    private array $ancestorsIds;
+    private array $ancestorsCodes;
+    private ?array $label;
+    private array $attributeCodesForAncestor;
+    private array $attributeCodesForThisLevel;
+    private array $additionalData = [];
 
     public function __construct(
         string $id,
         string $identifier,
         \DateTimeImmutable $createdDate,
         \DateTimeImmutable $updatedDate,
+        \DateTimeImmutable $entityUpdatedDate,
         bool $isEnabled,
         ?string $familyCode,
         ?array $familyLabels,
@@ -102,6 +65,7 @@ final class ElasticsearchProductProjection
         $this->identifier = $identifier;
         $this->createdDate = $createdDate;
         $this->updatedDate = $updatedDate;
+        $this->entityUpdatedDate = $entityUpdatedDate;
         $this->isEnabled = $isEnabled;
         $this->familyCode = $familyCode;
         $this->familyLabels = $familyLabels;
@@ -129,6 +93,7 @@ final class ElasticsearchProductProjection
             $this->identifier,
             $this->createdDate,
             $this->updatedDate,
+            $this->entityUpdatedDate,
             $this->isEnabled,
             $this->familyCode,
             $this->familyLabels,
@@ -171,6 +136,7 @@ final class ElasticsearchProductProjection
             'identifier' => $this->identifier,
             'created' => $this->createdDate->format(self::INDEX_DATE_FORMAT),
             'updated' => $this->updatedDate->format(self::INDEX_DATE_FORMAT),
+            'entity_updated' => $this->entityUpdatedDate->format(self::INDEX_DATE_FORMAT),
             'family' => $familyCode,
             'enabled' => $this->isEnabled,
             'categories' => $this->categoryCodes,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
@@ -20,6 +20,8 @@ mappings:
             type: 'date'
         updated:
             type: 'date'
+        entity_updated:
+            type: 'date'
         identifier:
             type: 'keyword'
             normalizer: 'identifier_normalizer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -12,6 +12,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\ReadValueCollectionFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Indexing\Value\ValueCollectionNormalizer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
@@ -21,23 +22,17 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class GetElasticsearchProductModelProjection implements GetElasticsearchProductModelProjectionInterface
 {
-    /** @var Connection */
-    private $connection;
-
-    /** @var ReadValueCollectionFactory */
-    private $readValueCollectionFactory;
-
-    /** @var NormalizerInterface */
-    private $valueCollectionNormalizer;
-
+    private Connection $connection;
+    private ReadValueCollectionFactory $readValueCollectionFactory;
+    private NormalizerInterface $valueCollectionNormalizer;
     /** @var GetAdditionalPropertiesForProductModelProjectionInterface[] */
-    private $additionalDataProviders = [];
+    private iterable $additionalDataProviders;
 
     public function __construct(
         Connection $connection,
         ReadValueCollectionFactory $readValueCollectionFactory,
         NormalizerInterface $valueCollectionNormalizer,
-        iterable $additionalDataProviders
+        iterable $additionalDataProviders = []
     ) {
         $this->connection = $connection;
         $this->readValueCollectionFactory = $readValueCollectionFactory;
@@ -70,6 +65,7 @@ class GetElasticsearchProductModelProjection implements GetElasticsearchProductM
                 $valuesAndProperties[$productModelCode]['code'],
                 $valuesAndProperties[$productModelCode]['created'],
                 $valuesAndProperties[$productModelCode]['updated'],
+                $valuesAndProperties[$productModelCode]['entity_updated'],
                 $valuesAndProperties[$productModelCode]['family_code'],
                 $valuesAndProperties[$productModelCode]['family_labels'],
                 $valuesAndProperties[$productModelCode]['family_variant_code'],
@@ -107,6 +103,7 @@ WITH
             product_model.created,
             root_product_model.code AS parent_code,
             GREATEST(product_model.updated, COALESCE(root_product_model.updated, 0)) as updated,
+            product_model.updated as entity_updated,
             JSON_MERGE_PATCH(COALESCE(root_product_model.raw_values, '{}'), COALESCE(product_model.raw_values, '{}')) AS raw_values,
             family.code AS family_code,
             family_variant.code AS family_variant_code,
@@ -178,18 +175,16 @@ SQL;
 
         $platform = $this->connection->getDatabasePlatform();
         $results = [];
+        $dateTimeImmutableType = Type::getType(Types::DATETIME_IMMUTABLE);
         foreach ($rows as $row) {
             $values = $row['raw_values'];
 
             $results[$row['code']] = [
                 'id' => (int) $row['id'],
                 'code' => $row['code'],
-                'created' => \DateTimeImmutable::createFromMutable(
-                    Type::getType(Type::DATETIME)->convertToPhpValue($row['created'], $platform)
-                ),
-                'updated' => \DateTimeImmutable::createFromMutable(
-                    Type::getType(Type::DATETIME)->convertToPhpValue($row['updated'], $platform)
-                ),
+                'created' => $dateTimeImmutableType->convertToPhpValue($row['created'], $platform),
+                'updated' => $dateTimeImmutableType->convertToPhpValue($row['updated'], $platform),
+                'entity_updated' => $dateTimeImmutableType->convertToPhpValue($row['entity_updated'], $platform),
                 'family_code' => $row['family_code'],
                 'family_labels' => json_decode($row['family_labels'], true),
                 'family_variant_code' => $row['family_variant_code'],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
@@ -324,10 +324,13 @@ class GetElasticsearchProductModelProjectionIntegration extends TestCase
     {
         $actual = $this->getProductModelProjectionArray($code);
 
-        Assert::assertRegexp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\+|-)\d{2}:\d{2}/', $actual['created']);
-        Assert::assertRegexp('/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\+|-)\d{2}:\d{2}/', $actual['updated']);
+        $dateRegExp = '/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\+|-)\d{2}:\d{2}/';
+        Assert::assertMatchesRegularExpression($dateRegExp, $actual['created']);
+        Assert::assertMatchesRegularExpression($dateRegExp, $actual['updated']);
+        Assert::assertMatchesRegularExpression($dateRegExp, $actual['entity_updated']);
         unset($actual['created']);
         unset($actual['updated']);
+        unset($actual['entity_updated']);
 
         Assert::assertEqualsCanonicalizing($expected, $actual);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
@@ -36,6 +36,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
             'identifier' => 'bar',
             'created' => $date->format('c'),
             'updated' => $date->format('c'),
+            'entity_updated' => $date->format('c'),
             'family' => [
                 'code' => 'familyA',
                 'labels' => [
@@ -153,6 +154,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
             'identifier' => 'bar',
             'created' => $date->format('c'),
             'updated' => $date->format('c'),
+            'entity_updated' => $date->format('c'),
             'family' => [
                 'code' => 'familyA',
                 'labels' => [
@@ -265,6 +267,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
             'identifier' => 'bar',
             'created' => $date->format('c'),
             'updated' => $date->format('c'),
+            'entity_updated' => $date->format('c'),
             'family' => null,
             'enabled' => true,
             'categories' => [],
@@ -709,6 +712,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
     {
         $productProjection['created']= DateSanitizer::sanitize($productProjection['created']);
         $productProjection['updated']= DateSanitizer::sanitize($productProjection['updated']);
+        $productProjection['entity_updated']= DateSanitizer::sanitize($productProjection['entity_updated']);
 
         self::sanitizeMediaAttributeData($productProjection);
         sort($productProjection['categories']);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -174,6 +174,7 @@ class ProductIndexerSpec extends ObjectBehavior
             $identifier,
             new \DateTimeImmutable('2019-03-16 12:03:00', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-03-16 12:03:00', new \DateTimeZone('UTC')),
+            new \DateTimeImmutable('2019-03-16 12:03:00', new \DateTimeZone('UTC')),
             true,
             'family_code',
             [],

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelIndexerSpec.php
@@ -170,6 +170,7 @@ class ProductModelIndexerSpec extends ObjectBehavior
             $code,
             new \DateTimeImmutable('2000-12-30'),
             new \DateTimeImmutable('2000-12-31'),
+            new \DateTimeImmutable('2000-12-31'),
             'familyCode',
             [],
             'familyVariantCode',

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Model/ElasticsearchProductModelProjectionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Model/ElasticsearchProductModelProjectionSpec.php
@@ -16,6 +16,7 @@ class ElasticsearchProductModelProjectionSpec extends ObjectBehavior
             'code',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
+            new \DateTimeImmutable('2019-04-24 15:55:50', new \DateTimeZone('UTC')),
             'family_code',
             ['family_label_1', 'family_label_2'],
             'family_variant_code',
@@ -53,6 +54,7 @@ class ElasticsearchProductModelProjectionSpec extends ObjectBehavior
             'identifier' => 'code',
             'created' => (new \DateTime('2019-04-23 15:55:50', new \DateTimeZone('UTC')))->format('c'),
             'updated' => (new \DateTime('2019-04-25 15:55:50', new \DateTimeZone('UTC')))->format('c'),
+            'entity_updated' => (new \DateTime('2019-04-24 15:55:50', new \DateTimeZone('UTC')))->format('c'),
             'family' => [
                 'code' => 'family_code',
                 'labels' => ['family_label_1', 'family_label_2'],
@@ -94,6 +96,7 @@ class ElasticsearchProductModelProjectionSpec extends ObjectBehavior
                 'identifier' => 'code',
                 'created' => (new \DateTime('2019-04-23 15:55:50', new \DateTimeZone('UTC')))->format('c'),
                 'updated' => (new \DateTime('2019-04-25 15:55:50', new \DateTimeZone('UTC')))->format('c'),
+                'entity_updated' => (new \DateTime('2019-04-24 15:55:50', new \DateTimeZone('UTC')))->format('c'),
                 'family' => [
                     'code' => 'family_code',
                     'labels' => ['family_label_1', 'family_label_2'],

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Model/ElasticsearchProductProjectionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Model/ElasticsearchProductProjectionSpec.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use PhpSpec\ObjectBehavior;
 
 /**
@@ -22,6 +21,7 @@ class ElasticsearchProductProjectionSpec extends ObjectBehavior
             'identifier',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
+            new \DateTimeImmutable('2019-04-24 15:55:50', new \DateTimeZone('UTC')),
             true,
             'family_code',
             ['family_label_1', 'family_label_2'],
@@ -56,6 +56,7 @@ class ElasticsearchProductProjectionSpec extends ObjectBehavior
             'identifier' => 'identifier',
             'created' => (new \DateTime('2019-04-23 15:55:50', new \DateTimeZone('UTC')))->format('c'),
             'updated' => (new \DateTime('2019-04-25 15:55:50', new \DateTimeZone('UTC')))->format('c'),
+            'entity_updated' => (new \DateTime('2019-04-24 15:55:50', new \DateTimeZone('UTC')))->format('c'),
             'family' => [
                 'code' => 'family_code',
                 'labels' => ['family_label_1', 'family_label_2'],
@@ -94,6 +95,7 @@ class ElasticsearchProductProjectionSpec extends ObjectBehavior
                 'identifier',
                 new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
                 new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
+                new \DateTimeImmutable('2019-04-24 15:55:50', new \DateTimeZone('UTC')),
                 true,
                 'family_code',
                 ['family_label_1', 'family_label_2'],

--- a/upgrades/schema/Version_6_0_20210615084255_add_entity_updated_in_product_mapping.php
+++ b/upgrades/schema/Version_6_0_20210615084255_add_entity_updated_in_product_mapping.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Elasticsearch\ClientBuilder;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * The goal is to add the new "entity_updated" field in product mapping.
+ * We can't change the mapping for an existing field without reindexing all, but we can add a nonexistent field.
+ * See https://www.elastic.co/guide/en/elasticsearch/reference/7.x/indices-put-mapping.html#indices-put-mapping
+ */
+final class Version_6_0_20210615084255_add_entity_updated_in_product_mapping extends AbstractMigration implements ContainerAwareInterface
+{
+    private ContainerInterface $container;
+
+    public function up(Schema $schema) : void
+    {
+        $this->disableMigrationWarning();
+        $indexHosts = $this->container->getParameter('index_hosts');
+        $productAndProductModelIndexName = $this->container->getParameter('product_and_product_model_index_name');
+
+        $builder = new ClientBuilder();
+        $hosts = [$indexHosts];
+
+        $client = $builder->setHosts($hosts)->build()->indices();
+
+        $existingMapping = $client->getMapping(['index' => $productAndProductModelIndexName]);
+        if (!\is_array($existingMapping) || !isset(current($existingMapping)['mappings']['properties'])) {
+            throw new \RuntimeException('Unable to retrieve existing mapping.');
+        }
+
+        $client->putMapping([
+            'index' => $productAndProductModelIndexName,
+            'body' => [
+                'properties' => [
+                    'entity_updated' => ['type' => 'date'],
+                ],
+            ],
+        ]);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        Assert::notNull($container);
+        $this->container = $container;
+    }
+
+    /**
+     * Function that does a non altering operation on the DB using SQL to hide the doctrine warning stating that no
+     * sql query has been made to the db during the migration process.
+     */
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20210615084255_add_entity_updated_in_product_mapping_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210615084255_add_entity_updated_in_product_mapping_Integration.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
+use Elasticsearch\Client as NativeClient;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Yaml\Yaml;
+
+final class Version_6_0_20210615084255_add_entity_updated_in_product_mapping_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    const MIGRATION_LABEL = '_6_0_20210615084255_add_entity_updated_in_product_mapping';
+
+    private NativeClient $nativeClient;
+    private Client $productAndProductModelClient;
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nativeClient = $this->get('akeneo_elasticsearch.client_builder')->build();
+        $this->productAndProductModelClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+    }
+
+    /** @test */
+    public function it_adds_the_entity_updated_property_to_the_mapping(): void
+    {
+
+        $this->recreateProductIndexWithoutEntityUpdatedMapping();
+        $properties = $this->getProductMappingProperties();
+        self::assertArrayNotHasKey('entity_updated', $properties);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $properties = $this->getProductMappingProperties();
+        self::assertArrayHasKey('entity_updated', $properties);
+        self::assertSame(['type' => 'date'], $properties['entity_updated']);
+    }
+
+    private function recreateProductIndexWithoutEntityUpdatedMapping(): void
+    {
+        $configFiles = $this->getParameter('elasticsearch_index_configuration_files');
+        $config = [];
+        foreach ($configFiles as $configFile) {
+            $config = array_merge($config, Yaml::parseFile($configFile));
+        }
+
+        self::assertArrayHasKey('mappings', $config);
+        self::assertIsArray($config['mappings']);
+        self::assertArrayHasKey('properties', $config['mappings']);
+        self::assertIsArray($config['mappings']['properties']);
+        self::assertArrayHasKey('entity_updated', $config['mappings']['properties'], 'Test cannot be relevant: "entity_updated" is missing');
+        unset($config['mappings']['properties']['entity_updated']);
+
+        $newConfigFile = tempnam(sys_get_temp_dir(), 'migration_entity_updated');
+        file_put_contents($newConfigFile, Yaml::dump($config));
+
+        $loader = new Loader([$newConfigFile], $this->get(ParameterBagInterface::class));
+        $client = new Client(
+            $this->get('akeneo_elasticsearch.client_builder'),
+            $loader,
+            [$this->getParameter('index_hosts')],
+            $this->productAndProductModelClient->getIndexName()
+        );
+        $client->resetIndex();
+    }
+
+    private function getProductMappingProperties(): array
+    {
+        $mapping = current($this->nativeClient->indices()->getMapping(
+            ['index' => $this->productAndProductModelClient->getIndexName()]
+        ));
+
+        return $mapping['mappings']['properties'] ?? [];
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-9719

To spot the desynchronization between a product in DB and in ES, we should have the `updated` information in ES (see the ticket for more info). 
But in ES the `updated` info is updated each time the parent product model or the root is updated. For instance for a product:

```sql
GREATEST(product.updated, COALESCE(sub_product_model.updated, 0), COALESCE(root_product_model.updated, 0)) AS updated_date
```

We can't change the behavior of this updated field as it is used for API.  
In this PR we add the `entity_updated` information that matches the real updated information in DB for a product/product model.

- add the information in the ES projections
- add the mapping for new installs
- add a migration to update the mapping for existing catalogs

**Definition Of Done (for Core Developer only)**

- [X] Tests
- [X] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
