### PR TITLE
Fix CI file permission issue

### DIFF
--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -45,6 +45,7 @@ cp composer.lock /tmp/composer.lock
 echo "Checkout EE 4.0 branch..."
 git branch -D real40 || true
 git checkout -b real40 --track origin/4.0
+sudo chown 1000:1000 -R .
 
 echo "Creation of image with php 7.3..."
 make php-image-dev
@@ -81,6 +82,7 @@ echo "Checkout EE PR branch (or master if it does not exist)..."
 git checkout $PR_BRANCH || git checkout master
 cp /tmp/composer.lock ./composer.lock
 touch composer.lock
+sudo chown 1000:1000 -R .
 make vendor
 
 echo "Copy CE migrations into EE to launch branch migrations..."


### PR DESCRIPTION
As you see below there is some ownership issues on the project files between the `circleci` and `ubuntu` user while running the `detect_structure_changes.sh` script.
This seems to be linked to git checkout(s) executing with the wrong user and messing up the permissions.
```
circleci@default-437057d9-9a1a-4fa0-a35e-5f233216f0b5:~/project$ ls -l
total 552088
-rw-rw-r--    1 circleci circleci     52052 Aug 27 07:55 behat.yml
drwxrwxr-x    2 ubuntu   ubuntu        4096 Aug 27 07:55 bin
-rw-rw-r--    1 ubuntu   ubuntu       51458 Aug 27 07:55 CHANGELOG-3.0.md
-rw-rw-r--    1 ubuntu   ubuntu       10168 Aug 27 07:55 CHANGELOG-3.2.md
-rw-rw-r--    1 ubuntu   ubuntu       36723 Aug 27 07:55 CHANGELOG-4.0.md
-rw-rw-r--    1 circleci circleci      6161 Aug 27 07:55 composer.json
-rwxrwxr-x    1 ubuntu   ubuntu      614554 Aug 27 07:34 composer.lock
drwxrwxr-x    6 ubuntu   ubuntu        4096 Aug 27 07:55 config
drwxrwxr-x    5 ubuntu   ubuntu        4096 Aug 27 07:55 deployments
drwxrwxr-x    3 ubuntu   ubuntu        4096 Aug 27 07:55 docker
-rwxrwxr-x    1 ubuntu   ubuntu         318 Aug 27 07:32 docker-compose.override.yml
-rw-rw-r--    1 circleci circleci      2800 Aug 27 07:55 docker-compose.saas-like.yml
-rw-rw-r--    1 circleci circleci      4211 Aug 27 07:55 docker-compose.yml
-rw-rw-r--    1 circleci circleci      6124 Aug 27 07:55 Dockerfile
drwxrwxr-x    4 ubuntu   ubuntu        4096 Aug 27 07:55 frontend
-rw-rw-r--    1 ubuntu   ubuntu        2062 Aug 27 07:55 generate.js
drwxrwxr-x    7 ubuntu   ubuntu        4096 Aug 27 07:55 internal_doc
-rw-rw-r--    1 ubuntu   ubuntu       21064 Aug 27 07:55 LICENCE.txt
drwxrwxr-x    2 ubuntu   ubuntu        4096 Aug 27 07:55 make-file
-rw-rw-r--    1 circleci circleci      5282 Aug 27 07:55 Makefile
drwxrwxr-x 1023 ubuntu   ubuntu       49152 Aug 27 07:36 node_modules
-rw-rw-r--    1 circleci circleci      4932 Aug 27 07:55 package.json
-rwxrwxr-x    1 ubuntu   ubuntu          58 Aug 27 07:31 persisted_env_vars
-rwxrwxr-x    1 ubuntu   ubuntu   563887104 Aug 27 07:33 php-pim-image.tar
-rw-rw-r--    1 circleci circleci      4388 Aug 27 07:55 phpspec.yml.dist
-rw-rw-r--    1 circleci circleci       374 Aug 27 07:55 phpstan.neon
-rw-rw-r--    1 circleci circleci      2287 Aug 27 07:55 phpunit.xml.dist
drwxrwxr-x    7 ubuntu   ubuntu        4096 Aug 27 07:55 public
-rw-rw-r--    1 circleci circleci       261 Aug 27 07:55 README.md
drwxrwxr-x    4 ubuntu   ubuntu        4096 Aug 27 07:55 src
drwxrwxr-x    3 ubuntu   ubuntu        4096 Aug 27 07:55 std-build
-rw-rw-r--    1 ubuntu   ubuntu        1256 Aug 27 07:55 symfony.lock
drwxrwxr-x    7 ubuntu   ubuntu        4096 Aug 27 07:31 tests
-rw-rw-r--    1 ubuntu   ubuntu         271 Aug 27 07:55 tsconfig.json
-rw-rw-r--    1 circleci circleci         0 Aug 27 07:55 UPGRADE_CLOUD.md
-rw-rw-r--    1 circleci circleci       114 Aug 27 07:55 UPGRADE.md
drwxrwxr-x   16 ubuntu   ubuntu        4096 Aug 27 07:55 upgrades
drwxrwxr-x    5 ubuntu   ubuntu        4096 Aug 27 07:36 var
drwxrwxr-x   70 ubuntu   ubuntu        4096 Aug 27 07:34 vendor
-rw-rw-r--    1 circleci circleci    442905 Aug 27 07:55 yarn.lock
```