### PR TITLE
CXP-832: change selenium/standalone-chrome-debug version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
       - 'pim'
 
   selenium:
-    image: 'selenium/standalone-chrome-debug:3.141.59-20210713'
+    image: 'selenium/standalone-chrome-debug:3.141.59-oxygen'
     volumes:
       - './:/srv/pim:ro'
       - '/dev/shm:/dev/shm'


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this specific behat scenario:
https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature

We are trying to switch between tabs: 
https://github.com/akeneo/pim-community-dev/pull/15096/commits/a3e6c4cdbc810c071eacc4be61f0fb046e156ce1#diff-4ba905568eb7567d0b21824e2cc274b0b77c5307246321ef165c23e7fb063de9R54

This is not working in our current driver version.
It seems it's an old issue https://github.com/SeleniumHQ/docker-selenium/issues/949
that was not answered, I've tested the suggestion in it, to rollback to the version `3.141.59-oxygen`, and it's now working.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
