### PR TITLE
PIM-9988: Fix quick export with attributes that are scopable, localizable and locale specific

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -102,6 +102,7 @@ PIM-9941: Metrics: Change Bar symbol for bar
 - PIM-9766: Prevent letter usage in grid Number filters
 - PIM-9774: Fix variant axis 'metric' validation on import.
 - PIM-9789: Synchronously update product form image on change
+- PIM-9988: Fix quick export with attributes that are scopable, localizable and locale specific 
 
 # 4.0.101 (2021-03-29)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ValuesFiller/FillMissingProductModelValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ValuesFiller/FillMissingProductModelValues.php
@@ -134,8 +134,14 @@ final class FillMissingProductModelValues implements FillMissingValuesInterface
                 }
             } elseif ($attribute->isScopable() && $attribute->isLocalizable()) {
                 foreach ($this->getChannels() as $channel) {
-                    foreach ($channel->getLocales() as $locale) {
-                        $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                    if ($attribute->isLocaleSpecific()) {
+                        foreach ($attribute->getAvailableLocales() as $locale) {
+                            $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                        }
+                    } else {
+                        foreach ($channel->getLocales() as $locale) {
+                            $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                        }
                     }
                 }
             }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ValuesFiller/FillMissingProductValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ValuesFiller/FillMissingProductValues.php
@@ -134,8 +134,14 @@ final class FillMissingProductValues implements FillMissingValuesInterface
                 }
             } elseif ($attribute->isScopable() && $attribute->isLocalizable()) {
                 foreach ($this->getChannels() as $channel) {
-                    foreach ($channel->getLocales() as $locale) {
-                        $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                    if ($attribute->isLocaleSpecific()) {
+                        foreach ($attribute->getAvailableLocales() as $locale) {
+                            $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                        }
+                    } else {
+                        foreach ($channel->getLocales() as $locale) {
+                            $nullValues[$attribute->getCode()][$channel->getCode()][$locale->getCode()] = $nullValue;
+                        }
                     }
                 }
             }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductModelValuesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductModelValuesSpec.php
@@ -50,7 +50,13 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
             ->addAttribute($localizablePrice)
             ->addAttribute($scopablePrice)
             ->addAttribute($scopableLocalizablePrice)
-            ->addAttribute($specificLocalizableName);
+            ->addAttribute($specificLocalizableName)
+            ->addAttribute(
+                (new Builder())
+                    ->aTextAttribute()
+                    ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->specificlocalizable()
+                    ->build()
+            );
 
 
         // common attributes: name, scopable_localizable_name, 123
@@ -137,6 +143,18 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                 ],
             ]
         );
@@ -182,6 +200,18 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                 ],
             ]
         );
@@ -242,6 +272,18 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                 ],
             ]
         );
@@ -357,6 +399,18 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                 ],
             ]
         );
@@ -534,6 +588,18 @@ class FillMissingProductModelValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                 ],
             ]
         );

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ValuesFiller/FillMissingProductValuesSpec.php
@@ -36,6 +36,12 @@ class FillMissingProductValuesSpec extends ObjectBehavior
         $family->addAttribute(
             (new Builder())->aTextAttribute()->withCode('specific_localizable_name')->specificlocalizable()->build()
         );
+        $family->addAttribute(
+            (new Builder())
+                ->aTextAttribute()
+                ->withCode('scopable_localizable_locale_specific_name')->localizable()->scopable()->specificlocalizable()
+                ->build()
+        );
 
         $family->addAttribute(
             (new Builder())->aTextAttribute()->withCode('scopable_name')->scopable()->build()
@@ -141,6 +147,18 @@ class FillMissingProductValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                     'scopable_name' => [
                         [
                             'scope' => 'tablet',
@@ -274,6 +292,18 @@ class FillMissingProductValuesSpec extends ObjectBehavior
                         'locale' => null,
                         'data' => null,
                     ]],
+                    'scopable_localizable_locale_specific_name' => [
+                        [
+                            'scope' => 'tablet',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                        [
+                            'scope' => 'ecommerce',
+                            'locale' => null,
+                            'data' => null
+                        ],
+                    ],
                     'scopable_name' => [
                         [
                             'scope' => 'tablet',


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
This PR fixes a bug with quick exports containing products that have scopable & localizable & locale specific attributes : in this particular use case, we must not export all the locales of the channel, but only the locales of the attribute. Scopable & localizable attributes work fine, but this use case was simply forgotten.

The side effect of this bug was that we couldn't reimport the generated file because it contained columns with locales that were not part of the locale specific attribute.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
