### PR TITLE
BH-681: Move the Event class to symfony/contracts

### DIFF
--- a/src/Akeneo/Channel/Component/Event/ChannelCategoryHasBeenUpdated.php
+++ b/src/Akeneo/Channel/Component/Event/ChannelCategoryHasBeenUpdated.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Component\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @author Paul Chasle <paul.chasle@akeneo.com>

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/Event/ParentHasBeenAddedToProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/Event/ParentHasBeenAddedToProduct.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\EntityWithFamily\Event;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * This event is raised when a product is converted to a variant product

--- a/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/Event/ParentHasBeenRemovedFromVariantProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/EntityWithFamily/Event/ParentHasBeenRemovedFromVariantProduct.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\EntityWithFamily\Event;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Event/BuildVersionEvent.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Event/BuildVersionEvent.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Build a new version

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Event/PreAdvisementVersionEvent.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Event/PreAdvisementVersionEvent.php
@@ -4,7 +4,7 @@ namespace Akeneo\Tool\Bundle\VersioningBundle\Event;
 
 use Akeneo\Tool\Bundle\VersioningBundle\Purger\PurgeableVersionList;
 use Akeneo\Tool\Component\Versioning\Model\VersionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event sent before a version is processed by the version purger

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Event/PrePurgeVersionEvent.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Event/PrePurgeVersionEvent.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Bundle\VersioningBundle\Event;
 
 use Akeneo\Tool\Component\Versioning\Model\VersionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @deprecated Will be removed in 4.0

--- a/src/Akeneo/Tool/Component/Batch/Event/InvalidItemEvent.php
+++ b/src/Akeneo/Tool/Component/Batch/Event/InvalidItemEvent.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Component\Batch\Event;
 
 use Akeneo\Tool\Component\Batch\Item\InvalidItemInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Invalid Item Event

--- a/src/Akeneo/Tool/Component/Batch/Event/JobExecutionEvent.php
+++ b/src/Akeneo/Tool/Component/Batch/Event/JobExecutionEvent.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Component\Batch\Event;
 
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event triggered during job execution

--- a/src/Akeneo/Tool/Component/Batch/Event/StepExecutionEvent.php
+++ b/src/Akeneo/Tool/Component/Batch/Event/StepExecutionEvent.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Tool\Component\Batch\Event;
 
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event triggered during stepExecution execution

--- a/src/Akeneo/Tool/Component/Batch/Job/Job.php
+++ b/src/Akeneo/Tool/Component/Batch/Job/Job.php
@@ -10,7 +10,7 @@ use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepInterface;
 use Akeneo\Tool\Component\Batch\Step\StoppableStepInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/Akeneo/Tool/Component/Batch/Step/AbstractStep.php
+++ b/src/Akeneo/Tool/Component/Batch/Step/AbstractStep.php
@@ -11,7 +11,7 @@ use Akeneo\Tool\Component\Batch\Job\ExitStatus;
 use Akeneo\Tool\Component\Batch\Job\JobInterruptedException;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/src/Oro/Bundle/DataGridBundle/Event/BuildAfter.php
+++ b/src/Oro/Bundle/DataGridBundle/Event/BuildAfter.php
@@ -3,7 +3,7 @@
 namespace Oro\Bundle\DataGridBundle\Event;
 
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class BuildBefore

--- a/src/Oro/Bundle/DataGridBundle/Event/BuildBefore.php
+++ b/src/Oro/Bundle/DataGridBundle/Event/BuildBefore.php
@@ -4,7 +4,7 @@ namespace Oro\Bundle\DataGridBundle\Event;
 
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class BuildBefore

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/Event/MassActionEvent.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/Event/MassActionEvent.php
@@ -4,7 +4,7 @@ namespace Oro\Bundle\PimDataGridBundle\Extension\MassAction\Event;
 
 use Oro\Bundle\DataGridBundle\Datagrid\DatagridInterface;
 use Oro\Bundle\DataGridBundle\Extension\MassAction\Actions\MassActionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Mass action event allows to do add easily some extra code

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/Event/ParentHasBeenAddedToProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/EntityWithFamily/Event/ParentHasBeenAddedToProductSpec.php
@@ -5,7 +5,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\EntityWithFamily
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamily\Event\ParentHasBeenAddedToProduct;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class ParentHasBeenAddedToProductSpec extends ObjectBehavior
 {


### PR DESCRIPTION
Symfony\Component\EventDispatcher\Event is deprectaed since Symfony 4.3

Link to the SF PR https://github.com/symfony/symfony/pull/30772