### PR TITLE
CPM-356: Fix useAutoFocus

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Dropdown/ItemCollection/ItemCollection.unit.tsx
@@ -13,6 +13,8 @@ const intersectionObserverMock = (callback: EntryCallback) => ({
 window.IntersectionObserver = jest.fn().mockImplementation(intersectionObserverMock);
 
 test('it handles arrow navigation', () => {
+  jest.useFakeTimers();
+
   render(
     <ItemCollection>
       <Item>First item</Item>
@@ -20,6 +22,8 @@ test('it handles arrow navigation', () => {
       An invalid element
     </ItemCollection>
   );
+
+  jest.runAllTimers();
 
   expect(screen.getByText('First item').parentNode).toHaveFocus();
   fireEvent.keyDown(screen.getByText('First item'), {key: 'ArrowDown', code: 'ArrowDown'});

--- a/front-packages/akeneo-design-system/src/hooks/useAutoFocus.ts
+++ b/front-packages/akeneo-design-system/src/hooks/useAutoFocus.ts
@@ -2,7 +2,9 @@ import {RefObject, useCallback, useEffect} from 'react';
 
 const useAutoFocus = (ref: RefObject<HTMLElement>): (() => void) => {
   const focus = useCallback(() => {
-    if (ref.current !== null) ref.current.focus();
+    setTimeout(() => {
+      if (ref.current !== null) ref.current.focus();
+    }, 0);
   }, [ref]);
 
   useEffect(focus, []);

--- a/front-packages/akeneo-design-system/src/hooks/useAutoFocus.unit.ts
+++ b/front-packages/akeneo-design-system/src/hooks/useAutoFocus.unit.ts
@@ -14,34 +14,43 @@ afterEach(() => {
 });
 
 test('It sets automatically the focus on the given ref', () => {
+  jest.useFakeTimers();
   renderHook(() => useAutoFocus(ref));
+  jest.runAllTimers();
+
   expect(button).toHaveFocus();
 });
 
 test('I can request the focus on the given ref', () => {
+  jest.useFakeTimers();
   const {result} = renderHook(() => useAutoFocus(ref));
   const focus = result.current;
 
+  jest.runAllTimers();
   expect(button).toHaveFocus();
 
   act(() => {
     button.blur();
   });
 
+  jest.runAllTimers();
   expect(button).not.toHaveFocus();
 
   act(() => {
     focus();
   });
 
+  jest.runAllTimers();
   expect(button).toHaveFocus();
 });
 
 test('It does not try to focus if the current ref is null', () => {
+  jest.useFakeTimers();
   const ref = {
     current: null,
   };
 
   renderHook(() => useAutoFocus(ref));
+  jest.runAllTimers();
   expect(button).not.toHaveFocus();
 });


### PR DESCRIPTION
The Dropdown Component was not working with autofocus, because it is displayed "after" the call of focus()
The timeout fix this.