### PR TITLE
BH-681: Bundle notation is deprecated

### DIFF
--- a/config/packages/oro_filter.yml
+++ b/config/packages/oro_filter.yml
@@ -1,3 +1,3 @@
 oro_filter:
     twig:
-        layout: PimFilterBundle:Filter:pim-layout.js.twig
+        layout: '@@PimFilter/Filter/pim-layout.js.twig'

--- a/config/packages/twig.yml
+++ b/config/packages/twig.yml
@@ -2,7 +2,7 @@ twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
     exception_controller: null
-    form_theme: ['PimUIBundle:Form:pim-fields.html.twig']
+    form_theme: ['@PimUI/Form/pim-fields.html.twig']
     globals:
         ws:
             port:        '%websocket_port%'

--- a/config/routes/routes.yml
+++ b/config/routes/routes.yml
@@ -57,8 +57,8 @@ pim_data_quality_insights:
 oro_default:
     path:  /
     defaults:
-        template:    PimUIBundle::index.html.twig
-        _controller: FrameworkBundle:Template:template
+        template:    '@PimUI/index.html.twig'
+        _controller: 'Symfony\Bundle\FrameworkBundle\Controller\TemplateController::templateAction'
 
 oro_config:
     resource: "@OroConfigBundle/Resources/config/oro/routing.yml"

--- a/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
@@ -10,12 +10,12 @@ datagrid:
             code:
                 label: Code
                 type: twig
-                template: PimDataGridBundle:Property:currency_label.html.twig
+                template: '@@PimDataGrid/Property/currency_label.html.twig'
                 frontend_type: html
             activated:
                 label: Enabled
                 type: twig
-                template: PimDataGridBundle:Property:activated.html.twig
+                template: '@PimDataGrid/Property/activated.html.twig'
                 frontend_type: html
         properties:
             id: ~

--- a/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/datagrid/currency.yml
@@ -10,7 +10,7 @@ datagrid:
             code:
                 label: Code
                 type: twig
-                template: '@@PimDataGrid/Property/currency_label.html.twig'
+                template: '@PimDataGrid/Property/currency_label.html.twig'
                 frontend_type: html
             activated:
                 label: Enabled

--- a/src/Akeneo/Channel/Bundle/Resources/config/datagrid/locale.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/datagrid/locale.yml
@@ -13,7 +13,7 @@ datagrid:
             activated:
                 label: Activated
                 type: twig
-                template: PimDataGridBundle:Property:activated.html.twig
+                template: '@PimDataGrid/Property/activated.html.twig'
                 frontend_type: html
         properties: ~
         actions: ~

--- a/src/Akeneo/Channel/Bundle/Resources/config/view_elements/attribute.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/view_elements/attribute.yml
@@ -1,5 +1,5 @@
 parameters:
-    pim_enrich.view_element.attribute.tab.history.template:   'PimUIBundle:Form:Tab/history.html.twig'
+    pim_enrich.view_element.attribute.tab.history.template:   '@@PimUI/Form/Tab/history.html.twig'
 
     pim_enrich.attribute.general_parameters.allowed_form_types:
         - code
@@ -30,7 +30,7 @@ services:
         class: '%pim_enrich.view_element.base.class%'
         arguments:
             - 'pane.accordion.general_parameters'
-            - 'PimUIBundle:Attribute:Tab/_default_parameter_form.html.twig'
+            - '@@PimUI/Attribute/Tab/_default_parameter_form.html.twig'
             -
                 allowed_form_types: '%pim_enrich.attribute.general_parameters.allowed_form_types%'
         tags:

--- a/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
+++ b/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
@@ -126,7 +126,7 @@ class LocaleExtension extends \Twig_Extension
     public function flag(Twig_Environment $environment, $code, $short = true, $translateIn = null)
     {
         return $environment->render(
-            'PimUIBundle:Locale:_flag.html.twig',
+            '@PimUI/Locale/_flag.html.twig',
             [
                 'label'    => $this->localeLabel($code, $translateIn),
                 'region'   => \Locale::getRegion($code),

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/CategoryTreeController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/CategoryTreeController.php
@@ -124,7 +124,7 @@ class CategoryTreeController extends AbstractController
         }
 
         return $this->render(
-            'AkeneoPimEnrichmentBundle:CategoryTree:listTree.json.twig',
+            '@AkeneoPimEnrichment/CategoryTree/listTree.json.twig',
             [
                 'trees'          => $this->categoryRepository->getTrees(),
                 'selectedTreeId' => $selectNode->isRoot() ? $selectNode->getId() : $selectNode->getRoot(),
@@ -217,9 +217,9 @@ class CategoryTreeController extends AbstractController
         $categories = $this->getChildrenCategories($request, $selectNode, $parent);
 
         if (null === $selectNode) {
-            $view = 'AkeneoPimEnrichmentBundle:CategoryTree:children.json.twig';
+            $view = '@AkeneoPimEnrichment/CategoryTree/children.json.twig';
         } else {
-            $view = 'AkeneoPimEnrichmentBundle:CategoryTree:children-tree.json.twig';
+            $view = '@AkeneoPimEnrichment/CategoryTree/children-tree.json.twig';
         }
 
         $withItemsCount = (bool) $request->get('with_items_count', false);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/renderers.yml
@@ -12,7 +12,7 @@ services:
             - '@liip_imagine.cache.manager'
             - '@liip_imagine.filter.manager'
             - '@pim_catalog.repository.cached_attribute'
-            - 'AkeneoPimEnrichmentBundle:Product:renderPdf.html.twig'
+            - '@@AkeneoPimEnrichment/Product/renderPdf.html.twig'
             - '@pim_catalog.repository.cached_attribute_option'
             - '%pim_pdf_generator_font%'
             - '@pim_catalog.repository.cached_attribute_option'

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/SystemInfoController.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/SystemInfoController.php
@@ -52,7 +52,7 @@ class SystemInfoController
 
         if ('txt' === $_format) {
             $content = $this->templating->render(
-                'PimAnalyticsBundle:SystemInfo:index.txt.twig',
+                '@PimAnalytics/SystemInfo/index.txt.twig',
                 ['data' => $data]
             );
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_execution.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_execution.yml
@@ -22,13 +22,13 @@ datagrid:
                 frontend_type: datetime
             status:
                 label:         Status
-                template:      PimImportExportBundle:Property:status.html.twig
+                template:      '@PimImportExport/Property/status.html.twig'
                 type:          twig
                 frontend_type: html
                 data_name:     statusLabel
             warning:
                 label:         Warnings
-                template:      PimImportExportBundle:Property:warning.html.twig
+                template:      '@PimImportExport/Property/warning.html.twig'
                 type:          twig
                 frontend_type: html
                 data_name:     warningCount

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_tracker.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/job_tracker.yml
@@ -36,7 +36,7 @@ datagrid:
                 label:         Warnings
                 type:          twig
                 data_name:     warningCount
-                template:      PimImportExportBundle:Property:warning.html.twig
+                template:      '@PimImportExport/Property/warning.html.twig'
                 frontend_type: html
             actions:
                 label: ~

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/datagrid/last_executions.yml
@@ -29,7 +29,7 @@ datagrid:
                     hasError: boolean
             warning:
                 label: Warnings
-                template: PimImportExportBundle:Property:warning.html.twig
+                template: '@PimImportExport/Property/warning.html.twig'
                 type: twig
                 frontend_type: html
                 data_name: warningCount

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/layout.html.twig
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/views/layout.html.twig
@@ -1,2 +1,2 @@
 
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Controller/NotificationController.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Controller/NotificationController.php
@@ -48,7 +48,7 @@ class NotificationController
 
         return (new JsonResponse())->setContent(
             $this->templating->render(
-                'PimNotificationBundle:Notification:list.json.twig',
+                '@PimNotification/Notification/list.json.twig',
                 [
                     'userNotifications' => $notifications,
                     'userTimezone' => $this->userContext->getUserTimezone(),

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/config/placeholders.yml
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/config/placeholders.yml
@@ -6,4 +6,4 @@ placeholders:
 
 items:
     notifications:
-        template: PimNotificationBundle:Default:notifications.html.twig
+        template: '@PimNotification/Default/notifications.html.twig'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/placeholders.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/placeholders.yml
@@ -16,6 +16,6 @@ placeholders:
 
 items:
     logo:
-        template: PimUIBundle:Default:logo.html.twig
+        template: '@PimUI/Default/logo.html.twig'
     help:
-        template: PimUIBundle:Default:help.html.twig
+        template: '@PimUI/Default/help.html.twig'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/JobExecution/index.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/JobExecution/index.html.twig
@@ -1,4 +1,4 @@
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}
 {% import 'PimDataGridBundle::macros.html.twig' as dataGrid %}
 
 {% block content %}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/actions/update.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/actions/update.html.twig
@@ -1,5 +1,5 @@
-{% import 'PimUIBundle::macros.html.twig' as UI %}
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/macros.html.twig' as UI %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}
 
 {% block page_container %}
     {% block content %}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/actions/view.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/actions/view.html.twig
@@ -1,5 +1,5 @@
-{% import 'PimUIBundle::macros.html.twig' as UI %}
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/macros.html.twig' as UI %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}
 
 {% block content %}
 <div class="AknDefault-mainContent layout-content">

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
@@ -91,8 +91,8 @@ class MailNotifier implements Notifier
             'log'          => $this->logger->getFilename(),
         ];
 
-        $txtBody = $this->twig->render('AkeneoBatchBundle:Mails:notification.txt.twig', $parameters);
-        $htmlBody = $this->twig->render('AkeneoBatchBundle:Mails:notification.html.twig', $parameters);
+        $txtBody = $this->twig->render('@AkeneoBatch/Mails/notification.txt.twig', $parameters);
+        $htmlBody = $this->twig->render('@AkeneoBatch/Mails/notification.html.twig', $parameters);
 
         $message = $this->mailer->createMessage();
         $message->setSubject('Job has been executed');

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -101,7 +101,7 @@ class ResetController extends AbstractController
             ->setFrom((string) SenderAddress::fromMailerUrl($this->mailerUrl))
             ->setTo($user->getEmail())
             ->setBody(
-                $this->renderView('PimUserBundle:Mail:reset.html.twig', ['user' => $user]),
+                $this->renderView('@PimUser/Mail/reset.html.twig', ['user' => $user]),
                 'text/html'
             );
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/placeholders.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/placeholders.yml
@@ -6,4 +6,4 @@ placeholders:
 
 items:
    menu_user:
-        template: PimUserBundle:Menu:menuProfile.html.twig
+        template: '@PimUser/Menu/menuProfile.html.twig'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/view_elements/group.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/view_elements/group.yml
@@ -1,6 +1,6 @@
 parameters:
-    pim_user.view_element.group.tab.general.template: 'PimUserBundle:Group:Tab/general.html.twig'
-    pim_user.view_element.group.tab.users.template:   'PimUserBundle:Group:Tab/users.html.twig'
+    pim_user.view_element.group.tab.general.template: '@@PimUser/Group/Tab/general.html.twig'
+    pim_user.view_element.group.tab.users.template:   '@@PimUser/Group/Tab/users.html.twig'
 
 services:
     pim_user.view_element.group.tab.general:

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/view_elements/user.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/view_elements/user.yml
@@ -1,9 +1,9 @@
 parameters:
-    pim_user.view_element.user.tab.general.template:        'PimUserBundle:User:Tab/general.html.twig'
-    pim_user.view_element.user.tab.additional.template:     'PimUserBundle:User:Tab/additional.html.twig'
-    pim_user.view_element.user.tab.group_and_role.template: 'PimUserBundle:User:Tab/group_and_role.html.twig'
-    pim_user.view_element.user.tab.password.template:       'PimUserBundle:User:Tab/password.html.twig'
-    pim_user.view_element.user.tab.interfaces.template:     'PimUserBundle:User:Tab/interfaces.html.twig'
+    pim_user.view_element.user.tab.general.template:        '@@PimUser/User/Tab/general.html.twig'
+    pim_user.view_element.user.tab.additional.template:     '@@PimUser/User/Tab/additional.html.twig'
+    pim_user.view_element.user.tab.group_and_role.template: '@@PimUser/User/Tab/group_and_role.html.twig'
+    pim_user.view_element.user.tab.password.template:       '@@PimUser/User/Tab/password.html.twig'
+    pim_user.view_element.user.tab.interfaces.template:     '@@PimUser/User/Tab/interfaces.html.twig'
 
 services:
     pim_user.view_element.user.tab.general:

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Group/update.html.twig
@@ -1,6 +1,6 @@
 {% extends 'PimUIBundle:actions:update.html.twig' %}
 {% import 'PimDataGridBundle::macros.html.twig' as dataGrid %}
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}
 
 {% set entityId = form.vars.value.id %}
 {% set title = entityId ? 'Update Group'|trans : 'New Group'|trans %}

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Mail/reset.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Mail/reset.html.twig
@@ -1,4 +1,4 @@
-{% extends 'PimUserBundle:Mail:layout.html.twig' %}
+{% extends '@PimUser/Mail/layout.html.twig' %}
 
 {% block content %}
 <h1>Hello, {{ user.username }}!</h1>

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/_fields.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/_fields.html.twig
@@ -1,4 +1,4 @@
-{% extends 'PimUIBundle:Form:pim-fields.html.twig' %}
+{% extends '@PimUI/Form/pim-fields.html.twig' %}
 
 {% block form_row_field %}
     <div class="InputBlock{% if attr.class is defined %} {{ attr.class }}{% endif %}">

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/reset.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/reset.html.twig
@@ -1,6 +1,6 @@
-{% extends 'PimUserBundle::layout.html.twig' %}
+{% extends '@PimUser/layout.html.twig' %}
 
-{% form_theme form 'PimUserBundle:Reset:_fields.html.twig' %}
+{% form_theme form '@PimUser/Reset/_fields.html.twig' %}
 
 {% block bodyClass %}AknLogin{% endblock %}
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Role/update.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Role/update.html.twig
@@ -1,6 +1,6 @@
-{% import 'PimUIBundle:Default:page_elements.html.twig' as elements %}
+{% import '@PimUI/Default/page_elements.html.twig' as elements %}
 {% import 'PimDataGridBundle::macros.html.twig' as dataGrid %}
-{% import 'PimUIBundle::macros.html.twig' as UI %}
+{% import '@PimUI/macros.html.twig' as UI %}
 
 {% block head_script %}
     <script type="text/javascript" nonce="{{ js_nonce() }}">

--- a/src/Oro/Bundle/DataGridBundle/Provider/SystemAwareResolver.php
+++ b/src/Oro/Bundle/DataGridBundle/Provider/SystemAwareResolver.php
@@ -12,6 +12,7 @@ class SystemAwareResolver implements ContainerAwareInterface
     const STATIC_METHOD_CLEAN_REGEX = '#([^\'"%:\s]+)::([\w\._]+)#';
     const SERVICE_METHOD = '#@([\w\._]+)->([\w\._]+)(\((.*)\))*#';
     const SERVICE = '#@([\w\._]+)#';
+    const TWIG_TEMPLATE = '#^@.+\.twig$#';
 
     /**
      * @var ContainerInterface
@@ -87,6 +88,9 @@ class SystemAwareResolver implements ContainerAwareInterface
         }
 
         switch (true) {
+            case preg_match(static::TWIG_TEMPLATE, $val, $match):
+                break;
+            // static call class:method or class::const
             case preg_match(static::PARAMETER_REGEX, $val, $match):
                 $val = $this->container->getParameter($match[1]);
                 break;

--- a/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
@@ -7,8 +7,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    const DEFAULT_LAYOUT = 'OroFilterBundle:Filter:layout.js.twig';
-    const DEFAULT_HEADER = 'OroFilterBundle:Filter:header.html.twig';
+    const DEFAULT_LAYOUT = '@OroFilter/Filter/layout.js.twig';
+    const DEFAULT_HEADER = '@OroFilter/Filter/header.html.twig';
 
     /**
      * {@inheritDoc}

--- a/src/Oro/Bundle/FilterBundle/Resources/views/Filter/header.html.twig
+++ b/src/Oro/Bundle/FilterBundle/Resources/views/Filter/header.html.twig
@@ -1,7 +1,7 @@
 {% block oro_filter_header_javascript %}
-    {% include 'OroFilterBundle:Header:javascript.html.twig' %}
+    {% include '@OroFilter/Header/javascript.html.twig' %}
 {% endblock %}
 
 {% block oro_filter_header_stylesheet %}
-    {% include 'OroFilterBundle:Header:stylesheet.html.twig' %}
+    {% include '@OroFilter/Header/stylesheet.html.twig' %}
 {% endblock %}

--- a/src/Oro/Bundle/TranslationBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/TranslationBundle/Resources/config/services.yml
@@ -4,7 +4,7 @@ parameters:
 services:
     oro_translation.controller:
         class: '%oro_translation.controller.class%'
-        arguments: ['@translator', '@twig', 'OroTranslationBundle:Translation:translation.js.twig', '']
+        arguments: ['@translator', '@twig', '@@OroTranslation/Translation/translation.js.twig', '']
         public: true
 
     Oro\Bundle\TranslationBundle\Command\OroTranslationDumpCommand:

--- a/tests/back/Platform/Specification/Bundle/NotificationBundle/Controller/NotificationControllerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/NotificationBundle/Controller/NotificationControllerSpec.php
@@ -44,7 +44,7 @@ class NotificationControllerSpec extends ObjectBehavior
         $context->getUserTimezone()->willReturn('Europe/Paris');
 
         $templating->render(
-            'PimNotificationBundle:Notification:list.json.twig',
+            '@PimNotification/Notification/list.json.twig',
             [
                 'userNotifications' => [$userNotification],
                 'userTimezone' => 'Europe/Paris',


### PR DESCRIPTION
https://symfony.com/blog/new-in-symfony-4-1-deprecated-the-bundle-notation

https://symfony.com/doc/current/templates.html#bundle-templates

**Note about `@@` notation**:

https://symfony.com/doc/current/service_container.html#service-parameters
```
# if the value of a string argument starts with '@', you need to escape
# it by adding another '@' so Symfony doesn't consider it a service
# the following example would be parsed as the string '@securepassword'
# - '@@securepassword'
```