### PR TITLE
PIM-10009: Fix error being printed in the response of partial update of product models API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - PIM-9942: Fix message on DQI dashboard in French UI locale
 - PIM-9947: Display validation errors message in the UI when `compute_family_variant_structure_changes` job fails
 - PIM-9987: Fix product grid count not accurate after specific SKU selection
+- PIM-10009: Fix error being printed in the response of partial update of product models API
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -100,6 +100,7 @@ services:
             - '@security.token_storage'
             - '@pim_catalog.event_subscriber.product_model.on_save.api_aggregator_event_subscriber'
             - '@pim_api.warmup_query_cache.dummy'
+            - '@logger'
             - '%pim_api.configuration%'
 
     pim_api.controller.category:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Like https://github.com/akeneo/pim-enterprise-dev/pull/8611 and https://github.com/akeneo/pim-community-dev/pull/11972. A deadlock can occurs during the completeness calculation, on the postSave event in partial update of product models.

This produce the following output:

```
{"line":98,"code":"CPLAL9","status_code":204}

{"line":99,"code":"CPLAA9","status_code":204}

{"line":100,"code":"CPLAN9","status_code":204}<!DOCTYPE html>

<html>

<head>

    <meta charset="UTF-8" />

    <meta name="robots" content="noindex,nofollow,noarchive" />

    <title>An Error Occurred: Internal Server Error</title>

    <style>body { background-color: #fff; color: #222; font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; margin: 0; }

.container { margin: 30px; max-width: 600px; }

h1 { color: #dc3545; font-size: 24px; }

h2 { font-size: 18px; }</style>

</head>

<body>

<div class="container">

    <h1>Oops! An Error Occurred</h1>

    <h2>The server returned a "500 Internal Server Error".</h2>



    <p>

        Something is broken. Please let us know what you were doing when this error occurred.

        We will fix it as soon as possible. Sorry for any inconvenience caused.

    </p>

</div>

</body>

</html>.
```

The proposed solution is to log the error instead of breaking the API response because it's already too late to change the response status, and also because, from a functional point of view, a completeness error should not block the product model update.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
