### PR TITLE
Fix corrupted front-packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,29 +119,8 @@ jobs:
           name: Build css
           command: make css
       - run:
-          name: Create hash for front packages
-          command: |
-            find << parameters.path_to_front_packages >> -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/front-packages.hash
-            date +%F >> ~/front-packages.hash
-      - run:
-          name: Set front-packages directory owner to circleci
-          command: sudo chown -R 1001:1001 << parameters.path_to_front_packages >>
-      - restore_cache:
-          name: Restore front-packages cache
-          key: front-packages-libs-{{ checksum "~/front-packages.hash" }}
-      - run:
-          name: Set front-packages directory owner to docker
-          command: sudo chown -R 1000:1000 << parameters.path_to_front_packages >>
-      - run:
           name: Build front-packages
-          command: ls << parameters.path_to_front_packages >>/*/lib 1> /dev/null 2>&1 || make front-packages
-      - save_cache:
-          name: Save front-packages cache
-          key: front-packages-libs-{{ checksum "~/front-packages.hash" }}
-          paths:
-            - << parameters.path_to_front_packages >>/akeneo-design-system/lib
-            - << parameters.path_to_front_packages >>/shared/lib
-            - << parameters.path_to_front_packages >>/measurement/lib
+          command: make front-packages
       - run:
           name: Build Javascript
           command: make javascript-dev


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Some developper alert us that CE build_dev CI does not work anymore due to the following error: 
  Watch plugin jest-watch-typeahead/filename cannot be found. Make sure the watchPlugins configuration option points to an existing node module. (https://app.circleci.com/pipelines/github/akeneo/pim-community-dev/23719/workflows/053cc1cc-5a6a-4c69-8137-99214fb44f5d/jobs/101618)

This PR remove will remove the front-packages cache **temporarily** in order to do not block anymore the others developers. We will in another PR, investigate about the error, add more check on cache and make sure it doesn't happen again.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
