### PR TITLE
PIM-9941: Metrics: Change Bar symbol for bar

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,9 @@
 # 4.0.x
 
+## Bug fixes
+
+PIM-9941: Metrics: Change Bar symbol for bar
+
 # 4.0.116 (2021-06-24)
 
 # 4.0.115 (2021-06-22)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/measure.yml
@@ -430,7 +430,7 @@ measures_config:
         units:
             BAR:
                 convert: [{'mul': '1'}]
-                symbol: Bar
+                symbol: bar
             PASCAL:
                 convert: [{'mul': '0.00001'}]
                 symbol: Pa
@@ -439,7 +439,7 @@ measures_config:
                 symbol: hPa
             MILLIBAR:
                 convert: [{'mul': '0.001'}]
-                symbol: mBar
+                symbol: mbar
             ATM:
                 convert: [{'mul': '1.01325'}]
                 symbol: atm


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

On the measure yml file, the bar symbol was written Bar. Same for millibar -> mBar.
The convention is 
Bar : the symbol should be bar
Millibar: the symbol should be mbar

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
