### PR TITLE
CXP-791: refactor 'get web marketplace url' endpoint

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/Marketplace/GetWebMarketplaceUrl.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/InternalApi/Controller/Marketplace/GetWebMarketplaceUrl.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller;
+namespace Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Marketplace;
 
 use Akeneo\Connectivity\Connection\Domain\Marketplace\MarketplaceUrlGeneratorInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class MarketplaceUrlController
+class GetWebMarketplaceUrl
 {
     private MarketplaceUrlGeneratorInterface $marketplaceUrlGenerator;
     private UserContext $userContext;
@@ -29,7 +29,7 @@ class MarketplaceUrlController
         $this->userContext = $userContext;
     }
 
-    public function get(Request $request): Response
+    public function __invoke(Request $request): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return new RedirectResponse('/');

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -45,9 +45,9 @@ services:
             - '@akeneo_connectivity.connection.persistence.query.search_event_subscription_debug_logs_query'
             - '@oro_security.security_facade'
 
-    akeneo_connectivity.connection.internal_api.controller.marketplace_url:
+    akeneo_connectivity.connection.internal_api.controller.marketplace.get_web_marketplace_url:
         public: true
-        class: Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\MarketplaceUrlController
+        class: Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Marketplace\GetWebMarketplaceUrl
         arguments:
             - '@akeneo_connectivity.connection.marketplace.url_generator'
             - '@pim_user.context.user'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -31,11 +31,6 @@ akeneo_connectivity_connection_marketplace_rest:
     resource: ./routing/marketplace.yml
     prefix: /rest/marketplace
 
-akeneo_connectivity_connection_marketplace_url_rest_get:
-    path: '/rest/marketplace-url'
-    defaults: { _controller: akeneo_connectivity.connection.internal_api.controller.marketplace_url:get }
-    methods: [GET]
-
 # Frontend
 
 ## Marketplace

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/marketplace.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/marketplace.yml
@@ -1,3 +1,8 @@
+akeneo_connectivity_connection_marketplace_rest_get_web_marketplace_url:
+    path: '/marketplace-url'
+    controller: akeneo_connectivity.connection.internal_api.controller.marketplace.get_web_marketplace_url
+    methods: [GET]
+
 akeneo_connectivity_connection_marketplace_rest_get_all_extensions:
     path: '/extensions'
     controller: akeneo_connectivity.connection.internal_api.controller.marketplace.get_all_extensions

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/GetWebMarketplaceUrlEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/GetWebMarketplaceUrlEndToEnd.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Marketplace;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetWebMarketplaceUrlEndToEnd extends WebTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_get_the_web_marketplace_url_for_the_current_user(): void
+    {
+        $this->authenticateAsAdmin();
+        $this->client->xmlHttpRequest('GET', '/rest/marketplace/marketplace-url');
+        $result = json_decode($this->client->getResponse()->getContent(), true);
+
+        Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        Assert::assertMatchesRegularExpression(
+            '/https:\/\/marketplace\.akeneo\.com\/.*/',
+            $result,
+        );
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/GetWebMarketplaceUrlEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/GetWebMarketplaceUrlEndToEnd.php
@@ -25,7 +25,7 @@ class GetWebMarketplaceUrlEndToEnd extends WebTestCase
         return $this->catalog->useMinimalCatalog();
     }
 
-    public function test_it_get_the_web_marketplace_url_for_the_current_user(): void
+    public function test_it_gets_the_web_marketplace_url_for_the_current_user(): void
     {
         $this->authenticateAsAdmin();
         $this->client->xmlHttpRequest('GET', '/rest/marketplace/marketplace-url');

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-marketplace-url.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-marketplace-url.ts
@@ -2,7 +2,7 @@ import {useCallback} from 'react';
 import {useRoute} from '../../shared/router';
 
 export const useFetchMarketplaceUrl = () => {
-    const url = useRoute('akeneo_connectivity_connection_marketplace_url_rest_get');
+    const url = useRoute('akeneo_connectivity_connection_marketplace_rest_get_web_marketplace_url');
 
     return useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-marketplace-url.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-marketplace-url.test.tsx
@@ -4,7 +4,7 @@ import {mockFetchResponses} from '../../../test-utils';
 
 test('it fetches the marketplace url', async () => {
     mockFetchResponses({
-        akeneo_connectivity_connection_marketplace_url_rest_get: {
+        akeneo_connectivity_connection_marketplace_rest_get_web_marketplace_url: {
             json: 'http://marketplace.test',
         },
     });


### PR DESCRIPTION
Following https://github.com/akeneo/pim-community-dev/pull/14885
The goal is to regroup marketplace action/controller

![image](https://user-images.githubusercontent.com/1671213/124140266-9d09ba80-da88-11eb-8e3b-16c4c8667afb.png)
