### PR TITLE
BH-666 Makes composer cache dir writable for Onboarder test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,11 @@ jobs:
                 at: ~/
           - run:
                 name: Change owner on project dir in order to archive the project into the workspace
-                command: sudo chown -R 1000:1000 ../project
+                command: |
+                  mkdir -p ~/.cache/yarn ~/.composer
+                  sudo chown -R 1000:1000 ../project
+                  sudo chown -R 1000:1000 ~/.composer
+                  sudo chown -R 1000:1000 ~/.cache/yarn
           - run:
                 name: Create an empty service account
                 command: |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Makes composer cache dir writable for Onboarder test

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
