### PR TITLE
PLG: fix category edit form display when the current translation is null

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
@@ -13,6 +13,7 @@ import {
 import {
   BreadcrumbStepSkeleton,
   FullScreenError,
+  getLabel,
   PageContent,
   PageHeader,
   PimView,
@@ -97,16 +98,10 @@ const CategoryEditPage: FC = () => {
     }
 
     const uiLocale = userContext.get('uiLocale');
-    const rootCategory = category && category.root ? category.root : category;
+    const rootCategory = category.root ? category.root : category;
 
-    setCategoryLabel(
-      category && category.labels.hasOwnProperty(uiLocale) ? category.labels[uiLocale] : `[${category.code}]`
-    );
-    setTreeLabel(
-      rootCategory && rootCategory.labels.hasOwnProperty(uiLocale)
-        ? rootCategory.labels[uiLocale]
-        : `[${rootCategory.code}]`
-    );
+    setCategoryLabel(getLabel(category.labels, uiLocale, category.code));
+    setTreeLabel(getLabel(rootCategory.labels, uiLocale, rootCategory.code));
     setTree(rootCategory);
   }, [category]);
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
There was a bug when the translation of the language used for the UI was empty. A sanity check was incomplete.

Before :
![image](https://user-images.githubusercontent.com/1978756/122582035-f8cf4f00-d057-11eb-9903-9fdc64f97331.png)

After :
![image](https://user-images.githubusercontent.com/1978756/122582129-12709680-d058-11eb-82bb-9c4d20053e70.png)


<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
