### PR TITLE
PIM-9987: Fix product grid count not accurate after specific SKU selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - PIM-9986: Fix error message returned by the backend not displayed when an error occured while deleting a category
 - PIM-9942: Fix message on DQI dashboard in French UI locale
 - PIM-9947: Display validation errors message in the UI when `compute_family_variant_structure_changes` job fails
+- PIM-9987: Fix product grid count not accurate after specific SKU selection
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -111,7 +111,7 @@ extensions:
             tab: pim-menu-products
 
     pim-product-index-mass-actions:
-        module: pim/grid/mass-actions
+        module: pim/product/grid/mass-actions
         parent: pim-product-index
         targetZone: bottom-panel
         config:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -981,6 +981,7 @@ config:
     pim/grid/locale-switcher:   pimui/js/product/grid/locale-switcher
     pim/grid/category-switcher: pimui/js/product/grid/category-switcher
     pim/grid/mass-actions:      pimui/js/grid/mass-actions
+    pim/product/grid/mass-actions: pimui/js/product/grid/mass-actions.ts
 
     # Category tree
     pim/grid/category-tree:      pimui/js/product/grid/category-tree

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js
@@ -140,13 +140,7 @@ define(['jquery', 'underscore', 'oro/translator', 'backbone', 'pim/form', 'pim/t
      * - The events of the sub extensions are lost after re-render.
      */
     updateView() {
-      let count = this.count;
-      if (this.datagrid) {
-        const selectionState = this.datagrid.getSelectionState();
-        if (!selectionState.inset) {
-          count = this.collection.state.totalRecords - Object.keys(selectionState.selectedModels).length;
-        }
-      }
+      const count = this.countEntities();
 
       if (count > 0) {
         this.$el.removeClass('AknDefault-bottomPanel--hidden');
@@ -172,6 +166,18 @@ define(['jquery', 'underscore', 'oro/translator', 'backbone', 'pim/form', 'pim/t
       }
 
       this.$el.find('.count').text(__(this.config.label, {count: count}, count));
+    },
+
+    countEntities() {
+      let count = this.count;
+      if (this.datagrid) {
+        const selectionState = this.datagrid.getSelectionState();
+        if (!selectionState.inset) {
+          count = this.collection.state.totalRecords - Object.keys(selectionState.selectedModels).length;
+        }
+      }
+
+      return count;
     },
   });
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/mass-actions.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/mass-actions.ts
@@ -1,0 +1,18 @@
+const BaseForm = require('pim/grid/mass-actions');
+
+class MassActions extends BaseForm {
+  countEntities() {
+    let count = this.count;
+    if (this.datagrid) {
+      const selectionState = this.datagrid.getSelectionState();
+      count = Object.keys(this.datagrid.getSelectionState().selectedModels).length;
+      if (!selectionState.inset) {
+        count = this.collection.state.totalRecords - Object.keys(selectionState.selectedModels).length;
+      }
+    }
+
+    return count;
+  }
+}
+
+export = MassActions;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
This PR fixes an issue with the product selection count in the product grid in a specific use case. For example if you selected 2 products, then searched for a specific SKU and added the product to the selection, the count was reset to 1, where the correct number should have been 3. Furthermore, the number of selected products was not coherent with the real number of products impacted by the mass action, because the mass action had the real number of selected products (3 in my example). Since it's difficult to explain, I added 2 gifs of the before / after behaviors at the end.

Technically, for a reason I can't understand, the number displayed in the mass action bar was only the number of currently selected products, and not the total number. So I used the same idea than [the mass action modal](https://github.com/akeneo/pim-community-dev/blob/master/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/mass-action.js#L54) to retrieve the real number of selected products. However, since the file `src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/grid/mass-actions.js` is used for ALL the grids in the PIM and all the grid don't have the same counting system as the product grid (for example the family grid that count only the visible selected families), I had to update the entities count only for the product grid. To achieve this, I move the count computing in a dedicated function and I extended the mass action module for the product grid to fix it only for this grid.

**Before :**
![before](https://user-images.githubusercontent.com/1978756/127162173-d44bc05a-3434-4334-8e6a-bf3de656def6.gif)

**After:**
![after](https://user-images.githubusercontent.com/1978756/127162187-05d66167-db10-445a-a07c-8fa629a98449.gif)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
