### PR TITLE
PIM-10037: Fix family variant query to return correct number of results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PIM-9989: Fix record code of reference entity field is case-sensitive
 - PIM-10026: Avoid session persistance for API
 - PIM-10019: Update product indexation on attribute as label change
+- PIM-10037: Fix family variant query to return correct number of results
 
 ## New features
 

--- a/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Doctrine/ORM/Repository/FamilyRepository.php
@@ -60,7 +60,7 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
 
         if (isset($options['identifiers'])) {
             $qb->andWhere('f.code IN (:identifiers)')
-               ->setParameter('identifiers', $options['identifiers']);
+                ->setParameter('identifiers', $options['identifiers']);
         }
 
         if ($limit) {
@@ -69,6 +69,8 @@ class FamilyRepository extends EntityRepository implements FamilyRepositoryInter
                 $qb->setFirstResult((int) $limit * ((int) $options['page'] - 1));
             }
         }
+
+        $qb->distinct();
         $qb->orderBy('f.code');
 
         return $qb->getQuery()->getResult();


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Fix the get families with variant query to select distinct results in order for the limit parameter to work as intended.
Before, with a limit of 20, the query would return multiple times the same family, as the select was not distinct:
<img width="455" alt="image" src="https://user-images.githubusercontent.com/3492179/131362087-5c852831-45f4-4c72-9d2d-2e985354d942.png">
After the DISTINCT, we have the correct number of results:
<img width="452" alt="image" src="https://user-images.githubusercontent.com/3492179/131362212-54f2df50-c787-47c1-ba76-8edd3a4c5bca.png">


**Definition Of Done (for Core Developer only)**

- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
