### PR TITLE
BH-669 Reduces Github API calls by avoiding using composer to change requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ jobs:
       - run:
           name: Require proper dev CE branch
           command: |
-            sed -i "s|\"akeneo/pim-community-dev\": \"dev-master|\"akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}|" composer.json
-            sed -i "s|\"akeneo/pim-community-dev\": \"dev-master|\"akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}|" grth/composer.json
+            sed -i "s#akeneo/pim-community-dev\": \"dev-master#akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}#" composer.json
+            sed -i "s#akeneo/pim-community-dev\": \"dev-master#akeneo/pim-community-dev\": \"dev-${CIRCLE_BRANCH}#" grth/composer.json
       - install_yq
       - run:
           name: Remove MySQL port translation (see BH-664)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR replaces the usage of composer to change requirements by a sed in order to reduce the API calls to Github and avoid reaching API limits.

Indeed, doing a composer require, even without the --no-update option, will validate that the requirement can work, and go through all dependencies again, including the private repositories hosted on Github.

This validation is not necessary as a bit later in the process we launch a full composer install, which will do the validation again.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
