### PR TITLE
Symfony codestyle

### DIFF
--- a/.php_cs_symfony.dist
+++ b/.php_cs_symfony.dist
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->name('*.php')
+    ->notName('*Spec.php')
+    ->in(__DIR__ . '/tests')
+    ->in(__DIR__ . '/src');
+
+$rules = [
+    '@Symfony' => true,
+];
+
+$config = new PhpCsFixer\Config();
+
+return $config
+    ->setRules($rules)
+    ->setFinder($finder)
+    ->setCacheFile('var/.php_cs_symfony.cache')
+    ->setRiskyAllowed(true);

--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -49,3 +49,6 @@ xdebug-on:
 cypress-interactive:
 	docker-compose -f docker-compose-cypress.yml run --rm -u 1000:1000 -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --entrypoint cypress cypress open --project .
 
+.PHONY: lint-fix-back
+lint-fix-back: #Doc: run php-cs-fixer with symfony codestyle
+	${PHP_RUN} vendor/bin/php-cs-fixer fix --config=.php_cs_symfony.dist --diff --path-mode=intersection ${O}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

**Note:** ~The 2 last commits are simple examples of what the new rules are, and are not meant to be merged in this PR~ the commits were removed

#### Description
This PR is an attempt to homogenize the code style in the pim's codebase. The goal is to apply the `@Symfony` php-cs-fixer ruleset on updated / new files, but not change the CI's config (with more permissive rules) in order not to have a failing build if some files were not updated according to the new rules. This will allow migrating the codebase progressively, and avoid a big PR with all the code base updated at once, which would cause a lot of file conflicts, and tedious PR rebases.

In order to do so, I added a new makefile target, which can be used at will or in the following pre-commit hook:

pre-commit hook:
```bash
#!/usr/bin/env bash
  
FILES=`git status --porcelain | grep -P '^[AM] .+\.php$' | cut -c 4- | tr '\n' ' '`

if [[ -z "$FILES" ]]
then
    exit 0
fi

PIM_CONTEXT=dev make lint-fix-back O=${FILES}
res=$?

if [[ $res -ne 0 ]]
then
    exit $res
fi

git add $FILES
exit 0
```
To install the hook, just copy/paste it into the `.git/hooks/pre-commit` file in your project, and give it execution rights (`chmod +x .git/hooks/pre-commit`). The hook will fix the codestyle for every added/updated PHP file tracked in the git index, and will display a diff of the fixes.

If you don't want to use the hook for a specific commit, you can do so by passing the `-n` (aka `--no-verify`) option to your `git commit` command.


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
