### PR TITLE
BH-681: Use AbstractController instead of the deprecated base Controller

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/AbstractListCategoryController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/AbstractListCategoryController.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Tool\Component\Classification\Repository\CategoryRepositoryInterface;
 use Doctrine\Common\Collections\Collection;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -19,30 +19,14 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-abstract class AbstractListCategoryController extends Controller
+abstract class AbstractListCategoryController extends AbstractController
 {
-    /** @var CategoryRepositoryInterface */
-    protected $categoryRepository;
+    protected CategoryRepositoryInterface $categoryRepository;
+    protected SecurityFacade $securityFacade;
+    protected string $categoryClass;
+    protected string $acl;
+    protected string $template;
 
-    /** @var SecurityFacade */
-    protected $securityFacade;
-
-    /** @var string */
-    protected $categoryClass;
-
-    /** @var string */
-    protected $acl;
-
-    /** @var string */
-    protected $template;
-
-    /**
-     * @param CategoryRepositoryInterface $categoryRepository
-     * @param SecurityFacade              $securityFacade
-     * @param string                      $categoryClass
-     * @param string                      $acl
-     * @param string                      $template
-     */
     public function __construct(
         CategoryRepositoryInterface $categoryRepository,
         SecurityFacade $securityFacade,
@@ -66,10 +50,8 @@ abstract class AbstractListCategoryController extends Controller
      * @param int        $categoryId The parent category id
      *
      * httpparam include_category if true, will include the parentCategory in the response
-     *
-     * @return Response
      */
-    public function listCategoriesAction(Request $request, $id, $categoryId)
+    public function listCategoriesAction(Request $request, $id, $categoryId): Response
     {
         if (!$this->securityFacade->isGranted($this->acl)) {
             throw new AccessDeniedException();

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/CategoryTreeController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/CategoryTreeController.php
@@ -14,7 +14,7 @@ use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Doctrine\Common\Collections\ArrayCollection;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -34,35 +34,17 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CategoryTreeController extends Controller
+class CategoryTreeController extends AbstractController
 {
-    /** @var EventDispatcherInterface */
-    protected $eventDispatcher;
-
-    /** @var UserContext */
-    protected $userContext;
-
-    /** @var SaverInterface */
-    protected $categorySaver;
-
-    /** @var RemoverInterface */
-    protected $categoryRemover;
-
-    /** @var SimpleFactoryInterface */
-    protected $categoryFactory;
-
-    /** @var CategoryRepositoryInterface */
-    protected $categoryRepository;
-
-    /** @var array */
-    protected $rawConfiguration;
-
-    /** @var SecurityFacade */
-    protected $securityFacade;
-
-    /** @var TranslatorInterface */
-    protected $translator;
-
+    protected EventDispatcherInterface $eventDispatcher;
+    protected UserContext $userContext;
+    protected SaverInterface $categorySaver;
+    protected RemoverInterface $categoryRemover;
+    protected SimpleFactoryInterface $categoryFactory;
+    protected CategoryRepositoryInterface $categoryRepository;
+    protected array $rawConfiguration;
+    protected SecurityFacade $securityFacade;
+    protected TranslatorInterface $translator;
     private ObjectUpdaterInterface $categoryUpdater;
 
     private NormalizerInterface $normalizer;

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/Ui/JobTrackerController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/Ui/JobTrackerController.php
@@ -16,7 +16,7 @@ use Akeneo\Tool\Component\FileStorage\StreamedFileResponse;
 use League\Flysystem\FilesystemInterface;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Psr\Log\LoggerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -33,7 +33,7 @@ use ZipStream\ZipStream;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class JobTrackerController extends Controller
+class JobTrackerController extends AbstractController
 {
     protected EventDispatcherInterface $eventDispatcher;
     protected JobExecutionRepository $jobExecutionRepo;

--- a/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
@@ -9,7 +9,7 @@ use Akeneo\UserManagement\Component\UserEvents;
 use Doctrine\ORM\EntityManagerInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Form\FormInterface;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class GroupController extends Controller
+class GroupController extends AbstractController
 {
     private EntityManagerInterface $entityManager;
     private RemoverInterface $remover;

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -8,13 +8,13 @@ use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Swift_Mailer;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-class ResetController extends Controller
+class ResetController extends AbstractController
 {
     const SESSION_EMAIL = 'pim_user_reset_email';
 

--- a/src/Akeneo/UserManagement/Bundle/Controller/RoleController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/RoleController.php
@@ -9,14 +9,14 @@ use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclSidManager;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class RoleController extends Controller
+class RoleController extends AbstractController
 {
     private RoleRepositoryInterface $roleRepository;
     private RemoverInterface $remover;

--- a/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
@@ -3,27 +3,18 @@
 namespace Akeneo\UserManagement\Bundle\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
-class SecurityController extends Controller
+class SecurityController extends AbstractController
 {
-    /** @var AuthenticationUtils */
-    private $authenticationUtils;
-
-    /** @var CsrfTokenManagerInterface */
-    private $csrfTokenManager;
-
-    /** @var string */
-    private $actionRoute;
-
-    /** @var string */
-    private $additionalHiddenFields;
-
-    /** @var LogoutUrlGenerator */
-    private $logoutUrlGenerator;
+    private AuthenticationUtils $authenticationUtils;
+    private CsrfTokenManagerInterface $csrfTokenManager;
+    private string $actionRoute;
+    private array $additionalHiddenFields;
+    private LogoutUrlGenerator $logoutUrlGenerator;
 
     public function __construct(
         AuthenticationUtils $authenticationUtils,

--- a/src/Oro/Bundle/DataGridBundle/Controller/GridController.php
+++ b/src/Oro/Bundle/DataGridBundle/Controller/GridController.php
@@ -3,26 +3,19 @@
 namespace Oro\Bundle\DataGridBundle\Controller;
 
 use Oro\Bundle\DataGridBundle\Datagrid\ManagerInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 
-class GridController extends Controller
+class GridController extends AbstractController
 {
-    /** @var ManagerInterface */
-    private $manager;
+    private ManagerInterface $manager;
 
     public function __construct(ManagerInterface $manager)
     {
         $this->manager = $manager;
     }
 
-    /**
-     * @param string $gridName
-     *
-     * @return JsonResponse
-     */
-    public function get($gridName)
+    public function get(string $gridName): JsonResponse
     {
         $grid = $this->manager->getDatagrid($gridName);
         $result = $grid->getData();


### PR DESCRIPTION
See https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-the-base-controller-class