### PR TITLE
CXP-812: create an App Role for OAuth scopes

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AppRoleWithScopesFactory.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AppRoleWithScopesFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps;
+
+use Akeneo\Tool\Bundle\ApiBundle\Security\ScopeToAclMapper;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\UserManagement\Component\Connector\RoleWithPermissions;
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Storage\Saver\RoleWithPermissionsSaver;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AppRoleWithScopesFactory
+{
+    private const APP_ROLE_TYPE = 'app';
+
+    private ScopeToAclMapper $scopeToAclMapper;
+    private SimpleFactoryInterface $roleFactory;
+    private RoleWithPermissionsSaver $roleWithPermissionsSaver;
+
+    public function __construct(
+        ScopeToAclMapper $scopeToAclMapper,
+        SimpleFactoryInterface $roleFactory,
+        RoleWithPermissionsSaver $roleWithPermissionsSaver
+    ) {
+        $this->scopeToAclMapper = $scopeToAclMapper;
+        $this->roleFactory = $roleFactory;
+        $this->roleWithPermissionsSaver = $roleWithPermissionsSaver;
+    }
+
+    public function createRole(string $label, array $scopes): RoleInterface
+    {
+        /** @var RoleInterface $role */
+        $role = $this->roleFactory->create();
+        $role->setRole($this->createRandomRoleCode());
+        $role->setLabel($label);
+        $role->setType(self::APP_ROLE_TYPE);
+
+        $permissions = [];
+
+        foreach ($scopes as $scope) {
+            $acls = $this->scopeToAclMapper->getAcls($scope);
+
+            foreach ($acls as $acl) {
+                $permissions[sprintf('action:%s', $acl)] = true;
+            }
+        }
+
+        $roleWithPermissions = RoleWithPermissions::createFromRoleAndPermissions($role, $permissions);
+        $this->roleWithPermissionsSaver->saveAll([$roleWithPermissions]);
+
+        return $role;
+    }
+
+    private function createRandomRoleCode(): string
+    {
+        return base_convert(bin2hex(random_bytes(16)), 16, 36);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
@@ -14,3 +14,10 @@ services:
         arguments:
             - '@validator'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\AppRoleWithScopesFactory:
+        arguments:
+            - '@Akeneo\Tool\Bundle\ApiBundle\Security\ScopeToAclMapper'
+            - '@pim_user.factory.role'
+            - '@pim_user.saver.role_with_permissions'
+        public: true

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/AppRoleWithScopesFactoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/AppRoleWithScopesFactoryIntegration.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\AppRoleWithScopesFactory;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class AppRoleWithScopesFactoryIntegration extends TestCase
+{
+    private AppRoleWithScopesFactory $factory;
+    private Connection $connection;
+    private AccessDecisionManagerInterface $accessDecisionManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->factory = $this->get(AppRoleWithScopesFactory::class);
+        $this->connection = $this->get('database_connection');
+        $this->accessDecisionManager = $this->get('security.access.decision_manager');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_creates_a_role_with_permissions_derived_from_the_scopes()
+    {
+        $role = $this->factory->createRole('foo', [
+            'read_products',
+            'write_products',
+        ]);
+
+        Assert::assertInstanceOf(RoleInterface::class, $role);
+        Assert::assertEquals('foo', $role->getLabel());
+
+        $this->assertRoleIsPersisted($role);
+        $this->assertRoleAcls($role->getRole(), [
+            'pim_api_product_list' => true,
+            'pim_api_product_edit' => true,
+            'pim_api_product_remove' => false,
+        ]);
+    }
+
+    private function assertRoleIsPersisted(RoleInterface $role): void
+    {
+        $query = <<<SQL
+SELECT * FROM oro_access_role WHERE label = :label
+SQL;
+        $stmt = $this->connection->executeQuery($query, [
+            'label' => $role->getLabel(),
+        ]);
+
+        $raw = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        Assert::assertNotFalse($raw);
+
+        Assert::assertArrayHasKey('role', $raw);
+        Assert::assertEquals($role->getRole(), $raw['role']);
+        Assert::assertArrayHasKey('label', $raw);
+        Assert::assertEquals($role->getLabel(), $raw['label']);
+        Assert::assertArrayHasKey('type', $raw);
+        Assert::assertEquals('app', $raw['type']);
+    }
+
+    private function assertRoleAcls(string $role, array $acls): void
+    {
+        $token = new UsernamePasswordToken('username', null, 'main', [$role]);
+
+        foreach ($acls as $acl => $expectedValue) {
+            assert(is_bool($expectedValue));
+
+            $isAllowed = $this->accessDecisionManager->decide($token, ['EXECUTE'], new ObjectIdentity('action', $acl));
+            $this->assertEquals($expectedValue, $isAllowed);
+        }
+    }
+}

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
@@ -17,3 +17,9 @@ Akeneo\UserManagement\Component\Model\Role:
         label:
             type: string
             lenght: 30
+        type:
+            type: string
+            nullable: true
+            length: 30
+            options:
+                default: null

--- a/src/Akeneo/UserManagement/Component/Model/Role.php
+++ b/src/Akeneo/UserManagement/Component/Model/Role.php
@@ -12,6 +12,7 @@ class Role implements RoleInterface
     protected ?int $id = null;
     protected ?string $role = null;
     protected ?string $label = null;
+    protected ?string $type = null;
 
     public function __construct(?string $role = null)
     {
@@ -56,6 +57,16 @@ class Role implements RoleInterface
     public function setLabel(?string $label): void
     {
         $this->label = $label;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(?string $type): void
+    {
+        $this->type = $type;
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Model/RoleInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/RoleInterface.php
@@ -43,4 +43,8 @@ interface RoleInterface
      * @param string|null $label New label
      */
     public function setLabel(?string $label): void;
+
+    public function getType(): ?string;
+
+    public function setType(?string $type): void;
 }

--- a/upgrades/schema/Version_6_0_20210817135301_add_role_type_column.php
+++ b/upgrades/schema/Version_6_0_20210817135301_add_role_type_column.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version_6_0_20210817135301_add_role_type_column extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('ALTER TABLE oro_access_role ADD type VARCHAR(30) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

For activating an App, and for creating the underlying Connection, we need a dedicated User Role with the ACLs corresponding to the requested scopes.

To be able to distinguish this new role type from other roles, we've added a new discriminator column in the `oro_access_role` table.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
