### PR TITLE
PIM-9948: Fix performance issue on product model import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - PIM-9925: Fix roles that couldn't contain dashes in their codes 
 - PIM-9933: Fix delete category menu that stays displayed on screen
 - PIM-9949: Fix category edit page to use catalog locale
+- PIM-9948: Fix performance issue on product model import
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiers.php
@@ -41,6 +41,7 @@ SELECT
     product.identifier
 FROM filter_product_model
     INNER JOIN pim_catalog_product_model product_model ON filter_product_model.id = product_model.parent_id
+        AND product_model.parent_id IS NOT NULL
     INNER JOIN pim_catalog_product product             ON product_model.id = product.product_model_id
 SQL;
 


### PR DESCRIPTION
By adding a where clause on the join, mysql isn't using a join buffer anymore and can rely on indexes.

`EXPLAIN` of old & new query:
![explain](https://user-images.githubusercontent.com/1671213/124487244-c2f7cd80-ddae-11eb-8492-2999cc51a0bc.png)

Old `EXPLAIN ANALYZE`:
![analyze_old](https://user-images.githubusercontent.com/1671213/124487250-c5f2be00-ddae-11eb-9d60-dd5642a92108.png)

New `EXPLAIN ANALYZE`:
![analyze_new](https://user-images.githubusercontent.com/1671213/124487261-c723eb00-ddae-11eb-89b5-afef472d49fc.png)
