### PR TITLE
OB-967: Remove Onboarder bundle PHP-CS-fixer & coupling detector execution from PIM CE CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,12 +637,6 @@ jobs:
                 name: Change owner of PIM as some files have been created with wrong owner
                 command: sudo chown -R 1000:1000 ~/project
           - run:
-                name: Execute static analysis
-                command: PIM_CONTEXT=onboarder make test-static-analysis
-          - run:
-                name: PHP coupling detector
-                command: PIM_CONTEXT=onboarder make test-coupling-detector
-          - run:
                 name: Start containers
                 command: |
                     APP_ENV=test C='mysql elasticsearch object-storage pubsub-emulator' make up


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

PIM CE CI does not need to run Onboarder bundle cs-fixer & coupling detector.
