### PR TITLE
PLG-364: Remove helper message  in Measurement page for Free-Trial

### DIFF
--- a/front-packages/measurement/src/feature/pages/list/List.tsx
+++ b/front-packages/measurement/src/feature/pages/list/List.tsx
@@ -13,6 +13,7 @@ import {
   useRoute,
   PimView,
   PageHeader,
+  useFeatureFlags,
 } from '@akeneo-pim-community/shared';
 import {useMeasurementFamilies} from '../../hooks/use-measurement-families';
 import {sortMeasurementFamily, filterOnLabelOrCode, MeasurementFamilyCode} from '../../model/measurement-family';
@@ -49,6 +50,7 @@ const List = () => {
   const [measurementFamilies] = useMeasurementFamilies();
   const [isCreateModalOpen, openCreateModal, closeCreateModal] = useBooleanState(false);
   const settingsHref = useRoute('pim_settings_index');
+  const featureFlags = useFeatureFlags();
 
   const handleModalClose = useCallback(
     (createdMeasurementFamilyCode?: MeasurementFamilyCode) => {
@@ -105,12 +107,14 @@ const List = () => {
         </PageHeader.Title>
       </PageHeader>
       <PageContent>
-        <Information illustration={<MeasurementIllustration />} title={`👋  ${translate('measurements.helper.title')}`}>
-          <p>{translate('measurements.helper.text')}</p>
-          <Link href="https://help.akeneo.com/pim/articles/what-about-measurements.html" target="_blank">
-            {translate('measurements.helper.link')}
-          </Link>
-        </Information>
+        {false === featureFlags.isEnabled('free_trial') && (
+          <Information illustration={<MeasurementIllustration />} title={`👋  ${translate('measurements.helper.title')}`}>
+            <p>{translate('measurements.helper.text')}</p>
+            <Link href="https://help.akeneo.com/pim/articles/what-about-measurements.html" target="_blank">
+              {translate('measurements.helper.link')}
+            </Link>
+          </Information>
+        )}
         {null === filteredMeasurementFamilies && (
           <TablePlaceholder className={`AknLoadingPlaceHolderContainer`}>
             {[...Array(5)].map((_e, i) => (

--- a/front-packages/shared/src/DependenciesContext.tsx
+++ b/front-packages/shared/src/DependenciesContext.tsx
@@ -1,5 +1,14 @@
 import {createContext} from 'react';
-import {Notify, Router, Security, Translate, UserContext, ViewBuilder, Mediator} from './DependenciesProvider.type';
+import {
+  Notify,
+  Router,
+  Security,
+  Translate,
+  UserContext,
+  ViewBuilder,
+  Mediator,
+  FeatureFlags
+} from './DependenciesProvider.type';
 
 type DependenciesContextProps = {
   notify?: Notify;
@@ -9,6 +18,7 @@ type DependenciesContextProps = {
   user?: UserContext;
   viewBuilder?: ViewBuilder;
   mediator?: Mediator;
+  featureFlags?: FeatureFlags;
 };
 
 const DependenciesContext = createContext<DependenciesContextProps>({});

--- a/front-packages/shared/src/DependenciesProvider.type.ts
+++ b/front-packages/shared/src/DependenciesProvider.type.ts
@@ -42,5 +42,9 @@ type Mediator = {
   off(event: string, callback: () => void): void;
 };
 
+type FeatureFlags = {
+  isEnabled(feature: string): boolean;
+}
+
 export {NotificationLevel};
-export type {Notify, RouteParams, Router, Security, Translate, UserContext, View, ViewBuilder, Mediator};
+export type {Notify, RouteParams, Router, Security, Translate, UserContext, View, ViewBuilder, Mediator, FeatureFlags};

--- a/front-packages/shared/src/hooks/index.ts
+++ b/front-packages/shared/src/hooks/index.ts
@@ -15,3 +15,4 @@ export * from './useViewBuilder';
 export * from './useFetch';
 export * from './useSessionStorageState';
 export * from './useSetPageTitle';
+export * from './useFeatureFlags';

--- a/front-packages/shared/src/hooks/useFeatureFlags.ts
+++ b/front-packages/shared/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,14 @@
+import {useDependenciesContext} from './useDependenciesContext';
+import {FeatureFlags} from "../DependenciesProvider.type";
+
+const useFeatureFlags = (): FeatureFlags => {
+  const {featureFlags} = useDependenciesContext();
+
+  if (!featureFlags) {
+    throw new Error('[DependenciesContext]: FeatureFlags has not been properly initiated');
+  }
+
+  return featureFlags;
+};
+
+export {useFeatureFlags};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/__mocks__/dependencies.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/__mocks__/dependencies.ts
@@ -41,6 +41,9 @@ const dependencies = {
     trigger: jest.fn((event: string) => event),
     on: jest.fn((event: string, _callback: () => void) => event),
   },
+  featureFlags: {
+    isEnabled: jest.fn(() => false),
+  },
 };
 
 export {dependencies};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/dependencies.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/dependencies.ts
@@ -6,6 +6,7 @@ const messenger = require('oro/messenger');
 const userContext = require('pim/user-context');
 const securityContext = require('pim/security-context');
 const mediator = require('oro/mediator');
+const featureFlags = require('pim/feature-flags');
 
 const dependencies = {
   router,
@@ -17,6 +18,7 @@ const dependencies = {
     isGranted: securityContext.isGranted.bind(securityContext),
   },
   mediator,
+  featureFlags,
 };
 
 export {dependencies};


### PR DESCRIPTION
The goal is to remove the helper message in the Measurements page on the Free-Trial. There will be a dedicated helper for the Free-Trial.

To do so, it was necessary to add a new dependency `FeatureFlags` in `akeneo-pim-community/shared`

<img width="1392" alt="Measurements-helper" src="https://user-images.githubusercontent.com/26378046/126970674-f636ace0-fee1-4615-93d3-700016f7428e.png">
