### PR TITLE
PIM-10026: fix session being stored during stateless calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PIM-10009: Fix error being printed in the response of partial update of product models API
 - PIM-10003: Fix translation in setting page are not plurializable
 - PIM-9989: Fix record code of reference entity field is case-sensitive
+- PIM-10026: Avoid session persistance for API
 
 ## New features
 

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -51,6 +51,7 @@ $rules = [
         'Oro\Bundle\SecurityBundle',
         'Sensio\Bundle\FrameworkExtraBundle',
         'Symfony\Bundle\FrameworkBundle',
+        'Symfony\Bundle\SecurityBundle',
         'FOS\OAuthServerBundle\Entity\ClientManager', // used by API client controller
         'OAuth2\OAuth2', // used by API client controller
         'Swift_Mailer',

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -371,7 +371,7 @@ class UserContext
     protected function getSessionLocale()
     {
         $request = $this->getCurrentRequest();
-        if (null !== $request && $request->hasSession() && $request->getSession()->isStarted()) {
+        if ($this->hasActiveSession($request)) {
             $localeCode = $request->getSession()->get('dataLocale');
             if (null !== $localeCode) {
                 $locale = $this->localeRepository->findOneByIdentifier($localeCode);

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -112,7 +112,10 @@ class UserContext
             throw new \LogicException('There are no activated locales');
         }
 
-        if (null !== $this->getCurrentRequest() && $this->getCurrentRequest()->hasSession()) {
+        if (null !== $this->getCurrentRequest()
+            && $this->getCurrentRequest()->hasSession()
+            && $this->getCurrentRequest()->getSession()->isStarted()
+        ) {
             $this->getCurrentRequest()->getSession()->set('dataLocale', $locale->getCode());
             $this->getCurrentRequest()->getSession()->save();
         }
@@ -351,7 +354,7 @@ class UserContext
     protected function getSessionLocale()
     {
         $request = $this->getCurrentRequest();
-        if (null !== $request && $request->hasSession()) {
+        if (null !== $request && $request->hasSession() && $request->getSession()->isStarted()) {
             $localeCode = $request->getSession()->get('dataLocale');
             if (null !== $localeCode) {
                 $locale = $this->localeRepository->findOneByIdentifier($localeCode);

--- a/src/Akeneo/UserManagement/Bundle/EventListener/LocaleSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/LocaleSubscriber.php
@@ -88,7 +88,7 @@ class LocaleSubscriber implements EventSubscriberInterface
      */
     protected function getLocale(Request $request)
     {
-        return null !== $request->getSession() && null !== $request->getSession()->get('_locale') ?
+        return null !== $request->getSession() && $request->getSession()->isStarted() && null !== $request->getSession()->get('_locale') ?
             $request->getSession()->get('_locale') : $this->getLocaleFromOroConfigValue();
     }
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/context.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/context.yml
@@ -12,3 +12,4 @@ services:
             - '@pim_catalog.repository.category'
             - '@request_stack'
             - '%env(APP_DEFAULT_LOCALE)%'
+            - '@security.firewall.map'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
@@ -37,6 +37,7 @@ services:
             - '@request_stack'
             - '@translator'
             - '@doctrine.orm.entity_manager'
+            - '@security.firewall.map'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
@@ -60,8 +60,6 @@ class UserContextSpec extends ObjectBehavior
         $channelRepository->findOneByIdentifier([])->willReturn($mobile);
         $productCategoryRepo->getTrees()->willReturn([$firstTree, $secondTree]);
 
-        $session->isStarted()->willReturn(true);
-
         $this->beConstructedWith(
             $tokenStorage,
             $localeRepository,

--- a/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
@@ -60,6 +60,8 @@ class UserContextSpec extends ObjectBehavior
         $channelRepository->findOneByIdentifier([])->willReturn($mobile);
         $productCategoryRepo->getTrees()->willReturn([$firstTree, $secondTree]);
 
+        $session->isStarted()->willReturn(true);
+
         $this->beConstructedWith(
             $tokenStorage,
             $localeRepository,

--- a/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Context/UserContextSpec.php
@@ -11,6 +11,8 @@ use Akeneo\Channel\Component\Model\LocaleInterface;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
 use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
 use Prophecy\Argument;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -35,7 +37,8 @@ class UserContextSpec extends ObjectBehavior
         CategoryRepositoryInterface $productCategoryRepo,
         RequestStack $requestStack,
         Request $request,
-        SessionInterface $session
+        SessionInterface $session,
+        FirewallMap $firewall
     ) {
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
@@ -60,13 +63,17 @@ class UserContextSpec extends ObjectBehavior
         $channelRepository->findOneByIdentifier([])->willReturn($mobile);
         $productCategoryRepo->getTrees()->willReturn([$firstTree, $secondTree]);
 
+        $firewallConfig = new FirewallConfig('foo', 'foo', null, true, false);
+        $firewall->getFirewallConfig(Argument::any())->willReturn($firewallConfig);
+
         $this->beConstructedWith(
             $tokenStorage,
             $localeRepository,
             $channelRepository,
             $productCategoryRepo,
             $requestStack,
-            'en_US'
+            'en_US',
+            $firewall
         );
     }
 

--- a/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
@@ -9,6 +9,8 @@ use Doctrine\DBAL\Statement;
 use Doctrine\ORM\EntityManager;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Bundle\SecurityBundle\Security\FirewallConfig;
+use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,10 +21,16 @@ use Symfony\Contracts\Translation\LocaleAwareInterface;
 
 class LocaleSubscriberSpec extends ObjectBehavior
 {
-    function let(RequestStack $requestStack, LocaleAwareInterface $localeAware, EntityManager $em)
-    {
-        $this->beConstructedWith($requestStack, $localeAware, $em);
-        $this->beConstructedWith($requestStack, $localeAware, $em);
+    function let(
+        RequestStack $requestStack,
+        LocaleAwareInterface $localeAware,
+        EntityManager $em,
+        FirewallMap $firewall
+    ) {
+        $firewallConfig = new FirewallConfig('foo', 'foo', null, true, false);
+        $firewall->getFirewallConfig(Argument::any())->willReturn($firewallConfig);
+
+        $this->beConstructedWith($requestStack, $localeAware, $em, $firewall);
     }
 
     function it_implements_an_event_listener_interface()
@@ -36,6 +44,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         SessionInterface $session
     ) {
         $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn('fr_FR');
         $request->setLocale('fr_FR')->shouldBeCalled();
@@ -52,6 +61,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         Statement $statement
     ) {
         $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
 
@@ -74,6 +84,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         Statement $statement
     ) {
         $event->getRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
 
@@ -100,6 +111,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $event->getArgument('current_user')->willReturn($user);
 
         $requestStack->getMasterRequest()->willReturn($request);
+        $request->hasSession()->willReturn(true);
         $request->getSession()->willReturn($session);
 
         $user->getUiLocale()->willReturn($locale);

--- a/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
@@ -40,6 +40,8 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $session->get('_locale')->willReturn('fr_FR');
         $request->setLocale('fr_FR')->shouldBeCalled();
 
+        $session->isStarted()->willReturn(true);
+
         $this->onKernelRequest($event);
     }
 
@@ -54,6 +56,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $event->getRequest()->willReturn($request);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
+        $session->isStarted()->willReturn(true);
 
         $em->getConnection()->willReturn($connection);
         $connection->executeQuery('SELECT value FROM oro_config_value WHERE name = "language" AND section = "pim_ui" LIMIT 1')->willReturn($statement);
@@ -76,6 +79,7 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $event->getRequest()->willReturn($request);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
+        $session->isStarted()->willReturn(true);
 
         $em->getConnection()->willReturn($connection);
         $connection->executeQuery('SELECT value FROM oro_config_value WHERE name = "language" AND section = "pim_ui" LIMIT 1')->willReturn($statement);

--- a/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/EventListener/LocaleSubscriberSpec.php
@@ -40,8 +40,6 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $session->get('_locale')->willReturn('fr_FR');
         $request->setLocale('fr_FR')->shouldBeCalled();
 
-        $session->isStarted()->willReturn(true);
-
         $this->onKernelRequest($event);
     }
 
@@ -56,7 +54,6 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $event->getRequest()->willReturn($request);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
-        $session->isStarted()->willReturn(true);
 
         $em->getConnection()->willReturn($connection);
         $connection->executeQuery('SELECT value FROM oro_config_value WHERE name = "language" AND section = "pim_ui" LIMIT 1')->willReturn($statement);
@@ -79,7 +76,6 @@ class LocaleSubscriberSpec extends ObjectBehavior
         $event->getRequest()->willReturn($request);
         $request->getSession()->willReturn($session);
         $session->get('_locale')->willReturn(null);
-        $session->isStarted()->willReturn(true);
 
         $em->getConnection()->willReturn($connection);
         $connection->executeQuery('SELECT value FROM oro_config_value WHERE name = "language" AND section = "pim_ui" LIMIT 1')->willReturn($statement);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

During API calls, the session is initialized because we access it on UserContext and LocaleSubscriber.
We don't have to create and save sessions during API calls.

The proposed solution is to check if the current firewall is stateless.
Since the API is of course stateless, it doesn't start a session anymore.
see https://github.com/akeneo/pim-community-dev/blob/master/config/packages/security.yml#L43-L48

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
