### PR TITLE
BH-681: RootNode Tree Builder Rector

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Pim/Structure/Bundle/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('akeneo_pim_structure');
+        $treeBuilder = new TreeBuilder('akeneo_pim_structure');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/DependencyInjection/Configuration.php
@@ -20,9 +20,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder
-            ->root('pim_notification')
+        $treeBuilder = new TreeBuilder('pim_notification');
+        $rootNode = $treeBuilder->getRootNode()
             ->children()
                 ->booleanNode('version_update')
                     ->defaultTrue()

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('pim_import_export');
+        $treeBuilder = new TreeBuilder('pim_import_export');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
@@ -19,10 +19,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('pim_ui');
 
-        $rootNode = $treeBuilder
-            ->root('pim_ui');
+        $rootNode = $treeBuilder->getRootNode();
 
         SettingsBuilder::append(
             $rootNode,

--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -17,9 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder
-            ->root('pim_api')
+        $treeBuilder = new TreeBuilder('pim_api');
+        $rootNode = $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('pagination')
                     ->children()

--- a/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/Configuration.php
@@ -19,9 +19,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('akeneo_batch');
 
-        $root = $treeBuilder->root('akeneo_batch');
+        $root = $treeBuilder->getRootNode();
 
         $root
             ->children()

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('akeneo_elasticsearch');
+        $treeBuilder = new TreeBuilder('akeneo_elasticsearch');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
@@ -19,8 +19,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('akeneo_storage_utils');
+        $treeBuilder = new TreeBuilder('akeneo_storage_utils');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Oro/Bundle/ConfigBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/ConfigBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $builder->root('oro_config')
+        $builder = new TreeBuilder('oro_config');
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('entity_output')
                 ->prototype('array')

--- a/src/Oro/Bundle/ConfigBundle/DependencyInjection/SettingsBuilder.php
+++ b/src/Oro/Bundle/ConfigBundle/DependencyInjection/SettingsBuilder.php
@@ -14,9 +14,8 @@ class SettingsBuilder
      */
     public static function append(ArrayNodeDefinition $root, $settings)
     {
-        $builder = new TreeBuilder();
-        $node = $builder
-            ->root('settings')
+        $builder = new TreeBuilder('settings');
+        $node = $builder->getRootNode()
             ->addDefaultsIfNotSet()
             ->children();
 

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/QueryConfiguration.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/QueryConfiguration.php
@@ -14,9 +14,9 @@ class QueryConfiguration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('query');
 
-        $builder->root('query')
+        $builder->getRootNode()
             ->addDefaultsIfNotSet()
             ->children()
                 ->booleanNode('distinct')

--- a/src/Oro/Bundle/DataGridBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('oro_data_grid');
+        $treeBuilder = new TreeBuilder('oro_data_grid');
+        $treeBuilder->getRootNode();
 
         return $treeBuilder;
     }

--- a/src/Oro/Bundle/DataGridBundle/Extension/Sorter/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Sorter/Configuration.php
@@ -18,9 +18,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('sorters');
 
-        $builder->root('sorters')
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('columns')
                     ->prototype('array')

--- a/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
@@ -12,9 +12,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('toolbarOptions');
 
-        $builder->root('toolbarOptions')
+        $builder->getRootNode()
             ->children()
                 ->booleanNode('hide')->defaultFalse()->end()
                 ->arrayNode('pageSize')->addDefaultsIfNotSet()

--- a/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
@@ -15,8 +15,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('oro_filter');
+        $treeBuilder = new TreeBuilder('oro_filter');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
@@ -29,9 +29,9 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('filters');
 
-        $builder->root('filters')
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('columns')
                     ->prototype('array')

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/Sorter/Configuration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/Sorter/Configuration.php
@@ -20,9 +20,9 @@ class Configuration extends OroConfiguration
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
+        $builder = new TreeBuilder('sorters');
 
-        $builder->root('sorters')
+        $builder->getRootNode()
             ->children()
                 ->arrayNode('columns')
                     ->prototype('array')

--- a/src/Oro/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('oro_security');
+        $treeBuilder = new TreeBuilder('oro_security');
+        $rootNode = $treeBuilder->getRootNode();
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/Oro/Bundle/TranslationBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/TranslationBundle/DependencyInjection/Configuration.php
@@ -12,8 +12,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('oro_translation')
+        $treeBuilder = new TreeBuilder('oro_translation');
+        $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('js_translation')
                     ->addDefaultsIfNotSet()


### PR DESCRIPTION
The tree builder configuration used in the PIM is deprecated.

Fix done with Rector rule `RootNodeTreeBuilderRector`
