### PR TITLE
BH-691 : [cypress] wait for DOM to be ready when switching view in product list

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,6 +48,9 @@ Cypress.Commands.add('goToProductsGrid', () => {
   cy.get('.search-zone').find('div[data-type="grouped-variant"]').click()
   cy.get('.search-zone').find('span[data-value="product"]').click()
   cy.wait('@productDatagrid');
+
+  // Wait for change in page title to be sure DOM is ready
+  cy.get('.AknTitleContainer-title div').invoke('text').should('not.contains', "product models");
 });
 
 Cypress.Commands.add('selectFirstProductInDatagrid', () => {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Cypress tests have stability issue when switching from "grouped" to "ungrouped" view in product list page because we try to access to the first element of the product list without waiting for DOM ready

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
