### PR TITLE
PIM-9944: Fix attribute group grid search

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-9944: Fix attribute group grid search
+
 # 5.0.37 (2021-07-01)
 
 # 5.0.36 (2021-06-25)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/attribute-groups/useFilteredAttributeGroups.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/attribute-groups/useFilteredAttributeGroups.ts
@@ -14,7 +14,9 @@ const useFilteredAttributeGroups = (groups: AttributeGroup[]) => {
     (searchValue: string) => {
       setFilteredGroups(
         Object.values(groups).filter((group: AttributeGroup) =>
-          group.labels[userContext.get('uiLocale')].toLowerCase().includes(searchValue.toLowerCase().trim())
+          (group.labels[userContext.get('catalogLocale')] ?? group.code)
+            .toLowerCase()
+            .includes(searchValue.toLowerCase().trim())
         )
       );
     },


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Fix the search on the attribute group datagrid:
- the search should be performed based on the catalog locale instead of the UI locale
- if no label is defined for the given locale, search on the code

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
