### PR TITLE
PIM-9973: Fix Asset attribute media type dropdown being hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PIM-9950: Fix import product model fail instead of warning vs permission
 - PIM-9948: Fix performance issue on product model import
 - PIM-9966: Fix Settings page crashing when coming from the PEF
+- PIM-9973: Fix Asset attribute media type dropdown being hidden
 
 ## New features
 
@@ -126,10 +127,9 @@ bin/console messenger:consume ui_job import_export_job data_maintenance_job
 - Change constructor of `Oro\Bundle\PimFilterBundle\Filter\ProductValue\MetricFilter` to remove `Symfony\Component\Translation\TranslatorInterface $translator`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\VersionNormalizer` to add `Symfony\Contracts\Translation\LocaleAwareInterface\LocaleAwareInterface $localeAware`
 - Change constructor of `Akeneo\UserManagement\Bundle\EventListener\LocaleSubscriber` to:
-    - remove `Symfony\Component\Translation\TranslatorInterface $translator`
-    - add  `Symfony\Contracts\Translation\LocaleAwareInterface\LocaleAwareInterface $localeAware`
+  - remove `Symfony\Component\Translation\TranslatorInterface $translator`
+  - add `Symfony\Contracts\Translation\LocaleAwareInterface\LocaleAwareInterface $localeAware`
 
 ### CLI commands
 
 ### Services
-


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Rerendering the content with the visible prop to trigger the ref being mounted and get its actual position and size

**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
