### PR TITLE
BH-589: Use first text filed in PEF for sanity checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,17 +249,12 @@ jobs:
           name: Install database
           command: APP_ENV=dev O="--catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev" make database
       - run:
-          name: Add "adminakeneo" user
-          command: APP_ENV=dev docker-compose exec -u www-data fpm bin/console pim:user:create adminakeneo adminakeneo product-team@akeneo.com admin1 admin2 en_US --admin -n
-      - run:
           name: Launch Cypress
-          command: CYPRESS_defaultCommandTimeout=8000 CYPRESS_requestTimeout=10000 make end-to-end-front
+          command: CYPRESS_defaultCommandTimeout=10000 CYPRESS_requestTimeout=15000 CYPRESS_responseTimeout=50000 make end-to-end-front
       - store_artifacts:
           path: cypress/screenshots
       - store_artifacts:
           path: cypress/videos
-      - store_artifacts:
-          path: var/logs
 
   test_back_behat_legacy:
     machine:

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,3 +63,7 @@ Cypress.Commands.add('saveProduct', () => {
 Cypress.Commands.add('updateField', (label, value) => {
   cy.findByLabelText(label).clear().type(value);
 });
+
+Cypress.Commands.add('findFirstTextField', () => {
+  return cy.get('input.AknTextField').first();
+});

--- a/docker/cypress/Dockerfile
+++ b/docker/cypress/Dockerfile
@@ -1,3 +1,3 @@
-FROM cypress/included:7.2.0
+FROM cypress/included:7.6.0
 
 RUN npm i @testing-library/cypress

--- a/tests/front/e2e/product/edit.js
+++ b/tests/front/e2e/product/edit.js
@@ -1,11 +1,11 @@
 describe('edit product sanity check', () => {
   it('User can enrich the first product of the products grid', () => {
-    cy.login('adminakeneo', 'adminakeneo');
+    cy.login('admin', 'admin');
     cy.goToProductsGrid();
     cy.selectFirstProductInDatagrid();
-    cy.updateField('Name', 'updated product');
+    cy.findFirstTextField().clear().type('updated value');
     cy.saveProduct();
     cy.reload();
-    cy.findByDisplayValue('updated product').should('exist');
+    cy.findFirstTextField().should('have.value', 'updated value');
   });
 });


### PR DESCRIPTION
The e2e suite is used to make sanity checks on real customers that don't always have a "name" text attribute and we must adapt the test to use the first available text filed in the PeF

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
