### PR TITLE
OB-848: Fix cache initialization

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -84,7 +84,7 @@ SQL;
             );
         }
 
-        $this->allMeasurementFamiliesCache = $this->all();
+        $this->all();
         $this->allMeasurementFamiliesCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
         $this->measurementFamilyCache[$normalizedMeasurementFamily['code']] = $measurementFamily;
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

Following this [PR](https://github.com/akeneo/pim-community-dev/pull/14629)

We need to initialize the cache by calling `all` method but we don't want to override caches values return by `all` method,
`all` method return `array_values` of measurmentFamilies (removing measurmentFamilies codes as key), and the cache need measurmentFamilies code as key to work properly


**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
