### PR TITLE
PIM-9951: Fix wrong locale used by spellcheck when comparing product attributes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-9951: Fix wrong locale used by spellcheck when comparing product attributes
+
 # 5.0.38 (2021-07-02)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/listener/ProductEditForm/CatalogContextListener.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/listener/ProductEditForm/CatalogContextListener.tsx
@@ -29,11 +29,15 @@ const CatalogContextListener: FunctionComponent<CatalogContextListenerProps> = (
 
   useEffect(() => {
     const handleCatalogLocaleChanged = (event: CustomEvent<LocaleEvent>) => {
-      dispatchAction(changeCatalogContextLocale(event.detail.locale));
+      if ('base_product' === event.detail.context) {
+        dispatchAction(changeCatalogContextLocale(event.detail.locale));
+      }
     };
 
     const handleCatalogChannelChanged = (event: CustomEvent<ChannelEvent>) => {
-      dispatchAction(changeCatalogContextChannel(event.detail.channel));
+      if ('base_product' === event.detail.context) {
+        dispatchAction(changeCatalogContextChannel(event.detail.channel));
+      }
     };
 
     window.addEventListener(CATALOG_CONTEXT_LOCALE_CHANGED, handleCatalogLocaleChanged as EventListener);


### PR DESCRIPTION
When using the compare/translate feature on a product, the spell-check is applied according to the locale of the comparison instead of the catalog context.

The locale and channel on DQI features must be changed only when the change is done on the product base context. 

![image-2021-07-02-16-44-06-177](https://user-images.githubusercontent.com/26378046/124452791-02aabf00-dd87-11eb-8055-7e6c92548733.png)
