### PR TITLE
BH-665 Exits queue daemon wrapper after signal handling

### DIFF
--- a/bin/queue-daemon-wrapper.sh
+++ b/bin/queue-daemon-wrapper.sh
@@ -13,6 +13,7 @@ catch() {
     log_as_monolog 'Waiting with grace for wrapped process to finish.'
     wait $pid
     log_as_monolog 'Wrapped process finished. Ended with grace.'
+    exit 0
 }
 
 trap 'catch' SIGTERM


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Exits queue daemon wrapper after signal handling


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
