### PR TITLE
CXP-345: enrich error on invalid locale for channel

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -41,6 +41,7 @@ The %attribute% attribute must not contain more than %limit% characters. The sub
 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.': 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.'
 'The {{ attribute_code }} attribute cannot be empty.': 'The {{ attribute_code }} attribute cannot be empty.'
 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.'
+'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.'
 The %attribute% attribute requires an e-mail address.: 'The %attribute% attribute requires an e-mail address.'
 pim_catalog:
     constraint:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -41,7 +41,7 @@ The %attribute% attribute must not contain more than %limit% characters. The sub
 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.': 'The {{ attribute_code }} attribute must match the following regular expression: {{ pattern }}.'
 'The {{ attribute_code }} attribute cannot be empty.': 'The {{ attribute_code }} attribute cannot be empty.'
 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.'
-'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.'
+'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel.': 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel.'
 The %attribute% attribute requires an e-mail address.: 'The %attribute% attribute requires an e-mail address.'
 pim_catalog:
     constraint:

--- a/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/LocalizableAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Error/DocumentationBuilder/LocalizableAttribute.php
@@ -18,11 +18,16 @@ use Symfony\Component\Validator\ConstraintViolationInterface;
  */
 class LocalizableAttribute implements DocumentationBuilderInterface
 {
+    const SUPPORTED_CONSTRAINTS_CODES = [
+        LocalizableValues::NON_ACTIVE_LOCALE,
+        LocalizableValues::INVALID_LOCALE_FOR_CHANNEL
+    ];
+
     public function support($object): bool
     {
         if (
             $object instanceof ConstraintViolationInterface
-            && $object->getCode() === LocalizableValues::NON_ACTIVE_LOCALE
+            && \in_array($object->getCode(), self::SUPPORTED_CONSTRAINTS_CODES)
         ) {
             return true;
         }
@@ -81,7 +86,7 @@ class LocalizableAttribute implements DocumentationBuilderInterface
     {
         if (
             $object instanceof ConstraintViolationInterface
-            && $object->getCode() === LocalizableValues::NON_ACTIVE_LOCALE
+            && \in_array($object->getCode(), self::SUPPORTED_CONSTRAINTS_CODES)
         ) {
             $parameters = $object->getParameters();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
@@ -17,7 +17,7 @@ class LocalizableValues extends Constraint
     public $nonActiveLocaleMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.';
 
     /** @var string */
-    public $invalidLocaleForChannelMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.';
+    public $invalidLocaleForChannelMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel.';
 
     /** @var string */
     public $invalidLocaleSpecificMessage = '"%invalid_locale%" is not part of the available locales for the locale specific attribute "%attribute_code%".';

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValues.php
@@ -11,12 +11,13 @@ use Symfony\Component\Validator\Constraint;
 class LocalizableValues extends Constraint
 {
     const NON_ACTIVE_LOCALE = '7962b972-e39a-461e-86f2-4900281a72aa';
+    const INVALID_LOCALE_FOR_CHANNEL = 'e2239e6b-934b-4791-aca8-9585d03ae43c';
 
     /** @var string */
     public $nonActiveLocaleMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale does not exist.';
 
     /** @var string */
-    public $invalidLocaleForChannelMessage = 'Attribute "%attribute_code%" expects a valid locale, "%invalid_locale%" is not bound to channel "%channel_code%".';
+    public $invalidLocaleForChannelMessage = 'The %attribute_code% attribute requires a valid locale. The %invalid_locale% locale is not bound to the %channel_code% channel or does not exist.';
 
     /** @var string */
     public $invalidLocaleSpecificMessage = '"%invalid_locale%" is not part of the available locales for the locale specific attribute "%attribute_code%".';

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValuesValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/LocalizableValuesValidator.php
@@ -88,7 +88,10 @@ final class LocalizableValuesValidator extends ConstraintValidator
                             '%channel_code%' => $localizableValue->getScopeCode(),
                             '%invalid_locale%' => $localizableValue->getLocaleCode(),
                         ]
-                    )->atPath(sprintf('[%s]', $key))->addViolation();
+                    )
+                        ->atPath(sprintf('[%s]', $key))
+                        ->setCode(LocalizableValues::INVALID_LOCALE_FOR_CHANNEL)
+                        ->addViolation();
 
                     continue;
                 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/LocalizableAttributeSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Error/DocumentationBuilder/LocalizableAttributeSpec.php
@@ -27,11 +27,17 @@ class LocalizableAttributeSpec extends ObjectBehavior
         $this->beAnInstanceOf(DocumentationBuilderInterface::class);
     }
 
-    function it_supports_the_constraint_non_active_locale(ConstraintViolationInterface $constraintViolation)
+    function it_supports_constraints_on_locale(ConstraintViolationInterface $constraintViolation)
     {
-        $constraintViolation->getCode()->willReturn(LocalizableValues::NON_ACTIVE_LOCALE);
+        $constraintCodes = [
+            LocalizableValues::NON_ACTIVE_LOCALE,
+            LocalizableValues::INVALID_LOCALE_FOR_CHANNEL,
+        ];
 
-        $this->support($constraintViolation)->shouldReturn(true);
+        foreach ($constraintCodes as $contraintCode) {
+            $constraintViolation->getCode()->willReturn($contraintCode);
+            $this->support($constraintViolation)->shouldReturn(true);
+        }
     }
 
     function it_does_not_support_other_types_of_error()
@@ -41,7 +47,7 @@ class LocalizableAttributeSpec extends ObjectBehavior
         $this->support($exception)->shouldReturn(false);
     }
 
-    function it_builds_the_documentation_for_the_constraint_non_active_locale(
+    function it_builds_the_documentation(
         ConstraintViolationInterface $constraintViolation
     ) {
         $constraintViolation->getCode()->willReturn(LocalizableValues::NON_ACTIVE_LOCALE);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/LocalizableValuesValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/LocalizableValuesValidatorSpec.php
@@ -178,6 +178,7 @@ class LocalizableValuesValidatorSpec extends ObjectBehavior
             ]
         )->willReturn($violationBuilder);
         $violationBuilder->atPath('[scopable_localizable_text-mobile-fr_FR]')->willReturn($violationBuilder);
+        $violationBuilder->setCode(LocalizableValues::INVALID_LOCALE_FOR_CHANNEL)->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($values, $constraint);

--- a/tests/features/pim/enrichment/product/validation/localizable_values.feature
+++ b/tests/features/pim/enrichment/product/validation/localizable_values.feature
@@ -48,7 +48,7 @@ Background:
     When a product is created with values:
       | attribute   | data       | scope     | locale  |
       | description | My product | ecommerce | fr_FR   |
-    Then the error 'The description attribute requires a valid locale. The fr_FR locale is not bound to the ecommerce channel or does not exist.' is raised
+    Then the error 'The description attribute requires a valid locale. The fr_FR locale is not bound to the ecommerce channel.' is raised
 
   @acceptance-back
   Scenario: Providing a locale part of a locale specific attribute's available locales should not raise an error

--- a/tests/features/pim/enrichment/product/validation/localizable_values.feature
+++ b/tests/features/pim/enrichment/product/validation/localizable_values.feature
@@ -48,7 +48,7 @@ Background:
     When a product is created with values:
       | attribute   | data       | scope     | locale  |
       | description | My product | ecommerce | fr_FR   |
-    Then the error 'Attribute "description" expects a valid locale, "fr_FR" is not bound to channel "ecommerce".' is raised
+    Then the error 'The description attribute requires a valid locale. The fr_FR locale is not bound to the ecommerce channel or does not exist.' is raised
 
   @acceptance-back
   Scenario: Providing a locale part of a locale specific attribute's available locales should not raise an error


### PR DESCRIPTION
Improve error message and error monitoring
![image](https://user-images.githubusercontent.com/1671213/123095750-b11d3e80-d42e-11eb-8555-6a7cd0be8486.png)
![image](https://user-images.githubusercontent.com/1671213/123095806-bed2c400-d42e-11eb-90a9-2edb64798bbe.png)
(screenshots not up-to-date with the last error message change)