### PR TITLE
PIM-9943: Fix product-grid quality score filter all

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-9956: [Backport] PIM-9852: Fix exception during PRE_REMOVE on removeAll cause ES desynchronisation
+- PIM-9943: Fix product-grid quality score filter all
 
 # 5.0.39 (2021-07-06)
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/QualityScoreFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/QualityScoreFilter.php
@@ -20,7 +20,7 @@ final class QualityScoreFilter extends ChoiceFilter
     {
         $filterValue = $data['value'] ?? null;
 
-        if (null === $filterValue || ! is_array($filterValue)) {
+        if (! is_array($filterValue) || empty($filterValue)) {
             return false;
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/ProductGrid/QualityScoreFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/ProductGrid/QualityScoreFilterSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\ProductGrid;
+
+use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
+use Oro\Bundle\FilterBundle\Filter\FilterUtility;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Form\FormFactoryInterface;
+
+class QualityScoreFilterSpec extends ObjectBehavior
+{
+    public function let(FormFactoryInterface $formFactory, FilterUtility $filterUtility)
+    {
+        $this->beConstructedWith($formFactory, $filterUtility);
+    }
+
+    public function it_applies_the_quality_score_filter(
+        $filterUtility,
+        FilterDatasourceAdapterInterface $filterDatasource
+    ) {
+        $filterUtility->applyFilter($filterDatasource, 'data_quality_insights_score', 'IN', [1, 3])->shouldBeCalled();
+
+        $this->apply($filterDatasource, ['value' => [1, 3]]);
+    }
+
+    public function it_does_not_apply_quality_score_filter_when_the_filter_values_are_empty(
+        $filterUtility,
+        FilterDatasourceAdapterInterface $filterDatasource
+    ) {
+        $filterUtility->applyFilter(Argument::cetera())->shouldNotBeCalled();
+
+        $this->apply($filterDatasource, ['value' => []]);
+    }
+
+    public function it_does_not_apply_quality_score_filter_when_the_filter_values_are_not_an_array(
+        $filterUtility,
+        FilterDatasourceAdapterInterface $filterDatasource
+    ) {
+        $filterUtility->applyFilter(Argument::cetera())->shouldNotBeCalled();
+
+        $this->apply($filterDatasource, ['value' => 1]);
+    }
+}


### PR DESCRIPTION
Under some conditions, filtering the products on their quality score with the choice "all" could lead to empty list.

The choice "All" should not apply the filter on quality score at all.