### PR TITLE
CXP-344: enrich "non active locale" error

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/documentation.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/documentation.yml
@@ -18,3 +18,6 @@ services:
 
     Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\UnknownFamily:
         tags: [pim_enrich.error.documentation_builder]
+
+    Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\LocalizableAttribute:
+        tags: [pim_enrich.error.documentation_builder]

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -40,6 +40,7 @@ The {{ attribute }} attribute requires a number, and the submitted {{ value }} v
 The %attribute% attribute must not contain more than %limit% characters. The submitted value is too long.: The %attribute% attribute must not contain more than %limit% characters. The submitted value is too long.
 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.': 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.'
 'The {{ attribute_code }} attribute cannot be empty.': 'The {{ attribute_code }} attribute cannot be empty.'
+'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.'
 The %attribute% attribute requires an e-mail address.: 'The %attribute% attribute requires an e-mail address.'
 pim_catalog:
     constraint:

--- a/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/LocalizableAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/LocalizableAttribute.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder;
+
+use Akeneo\Pim\Enrichment\Component\Error\Documentation\Documentation;
+use Akeneo\Pim\Enrichment\Component\Error\Documentation\DocumentationCollection;
+use Akeneo\Pim\Enrichment\Component\Error\Documentation\HrefMessageParameter;
+use Akeneo\Pim\Enrichment\Component\Error\Documentation\RouteMessageParameter;
+use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\LocalizableValues;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class LocalizableAttribute implements DocumentationBuilderInterface
+{
+    public function support($object): bool
+    {
+        if (
+            $object instanceof ConstraintViolationInterface
+            && $object->getCode() === LocalizableValues::NON_ACTIVE_LOCALE
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param ConstraintViolationInterface $object
+     */
+    public function buildDocumentation($object): DocumentationCollection
+    {
+        if (false === $this->support($object)) {
+            throw new \InvalidArgumentException('Parameter $object is not supported.');
+        }
+
+        $attributeCode = $this->getAttributeCode($object);
+
+        return new DocumentationCollection([
+            new Documentation(
+                'Please check your {channels_settings} or the {attribute_edit_route}.',
+                [
+                    'channels_settings' => new RouteMessageParameter(
+                        'Channel settings',
+                        'pim_enrich_channel_index'
+                    ),
+                    'attribute_edit_route' => new RouteMessageParameter(
+                        sprintf('%s attributes settings', $attributeCode),
+                        'pim_enrich_attribute_edit',
+                        ['code' => $attributeCode]
+                    )
+                ],
+                Documentation::STYLE_TEXT
+            ),
+            new Documentation(
+                'More information about channels and locales: {enable_locale} {add_locale}',
+                [
+                    'enable_locale' => new HrefMessageParameter(
+                        'How to enable a locale?',
+                        'https://help.akeneo.com/pim/serenity/articles/manage-your-locales.html#how-to-enabledisable-a-locale'
+                    ),
+                    'add_locale' => new HrefMessageParameter(
+                        'How to add a new locale?',
+                        'https://help.akeneo.com/pim/serenity/articles/manage-your-locales.html#how-to-add-a-new-locale'
+                    )
+                ],
+                Documentation::STYLE_INFORMATION
+            )
+        ]);
+    }
+
+    /**
+     * @param ConstraintViolationInterface $object
+     */
+    private function getAttributeCode($object): string
+    {
+        if (
+            $object instanceof ConstraintViolationInterface
+            && $object->getCode() === LocalizableValues::NON_ACTIVE_LOCALE
+        ) {
+            $parameters = $object->getParameters();
+
+            if (!isset($parameters['%attribute_code%'])) {
+                throw new \LogicException('ConstraintViolation parameter "%attribute_code%" should be defined.');
+            }
+
+            return $parameters['%attribute_code%'];
+        }
+
+        throw new \LogicException('Attribute code should be defined.');
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
@@ -10,8 +10,10 @@ use Symfony\Component\Validator\Constraint;
  */
 class LocalizableValues extends Constraint
 {
+    const NON_ACTIVE_LOCALE = '7962b972-e39a-461e-86f2-4900281a72aa';
+
     /** @var string */
-    public $nonActiveLocaleMessage = 'Attribute "%attribute_code%" expects an existing and activated locale, "%invalid_locale%" given.';
+    public $nonActiveLocaleMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.';
 
     /** @var string */
     public $invalidLocaleForChannelMessage = 'Attribute "%attribute_code%" expects a valid locale, "%invalid_locale%" is not bound to channel "%channel_code%".';

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValuesValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValuesValidator.php
@@ -67,7 +67,10 @@ final class LocalizableValuesValidator extends ConstraintValidator
                         '%attribute_code%' => $localizableValue->getAttributeCode(),
                         '%invalid_locale%' => $localizableValue->getLocaleCode(),
                     ]
-                )->atPath(sprintf('[%s]', $key))->addViolation();
+                )
+                    ->atPath(sprintf('[%s]', $key))
+                    ->setCode(LocalizableValues::NON_ACTIVE_LOCALE)
+                    ->addViolation();
 
                 continue;
             }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductModelMediaFileEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductModelMediaFileEndToEnd.php
@@ -348,7 +348,7 @@ JSON;
     "errors": [
         {
             "property": "values",
-            "message": "Attribute \"a_localizable_scopable_image\" expects an existing and activated locale, \"Esperanto\" given.",
+            "message": "The a_localizable_scopable_image attribute requires a valid locale. The Esperanto locale does not exist.",
             "attribute": "a_localizable_scopable_image",
             "locale": "Esperanto",
             "scope": "tablet"
@@ -447,8 +447,9 @@ JSON;
                     'a_yes_no',
                     'an_image',
                     'a_localizable_scopable_image'
+                ]
             ]
-        ]);
+        );
         $this->assertCount(0, $this->get('validator')->validate($familyA));
         $this->get('pim_catalog.saver.family')->save($familyA);
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/LocalizableAttributeSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/LocalizableAttributeSpec.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder;
+
+use Akeneo\Pim\Enrichment\Component\Error\Documentation\DocumentationCollection;
+use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilder\LocalizableAttribute;
+use Akeneo\Pim\Enrichment\Component\Error\DocumentationBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\LocalizableValues;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class LocalizableAttributeSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->beAnInstanceOf(LocalizableAttribute::class);
+    }
+
+    function it_is_a_documentation_builder()
+    {
+        $this->beAnInstanceOf(DocumentationBuilderInterface::class);
+    }
+
+    function it_supports_the_constraint_non_active_locale(ConstraintViolationInterface $constraintViolation)
+    {
+        $constraintViolation->getCode()->willReturn(LocalizableValues::NON_ACTIVE_LOCALE);
+
+        $this->support($constraintViolation)->shouldReturn(true);
+    }
+
+    function it_does_not_support_other_types_of_error()
+    {
+        $exception = new \Exception();
+
+        $this->support($exception)->shouldReturn(false);
+    }
+
+    function it_builds_the_documentation_for_the_constraint_non_active_locale(
+        ConstraintViolationInterface $constraintViolation
+    ) {
+        $constraintViolation->getCode()->willReturn(LocalizableValues::NON_ACTIVE_LOCALE);
+        $constraintViolation->getParameters()->willReturn(['%attribute_code%' => 'attribute_code']);
+
+        $documentation = $this->buildDocumentation($constraintViolation);
+
+        $documentation->shouldHaveType(DocumentationCollection::class);
+        $documentation->normalize()->shouldReturn([
+            [
+                'message' => 'Please check your {channels_settings} or the {attribute_edit_route}.',
+                'parameters' => [
+                    'channels_settings' => [
+                        'type' => 'route',
+                        'route' => 'pim_enrich_channel_index',
+                        'routeParameters' => [],
+                        'title' => 'Channel settings',
+                    ],
+                    'attribute_edit_route' => [
+                        'type' => 'route',
+                        'route' => 'pim_enrich_attribute_edit',
+                        'routeParameters' => ['code' => 'attribute_code'],
+                        'title' => 'attribute_code attributes settings',
+                    ],
+                ],
+                'style' => 'text'
+            ],
+            [
+                'message' => 'More information about channels and locales: {enable_locale} {add_locale}',
+                'parameters' => [
+                    'enable_locale' => [
+                        'type' => 'href',
+                        'href' => 'https://help.akeneo.com/pim/serenity/articles/manage-your-locales.html#how-to-enabledisable-a-locale',
+                        'title' => 'How to enable a locale?',
+                    ],
+                    'add_locale' => [
+                        'type' => 'href',
+                        'href' => 'https://help.akeneo.com/pim/serenity/articles/manage-your-locales.html#how-to-add-a-new-locale',
+                        'title' => 'How to add a new locale?',
+                    ],
+                ],
+                'style' => 'information'
+            ]
+        ]);
+    }
+
+    function it_does_not_build_the_documentation_for_an_unsupported_error(\Exception $exception)
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)
+            ->during('buildDocumentation', [$exception]);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/LocalizableValuesValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/LocalizableValuesValidatorSpec.php
@@ -98,6 +98,7 @@ class LocalizableValuesValidatorSpec extends ObjectBehavior
             '%invalid_locale%' => 'non_EXISTING',
         ])->willReturn($violationBuilder);
         $violationBuilder->atPath('[localizable_text-<all_channels>-non_EXISTING]')->willReturn($violationBuilder);
+        $violationBuilder->setCode(LocalizableValues::NON_ACTIVE_LOCALE)->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($values, $constraint);
@@ -136,6 +137,7 @@ class LocalizableValuesValidatorSpec extends ObjectBehavior
             ]
         )->willReturn($violationBuilder);
         $violationBuilder->atPath('[localizable_text-<all_channels>-es_DO]')->willReturn($violationBuilder);
+        $violationBuilder->setCode(LocalizableValues::NON_ACTIVE_LOCALE)->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($values, $constraint);

--- a/tests/features/pim/enrichment/product/validation/localizable_values.feature
+++ b/tests/features/pim/enrichment/product/validation/localizable_values.feature
@@ -23,18 +23,18 @@ Background:
     Then no error is raised
 
   @acceptance-back
-  Scenario: Providing a non erxistent locale should raise an error
+  Scenario: Providing a non existent locale should raise an error
     When a product is created with values:
       | attribute | data       | locale  |
       | name      | My product | non_EXI |
-    Then the error 'Attribute "name" expects an existing and activated locale, "non_EXI" given.' is raised
+    Then the error 'The name attribute requires a valid locale. The non_EXI locale does not exist.' is raised
 
   @acceptance-back
   Scenario: Providing an inactive locale should raise an error
     When a product is created with values:
       | attribute | data       | locale |
       | name      | My product | es_ES  |
-    Then the error 'Attribute "name" expects an existing and activated locale, "es_ES" given.' is raised
+    Then the error 'The name attribute requires a valid locale. The es_ES locale does not exist.' is raised
 
   @acceptance-back
   Scenario: Providing a locale bound to the channel should not raise an error


### PR DESCRIPTION
Update the following error message from `Attribute "%attribute_code%" expects an existing and activated locale, "%invalid_locale%" given.` to `The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.` for inactive or non-existent locales.

API Response
![image](https://user-images.githubusercontent.com/1671213/122793779-dfc6d800-d2bb-11eb-89d6-84b7e23ff486.png)

Error Monitoring UI
![image](https://user-images.githubusercontent.com/1671213/122793715-d0478f00-d2bb-11eb-901a-a53980352082.png)
