### PR TITLE
PIM-9949: Fix category edit page to use catalog locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PIM-9886: Fix display of completeness in the PEF when the selected locale is deactivated
 - PIM-9925: Fix roles that couldn't contain dashes in their codes 
 - PIM-9933: Fix delete category menu that stays displayed on screen
+- PIM-9949: Fix category edit page to use catalog locale
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/categories/CategoryEditPage.tsx
@@ -97,13 +97,13 @@ const CategoryEditPage: FC = () => {
       return;
     }
 
-    const uiLocale = userContext.get('uiLocale');
+    const catalogLocale = userContext.get('catalogLocale');
     const rootCategory = category.root ? category.root : category;
 
-    setCategoryLabel(getLabel(category.labels, uiLocale, category.code));
-    setTreeLabel(getLabel(rootCategory.labels, uiLocale, rootCategory.code));
+    setCategoryLabel(getLabel(category.labels, catalogLocale, category.code));
+    setTreeLabel(getLabel(rootCategory.labels, catalogLocale, rootCategory.code));
     setTree(rootCategory);
-  }, [category]);
+  }, [category, userContext]);
 
   if (categoryLoadingStatus === 'error') {
     return (


### PR DESCRIPTION
Fix edit category page to display the breadcrumb & title value with the catalog locale (en_US) and not the UI locale (fr_FR)

![image](https://user-images.githubusercontent.com/1671213/124447313-8661ad00-dd81-11eb-880f-9cdd0cbb5edc.png)
