### PR TITLE
CXP-811: Reinstate product web API ACL

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -49,6 +49,7 @@ use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Elasticsearch\Common\Exceptions\BadRequest400Exception;
 use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
+use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -245,6 +246,8 @@ class ProductController
     }
 
     /**
+     * @AclAncestor("pim_api_product_list")
+     *
      * @param Request $request
      *
      * @return JsonResponse
@@ -311,6 +314,8 @@ class ProductController
     }
 
     /**
+     * @AclAncestor("pim_api_product_list")
+     *
      * @param Request $request
      * @param string $code
      * @return JsonResponse
@@ -344,6 +349,8 @@ class ProductController
     }
 
     /**
+     * @AclAncestor("pim_api_product_remove")
+     *
      * @param string $code
      *
      * @return Response
@@ -366,6 +373,8 @@ class ProductController
     }
 
     /**
+     * @AclAncestor("pim_api_product_edit")
+     *
      * @param Request $request
      *
      * @return Response
@@ -407,6 +416,8 @@ class ProductController
     }
 
     /**
+     * @AclAncestor("pim_api_product_edit")
+     *
      * @param Request $request
      * @param string  $code
      *
@@ -472,6 +483,8 @@ class ProductController
 
     /**
      * Products are saved 1 by 1, but we batch events in order to improve performances.
+     *
+     * @AclAncestor("pim_api_product_edit")
      *
      * @param Request $request
      *

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Security/AccessDeniedHandler.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Security/AccessDeniedHandler.php
@@ -39,7 +39,7 @@ class AccessDeniedHandler implements AccessDeniedHandlerInterface
     protected function getMessage(Request $request, AccessDeniedException $exception)
     {
         if ($exception instanceof OroAccessDeniedException) {
-            $actionName = 'GET' === $request->getMethod() ? 'list' : 'create or update';
+            $actionName = $this->getActionName($request);
 
             preg_match('`\\\\(\w+)Controller`', $exception->getControllerClass(), $matches);
             $englishInflector = new EnglishInflector();
@@ -56,5 +56,17 @@ class AccessDeniedHandler implements AccessDeniedHandlerInterface
     private function getInflector(): Inflector
     {
         return new Inflector(new NoopWordInflector(), new NoopWordInflector());
+    }
+
+    private function getActionName(Request $request): string
+    {
+        if (Request::METHOD_GET === $request->getMethod()) {
+            return 'list';
+        }
+        if (Request::METHOD_DELETE === $request->getMethod()) {
+            return 'delete';
+        }
+
+        return 'create or update';
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -48,6 +48,32 @@ JSON;
         $this->assertSame('', $response->getContent());
     }
 
+    public function test_access_denied_on_create_a_product_if_no_permission()
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->removeAclFromRole('action:pim_api_product_edit');
+
+        $data =
+            <<<JSON
+    {
+        "identifier": "product_create_headers"
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
+
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to create or update products."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
     public function testProductCreationWithFamily()
     {
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -40,6 +40,28 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
         $this->assertEventCount(1, ProductRemoved::class);
     }
 
+    public function test_access_denied_on_get_a_product_if_no_permission()
+    {
+        $this->createAdminUser();
+        $this->assertCount(7, $this->get('pim_catalog.repository.product')->findAll());
+        $client = $this->createAuthenticatedClient();
+        $this->removeAclFromRole('action:pim_api_product_remove');
+        $this->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductIdentifier('foo');
+        $client->request('DELETE', 'api/rest/v1/products/foo');
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to delete products."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+
+        $this->assertCount(7, $this->get('pim_catalog.repository.product')->findAll());
+    }
+
     public function testNotFoundAProduct()
     {
         $this->createAdminUser();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ErrorListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ErrorListProductEndToEnd.php
@@ -252,6 +252,23 @@ JSON;
         $this->assertJsonStringEqualsJsonString($expected, $client->getResponse()->getContent());
     }
 
+    public function test_access_denied_on_list_products_if_no_permission()
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->removeAclFromRole('action:pim_api_product_list');
+        $client->request('GET', 'api/rest/v1/products?page=1limit=1');
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to list products."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
     /**
      * @param Client $client
      * @param string $message

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -100,6 +100,29 @@ JSON;
         Assert::assertEquals('familyA2', $esProduct['family']['code']);
     }
 
+    public function testAccessDeniedOnUpdateAPartialProductIfNoPermission()
+    {
+        $this->removeAclFromRole('action:pim_api_product_edit');
+
+        $data = <<<JSON
+{"line":1,"identifier":"product_family","status_code":204}
+{"line":2,"identifier":"my_identifier","status_code":201}
+JSON;
+
+        $result = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to create or update products."
+}
+JSON;
+
+        $response = $result['http_response'];
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
+    }
+
     public function testCreateAndUpdateSameProduct()
     {
         $data =

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -7,6 +7,11 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Oro\Bundle\SecurityBundle\Acl\AccessLevel;
+use Oro\Bundle\SecurityBundle\Model\AclPermission;
+use Oro\Bundle\SecurityBundle\Model\AclPrivilege;
+use Oro\Bundle\SecurityBundle\Model\AclPrivilegeIdentity;
 use Symfony\Component\HttpFoundation\Response;
 
 class PartialUpdateProductEndToEnd extends AbstractProductTestCase
@@ -430,6 +435,32 @@ JSON;
 
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
         $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+    }
+
+    public function testAccessDeniedOnUpdateAPartialProductIfNoPermission()
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->removeAclFromRole('action:pim_api_product_edit');
+        $data =
+            <<<JSON
+    {
+        "identifier": "product_family",
+        "family": "familyA"
+    }
+JSON;
+
+        $client->request('PATCH', 'api/rest/v1/products/product_family', [], [], [], $data);
+
+        $expectedResponse = <<<JSON
+{
+    "code": 403,
+    "message": "Access forbidden. You are not allowed to create or update products."
+}
+JSON;
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
     public function testProductPartialUpdateWithTheFamilyUpdated()


### PR DESCRIPTION
This reverts commit 3ef6d1af578afaa331be9b9a135a73423f9e4ef4.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Since there was no migration, the new ACLs broke the prod.
They were reverted in https://github.com/akeneo/pim-community-dev/pull/15049
This only adds them back since a PR was opened with the missing migration: https://github.com/akeneo/pim-community-dev/pull/15082

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
