### PR TITLE
Fix coupling between Connectivity and UserManagement

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
@@ -9,6 +9,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Exception\WebhookEventDataBuil
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -46,9 +47,12 @@ class WebhookEventBuilder
         $context = $this->resolveOptions($context);
         $eventDataBuilder = $this->getEventDataBuilder($pimEventBulk);
 
+        /** @var UserInterface $user */
+        $user = $context['user'];
+
         $eventDataCollection = $eventDataBuilder->build(
             $pimEventBulk,
-            $context['user']
+            new Context($user->getUsername(), $user->getId())
         );
 
         return $this->buildWebhookEvents(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
@@ -12,6 +12,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Platform\Component\EventQueue\Event;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -49,13 +50,16 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEvent = $this->createEvent($author, ['data'], 1599814161, 'a20832d1-a1e6-4f39-99ea-a1dd859faddb');
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
+        $user->getId()->willReturn(10);
+        $user->getUsername()->willReturn('ecommerce_0000');
+
         $collection = new EventDataCollection();
         $collection->setEventData($pimEvent, ['data']);
 
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, $user)->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
 
         $this->build(
             $pimEventBulk,
@@ -89,13 +93,16 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEvent = $this->createEvent($author, ['data'], 1599814161, 'a20832d1-a1e6-4f39-99ea-a1dd859faddb');
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
+        $user->getId()->willReturn(10);
+        $user->getUsername()->willReturn('ecommerce_0000');
+
         $collection = new EventDataCollection();
         $collection->setEventDataError($pimEvent, new \Exception());
 
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, $user)->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
 
         $this->build(
             $pimEventBulk,
@@ -120,13 +127,16 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEvent = $this->createEvent($author, ['data'], 1599814161, 'a20832d1-a1e6-4f39-99ea-a1dd859faddb');
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
+        $user->getId()->willReturn(10);
+        $user->getUsername()->willReturn('ecommerce_0000');
+
         $collection = new EventDataCollection();
         $collection->setEventDataError($pimEvent, new \Exception());
 
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, $user)->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
 
         $apiEventBuildErrorLogger->logResourceNotFoundOrAccessDenied(
             'ecommerce',

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -8,14 +8,12 @@ use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductNormalizer;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductNotFoundException;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
  * @author    Willy Mesnage <willy.mesnage@akeneo.com>
@@ -50,9 +48,12 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
         return true;
     }
 
-    public function build(BulkEventInterface $bulkEvent, UserInterface $user): EventDataCollection
+    public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
-        $products = $this->getConnectorProducts($this->getProductIdentifiers($bulkEvent->getEvents()), $user->getId());
+        $products = $this->getConnectorProducts(
+            $this->getProductIdentifiers($bulkEvent->getEvents()),
+            $context->getUserId()
+        );
 
         $collection = new EventDataCollection();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilder.php
@@ -9,13 +9,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductModelNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetConnectorProductModels;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductModelNotFoundException;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
  * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
@@ -50,9 +48,12 @@ class ProductModelCreatedAndUpdatedEventDataBuilder implements EventDataBuilderI
         return true;
     }
 
-    public function build(BulkEventInterface $bulkEvent, UserInterface $user): EventDataCollection
+    public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
-        $productModels = $this->getConnectorProductModels($this->getProductModelCodes($bulkEvent->getEvents()), $user->getId());
+        $productModels = $this->getConnectorProductModels(
+            $this->getProductModelCodes($bulkEvent->getEvents()),
+            $context->getUserId()
+        );
 
         $collection = new EventDataCollection();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductModelRemovedEventDataBuilder.php
@@ -6,9 +6,9 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Webhook;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -31,7 +31,7 @@ class ProductModelRemovedEventDataBuilder implements EventDataBuilderInterface
         return true;
     }
 
-    public function build(BulkEventInterface $bulkEvent, UserInterface $user): EventDataCollection
+    public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
         $collection = new EventDataCollection();
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductRemovedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductRemovedEventDataBuilder.php
@@ -6,9 +6,9 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Webhook;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -31,7 +31,7 @@ class ProductRemovedEventDataBuilder implements EventDataBuilderInterface
         return true;
     }
 
-    public function build(BulkEventInterface $bulkEvent, UserInterface $user): EventDataCollection
+    public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
         $collection = new EventDataCollection();
 

--- a/src/Akeneo/Platform/Component/Webhook/Context.php
+++ b/src/Akeneo/Platform/Component/Webhook/Context.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Component\Webhook;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Context
+{
+    private string $username;
+    private int $userId;
+
+    public function __construct(string $username, int $userId)
+    {
+        $this->username = $username;
+        $this->userId = $userId;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/src/Akeneo/Platform/Component/Webhook/EventDataBuilderInterface.php
+++ b/src/Akeneo/Platform/Component/Webhook/EventDataBuilderInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Platform\Component\Webhook;
 
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -15,8 +14,5 @@ interface EventDataBuilderInterface
 {
     public function supports(BulkEventInterface $event): bool;
 
-    /**
-     * @return array<mixed> Normalized data.
-     */
-    public function build(BulkEventInterface $event, UserInterface $user): EventDataCollection;
+    public function build(BulkEventInterface $event, Context $context): EventDataCollection;
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
@@ -6,25 +6,22 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Webhook;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductList;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
+use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ValuesNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\DateTimeNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
-use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
-use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductCreatedAndUpdatedEventDataBuilder;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
 use Prophecy\Argument;
@@ -78,8 +75,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_builds_a_bulk_event_of_product_created_and_updated_event(
         GetConnectorProducts $getConnectorProductsQuery
     ): void {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $blueJeanEvent = new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',
@@ -128,7 +124,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
             ],
         ]);
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }
@@ -136,8 +132,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_builds_a_bulk_event_of_product_created_and_updated_event_if_a_product_as_been_removed(
         GetConnectorProducts $getConnectorProductsQuery
     ): void {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $productList = new ConnectorProductList(1, [$this->buildConnectorProduct(1, 'blue_jean')]);
 
@@ -169,7 +164,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         ]);
         $expectedCollection->setEventDataError($redJeanEvent, new ProductNotFoundException('red_jean'));
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelCreatedAndUpdatedEventDataBuilderSpec.php
@@ -15,16 +15,13 @@ use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ValuesNormali
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\DateTimeNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetConnectorProductModels;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductModelNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductModelCreatedAndUpdatedEventDataBuilder;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
 use Prophecy\Argument;
@@ -84,8 +81,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_builds_a_bulk_event_of_product_created_and_updated_event(
         GetConnectorProductModels $getConnectorProductModelsQuery
     ): void {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $jeanEvent = new ProductModelCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'code' => 'jean',
@@ -133,7 +129,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
             ],
         ]);
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }
@@ -141,8 +137,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_builds_a_bulk_event_of_product_created_and_updated_event_if_a_product_as_been_removed(
         GetConnectorProductModels $getConnectorProductModelsQuery
     ): void {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $productList = new ConnectorProductModelList(1, [$this->buildConnectorProductModel(1, 'jean')]);
 
@@ -174,7 +169,7 @@ class ProductModelCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         ]);
         $expectedCollection->setEventDataError($shoesEvent, new ProductModelNotFoundException('shoes'));
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
@@ -9,9 +9,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductModelRemovedEventDataBuilder;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
 
@@ -50,8 +50,7 @@ class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
 
     public function it_builds_a_bulk_event_of_product_removed_event(): void
     {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $blueJeanEvent = new ProductModelRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'code' => 'blue_jean',
@@ -67,7 +66,7 @@ class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
         $expectedCollection->setEventData($blueJeanEvent, ['resource' => ['code' => 'blue_jean']]);
         $expectedCollection->setEventData($redJeanEvent, ['resource' => ['code' => 'red_jean']]);
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductRemovedEventDataBuilderSpec.php
@@ -9,9 +9,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\ProductRemovedEventDataBuilder;
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\BulkEvent;
+use Akeneo\Platform\Component\Webhook\Context;
 use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
-use Akeneo\UserManagement\Component\Model\User;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
 
@@ -50,8 +50,7 @@ class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
 
     public function it_builds_a_bulk_event_of_product_removed_event(): void
     {
-        $user = new User();
-        $user->setId(10);
+        $context = new Context('ecommerce_0000', 10);
 
         $blueJeanEvent = new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',
@@ -67,7 +66,7 @@ class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
         $expectedCollection->setEventData($blueJeanEvent, ['resource' => ['identifier' => 'blue_jean']]);
         $expectedCollection->setEventData($redJeanEvent, ['resource' => ['identifier' => 'red_jean']]);
 
-        $collection = $this->build($bulkEvent, $user)->getWrappedObject();
+        $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 
         Assert::assertEquals($expectedCollection, $collection);
     }

--- a/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
+++ b/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Platform\Component\Webhook;
+
+use Akeneo\Platform\Component\Webhook\Context;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class EventDataCollectionSpec extends ObjectBehavior
+{
+    public function it_is_a_context(): void
+    {
+        $this->shouldBeAnInstanceOf(Context::class);
+    }
+}

--- a/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
+++ b/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
@@ -11,10 +11,25 @@ use PhpSpec\ObjectBehavior;
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class EventDataCollectionSpec extends ObjectBehavior
+class ContextSpec extends ObjectBehavior
 {
+    public function let(): void
+    {
+        $this->beConstructedWith('username_0000', 10);
+    }
+
     public function it_is_a_context(): void
     {
         $this->shouldBeAnInstanceOf(Context::class);
+    }
+
+    public function it_returns_a_username(): void
+    {
+        $this->getUsername()->shouldReturn('username_0000');
+    }
+
+    public function it_returns_a_user_id(): void
+    {
+        $this->getUserId()->shouldReturn(10);
     }
 }


### PR DESCRIPTION
The goal of this PR is to remove the dependency on the *UserManagement* bounded context from the "EventDataBuilder" interfaces used by the *Enrichment* bounded context to build its own events data sent by the Events API.

From the
```php
namespace Akeneo\Platform\Component\Webhook;

interface EventDataBuilderInterface
```

Before, with the coupling to UserManagement
```php
public function build(BulkEventInterface $event, Akeneo\UserManagement\Component\Model\UserInterface $user): EventDataCollection;
```

After, the interface is not coupled to UserManagement but use a simple DTO with only its required data (user id & username)
```php
public function build(BulkEventInterface $event, Context $context): EventDataCollection;
```