### PR TITLE
BH-691: Cypress save product stabilization

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -78,6 +78,14 @@ Cypress.Commands.add('saveProduct', () => {
   cy.wait('@saveProduct');
 });
 
+Cypress.Commands.add('reloadProduct', () => {
+  cy.reload();
+  cy.intercept('GET', /\/enrich\/product\/rest\/.*/).as('getProduct');
+  cy.intercept('GET', /\/configuration\/rest\/.*/).as('configuration');
+  cy.wait('@getProduct');
+  cy.wait('@configuration');
+});
+
 Cypress.Commands.add('updateField', (label, value) => {
   cy.findByLabelText(label).clear().type(value);
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -84,6 +84,7 @@ Cypress.Commands.add('reloadProduct', () => {
   cy.intercept('GET', /\/configuration\/rest\/.*/).as('configuration');
   cy.wait('@getProduct');
   cy.wait('@configuration');
+  cy.findFirstTextField();
 });
 
 Cypress.Commands.add('updateField', (label, value) => {

--- a/tests/front/e2e/product/edit.js
+++ b/tests/front/e2e/product/edit.js
@@ -5,7 +5,7 @@ describe('edit product sanity check', () => {
     cy.selectFirstProductInDatagrid();
     cy.findFirstTextField().clear().type('updated value');
     cy.saveProduct();
-    cy.reload();
+    cy.reloadProduct();
     cy.findFirstTextField().should('have.value', 'updated value');
   });
 });


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Cypress tests have stability issue when saving a product attribute and reloading. This PR add a new cypress command "reloadProduct" and use it with tests 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
