### PR TITLE
PIM-10013: Decrease memory consumption when indexing products / product models

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/GetElasticsearchProductModelProjectionInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/GetElasticsearchProductModelProjectionInterface.php
@@ -16,7 +16,7 @@ interface GetElasticsearchProductModelProjectionInterface
     /**
      * @param string[] $productModelCodes
      *
-     * @return ElasticsearchProductModelProjection[]
+     * @return iterable<string, ElasticsearchProductModelProjection>
      */
-    public function fromProductModelCodes(array $productModelCodes): array;
+    public function fromProductModelCodes(array $productModelCodes): iterable;
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/GetElasticsearchProductProjectionInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/GetElasticsearchProductProjectionInterface.php
@@ -15,7 +15,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 interface GetElasticsearchProductProjectionInterface
 {
     /**
+     * @return iterable<string, ElasticsearchProductProjection>
+     *
      * @throws ObjectNotFoundException when one or several of the product are not found
      */
-    public function fromProductIdentifiers(array $productIdentifiers): array;
+    public function fromProductIdentifiers(array $productIdentifiers): iterable;
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductProjectionInterface;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
@@ -69,12 +68,14 @@ class ProductIndexer implements ProductIndexerInterface
             $elasticsearchProductProjections = $this->getElasticsearchProductProjection->fromProductIdentifiers(
                 $productIdentifiersChunk
             );
-            $normalizedProductProjections = array_map(
-                function (ElasticsearchProductProjection $elasticsearchProductProjection) {
-                    return $elasticsearchProductProjection->toArray();
-                },
-                $elasticsearchProductProjections
-            );
+
+            $normalizedProductProjections = (
+                function (iterable $projections): iterable {
+                    foreach ($projections as $identifier => $projection) {
+                        yield $identifier => $projection->toArray();
+                    }
+                }
+            )($elasticsearchProductProjections);
 
             $this->productAndProductModelClient->bulkIndexes($normalizedProductProjections, 'id', $indexRefresh);
         }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -91,8 +91,8 @@ class Client
     }
 
     /**
-     * @param array        $documents
-     * @param ?string      $keyAsId
+     * @param iterable $documents
+     * @param ?string $keyAsId
      * @param Refresh|null $refresh
      *
      * @throws MissingIdentifierException

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjectionIntegration.php
@@ -337,11 +337,12 @@ class GetElasticsearchProductModelProjectionIntegration extends TestCase
 
     private function getProductModelProjectionArray($code): array
     {
-        $productModelProjection = $this
-            ->getGetElasticsearchProductModelProjection()
-            ->fromProductModelCodes([$code])[$code];
+        $productModelProjections = $this->getGetElasticsearchProductModelProjection()->fromProductModelCodes([$code]);
+        if (!\is_array($productModelProjections)) {
+            $productModelProjections = \iterator_to_array($productModelProjections);
+        }
 
-        return $productModelProjection->toArray();
+        return $productModelProjections[$code]->toArray();
     }
 
     private function getGetElasticsearchProductModelProjection(): GetElasticsearchProductModelProjectionInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ElasticsearchProjection;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\DateSanitizer;
 use Doctrine\DBAL\Connection;
@@ -17,11 +19,6 @@ use PHPUnit\Framework\Assert;
  */
 class GetElasticsearchProductProjectionIntegration extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function test_it_gets_product_projection_of_a_variant_product_with_two_levels()
     {
         $this->createVariantProductWithTwoLevels();
@@ -301,9 +298,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
     {
         $this->createProductWithFamily();
 
-        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
-        $productProjection = $query->fromProductIdentifiers(['bar'])['bar'];
-        $normalizedProductProjection = $productProjection->toArray();
+        $normalizedProductProjection = $this->getProductProjection('bar')->toArray();
 
         $expectedAttributeCodesForThisLevel = [
             'a_date',
@@ -337,9 +332,8 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
     public function test_it_gets_product_projection_values_of_a_product()
     {
         $this->createProductWithFamilyAndValues();
-        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
-        $productProjection = $query->fromProductIdentifiers(['bar'])['bar'];
-        $normalizedProductProjection = $productProjection->toArray();
+
+        $normalizedProductProjection = $this->getProductProjection('bar')->toArray();
 
         $expectedValues = [
             'values' => [
@@ -480,8 +474,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
         $this->getConnection()->executeQuery($sql, ['updated_date' => '2028-10-01 12:34:56', 'code' => 'root_product_model']);
         $this->getConnection()->executeQuery($sql, ['updated_date' => '2030-10-01 12:34:56', 'code' => 'sub_product_model']);
 
-        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
-        $productProjection = $query->fromProductIdentifiers(['bar'])['bar'];
+        $productProjection = $this->getProductProjection('bar');
 
         $this->assertEquals('2030-10-01T14:34:56+02:00', $productProjection->toArray()['updated']);
     }
@@ -490,11 +483,10 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
     {
         $this->expectException(ObjectNotFoundException::class);
 
-        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
-        $query->fromProductIdentifiers(['bar'])['bar'];
+        $this->getProductProjection('unknown_product');
     }
 
-    protected function getConfiguration()
+    protected function getConfiguration(): Configuration
     {
         return $this->catalog->useTechnicalCatalog();
     }
@@ -688,10 +680,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
 
     private function assertProductIndexingFormat(string $identifier, array $expected)
     {
-
-        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
-        $productProjections = $query->fromProductIdentifiers([$identifier]);
-        $productProjection = $productProjections[$identifier];
+        $productProjection = $this->getProductProjection($identifier);
 
         $normalizedProductProjection = $productProjection->toArray();
         // allows to execute test from EE by removing additional properties
@@ -706,6 +695,17 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
         unset($expected['id'], $normalizedProductProjection['id'], $normalizedProductProjection['ancestors']['ids'], $expected['ancestors']['ids']);
 
         $this->assertEquals($expected, $normalizedProductProjection);
+    }
+
+    private function getProductProjection(string $identifier): ElasticsearchProductProjection
+    {
+        $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
+        $productProjections = $query->fromProductIdentifiers([$identifier]);
+        if (!\is_array($productProjections)) {
+            $productProjections = \iterator_to_array($productProjections);
+        }
+
+        return $productProjections[$identifier];
     }
 
     private static function sanitizeData(array &$productProjection): void


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Since #10831 the indexation of products and product models only uses plain DBAL queries (the ORM is not used anymore). This  has allowed improved performances and a better management of the used memory during indexation. 
However, when trying to index a batch of really "big" products (with lots of values), the memory can still be pretty full during the process. 

This PR tries to take advantage of PHP's generators in order to load/instantiate indexation-related objects only when they are needed, thus reducing the peak memory usage of the script. 

I don't have a real benchmark, but on a real use case, the peak memory usage of an API request to patch 100 root product models (with 480 sub product models and ~3000 variant products) was lowered by 21% (433 Mb => 340 Mb)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
