### PR TITLE
PIM-9933: Fix delete category menu that stays displayed on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,8 @@
 - PIM-9863: Remove temporisation and add unit tests for product model reindexation.
 - PIM-9891: Fix missing sanity checks when computing enrichment status
 - PIM-9886: Fix display of completeness in the PEF when the selected locale is deactivated
-- PIM-9925: Fix roles that couldn't contain dashes in their codes
+- PIM-9925: Fix roles that couldn't contain dashes in their codes 
+- PIM-9933: Fix delete category menu that stays displayed on screen
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
@@ -164,6 +164,7 @@ const CategoryEditPage: FC = () => {
                             openDeleteCategoryModal();
                           }
                         });
+                        closeSecondaryAction();
                       }}
                       className="AknDropdown-menuLink"
                     >


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
