### PR TITLE
CPM-156 stabilize job tests

### DIFF
--- a/config/services/behat/services.yml
+++ b/config/services/behat/services.yml
@@ -65,6 +65,7 @@ services:
             - '@kernel'
             - '@database_connection'
             - !tagged akeneo.pim.tests.pub_sub_queue_status.job
+            - '@logger'
 
     akeneo_integration_tests.pub_sub_queue_status.ui_job:
         class: AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus

--- a/config/services/behat/services.yml
+++ b/config/services/behat/services.yml
@@ -51,9 +51,47 @@ services:
             - '@akeneo_measure.installer.measurement_installer'
             - '@messenger.transport.business_event'
             - '@event_dispatcher'
+            - '@akeneo_integration_tests.launcher.job_launcher'
             - '%env(APP_DATABASE_HOST)%'
             - '%env(APP_DATABASE_NAME)%'
             - '%env(APP_DATABASE_USER)%'
             - '%env(APP_DATABASE_PASSWORD)%'
             - '%kernel.cache_dir%/sql-dump/'
             - '%index_hosts%'
+
+    akeneo_integration_tests.launcher.job_launcher:
+        class: Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher
+        arguments:
+            - '@kernel'
+            - '@database_connection'
+            - !tagged akeneo.pim.tests.pub_sub_queue_status.job
+
+    akeneo_integration_tests.pub_sub_queue_status.ui_job:
+        class: AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus
+        arguments:
+            - '@Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\PubSubClientFactory'
+            - '%env(GOOGLE_CLOUD_PROJECT)%'
+            - '%env(PUBSUB_TOPIC_JOB_QUEUE_UI)%'
+            - '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_UI)%'
+        tags:
+            - { name: 'akeneo.pim.tests.pub_sub_queue_status.job' }
+
+    akeneo_integration_tests.pub_sub_queue_status.import_export_job:
+        class: AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus
+        arguments:
+            - '@Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\PubSubClientFactory'
+            - '%env(GOOGLE_CLOUD_PROJECT)%'
+            - '%env(PUBSUB_TOPIC_JOB_QUEUE_IMPORT_EXPORT)%'
+            - '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_IMPORT_EXPORT)%'
+        tags:
+            - { name: 'akeneo.pim.tests.pub_sub_queue_status.job' }
+
+    akeneo_integration_tests.pub_sub_queue_status.data_maintenance_job:
+        class: AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus
+        arguments:
+            - '@Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\PubSubClientFactory'
+            - '%env(GOOGLE_CLOUD_PROJECT)%'
+            - '%env(PUBSUB_TOPIC_JOB_QUEUE_DATA_MAINTENANCE)%'
+            - '%env(PUBSUB_SUBSCRIPTION_JOB_QUEUE_DATA_MAINTENANCE)%'
+        tags:
+            - { name: 'akeneo.pim.tests.pub_sub_queue_status.job' }

--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -55,6 +55,7 @@ services:
             - '@akeneo_measure.installer.measurement_installer'
             - '@messenger.transport.business_event'
             - '@event_dispatcher'
+            - '@akeneo_integration_tests.launcher.job_launcher'
             - '%env(APP_DATABASE_HOST)%'
             - '%env(APP_DATABASE_NAME)%'
             - '%env(APP_DATABASE_USER)%'
@@ -156,7 +157,6 @@ services:
         arguments:
             - '@kernel'
             - '@database_connection'
-            - '@messenger.receiver_locator'
             - !tagged akeneo.pim.tests.pub_sub_queue_status.job
 
     akeneo_integration_tests.pub_sub_queue_status.ui_job:

--- a/config/services/test/test_services.yml
+++ b/config/services/test/test_services.yml
@@ -158,6 +158,7 @@ services:
             - '@kernel'
             - '@database_connection'
             - !tagged akeneo.pim.tests.pub_sub_queue_status.job
+            - '@logger'
 
     akeneo_integration_tests.pub_sub_queue_status.ui_job:
         class: AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/Client.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/Client.php
@@ -7,7 +7,6 @@ namespace Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub;
 use Google\Cloud\PubSub\Subscription;
 use Google\Cloud\PubSub\Topic;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Webmozart\Assert\Assert;
 
 /**
  * Simple abstraction over the Google PubSubClient.
@@ -86,7 +85,17 @@ class Client
             $this->topic->create();
         }
 
-        if (null !== $this->subscription && !$this->subscription->exists()) {
+        if (null === $this->subscription) {
+            $this->subscription->create($this->subscriptionOptions);
+            return;
+        }
+
+        try {
+            // The "exist" method below use cached info. "reload" avoid to have cache problems.
+            $this->subscription->reload();
+        } catch (\Exception $e) {
+        }
+        if (!$this->subscription->exists()) {
             $this->subscription->create($this->subscriptionOptions);
         }
     }

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/ClientSpec.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/spec/Transport/GooglePubSub/ClientSpec.php
@@ -76,15 +76,12 @@ class ClientSpec extends ObjectBehavior
 
     public function it_can_be_setup(Topic $topic, Subscription $subscription): void
     {
-        $topic->exists()
-            ->willReturn(false);
-        $subscription->exists()
-            ->willReturn(false);
+        $topic->exists()->willReturn(false);
+        $subscription->reload()->shouldBeCalled();
+        $subscription->exists()->willReturn(false);
 
-        $topic->create()
-            ->shouldBeCalled();
-        $subscription->create([])
-            ->shouldBeCalled();
+        $topic->create()->shouldBeCalled();
+        $subscription->create([])->shouldBeCalled();
 
         $this->setup();
     }
@@ -107,15 +104,12 @@ class ClientSpec extends ObjectBehavior
             ],
         ]);
 
-        $topic->exists()
-            ->willReturn(false);
-        $subscription->exists()
-            ->willReturn(false);
+        $topic->exists()->willReturn(false);
+        $subscription->reload()->shouldBeCalled();
+        $subscription->exists()->willReturn(false);
 
-        $topic->create()
-            ->shouldBeCalled();
-        $subscription->create(['filter' => 'the_filter'])
-            ->shouldBeCalled();
+        $topic->create()->shouldBeCalled();
+        $subscription->create(['filter' => 'the_filter'])->shouldBeCalled();
 
         $this->setup();
     }

--- a/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
@@ -10,7 +10,6 @@ use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use AkeneoTest\Integration\IntegrationTestsBundle\Launcher\PubSubQueueStatus;
 use Doctrine\DBAL\Driver\Connection;
 use Google\Cloud\PubSub\Message;
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -31,7 +30,7 @@ use Webmozart\Assert\Assert;
 class JobLauncher
 {
     private const MESSENGER_COMMAND_NAME = 'messenger:consume';
-    private const MESSENGER_RECEIVERS = ['ui_job', 'import_export_job', 'data_maintenance_job'];
+    private const MESSENGER_RECEIVERS = ['data_maintenance_job', 'import_export_job', 'ui_job'];
 
     const EXPORT_DIRECTORY = 'pim-integration-tests-export';
 
@@ -39,20 +38,17 @@ class JobLauncher
 
     private KernelInterface $kernel;
     private Connection $dbConnection;
-    private ContainerInterface $receiverLocator;
     /** @var PubSubQueueStatus[] */
     private iterable $pubSubQueueStatuses;
 
     public function __construct(
         KernelInterface $kernel,
         Connection $dbConnection,
-        ContainerInterface $receiverLocator,
         iterable $pubSubQueueStatuses
     ) {
         Assert::allIsInstanceOf($pubSubQueueStatuses, PubSubQueueStatus::class);
         $this->kernel = $kernel;
         $this->dbConnection = $dbConnection;
-        $this->receiverLocator = $receiverLocator;
         $this->pubSubQueueStatuses = $pubSubQueueStatuses;
     }
 
@@ -459,15 +455,22 @@ class JobLauncher
 
     public function flushJobQueue(): void
     {
-        foreach (static::MESSENGER_RECEIVERS as $receiverName) {
-            Assert::true($this->receiverLocator->has($receiverName), sprintf(
-                'The "%s" transport does not exist',
-                $receiverName
-            ));
+        foreach ($this->pubSubQueueStatuses as $pubSubStatus) {
+            $subscription = $pubSubStatus->getSubscription();
+            try {
+                $subscription->reload();
+            } catch (\Exception $e) {
+            }
+            if (!$subscription->exists()) {
+                continue;
+            }
+
             do {
-                $receiver = $this->receiverLocator->get($receiverName);
-                $envelopes = $receiver->get();
-                $count = is_array($envelopes) ? count($envelopes) : iterator_count($envelopes);
+                $messages = $subscription->pull(['maxMessages' => 10, 'returnImmediately' => true]);
+                $count = count($messages);
+                if ($count > 0) {
+                    $subscription->acknowledgeBatch($messages);
+                }
             } while (0 < $count);
         }
     }

--- a/tests/back/Integration/IntegrationTestsBundle/Launcher/PubSubQueueStatus.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Launcher/PubSubQueueStatus.php
@@ -6,6 +6,7 @@ namespace AkeneoTest\Integration\IntegrationTestsBundle\Launcher;
 use Akeneo\Tool\Bundle\MessengerBundle\Transport\GooglePubSub\PubSubClientFactory;
 use Google\Cloud\Core\Exception\ServiceException;
 use Google\Cloud\PubSub\Message;
+use Google\Cloud\PubSub\Subscription;
 
 /**
  * This class provides some helping method to test the message in a pub/sub queue.
@@ -57,6 +58,7 @@ final class PubSubQueueStatus
             ]);
 
             foreach ($messages as $message) {
+                // From documentation: Specifying zero may immediately make the message available for another pull request
                 $subscription->modifyAckDeadline($message, 0);
             }
 
@@ -103,5 +105,13 @@ final class PubSubQueueStatus
         } catch (ServiceException $exception) {
             throw new \RuntimeException(sprintf('Unable to access Pub/Sub: %s', $exception->getMessage()));
         }
+    }
+
+    public function getSubscription(): Subscription
+    {
+        $pubSubClient = $this->pubSubClientFactory->createPubSubClient(['projectId' => $this->projectId]);
+        $topic = $pubSubClient->topic($this->topicName);
+
+        return $topic->subscription($this->subscriptionName);
     }
 }

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -10,6 +10,7 @@ use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
 use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
 use Akeneo\Platform\Bundle\InstallerBundle\FixtureLoader\FixtureJobLoader;
 use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
 use Akeneo\Test\IntegrationTestsBundle\Security\SystemUserAuthenticator;
 use Akeneo\Tool\Bundle\BatchBundle\Job\DoctrineJobRepository;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
@@ -103,6 +104,7 @@ class FixturesLoader implements FixturesLoaderInterface
     private $transport;
 
     private EventDispatcherInterface $eventDispatcher;
+    private JobLauncher $jobLauncher;
 
     public function __construct(
         KernelInterface $kernel,
@@ -121,6 +123,7 @@ class FixturesLoader implements FixturesLoaderInterface
         MeasurementInstaller $measurementInstaller,
         TransportInterface $transport,
         EventDispatcherInterface $eventDispatcher,
+        JobLauncher $jobLauncher,
         string $databaseHost,
         string $databaseName,
         string $databaseUser,
@@ -156,6 +159,7 @@ class FixturesLoader implements FixturesLoaderInterface
         $this->measurementInstaller = $measurementInstaller;
         $this->transport = $transport;
         $this->eventDispatcher = $eventDispatcher;
+        $this->jobLauncher = $jobLauncher;
     }
 
     public function __destruct()
@@ -187,6 +191,7 @@ class FixturesLoader implements FixturesLoaderInterface
 
         $this->nativeElasticsearchClient->indices()->refresh(['index' => $this->getIndexNames()]);
         $this->clearAclCache();
+        $this->jobLauncher->flushJobQueue();
 
         $this->systemUserAuthenticator->createSystemUser();
 

--- a/tests/legacy/features/Behat/Context/HookContext.php
+++ b/tests/legacy/features/Behat/Context/HookContext.php
@@ -9,6 +9,7 @@ use Behat\Mink\Driver\Selenium2Driver;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Testwork\Tester\Result\TestResult;
 use Context\FeatureContext;
+use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Component\Process\Process;
 use WebDriver\Exception\UnexpectedAlertOpen;
@@ -44,7 +45,15 @@ class HookContext extends PimContext
     {
         $process = new Process(sprintf('exec bin/console %s --env=behat', self::MESSENGER_JOB_COMMAND_NAME));
         $process->setTimeout(null);
-        $process->start();
+        $process->start(function (string $type, string $data) {
+            /** @var LoggerInterface $logger */
+            $logger = $this->getService('logger');
+            if ($type === Process::ERR) {
+                $logger->error($data);
+            } else {
+                $logger->info($data);
+            }
+        });
 
         $this->jobConsumerProcess = $process;
     }

--- a/tests/legacy/features/Behat/Context/ImportExportFileContext.php
+++ b/tests/legacy/features/Behat/Context/ImportExportFileContext.php
@@ -35,11 +35,6 @@ final class ImportExportFileContext extends PimContext implements SnippetAccepti
 
     private const USERNAME_FOR_JOB_LAUNCH = 'admin';
 
-    public function __construct(string $mainContextClass)
-    {
-        parent::__construct($mainContextClass);
-    }
-
     /**
      * @When /^the (.*) are imported via the job ([\w\_]+)$/
      */


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The phpunit/behat tests failed randomly. When the jobs were in the database we just had to clear the database, now we the jobs are in the pubsub emulator and we had to flush the queues between each tests (otherwise a test can create several jobs and pollute the next tests).

- Flush the queues between each behat tests
- Fix creation of subscription by "reload" the data (bypass the cache): sometimes the daemon failed because it tried to create a subscription that already exist, or try to use a subscription that didn't exist. Random tests that are very hard to debug
- Clear doctrine repo cache before fetching the job execution object


**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
