### PR TITLE
RAC-609: Fix multi-select-input bug when codes don't have associated children

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.stories.mdx
+++ b/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.stories.mdx
@@ -68,7 +68,7 @@ The placeholder text provides tips or examples of items to enter. Placeholder te
       const [value, setValue] = useState([]);
       return (
         <>
-          <MultiSelectInput readOnly={true} value={[]} placeholder="Placeholder" emptyResultLabel="Not matches found">
+          <MultiSelectInput readOnly={true} value={['en_US']} placeholder="Placeholder" emptyResultLabel="Not matches found">
             <MultiSelectInput.Option value="en_US">English (United States)</MultiSelectInput.Option>
             <MultiSelectInput.Option value="fr_FR">French (France)</MultiSelectInput.Option>
             <MultiSelectInput.Option value="de_DE">German (Germany)</MultiSelectInput.Option>

--- a/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.tsx
@@ -245,7 +245,7 @@ const MultiSelectInput = ({
           ref={inputRef}
           id={id}
           placeholder={placeholder}
-          value={value.map(chipCode => indexedChips[chipCode])}
+          value={value.map(chipCode => indexedChips[chipCode] ?? {code: chipCode, label:chipCode})}
           searchValue={searchValue}
           removeLabel={removeLabel}
           readOnly={readOnly}

--- a/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.tsx
@@ -245,7 +245,7 @@ const MultiSelectInput = ({
           ref={inputRef}
           id={id}
           placeholder={placeholder}
-          value={value.map(chipCode => indexedChips[chipCode] ?? {code: chipCode, label:chipCode})}
+          value={value.map(chipCode => indexedChips[chipCode] ?? {code: chipCode, label: chipCode})}
           searchValue={searchValue}
           removeLabel={removeLabel}
           readOnly={readOnly}

--- a/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.unit.tsx
@@ -106,35 +106,25 @@ test('it handles empty cases', () => {
   expect(onChange).not.toHaveBeenCalled();
 });
 
-test('it handles empty cases', () => {
+test('it handles codes that do not have a label', () => {
   const onChange = jest.fn();
   render(
     <MultiSelectInput
-      value={[]}
+      value={['fr_FR', 'unknown']}
       onChange={onChange}
       placeholder="Placeholder"
       removeLabel="Remove"
       emptyResultLabel="Empty result"
     >
-      <MultiSelectInput.Option value="en_US">English</MultiSelectInput.Option>
       <MultiSelectInput.Option value="fr_FR">French</MultiSelectInput.Option>
-      <MultiSelectInput.Option value="de_DE">German</MultiSelectInput.Option>
-      <MultiSelectInput.Option value="es_ES">Spanish</MultiSelectInput.Option>
     </MultiSelectInput>
   );
 
-  const input = screen.getByRole('textbox');
-  fireEvent.click(input);
-  fireEvent.change(input, {target: {value: 'France 3'}});
+  const codeWithOption = screen.queryByText('French');
+  expect(codeWithOption).toBeInTheDocument();
 
-  const germanOption = screen.queryByText('German');
-  expect(germanOption).not.toBeInTheDocument();
-  const frenchOption = screen.queryByText('French');
-  expect(frenchOption).not.toBeInTheDocument();
-  expect(screen.getByText('Empty result')).toBeInTheDocument();
-
-  fireEvent.keyDown(input, {key: 'Enter', code: 'Enter'});
-  expect(onChange).not.toHaveBeenCalled();
+  const codeWithoutOption = screen.queryByText('unknown');
+  expect(codeWithoutOption).toBeInTheDocument();
 });
 
 test('it handles removing a Chip', () => {

--- a/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MultiSelectInput/MultiSelectInput.unit.tsx
@@ -106,6 +106,37 @@ test('it handles empty cases', () => {
   expect(onChange).not.toHaveBeenCalled();
 });
 
+test('it handles empty cases', () => {
+  const onChange = jest.fn();
+  render(
+    <MultiSelectInput
+      value={[]}
+      onChange={onChange}
+      placeholder="Placeholder"
+      removeLabel="Remove"
+      emptyResultLabel="Empty result"
+    >
+      <MultiSelectInput.Option value="en_US">English</MultiSelectInput.Option>
+      <MultiSelectInput.Option value="fr_FR">French</MultiSelectInput.Option>
+      <MultiSelectInput.Option value="de_DE">German</MultiSelectInput.Option>
+      <MultiSelectInput.Option value="es_ES">Spanish</MultiSelectInput.Option>
+    </MultiSelectInput>
+  );
+
+  const input = screen.getByRole('textbox');
+  fireEvent.click(input);
+  fireEvent.change(input, {target: {value: 'France 3'}});
+
+  const germanOption = screen.queryByText('German');
+  expect(germanOption).not.toBeInTheDocument();
+  const frenchOption = screen.queryByText('French');
+  expect(frenchOption).not.toBeInTheDocument();
+  expect(screen.getByText('Empty result')).toBeInTheDocument();
+
+  fireEvent.keyDown(input, {key: 'Enter', code: 'Enter'});
+  expect(onChange).not.toHaveBeenCalled();
+});
+
 test('it handles removing a Chip', () => {
   const onChange = jest.fn();
   render(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fixes an issue occuring on the multi select input when one of the codes of the options given for the multi select does not exist as an Option in the Children

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
