### PR TITLE
PIM-9985: Improve channels sentence display in the settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 ## Improvements
 
 - PIM-9716: Autoselect last element of pasted list in choice filter
+- PIM-9985: Improve channels sentence display in the settings menu
 
 # Technical Improvements
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
@@ -128,7 +128,11 @@ const SettingsIndex = () => {
                     onClick={() => redirectToRoute('pim_enrich_channel_index')}
                     content={
                       countEntities.hasOwnProperty('count_channels')
-                        ? translate('pim_settings.count.channels', {count: countEntities['count_channels']}, countEntities['count_channels'])
+                        ? translate(
+                            'pim_settings.count.channels',
+                            {count: countEntities['count_channels']},
+                            countEntities['count_channels']
+                          )
                         : ''
                     }
                   />

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
@@ -128,9 +128,7 @@ const SettingsIndex = () => {
                     onClick={() => redirectToRoute('pim_enrich_channel_index')}
                     content={
                       countEntities.hasOwnProperty('count_channels')
-                        ? countEntities['count_channels'] === 1
-                          ? translate('pim_settings.count.channel')
-                          : translate('pim_settings.count.channels', {count: countEntities['count_channels']})
+                        ? translate('pim_settings.count.channels', {count: countEntities['count_channels']}, countEntities['count_channels'])
                         : ''
                     }
                   />

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/SettingsIndex.tsx
@@ -128,7 +128,9 @@ const SettingsIndex = () => {
                     onClick={() => redirectToRoute('pim_enrich_channel_index')}
                     content={
                       countEntities.hasOwnProperty('count_channels')
-                        ? translate('pim_settings.count.channels', {count: countEntities['count_channels']})
+                        ? countEntities['count_channels'] === 1
+                          ? translate('pim_settings.count.channel')
+                          : translate('pim_settings.count.channels', {count: countEntities['count_channels']})
                         : ''
                     }
                   />

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -396,8 +396,7 @@ pim_settings:
   product_settings: Product settings
   count:
     categories: You have {{ countTrees }} trees and {{ countCategories }} categories
-    channel: You have 1 channel
-    channels: You have {{ count }} channels
+    channels: '{1}You have 1 channel|]1, Inf[You have {{ count }} channels'
     locales: You have {{ count }} enabled locales
     currencies: You have {{ count }} enabled currencies
     attribute_groups: You have {{ count }} attribute groups

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -396,6 +396,7 @@ pim_settings:
   product_settings: Product settings
   count:
     categories: You have {{ countTrees }} trees and {{ countCategories }} categories
+    channel: You have 1 channel
     channels: You have {{ count }} channels
     locales: You have {{ count }} enabled locales
     currencies: You have {{ count }} enabled currencies

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -374,6 +374,7 @@ pim_settings:
   product_settings: Paramètres produit
   count:
     categories: Vous avez {{ countTrees }} arbres et {{ countCategories }} catégories
+    channel: Vous avez 1 canal
     channels: Vous avez {{ count }} canaux
     locales: Vous avez {{ count }} locales activées
     currencies: Vous avez {{ count }} devises activées

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.fr_FR.yml
@@ -374,8 +374,7 @@ pim_settings:
   product_settings: Paramètres produit
   count:
     categories: Vous avez {{ countTrees }} arbres et {{ countCategories }} catégories
-    channel: Vous avez 1 canal
-    channels: Vous avez {{ count }} canaux
+    channels: '{1}Vous avez 1 canal|]1, Inf[Vous avez {{ count }} canaux'
     locales: Vous avez {{ count }} locales activées
     currencies: Vous avez {{ count }} devises activées
     attribute_groups: Vous avez {{ count }} groupes d'attributs


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In the settings menu, when you had only one channel, the sentence displayed was "You have 1 channels".
I tried to write a conditional translation like this:
`channels: '{1}You have 1 channel|]1, Inf[You have {{ count }} channels'`
but it doesn't work 
so I created a second key and added the condition in the SettingsIndex.tsx file.

Do not hesitate to offer me a better solution ;-)

(Will be fixed in Crowdin too, for the French translation)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
