### PR TITLE
PLG-212: Add default value for the new environment variables

### DIFF
--- a/src/Akeneo/FreeTrial/back/Infrastructure/Symfony/Resources/config/akeneo_connect.yml
+++ b/src/Akeneo/FreeTrial/back/Infrastructure/Symfony/Resources/config/akeneo_connect.yml
@@ -1,3 +1,9 @@
+parameters:
+  env(AKENEO_CONNECT_API_CLIENT_ID): ''
+  env(AKENEO_CONNECT_API_CLIENT_SECRET): ''
+  env(AKENEO_CONNECT_API_CLIENT_USERNAME): ''
+  env(AKENEO_CONNECT_API_CLIENT_PASSWORD): ''
+
 services:
   Akeneo\FreeTrial\Domain\API\InviteUserAPI:
     class: Akeneo\FreeTrial\Infrastructure\AkeneoConnect\AkeneoConnectInviteUserAPI


### PR DESCRIPTION
The services `Akeneo\FreeTrial\Domain\API\InviteUserAPI` and `akeneo.free_trial.akeneo_connect.guzzle_client` will be instanciated for any cloud PIM deployment (Serenity, Growth Edition, Free Trial) even if it's irrelevant (Serenity EE). But they have environment variables as parameters, so if one of them are not defined or have no default value, Symfony will throw an error `Symfony\Component\DependencyInjection\Exception\EnvNotFoundException: Environment variable not found`

The easiest way to prevent that is to define default fallback values for the new environment variables in the services configuration. This will avoid to declare the new environment variables in irrelevant `.env` files  (ex: in EE)