### PR TITLE
Only cache design system

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ jobs:
         is_ee_built:
             type: boolean
             default: true
-        path_to_front_packages:
+        path_to_dsm:
             type: string
-            default: front-packages
+            default: front-packages/akeneo-design-system
     machine:
       image: ubuntu-2004:202101-01
     steps:
@@ -118,6 +118,28 @@ jobs:
       - run:
           name: Build css
           command: make css
+      - run:
+          name: Create hash for front packages
+          command: |
+            find << parameters.path_to_dsm >>  -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/akeneo-design-system.hash
+            date +%F >> ~/akeneo-design-system.hash
+      - run:
+          name: Set DSM directory owner to circleci
+          command: sudo chown -R 1001:1001 << parameters.path_to_dsm >>
+      - restore_cache:
+          name: Restore DSM cache
+          key: dsm-lib-{{ checksum "~/akeneo-design-system.hash" }}
+      - run:
+          name: Set DSM directory owner to docker
+          command: sudo chown -R 1000:1000 << parameters.path_to_dsm >>
+      - run:
+          name: Build DSM
+          command: ls << parameters.path_to_dsm >>/lib 1> /dev/null 2>&1 || make dsm
+      - save_cache:
+          name: Save DSM cache
+          key: dsm-lib-{{ checksum "~/akeneo-design-system.hash" }}
+          paths:
+            - << parameters.path_to_dsm >>/lib
       - run:
           name: Build front-packages
           command: make front-packages
@@ -644,7 +666,7 @@ workflows:
                 requires:
                     - ready_to_build?
           - build_dev:
-                path_to_front_packages: vendor/akeneo/pim-community-dev/front-packages
+                path_to_dsm: vendor/akeneo/pim-community-dev/front-packages/akeneo-design-system
                 requires:
                     - checkout_ee
           - build_prod:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ javascript-extensions:
 front-packages:
 	$(YARN_RUN) packages:build
 
+.PHONY: dsm
+dsm:
+	$(YARN_RUN) dsm:build
+
 .PHONY: assets
 assets:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/bundles public/js

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "yamljs": "0.3.0"
   },
   "dependencies": {
-    "@akeneo-pim-community/shared": "link:front-packages/shared",
     "@akeneo-pim-community/measurement": "link:front-packages/measurement",
+    "@akeneo-pim-community/shared": "link:front-packages/shared",
     "ajv": "^6.10.2",
     "akeneo-design-system": "link:front-packages/akeneo-design-system",
     "babel-polyfill": "6.26.0",
@@ -144,9 +144,6 @@
     "summernote": "0.6.16",
     "underscore": "1.8.3",
     "victory": "^33.1.6"
-  },
-  "resolutions": {
-    "jest/**/ip-regex": "2.1.0"
   },
   "private": true,
   "workspaces": [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Related to : https://github.com/akeneo/pim-community-dev/pull/14732

We decided to cache only the DSM, this packages take time to be installed. For now we don't need to add each front-packages in cache.

We decided to do this in first time, when we will migrate to yarn 2 we will cache the compressed node_module of each front-packages.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
