### PR TITLE
RAC-795: Fix placeholders are removed on second translation

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/translator.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/translator.js
@@ -11,7 +11,6 @@ var Translator = (function () {
 
   /**
    * replace placeholders in given message.
-   * **WARNING:** used placeholders are removed.
    *
    * @param {String} message      The translated message.
    * @param {Object} placeholders The placeholders to replace.
@@ -28,7 +27,6 @@ var Translator = (function () {
 
       if (_r.test(message)) {
         message = message.replace(_r, placeholders[_i]);
-        delete placeholders[_i];
       }
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Oro translator is removing placeholders when translating a message, so when translating a second time, the placeholders are missing...

See: https://github.com/oroinc/platform/commit/bafde8ad778f4659420c4c500a4e2cde2a57f228

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
