### PR TITLE
PLG-362: Remove helper messages in Connectivity for Free-Trial

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/dependencies.ts
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/dependencies.ts
@@ -4,6 +4,7 @@ const viewBuilder = require('pim/form-builder');
 const messenger = require('oro/messenger');
 const userContext = require('pim/user-context');
 const securityContext = require('pim/security-context');
+const featureFlags = require('pim/feature-flags');
 
 export const dependencies = {
   router,
@@ -14,4 +15,5 @@ export const dependencies = {
   security: {
     isGranted: securityContext.isGranted.bind(securityContext),
   },
+  featureFlags,
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Dashboard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/audit/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import {useConnections} from '../hooks/api/use-connections';
 import {useFetchConnectionsAuditData} from '../hooks/api/use-fetch-connections-audit-data';
 import {Breadcrumb} from 'akeneo-design-system';
 import {UserButtons} from '../../shared/user';
+import {useFeatureFlags} from '../../shared/feature-flags';
 
 export const Dashboard = memo(() => {
     const {connections} = useConnections();
@@ -29,6 +30,8 @@ export const Dashboard = memo(() => {
 
     const dashboardHref = `#${useRoute('akeneo_connectivity_connection_audit_index')}`;
 
+    const featureFlags = useFeatureFlags();
+
     const breadcrumb = (
         <Breadcrumb>
             <Breadcrumb.Step href={dashboardHref}>
@@ -47,18 +50,22 @@ export const Dashboard = memo(() => {
             </PageHeader>
 
             <PageContent>
-                <Helper>
-                    <HelperTitle>
-                        <Translate id='akeneo_connectivity.connection.dashboard.helper.title' />
-                    </HelperTitle>
-                    <p>
-                        <Translate id='akeneo_connectivity.connection.dashboard.helper.description' />
-                    </p>
-                    <HelperLink href='https://help.akeneo.com/pim/articles/connection-dashboard.html' target='_blank'>
-                        <Translate id='akeneo_connectivity.connection.dashboard.helper.link' />
-                    </HelperLink>
-                </Helper>
-
+                {!featureFlags.isEnabled('free_trial') && (
+                    <Helper>
+                        <HelperTitle>
+                            <Translate id='akeneo_connectivity.connection.dashboard.helper.title' />
+                        </HelperTitle>
+                        <p>
+                            <Translate id='akeneo_connectivity.connection.dashboard.helper.description' />
+                        </p>
+                        <HelperLink
+                            href='https://help.akeneo.com/pim/articles/connection-dashboard.html'
+                            target='_blank'
+                        >
+                            <Translate id='akeneo_connectivity.connection.dashboard.helper.link' />
+                        </HelperLink>
+                    </Helper>
+                )}
                 <DashboardContent />
             </PageContent>
         </>

--- a/src/Akeneo/Connectivity/Connection/front/src/error-management/components/ConnectionErrors.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/error-management/components/ConnectionErrors.tsx
@@ -3,6 +3,7 @@ import {Loading} from '../../common';
 import {useConnectionErrors} from '../hooks/api/use-connection-errors';
 import {ErrorList} from './ErrorList';
 import {ErrorsHelper} from './ErrorsHelper';
+import {useFeatureFlags} from '../../shared/feature-flags';
 
 type Props = {
     connectionCode: string;
@@ -10,6 +11,7 @@ type Props = {
 
 const ConnectionErrors: FC<Props> = ({connectionCode}) => {
     const {loading, connectionErrors} = useConnectionErrors(connectionCode);
+    const featureFlags = useFeatureFlags();
 
     if (loading) {
         return <Loading />;
@@ -17,7 +19,7 @@ const ConnectionErrors: FC<Props> = ({connectionCode}) => {
 
     return (
         <>
-            <ErrorsHelper errorCount={connectionErrors.length} />
+            {!featureFlags.isEnabled('free_trial') && <ErrorsHelper errorCount={connectionErrors.length} />}
             <ErrorList errors={connectionErrors} />
         </>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/infrastructure/dependencies-provider.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/infrastructure/dependencies-provider.tsx
@@ -7,6 +7,7 @@ import {TranslateContext, TranslateInterface} from '../shared/translate';
 import {UserContext, UserInterface} from '../shared/user';
 import {LegacyContext} from './legacy-context';
 import {ViewBuilder} from './pim-view/view-builder';
+import {FeatureFlagsContext, FeatureFlags} from '../shared/feature-flags';
 
 interface Props {
     router: RouterInterface;
@@ -15,6 +16,7 @@ interface Props {
     notify: NotifyInterface;
     user: UserInterface;
     security: SecurityInterface;
+    featureFlags: FeatureFlags;
 }
 
 const DependenciesProvider = ({children, ...dependencies}: PropsWithChildren<Props>) => (
@@ -27,7 +29,11 @@ const DependenciesProvider = ({children, ...dependencies}: PropsWithChildren<Pro
                     }}
                 >
                     <UserContext.Provider value={dependencies.user}>
-                        <SecurityContext.Provider value={dependencies.security}>{children}</SecurityContext.Provider>
+                        <SecurityContext.Provider value={dependencies.security}>
+                            <FeatureFlagsContext.Provider value={dependencies.featureFlags}>
+                                {children}
+                            </FeatureFlagsContext.Provider>
+                        </SecurityContext.Provider>
                     </UserContext.Provider>
                 </LegacyContext.Provider>
             </NotifyContext.Provider>

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/feature-flags-context.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/feature-flags-context.ts
@@ -1,0 +1,8 @@
+import {createContext} from 'react';
+import {FeatureFlags} from './feature-flags.interface';
+
+export const FeatureFlagsContext = createContext<FeatureFlags>({
+    isEnabled: () => {
+        return false;
+    },
+});

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/feature-flags.interface.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/feature-flags.interface.ts
@@ -1,0 +1,3 @@
+export interface FeatureFlags {
+    isEnabled: (feature: string) => boolean;
+}

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/index.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/index.ts
@@ -1,0 +1,5 @@
+import {FeatureFlagsContext} from './feature-flags-context';
+import {FeatureFlags} from './feature-flags.interface';
+import {useFeatureFlags} from './use-feature-flags';
+
+export {FeatureFlagsContext, FeatureFlags, useFeatureFlags};

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/use-feature-flags.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/feature-flags/use-feature-flags.ts
@@ -1,0 +1,4 @@
+import {useContext} from 'react';
+import {FeatureFlagsContext} from './feature-flags-context';
+
+export const useFeatureFlags = () => useContext(FeatureFlagsContext);


### PR DESCRIPTION
The goal is to remove the helper messages in the Connectivity pages on the Free-Trial. There will be a dedicated helpers for the Free-Trial.

<img width="1399" alt="Helper-dataflows" src="https://user-images.githubusercontent.com/26378046/126999429-6fe91ef8-c465-44d3-81dd-ec7485067db7.png">
<img width="1393" alt="Helper-connections-monitoring" src="https://user-images.githubusercontent.com/26378046/126999531-956405ae-b681-43d8-a2b8-f70b6328f6a8.png">

