### PR TITLE
PIM-10012: Add dataLocale parameter to qb in mass action context

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\PimDataGridBundle\Extension\MassAction;
 
+use Doctrine\ORM\QueryBuilder;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\ManagerInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
@@ -153,10 +154,11 @@ class MassActionDispatcher
         $this->requestParams->set(FilterExtension::FILTER_ROOT_PARAM, $filters);
 
         $qb = $datagrid->getAcceptedDatasource()->getQueryBuilder();
-        if (self::FAMILY_GRID_NAME === $parameters['gridName']) {
+        if ($qb instanceof QueryBuilder) {
             $qbLocaleParameter = $qb->getParameter('localeCode');
-            if (null !== $qbLocaleParameter && null === $qbLocaleParameter->getValue()) {
-                $qb->setParameter('localeCode', $parameters['dataLocale']);
+            $dataLocale = $parameters['dataLocale'] ?? null;
+            if (null !== $qbLocaleParameter && null === $qbLocaleParameter->getValue() && null !== $dataLocale) {
+                $qb->setParameter('localeCode', $dataLocale);
             }
         }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The MassActionDispatcher used to add the "dataLocale" parameter to the grid's query builder only for the family datagrid, but it is also needed for the EE rules datagrid mass actions. (Note: currently only the family and the rules grids have mass actions - besides product and published product grids of course)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
