### PR TITLE
PIM-9986: Fix error message returned by the backend not displayed when an error occured while deleting a category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@
 - PIM-9948: Fix performance issue on product model import
 - PIM-9966: Fix Settings page crashing when coming from the PEF
 - PIM-9973: Fix Asset attribute media type dropdown being hidden
+- PIM-9986: Fix error message returned by the backend not displayed when an error occured while deleting a category
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useDeleteCategory.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useDeleteCategory.ts
@@ -31,15 +31,15 @@ const useDeleteCategory = () => {
   };
 
   const handleDeleteCategory = async (categoryToDelete: CategoryToDelete) => {
-    const success = await deleteCategory(categoryToDelete.identifier);
-    success && categoryToDelete.onDelete();
+    const response = await deleteCategory(categoryToDelete.identifier);
+    response.ok && categoryToDelete.onDelete();
 
-    const message = success
+    const message = response.ok
       ? 'pim_enrich.entity.category.category_deletion.success'
-      : 'pim_enrich.entity.category.category_deletion.error';
+      : response.errorMessage || 'pim_enrich.entity.category.category_deletion.error';
 
     notify(
-      success ? NotificationLevel.SUCCESS : NotificationLevel.ERROR,
+      response.ok ? NotificationLevel.SUCCESS : NotificationLevel.ERROR,
       translate(message, {name: categoryToDelete.label})
     );
   };

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/infrastructure/removers/deleteCategory.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/infrastructure/removers/deleteCategory.ts
@@ -2,13 +2,23 @@ const Routing = require('routing');
 
 const ROUTE_NAME = 'pim_enrich_categorytree_remove';
 
-const deleteCategory = async (categoryId: number): Promise<boolean> => {
+type Response = {
+  ok: boolean;
+  errorMessage: string;
+};
+
+const deleteCategory = async (categoryId: number): Promise<Response> => {
   const response = await fetch(Routing.generate(ROUTE_NAME, {id: categoryId}), {
     method: 'DELETE',
     headers: [['X-Requested-With', 'XMLHttpRequest']],
   });
 
-  return response.ok;
+  const errorMessage = response.ok ? '' : (await response.json()).message;
+
+  return {
+    ok: response.ok,
+    errorMessage,
+  };
 };
 
 export {deleteCategory};


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
When we updated the category UI, we forgot to use the error message returned by the backend when an error occurs while deleting a category. This PR fixes this behavior so we display a proper error message instead of a generic message, for example when in EE we try to delete a category that has published product in it :
![image](https://user-images.githubusercontent.com/1978756/127010198-fb9ac48d-65b7-472f-9cee-a6944e1eecc3.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
