### PR TITLE
PIM-9914: Fix backslash incorrectly considered as an escape character in exports

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 
 - PIM-9902: fix specific local attribute export in model and product model
 - PIM-9901: Error 403 on a 2-levels product variant when displaying a variant product without having permission on product model
+- PIM-9914: Fix backslash "\" incorrectly considered as an escape character in exports
 
 # 4.0.113 (2021-06-04)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,12 +1,15 @@
 # 4.0.x
 
+## Bug fixes
+
+- PIM-9914: Fix backslash incorrectly considered as an escape character in exports
+
 # 4.0.114 (2021-06-14)
 
 ## Bug fixes
 
 - PIM-9902: fix specific local attribute export in model and product model
 - PIM-9901: Error 403 on a 2-levels product variant when displaying a variant product without having permission on product model
-- PIM-9914: Fix backslash "\" incorrectly considered as an escape character in exports
 
 # 4.0.113 (2021-06-04)
 

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
@@ -4,8 +4,8 @@ namespace Akeneo\Tool\Component\Connector\Writer\File;
 
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Tool\Component\Connector\Writer\WriterFactory;
 use Box\Spout\Common\Exception\UnsupportedTypeException;
-use Box\Spout\Writer\WriterFactory;
 use Box\Spout\Writer\WriterInterface;
 
 /**

--- a/src/Akeneo/Tool/Component/Connector/Writer/GlobalFunctionsHelper.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/GlobalFunctionsHelper.php
@@ -7,9 +7,7 @@ namespace Akeneo\Tool\Component\Connector\Writer;
 use Box\Spout\Common\Helper\GlobalFunctionsHelper as SpoutGlobalFunctionsHelper;
 
 /**
- * @author    Pierre Jolly <pierre.jolly@akeneo.com>
- * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @todo merge master/6.0: drop this class and bump box/spout to v3
  */
 class GlobalFunctionsHelper extends SpoutGlobalFunctionsHelper
 {

--- a/src/Akeneo/Tool/Component/Connector/Writer/GlobalFunctionsHelper.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/GlobalFunctionsHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Connector\Writer;
+
+use Box\Spout\Common\Helper\GlobalFunctionsHelper as SpoutGlobalFunctionsHelper;
+
+/**
+ * @author    Pierre Jolly <pierre.jolly@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GlobalFunctionsHelper extends SpoutGlobalFunctionsHelper
+{
+    public function fgetcsv($handle, $length = null, $delimiter = null, $enclosure = null)
+    {
+        // PHP uses '\' as the default escape character. This is not RFC-4180 compliant...
+        // To fix that, simply disable the escape character.
+        // @see https://bugs.php.net/bug.php?id=43225
+        // @see http://tools.ietf.org/html/rfc4180
+        $escapeCharacter = PHP_VERSION_ID >= 70400 ? '' : "\0";
+
+        return \fgetcsv($handle, $length, $delimiter, $enclosure, $escapeCharacter);
+    }
+
+    public function fputcsv($handle, array $fields, $delimiter = null, $enclosure = null)
+    {
+        // PHP uses '\' as the default escape character. This is not RFC-4180 compliant...
+        // To fix that, simply disable the escape character.
+        // @see https://bugs.php.net/bug.php?id=43225
+        // @see http://tools.ietf.org/html/rfc4180
+        $escapeCharacter = PHP_VERSION_ID >= 70400 ? '' : "\0";
+
+        return \fputcsv($handle, $fields, $delimiter, $enclosure, $escapeCharacter);
+    }
+}

--- a/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
@@ -7,9 +7,7 @@ namespace Akeneo\Tool\Component\Connector\Writer;
 use Box\Spout\Writer\WriterFactory as SpoutWriterFactory;
 
 /**
- * @author    Pierre Jolly <pierre.jolly@akeneo.com>
- * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @todo merge master/6.0: drop this class and bump box/spout to v3
  */
 final class WriterFactory extends SpoutWriterFactory
 {

--- a/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Component\Connector\Writer;
 
-
 use Box\Spout\Writer\WriterFactory as SpoutWriterFactory;
 
 /**

--- a/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
@@ -6,7 +6,6 @@ namespace Akeneo\Tool\Component\Connector\Writer;
 
 
 use Box\Spout\Writer\WriterFactory as SpoutWriterFactory;
-use Box\Spout\Writer\WriterInterface;
 
 /**
  * @author    Pierre Jolly <pierre.jolly@akeneo.com>

--- a/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/WriterFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Connector\Writer;
+
+
+use Box\Spout\Writer\WriterFactory as SpoutWriterFactory;
+use Box\Spout\Writer\WriterInterface;
+
+/**
+ * @author    Pierre Jolly <pierre.jolly@akeneo.com>
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class WriterFactory extends SpoutWriterFactory
+{
+    public static function create($writerType)
+    {
+        $writer = parent::create($writerType);
+        $writer->setGlobalFunctionsHelper(new GlobalFunctionsHelper());
+
+        return $writer;
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -160,6 +160,9 @@
     "elasticsearch/elasticsearch": {
         "version": "v7.2.2"
     },
+    "evenement/evenement": {
+        "version": "v3.0.1"
+    },
     "friends-of-behat/symfony-extension": {
         "version": "2.0",
         "recipe": {
@@ -258,6 +261,24 @@
     },
     "liuggio/fastest": {
         "version": "v1.6.1"
+    },
+    "mcustiel/creature": {
+        "version": "v2.0.0"
+    },
+    "mcustiel/mockable-datetime": {
+        "version": "v1.1.2"
+    },
+    "mcustiel/phiremock": {
+        "version": "v1.12.1"
+    },
+    "mcustiel/php-simple-di": {
+        "version": "1.2.1"
+    },
+    "mcustiel/php-simple-request": {
+        "version": "v3.1.0"
+    },
+    "mcustiel/power-route": {
+        "version": "v3.0.1"
     },
     "monolog/monolog": {
         "version": "1.23.0"
@@ -394,6 +415,9 @@
     "psr/http-client": {
         "version": "1.0.1"
     },
+    "psr/http-factory": {
+        "version": "1.0.1"
+    },
     "psr/http-message": {
         "version": "1.0.1"
     },
@@ -406,8 +430,35 @@
     "ramsey/uuid": {
         "version": "3.7.0"
     },
+    "react/cache": {
+        "version": "v1.1.0"
+    },
+    "react/dns": {
+        "version": "v1.4.0"
+    },
+    "react/event-loop": {
+        "version": "v1.1.1"
+    },
+    "react/http": {
+        "version": "v0.8.7"
+    },
     "react/promise": {
         "version": "v2.7.1"
+    },
+    "react/promise-stream": {
+        "version": "v1.2.0"
+    },
+    "react/promise-timer": {
+        "version": "v1.6.0"
+    },
+    "react/socket": {
+        "version": "v1.6.0"
+    },
+    "react/stream": {
+        "version": "v1.1.1"
+    },
+    "ringcentral/psr7": {
+        "version": "1.3.0"
     },
     "sabberworm/php-css-parser": {
         "version": "8.3.0"
@@ -864,6 +915,9 @@
     },
     "zendframework/zend-code": {
         "version": "3.3.2"
+    },
+    "zendframework/zend-diactoros": {
+        "version": "2.2.1"
     },
     "zendframework/zend-eventmanager": {
         "version": "3.2.1"

--- a/symfony.lock
+++ b/symfony.lock
@@ -160,9 +160,6 @@
     "elasticsearch/elasticsearch": {
         "version": "v7.2.2"
     },
-    "evenement/evenement": {
-        "version": "v3.0.1"
-    },
     "friends-of-behat/symfony-extension": {
         "version": "2.0",
         "recipe": {
@@ -261,24 +258,6 @@
     },
     "liuggio/fastest": {
         "version": "v1.6.1"
-    },
-    "mcustiel/creature": {
-        "version": "v2.0.0"
-    },
-    "mcustiel/mockable-datetime": {
-        "version": "v1.1.2"
-    },
-    "mcustiel/phiremock": {
-        "version": "v1.12.1"
-    },
-    "mcustiel/php-simple-di": {
-        "version": "1.2.1"
-    },
-    "mcustiel/php-simple-request": {
-        "version": "v3.1.0"
-    },
-    "mcustiel/power-route": {
-        "version": "v3.0.1"
     },
     "monolog/monolog": {
         "version": "1.23.0"
@@ -415,9 +394,6 @@
     "psr/http-client": {
         "version": "1.0.1"
     },
-    "psr/http-factory": {
-        "version": "1.0.1"
-    },
     "psr/http-message": {
         "version": "1.0.1"
     },
@@ -430,35 +406,8 @@
     "ramsey/uuid": {
         "version": "3.7.0"
     },
-    "react/cache": {
-        "version": "v1.1.0"
-    },
-    "react/dns": {
-        "version": "v1.4.0"
-    },
-    "react/event-loop": {
-        "version": "v1.1.1"
-    },
-    "react/http": {
-        "version": "v0.8.7"
-    },
     "react/promise": {
         "version": "v2.7.1"
-    },
-    "react/promise-stream": {
-        "version": "v1.2.0"
-    },
-    "react/promise-timer": {
-        "version": "v1.6.0"
-    },
-    "react/socket": {
-        "version": "v1.6.0"
-    },
-    "react/stream": {
-        "version": "v1.1.1"
-    },
-    "ringcentral/psr7": {
-        "version": "1.3.0"
     },
     "sabberworm/php-css-parser": {
         "version": "8.3.0"
@@ -915,9 +864,6 @@
     },
     "zendframework/zend-code": {
         "version": "3.3.2"
-    },
-    "zendframework/zend-diactoros": {
-        "version": "2.2.1"
     },
     "zendframework/zend-eventmanager": {
         "version": "3.2.1"

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsIntegration.php
@@ -76,6 +76,10 @@ class ExportProductsIntegration extends AbstractExportTestCase
                 'tablet' => ['sku', 'name']
             ]
         ]);
+        $this->createFamily([
+            'code' => 'a_family',
+            'attributes' => ['sku', 'a_text_area']
+        ]);
         $this->createFamilyVariant([
             'code'        => 'clothing_color_size',
             'family'      => 'clothing',
@@ -131,6 +135,10 @@ class ExportProductsIntegration extends AbstractExportTestCase
                 ]
             ]
         );
+    }
+
+    public function testVariantProductExport()
+    {
         $this->createVariantProduct(
             'apollon_pink_m',
             [
@@ -166,15 +174,32 @@ class ExportProductsIntegration extends AbstractExportTestCase
                 ]
             ]
         );
-    }
 
-    public function testVariantProductExport()
-    {
         $expectedCsv = <<<CSV
 sku;categories;enabled;family;parent;groups;color;ean;name-en_US;size;variation_name
 apollon_pink_m;round-neck,spring,tshirt;1;clothing;apollon_pink;;pink;12345678;;m;"my pink tshirt"
 apollon_pink_l;round-neck,tshirt;1;clothing;apollon_pink;;pink;12345679;;l;"my pink tshirt"
 apollon_pink_xl;round-neck,summer,tshirt;1;clothing;apollon_pink;;pink;12345465;;xl;"my pink tshirt"
+
+CSV;
+
+        $this->assertProductExport($expectedCsv, []);
+    }
+
+    public function testItEscapeCharacterCorrectly()
+    {
+        $this->createProduct('product_1', [
+            'family' => 'a_family',
+            'values'     => [
+                'a_text_area' => [
+                    ['data' => 'test "1234" DLE test  \" joli produit ; vive la data "', 'locale' => null, 'scope' => null]
+                ]
+            ]
+        ]);
+
+        $expectedCsv = <<<CSV
+sku;categories;enabled;family;groups;a_text_area
+product_1;;1;a_family;;"test ""1234"" DLE test  \"" joli produit ; vive la data """
 
 CSV;
 

--- a/tests/legacy/features/Behat/Context/Domain/Collect/ImportProfilesContext.php
+++ b/tests/legacy/features/Behat/Context/Domain/Collect/ImportProfilesContext.php
@@ -3,10 +3,10 @@
 namespace Pim\Behat\Context\Domain\Collect;
 
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Akeneo\Tool\Component\Connector\Writer\WriterFactory;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Box\Spout\Common\Type;
-use Box\Spout\Writer\WriterFactory;
 use Context\Spin\SpinCapableTrait;
 use Pim\Behat\Context\Domain\ImportExportContext;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

* The backslash \ should not be considered as a an escape character where today the PIM says it is an escape character
* The quote ” should always be doubled when it is set as a value (which is today’s behavior except when there are backslashes)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Changelog (maintenance bug fixes)
