### PR TITLE
RAC-834: Fix tabbar detection of hidden tab

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
+++ b/front-packages/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.tsx
@@ -83,8 +83,9 @@ const ItemCollection = React.forwardRef<HTMLDivElement, ItemCollectionProps>(
         threshold: 0,
       };
 
-      const observer = new IntersectionObserver((entries: IntersectionObserverEntry[]) => {
-        if (entries[0].isIntersecting) {
+      const observer = new IntersectionObserver(entries => {
+        const lastEntry = entries[entries.length - 1];
+        if (lastEntry.isIntersecting) {
           onNextPage();
         }
       }, options);

--- a/front-packages/akeneo-design-system/src/components/TabBar/TabBar.tsx
+++ b/front-packages/akeneo-design-system/src/components/TabBar/TabBar.tsx
@@ -132,8 +132,10 @@ const Tab = ({children, onClick, isActive, parentRef, onVisibilityChange, ...res
       threshold: 0,
     };
 
-    const observer = new IntersectionObserver(event => {
-      onVisibilityChange?.(event[0].isIntersecting);
+    const observer = new IntersectionObserver(entries => {
+      const lastEntry = entries[entries.length - 1];
+
+      onVisibilityChange?.(lastEntry.isIntersecting);
     }, options);
 
     observer.observe(tabElement);


### PR DESCRIPTION
Tab bar detection of hidden tab does not work in chrome because entries length is higher than 1, we should only take care of the last entry in case of there is multiple entries

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
