### PR TITLE
Fix test_onboarder_bundle CircleCI job following flysystem upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,11 +615,8 @@ jobs:
                     mkdir secret
                     echo "{}" > secret/serviceAccount.json
           - run:
-                name: Start containers
-                command: |
-                    docker load -i php-pim-image.tar
-                    APP_ENV=test C='mysql elasticsearch object-storage pubsub-emulator' make up
-                    docker/wait_docker_up.sh
+                name: Load php pim image
+                command: docker load -i php-pim-image.tar
           - run:
                 name: Load make commands
                 command: cp vendor/akeneo/pim-onboarder/onboarder.mk make-file/onboarder.mk
@@ -645,6 +642,11 @@ jobs:
           - run:
                 name: PHP coupling detector
                 command: PIM_CONTEXT=onboarder make test-coupling-detector
+          - run:
+                name: Start containers
+                command: |
+                    APP_ENV=test C='mysql elasticsearch object-storage pubsub-emulator' make up
+                    docker/wait_docker_up.sh
           - run:
                 name: Execute specifications
                 command: PIM_CONTEXT=onboarder make test-spec


### PR DESCRIPTION
Following the tag of the Onboarder this morning, we have broken the `test_onboarder_bundle` job in the PIM CI. 
Issue was that we were starting the docker containers too early (because we do [some changes](https://github.com/akeneo/pim-onboarder/pull/736/files#diff-64053cf08d8acec719799250b6691a8eee37b542e033c703002cb4523d4b1100R158) in `docker-compose.yml` through the `onboarder.mk`)