### PR TITLE
PIM-9916: Fix value updating for text, simple select and date attribute used as product export filter not saved

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,7 @@
 # 5.0.x
 
+- PIM-9916: Fix value updating for text, simple select and date attribute used as product export filter not saved
+
 # 5.0.33 (2021-06-18)
 
 # 5.0.32 (2021-06-16)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content/data.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content/data.js
@@ -87,6 +87,10 @@ define([
         .then(this.buildFilterView.bind(this))
         .then(
           function (filterView) {
+            //condition to avoid adding the same filter twice
+            if (this.filterViews.some(filterView => filterView.filterCode === fieldCode)) {
+              return;
+            }
             this.listenTo(filterView, 'pim_enrich:form:entity:post_update', this.updateModel.bind(this));
             this.listenTo(filterView, 'filter:remove', this.removeFilter.bind(this));
             this.listenTo(


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When a text, a simple select or a date attribute was used as a filter for a product export profile, update of values on each filter after the first saved value was never applied even after clicking the Save button.
The same filter was applied twice, so, we created a condition to avoid this issue.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
