### PR TITLE
PIM-9716: Autoselect last element of pasted list in choice filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
 ## Improvements
 
+- PIM-9716: Autoselect last element of pasted list in choice filter
+
 # Technical Improvements
 
 - PIM-9648: Mitigate DDoS risk on API auth endpoint by rejecting too large content

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/choice-filter.js
@@ -205,6 +205,19 @@ define([
       initSelect2.init(this.$(this.criteriaValueSelectors.value), {
         multiple: true,
         tokenSeparators: [',', ' ', ';'],
+        tokenizer: function (input, selection, callback) {
+          if (![',', ' ', ';'].some(separator => input.includes(separator))) {
+            return;
+          }
+
+          input.split(/,| |;/).forEach(part => {
+            if ('' === part) {
+              return;
+            }
+
+            callback({id: part, text: part});
+          });
+        },
         tags: [],
         width: '290px',
         formatNoMatches: function () {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Providing Select2 choice filter a custom tokenizer that selects the last element of a pasted list (separated by `,`, `;` or ` `)

Before:
![Jul-13-2021 11-29-53](https://user-images.githubusercontent.com/3492179/125428465-f482e9c4-4e33-4010-844b-4820de32d36f.gif)
After:
![after](https://user-images.githubusercontent.com/3492179/125428478-17384c72-d157-4847-8237-d119eacf6249.gif)


**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)

