### PR TITLE
CXP-811: add a migration for product acls

### DIFF
--- a/upgrades/schema/Version_6_0_20210715082931_add_product_web_api_acl.php
+++ b/upgrades/schema/Version_6_0_20210715082931_add_product_web_api_acl.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
-use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
 use Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository;
 use Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleWithPermissionsRepository;
 use Akeneo\UserManagement\Component\Model\Role;
@@ -35,8 +34,6 @@ final class Version_6_0_20210715082931_add_product_web_api_acl extends AbstractM
         $roleWithPermissionsSaver = $this->container->get('pim_user.saver.role_with_permissions');
         /** @var RoleRepository $roleRepository */
         $roleRepository = $this->container->get('pim_user.repository.role');
-        /** @var UnitOfWorkAndRepositoriesClearer $cacheClearer */
-        $cacheClearer = $this->container->get('pim_connector.doctrine.cache_clearer');
 
         /** @var Role[] $roles */
         $roles = $roleRepository->findAll();
@@ -54,12 +51,10 @@ final class Version_6_0_20210715082931_add_product_web_api_acl extends AbstractM
             $roleWithPermissions->setPermissions($permissions);
 
             $roleWithPermissionsSaver->saveAll([$roleWithPermissions]);
+
+            $aclManager->flush();
+            $aclManager->clearCache();
         }
-
-        $aclManager->flush();
-
-        $aclManager->clearCache();
-        $cacheClearer->clear();
     }
 
     /**

--- a/upgrades/schema/Version_6_0_20210715082931_add_product_web_api_acl.php
+++ b/upgrades/schema/Version_6_0_20210715082931_add_product_web_api_acl.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
+use Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository;
+use Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleWithPermissionsRepository;
+use Akeneo\UserManagement\Component\Model\Role;
+use Akeneo\UserManagement\Component\Storage\Saver\RoleWithPermissionsSaver;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_6_0_20210715082931_add_product_web_api_acl extends AbstractMigration implements ContainerAwareInterface
+{
+    private static $acls = [
+        'pim_api_product_list',
+        'pim_api_product_edit',
+    ];
+
+    private ?ContainerInterface $container;
+
+    public function up(Schema $schema): void
+    {
+        $this->disableMigrationWarning();
+
+        /** @var AclManager $aclManager */
+        $aclManager = $this->container->get('oro_security.acl.manager');
+        /** @var RoleWithPermissionsRepository $roleWithPermissionsRepository */
+        $roleWithPermissionsRepository = $this->container->get('pim_user.repository.role_with_permissions');
+        /** @var RoleWithPermissionsSaver $roleWithPermissionsSaver */
+        $roleWithPermissionsSaver = $this->container->get('pim_user.saver.role_with_permissions');
+        /** @var RoleRepository $roleRepository */
+        $roleRepository = $this->container->get('pim_user.repository.role');
+        /** @var UnitOfWorkAndRepositoriesClearer $cacheClearer */
+        $cacheClearer = $this->container->get('pim_connector.doctrine.cache_clearer');
+
+        foreach (self::$acls as $acl) {
+            /** @var Role[] $roles */
+            $roles = $roleRepository->findAll();
+
+            foreach ($roles as $role) {
+                $roleWithPermissions = $roleWithPermissionsRepository->findOneByIdentifier($role->getRole());
+                if (null === $roleWithPermissions) {
+                    continue;
+                }
+
+                $permissions = $roleWithPermissions->permissions();
+                $permissions[sprintf('action:%s', $acl)] = true;
+                $roleWithPermissions->setPermissions($permissions);
+
+                $roleWithPermissionsSaver->saveAll([$roleWithPermissions]);
+            }
+
+            $aclManager->flush();
+
+            $aclManager->clearCache();
+            $cacheClearer->clear();
+        }
+    }
+
+    /**
+     * Function that does a non altering operation on the DB using SQL to hide the doctrine warning stating that no
+     * sql query has been made to the db during the migration process.
+     */
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
@@ -133,7 +133,7 @@ class Version_6_0_20210715082931_add_product_web_api_acl_Integration extends Tes
     {
         /** @var AccessDecisionManagerInterface $decisionManager */
         $decisionManager = $this->get('security.access.decision_manager');
-        $token = new UsernamePasswordToken(base_convert(bin2hex(random_bytes(32)), 16, 36), null, 'main', [$role]);
+        $token = new UsernamePasswordToken('username', null, 'main', [$role]);
 
         foreach ($acls as $acl => $expectedValue) {
             assert(is_bool($expectedValue));

--- a/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleWithPermissionsRepository;
+use Akeneo\UserManagement\Component\Model\Role;
+use Akeneo\UserManagement\Component\Storage\Saver\RoleWithPermissionsSaver;
+use Akeneo\UserManagement\Component\Updater\RoleWithPermissionsUpdater;
+use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class Version_6_0_20210715082931_add_product_web_api_acl_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    /** @var string[] */
+    private static array $acls = [
+        'pim_api_product_list',
+        'pim_api_product_edit',
+    ];
+
+    private AclManager $aclManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->aclManager = $this->get('oro_security.acl.manager');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    public function test_the_migration_adds_the_new_permissions_to_existing_roles()
+    {
+        /** @var SimpleFactoryInterface $roleFactory */
+        $roleFactory = $this->get('pim_user.factory.role');
+        /** @var SaverInterface $roleSaver */
+        $roleSaver = $this->get('pim_user.saver.role');
+
+        /** @var Role $role */
+        $role = $roleFactory->create();
+        $role->setRole('ROLE_WITHOUT_PERMS');
+        $role->setLabel('Test');
+        $roleSaver->save($role);
+
+        foreach (self::$acls as $acl) {
+            $this->assertIsNotGranted('ROLE_WITHOUT_PERMS', $acl);
+        }
+
+        $this->reExecuteMigration($this->getMigrationLabel());
+
+        foreach (self::$acls as $acl) {
+            $this->assertIsGranted('ROLE_WITHOUT_PERMS', $acl);
+        }
+    }
+
+    private function assertIsGranted(string $role, string $acl): void
+    {
+        /** @var AccessDecisionManagerInterface $decisionManager */
+        $decisionManager = $this->get('security.access.decision_manager');
+
+        $token = new UsernamePasswordToken('test', null, 'main', [$role]);
+        $isAllowed = $decisionManager->decide($token, ['EXECUTE'], new ObjectIdentity('action', $acl));
+
+        $this->assertTrue($isAllowed);
+    }
+
+    private function assertIsNotGranted(string $role, string $acl): void
+    {
+        /** @var AccessDecisionManagerInterface $decisionManager */
+        $decisionManager = $this->get('security.access.decision_manager');
+
+        $token = new UsernamePasswordToken('test', null, 'main', [$role]);
+        $isAllowed = $decisionManager->decide($token, ['EXECUTE'], new ObjectIdentity('action', $acl));
+
+        $this->assertFalse($isAllowed);
+    }
+
+    private function getMigrationLabel(): string
+    {
+        $migration = (new \ReflectionClass($this))->getShortName();
+        $migration = str_replace('_Integration', '', $migration);
+        $migration = str_replace('Version', '', $migration);
+
+        return $migration;
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210715082931_add_product_web_api_acl_Integration.php
@@ -26,12 +26,6 @@ class Version_6_0_20210715082931_add_product_web_api_acl_Integration extends Tes
 {
     use ExecuteMigrationTrait;
 
-    /** @var string[] */
-    private static array $acls = [
-        'pim_api_product_list',
-        'pim_api_product_edit',
-    ];
-
     private AclManager $aclManager;
 
     protected function setUp(): void
@@ -58,18 +52,18 @@ class Version_6_0_20210715082931_add_product_web_api_acl_Integration extends Tes
         $role->setLabel('Test');
         $roleSaver->save($role);
 
-        foreach (self::$acls as $acl) {
-            $this->assertIsNotGranted('ROLE_WITHOUT_PERMS', $acl);
-        }
+        $this->assertRoleDoesNotHaveAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_list');
+        $this->assertRoleDoesNotHaveAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_edit');
+        $this->assertRoleDoesNotHaveAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_remove');
 
         $this->reExecuteMigration($this->getMigrationLabel());
 
-        foreach (self::$acls as $acl) {
-            $this->assertIsGranted('ROLE_WITHOUT_PERMS', $acl);
-        }
+        $this->assertRoleHasAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_list');
+        $this->assertRoleHasAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_edit');
+        $this->assertRoleHasAcl('ROLE_WITHOUT_PERMS', 'pim_api_product_remove');
     }
 
-    private function assertIsGranted(string $role, string $acl): void
+    private function assertRoleHasAcl(string $role, string $acl): void
     {
         /** @var AccessDecisionManagerInterface $decisionManager */
         $decisionManager = $this->get('security.access.decision_manager');
@@ -80,7 +74,7 @@ class Version_6_0_20210715082931_add_product_web_api_acl_Integration extends Tes
         $this->assertTrue($isAllowed);
     }
 
-    private function assertIsNotGranted(string $role, string $acl): void
+    private function assertRoleDoesNotHaveAcl(string $role, string $acl): void
     {
         /** @var AccessDecisionManagerInterface $decisionManager */
         $decisionManager = $this->get('security.access.decision_manager');


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In the PR https://github.com/akeneo/pim-community-dev/pull/14978 that was introducing new ACLs, the lack of migration created inconsistencies between roles in production.

complete technical analysis on notion: https://www.notion.so/akeneo/Technical-analysis-a2a4188bac60430b8e77af655f64ad58

This PR introduce the missing migration.
My only regret is to not be able to write a pure sql migration, I've tried and some OroAcl behavior is completely unexpected.
For example, I was not able to properly manage the `ace_order` value in the `acl_entries` table.
Any mistake in the inserted data will completely corrupt the ACLs when you try to save the same role from the UI with updated permissions, which is unacceptable.

**Edit**

Following @mmetayer's suggestion, I've tried to add more assertions.
And all hell broke loose.
By adding more assertions (which are read-only, I've inspected the SQL logs for any unexpected query from OroAcl), some existing ones are broken.
Worst, the assertions are randomly failing depending on the order they are executed.

Why ?
I went digging with xdebug and the problem is, the ACL services (in `symfony/security-acl`) are completely stateful.
https://github.com/symfony/security-acl/blob/5855e094f7e4d8319d479b08e48decb503ab2aca/Dbal/AclProvider.php#L493-L494
https://github.com/symfony/security-acl/blob/5855e094f7e4d8319d479b08e48decb503ab2aca/Dbal/AclProvider.php#L559-L560

Innocently, a solution would be clear those reference after the migration.
This cannot be done, they explicitly check for it and throw if it happened:
https://github.com/symfony/security-acl/blob/5855e094f7e4d8319d479b08e48decb503ab2aca/Dbal/MutableAclProvider.php#L317

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
