### PR TITLE
RAC-613: Fix export with label is not available for published product we cannot check it by it's code

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/field/with-label.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/field/with-label.js
@@ -23,11 +23,6 @@ define([
      * {@inheritdoc}
      */
     render: function () {
-      const code = this.getFormData().code;
-      if ('csv_published_product_export' === code || 'xlsx_published_product_export' === code) {
-        return this;
-      }
-
       BaseField.prototype.render.apply(this, arguments);
 
       this.$('.switch').bootstrapSwitch();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually the export with label is available for published product when code is not the default one, in this PR I create a JobInstanceFormProvider dedicated for published product and i remove ugly fix

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
