### PR TITLE
RAC-739: update CategoryTree component to allow display depending on parents

### DIFF
--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -33,13 +33,12 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   onClick,
   initCallback,
   isCategorySelected,
-   // @ts-ignore
-   shouldRerender,
+  shouldRerender,
   ...rest
-}: CategoryTreeProps) => {
+}) => {
   const [tree, setTree] = React.useState<CategoryTreeModel>();
 
-  const recursiveGetFirstSelectedCategoryLabel: (category: CategoryTreeModel, tree?: CategoryTreeModel) => string | undefined = (category, tree) => {
+  const recursiveGetFirstSelectedCategoryLabel: (category: CategoryTreeModel) => string | undefined = category => {
     if (
       isCategorySelected &&
       isCategorySelected({
@@ -51,7 +50,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
       return category.label;
     }
     return (category.children || []).reduce(
-      (previous, subCategory) => previous || recursiveGetFirstSelectedCategoryLabel(subCategory, tree),
+      (previous, subCategory) => previous || recursiveGetFirstSelectedCategoryLabel(subCategory),
       undefined as string | undefined
     );
   };
@@ -74,6 +73,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   return (
     <RecursiveCategoryTree
       tree={tree}
+      parentTree={tree}
       childrenCallback={childrenCallback}
       onChange={onChange}
       onClick={onClick}

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -27,7 +27,6 @@ type CategoryTreeProps = {
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
   isCategorySelected?: (category: CategoryValue, parentCategory: ParentCategoryTree) => boolean;
   isCategoryReadOnly?: (category: CategoryTreeModel, parentCategory: ParentCategoryTree) => boolean;
-  shouldRerender?: boolean;
 };
 
 const CategoryTree: React.FC<CategoryTreeProps> = ({
@@ -39,7 +38,6 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   initCallback,
   isCategorySelected,
   isCategoryReadOnly,
-  shouldRerender,
   ...rest
 }) => {
   const [tree, setTree] = React.useState<CategoryTreeModel>();
@@ -85,7 +83,6 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
       onClick={onClick}
       isCategorySelected={isCategorySelected}
       isCategoryReadOnly={isCategoryReadOnly}
-      shouldRerender={shouldRerender}
       {...rest}
     />
   );

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -11,7 +11,7 @@ type CategoryTreeModel = {
   selected?: boolean;
   readOnly?: boolean;
   children?: CategoryTreeModel[];
-  parent?: CategoryTreeModel;
+  parent?: CategoryTreeModel | null;
 };
 
 type CategoryTreeProps = {

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -16,11 +16,12 @@ type CategoryTreeModel = {
 type CategoryTreeProps = {
   categoryTreeCode?: string;
   init: (categoryTreeCode?: string) => Promise<CategoryTreeModel>;
-  childrenCallback: (value: any) => Promise<CategoryTreeModel[]>;
+  childrenCallback: (value: any, parentCategory?: CategoryTreeModel) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
   isCategorySelected?: (category: CategoryValue) => boolean;
+  shouldRerender?: boolean;
 };
 
 const CategoryTree: React.FC<CategoryTreeProps> = ({
@@ -31,8 +32,10 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   onClick,
   initCallback,
   isCategorySelected,
+                                                     // @ts-ignore
+                                                     shouldRerender,
   ...rest
-}) => {
+}: CategoryTreeProps) => {
   const [tree, setTree] = React.useState<CategoryTreeModel>();
 
   const recursiveGetFirstSelectedCategoryLabel: (category: CategoryTreeModel) => string | undefined = category => {
@@ -74,6 +77,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
       onChange={onChange}
       onClick={onClick}
       isCategorySelected={isCategorySelected}
+      shouldRerender={shouldRerender}
       {...rest}
     />
   );

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -11,6 +11,7 @@ type CategoryTreeModel = {
   selected?: boolean;
   readOnly?: boolean;
   children?: CategoryTreeModel[];
+  parent?: CategoryTreeModel;
 };
 
 type CategoryTreeProps = {
@@ -20,7 +21,7 @@ type CategoryTreeProps = {
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
-  isCategorySelected?: (category: CategoryValue) => boolean;
+  isCategorySelected?: (category: CategoryValue, parentCategory?: CategoryTreeModel) => boolean;
   shouldRerender?: boolean;
 };
 
@@ -32,13 +33,13 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   onClick,
   initCallback,
   isCategorySelected,
-                                                     // @ts-ignore
-                                                     shouldRerender,
+   // @ts-ignore
+   shouldRerender,
   ...rest
 }: CategoryTreeProps) => {
   const [tree, setTree] = React.useState<CategoryTreeModel>();
 
-  const recursiveGetFirstSelectedCategoryLabel: (category: CategoryTreeModel) => string | undefined = category => {
+  const recursiveGetFirstSelectedCategoryLabel: (category: CategoryTreeModel, tree?: CategoryTreeModel) => string | undefined = (category, tree) => {
     if (
       isCategorySelected &&
       isCategorySelected({
@@ -50,7 +51,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
       return category.label;
     }
     return (category.children || []).reduce(
-      (previous, subCategory) => previous || recursiveGetFirstSelectedCategoryLabel(subCategory),
+      (previous, subCategory) => previous || recursiveGetFirstSelectedCategoryLabel(subCategory, tree),
       undefined as string | undefined
     );
   };

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -16,13 +16,12 @@ type CategoryTreeModel = {
   selected?: boolean;
   readOnly?: boolean;
   children?: CategoryTreeModel[];
-  parent?: ParentCategoryTree;
 };
 
 type CategoryTreeProps = {
   categoryTreeCode?: string;
   init: (categoryTreeCode?: string) => Promise<CategoryTreeModel>;
-  childrenCallback: (value: any, parentCategory: ParentCategoryTree) => Promise<CategoryTreeModel[]>;
+  childrenCallback: (value: any) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
@@ -80,6 +79,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   return (
     <RecursiveCategoryTree
       tree={tree}
+      parentTree={null}
       childrenCallback={childrenCallback}
       onChange={onChange}
       onClick={onClick}

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -27,6 +27,7 @@ type CategoryTreeProps = {
   onClick?: any;
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
   isCategorySelected?: (category: CategoryValue, parentCategory: ParentCategoryTree) => boolean;
+  isCategoryReadOnly?: (category: CategoryTreeModel, parentCategory: ParentCategoryTree) => boolean;
   shouldRerender?: boolean;
 };
 
@@ -38,6 +39,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   onClick,
   initCallback,
   isCategorySelected,
+  isCategoryReadOnly,
   shouldRerender,
   ...rest
 }) => {
@@ -82,6 +84,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
       onChange={onChange}
       onClick={onClick}
       isCategorySelected={isCategorySelected}
+      isCategoryReadOnly={isCategoryReadOnly}
       shouldRerender={shouldRerender}
       {...rest}
     />

--- a/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTree.tsx
@@ -2,6 +2,11 @@ import React from 'react';
 import {CategoryValue, RecursiveCategoryTree} from './RecursiveCategoryTree';
 import {Tree} from 'akeneo-design-system/lib/components/Tree/Tree';
 
+type ParentCategoryTree = {
+  code: string;
+  parent: ParentCategoryTree;
+} | null;
+
 type CategoryTreeModel = {
   id: number;
   code: string;
@@ -11,17 +16,17 @@ type CategoryTreeModel = {
   selected?: boolean;
   readOnly?: boolean;
   children?: CategoryTreeModel[];
-  parent?: CategoryTreeModel | null;
+  parent?: ParentCategoryTree;
 };
 
 type CategoryTreeProps = {
   categoryTreeCode?: string;
   init: (categoryTreeCode?: string) => Promise<CategoryTreeModel>;
-  childrenCallback: (value: any, parentCategory?: CategoryTreeModel) => Promise<CategoryTreeModel[]>;
+  childrenCallback: (value: any, parentCategory: ParentCategoryTree) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   initCallback?: (treeLabel: string, categoryLabel?: string) => void;
-  isCategorySelected?: (category: CategoryValue, parentCategory?: CategoryTreeModel) => boolean;
+  isCategorySelected?: (category: CategoryValue, parentCategory: ParentCategoryTree) => boolean;
   shouldRerender?: boolean;
 };
 
@@ -45,7 +50,7 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
         id: category.id,
         code: category.code,
         label: category.label,
-      })
+      }, null)
     ) {
       return category.label;
     }
@@ -73,7 +78,6 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   return (
     <RecursiveCategoryTree
       tree={tree}
-      parentTree={tree}
       childrenCallback={childrenCallback}
       onChange={onChange}
       onClick={onClick}
@@ -84,5 +88,5 @@ const CategoryTree: React.FC<CategoryTreeProps> = ({
   );
 };
 
-export type {CategoryTreeModel};
+export type {CategoryTreeModel, ParentCategoryTree};
 export {CategoryTree};

--- a/front-packages/shared/src/components/CategoryTree/CategoryTrees.tsx
+++ b/front-packages/shared/src/components/CategoryTree/CategoryTrees.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {CategoryTree, CategoryTreeModel} from './CategoryTree';
+import {CategoryTree, CategoryTreeModel, ParentCategoryTree} from './CategoryTree';
 import {BooleanInput} from 'akeneo-design-system/lib/components/Input/BooleanInput/BooleanInput';
 import {Tree, getColor} from 'akeneo-design-system';
 import {useTranslate} from '../../hooks';
@@ -124,7 +124,7 @@ const CategoryTrees: React.FC<CategoryTreesProps> = ({
     />
   );
 
-  const isCategorySelected: (category: CategoryValue) => boolean = category => {
+  const isCategorySelected: (category: CategoryValue, _: ParentCategoryTree) => boolean = category => {
     return category.id === selectedTreeId;
   };
 

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -10,15 +10,17 @@ type CategoryValue = {
 
 type RecursiveCategoryTreeProps = {
   tree: CategoryTreeModel;
+  parentTree?: CategoryTreeModel;
   childrenCallback: (value: any, parentCategory?: CategoryTreeModel) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
-  isCategorySelected?: (category: CategoryValue) => boolean;
+  isCategorySelected?: (category: CategoryValue, parentCategory?: CategoryTreeModel) => boolean;
   shouldRerender?: boolean
 };
 
 const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   tree,
+  parentTree,
   childrenCallback,
   onChange,
   onClick,
@@ -43,6 +45,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
     }
   };
 
+
   return (
     <Tree<CategoryValue>
       label={categoryState.label}
@@ -51,7 +54,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={categoryState.selected || (isCategorySelected ? isCategorySelected(categoryState) : categoryState.selected)}
+      selected={categoryState.selected || (isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected)}
       isLoading={categoryState.loading}
       readOnly={categoryState.readOnly}
       selectable={categoryState.selectable}
@@ -66,10 +69,11 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
             <RecursiveCategoryTree
               key={childNode.id}
               tree={childNode}
+              parentTree={categoryState}
               onChange={onChange}
               childrenCallback={childrenCallback}
               onClick={onClick}
-              isCategorySelected={isCategorySelected}
+              isCategorySelected={isCategorySelected} // Give a reference of the parent to the child via currying ? or just pass the parent tree to the child
               shouldRerender={shouldRerender}
             />
           );

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -51,8 +51,8 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected}
       isLoading={categoryState.loading}
+      selected={isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected}
       readOnly={isCategoryReadOnly ? isCategoryReadOnly(categoryState, parentTree) : categoryState.readOnly}
       selectable={categoryState.selectable}
       isLeaf={Array.isArray(categoryState.children) && categoryState.children.length === 0}

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -14,6 +14,7 @@ type RecursiveCategoryTreeProps = {
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   isCategorySelected?: (category: CategoryValue, categoryParentTree: ParentCategoryTree) => boolean;
+  isCategoryReadOnly?: (category: CategoryTreeModel, categoryParentTree: ParentCategoryTree) => boolean;
   shouldRerender?: boolean
 };
 
@@ -23,6 +24,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   onChange,
   onClick,
   isCategorySelected,
+  isCategoryReadOnly,
   shouldRerender,
 }) => {
   const [categoryState, setCategoryState] = React.useState<CategoryTreeModel>(tree);
@@ -51,7 +53,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
       }}
       selected={isCategorySelected ? isCategorySelected(categoryState, tree.parent ?? null) : categoryState.selected}
       isLoading={categoryState.loading}
-      readOnly={categoryState.readOnly}
+      readOnly={isCategoryReadOnly ? isCategoryReadOnly(categoryState, tree.parent ?? null) : categoryState.readOnly}
       selectable={categoryState.selectable}
       isLeaf={Array.isArray(categoryState.children) && categoryState.children.length === 0}
       onChange={handleChange}
@@ -68,6 +70,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
               childrenCallback={childrenCallback}
               onClick={onClick}
               isCategorySelected={isCategorySelected}
+              isCategoryReadOnly={isCategoryReadOnly}
               shouldRerender={shouldRerender}
             />
           );

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -16,7 +16,6 @@ type RecursiveCategoryTreeProps = {
   onClick?: any;
   isCategorySelected?: (category: CategoryValue, categoryParentTree: ParentCategoryTree) => boolean;
   isCategoryReadOnly?: (category: CategoryTreeModel, categoryParentTree: ParentCategoryTree) => boolean;
-  shouldRerender?: boolean
 };
 
 const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
@@ -27,7 +26,6 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   onClick,
   isCategorySelected,
   isCategoryReadOnly,
-  shouldRerender,
 }) => {
   const [categoryState, setCategoryState] = React.useState<CategoryTreeModel>(tree);
 
@@ -74,7 +72,6 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
               onClick={onClick}
               isCategorySelected={isCategorySelected}
               isCategoryReadOnly={isCategoryReadOnly}
-              shouldRerender={shouldRerender}
             />
           );
         })}

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -32,7 +32,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   const handleOpen = React.useCallback(() => {
     if (typeof categoryState.children === 'undefined') {
       setCategoryState(currentCategoryState => ({...currentCategoryState, loading: true}));
-      childrenCallback(categoryState.id, parentTree).then(children => {
+      childrenCallback(categoryState.id, tree).then(children => {
         setCategoryState(currentCategoryState => ({...currentCategoryState, loading: false, children}));
       });
     }
@@ -45,7 +45,6 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
     }
   };
 
-
   return (
     <Tree<CategoryValue>
       label={categoryState.label}
@@ -54,7 +53,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={isCategorySelected ? isCategorySelected(categoryState) : categoryState.selected}
+      selected={isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected}
       isLoading={categoryState.loading}
       readOnly={categoryState.readOnly}
       selectable={categoryState.selectable}

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -10,7 +10,8 @@ type CategoryValue = {
 
 type RecursiveCategoryTreeProps = {
   tree: CategoryTreeModel;
-  childrenCallback: (value: any, parentCategory: ParentCategoryTree) => Promise<CategoryTreeModel[]>;
+  parentTree: ParentCategoryTree;
+  childrenCallback: (value: any) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   isCategorySelected?: (category: CategoryValue, categoryParentTree: ParentCategoryTree) => boolean;
@@ -20,6 +21,7 @@ type RecursiveCategoryTreeProps = {
 
 const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   tree,
+  parentTree,
   childrenCallback,
   onChange,
   onClick,
@@ -32,7 +34,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   const handleOpen = React.useCallback(() => {
     if (typeof categoryState.children === 'undefined') {
       setCategoryState(currentCategoryState => ({...currentCategoryState, loading: true}));
-      childrenCallback(categoryState.id, tree.parent ?? null).then(children => {
+      childrenCallback(categoryState.id).then(children => {
         setCategoryState(currentCategoryState => ({...currentCategoryState, loading: false, children}));
       });
     }
@@ -51,9 +53,9 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={isCategorySelected ? isCategorySelected(categoryState, tree.parent ?? null) : categoryState.selected}
+      selected={isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected}
       isLoading={categoryState.loading}
-      readOnly={isCategoryReadOnly ? isCategoryReadOnly(categoryState, tree.parent ?? null) : categoryState.readOnly}
+      readOnly={isCategoryReadOnly ? isCategoryReadOnly(categoryState, parentTree) : categoryState.readOnly}
       selectable={categoryState.selectable}
       isLeaf={Array.isArray(categoryState.children) && categoryState.children.length === 0}
       onChange={handleChange}
@@ -67,6 +69,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
               key={childNode.id}
               tree={childNode}
               onChange={onChange}
+              parentTree={{code: categoryState.code, parent: parentTree}}
               childrenCallback={childrenCallback}
               onClick={onClick}
               isCategorySelected={isCategorySelected}

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -32,7 +32,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   const handleOpen = React.useCallback(() => {
     if (typeof categoryState.children === 'undefined') {
       setCategoryState(currentCategoryState => ({...currentCategoryState, loading: true}));
-      childrenCallback(categoryState.id, tree).then(children => {
+      childrenCallback(categoryState.id, parentTree).then(children => {
         setCategoryState(currentCategoryState => ({...currentCategoryState, loading: false, children}));
       });
     }
@@ -54,7 +54,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={categoryState.selected || (isCategorySelected ? isCategorySelected(categoryState, parentTree) : categoryState.selected)}
+      selected={isCategorySelected ? isCategorySelected(categoryState) : categoryState.selected}
       isLoading={categoryState.loading}
       readOnly={categoryState.readOnly}
       selectable={categoryState.selectable}

--- a/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
+++ b/front-packages/shared/src/components/CategoryTree/RecursiveCategoryTree.tsx
@@ -10,10 +10,11 @@ type CategoryValue = {
 
 type RecursiveCategoryTreeProps = {
   tree: CategoryTreeModel;
-  childrenCallback: (value: any) => Promise<CategoryTreeModel[]>;
+  childrenCallback: (value: any, parentCategory?: CategoryTreeModel) => Promise<CategoryTreeModel[]>;
   onChange?: (value: string, checked: boolean) => void;
   onClick?: any;
   isCategorySelected?: (category: CategoryValue) => boolean;
+  shouldRerender?: boolean
 };
 
 const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
@@ -22,13 +23,14 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
   onChange,
   onClick,
   isCategorySelected,
+  shouldRerender,
 }) => {
   const [categoryState, setCategoryState] = React.useState<CategoryTreeModel>(tree);
 
   const handleOpen = React.useCallback(() => {
     if (typeof categoryState.children === 'undefined') {
       setCategoryState(currentCategoryState => ({...currentCategoryState, loading: true}));
-      childrenCallback(categoryState.id).then(children => {
+      childrenCallback(categoryState.id, tree).then(children => {
         setCategoryState(currentCategoryState => ({...currentCategoryState, loading: false, children}));
       });
     }
@@ -49,7 +51,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
         code: categoryState.code,
         label: categoryState.label,
       }}
-      selected={isCategorySelected ? isCategorySelected(categoryState) : categoryState.selected}
+      selected={categoryState.selected || (isCategorySelected ? isCategorySelected(categoryState) : categoryState.selected)}
       isLoading={categoryState.loading}
       readOnly={categoryState.readOnly}
       selectable={categoryState.selectable}
@@ -68,6 +70,7 @@ const RecursiveCategoryTree: React.FC<RecursiveCategoryTreeProps> = ({
               childrenCallback={childrenCallback}
               onClick={onClick}
               isCategorySelected={isCategorySelected}
+              shouldRerender={shouldRerender}
             />
           );
         })}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/category/Selector.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/product/category/Selector.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {DependenciesProvider} from '@akeneo-pim-community/legacy-bridge';
-import {Channel, Category, CategoryTree, CategoryTreeModel, CategoryValue} from '@akeneo-pim-community/shared';
+import {
+  Channel,
+  Category,
+  CategoryTree,
+  CategoryTreeModel,
+  CategoryValue,
+  ParentCategoryTree,
+} from '@akeneo-pim-community/shared';
 import styled, {ThemeProvider} from 'styled-components';
 import {pimTheme} from 'akeneo-design-system';
 import {Tree} from 'akeneo-design-system/lib';
@@ -30,7 +37,7 @@ const CategorySelectorWithAllProducts: React.FC<CategorySelectorWithAllProductsP
 }) => {
   const [categoryCodes, setCategoryCodes] = React.useState<string[]>(initialCategoryCodes);
 
-  const isCategorySelected: (category: CategoryValue) => boolean = category => {
+  const isCategorySelected: (category: CategoryValue, _: ParentCategoryTree) => boolean = category => {
     return categoryCodes.includes(category.code);
   };
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

_Those new features have been implemented in the context of the following PR. https://github.com/akeneo/pim-enterprise-dev/pull/11165. In this PR, the display of each category might depend on the state of their parent category._

This PRs extends a bit more the possibilities of the CategoryTree (and recursive categorytrees) by:
- Modifying the isCategorySelected callback signature to take into account an additonnal (optional) argument that is an object representing the parent category of the current category.
- introducing a new callback that checks for each node if the node should be displayed read-only or not (just like the isCategorySelected callback works.
    - this callbacks takes the current displayed category as well as it's parent.
