### PR TITLE
PIM-10058 Added missing pipes for pluralization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PIM-10037: Fix family variant query to return correct number of results
 - PIM-10041: Change configuration to apply APP_ELASTICSEARCH_TOTAL_FIELDS_LIMIT to assets and references entities
 - PIM-9990: Fix lost of keyup event when tab key is pressed too fast on input field
+- PIM-10058: Corrected pluralization for a translation message in Spanish
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.es_ES.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.es_ES.yml
@@ -331,7 +331,7 @@ pim_enrich.export.product:
     title: Configuración global
 pim_enrich.mass_edit.product:
   title: Acción en masa del producto
-  confirm: "{0}Está a punto de actualizar algunos productos con la siguiente información, por favor confirme.{1}Está a punto de actualizar un producto con la siguiente información, por favor confirme. ]1, Inf[Estás a punto de actualizar {{ itemsCount }} productos con la siguiente información, por favor confirme."
+  confirm: "{0}Está a punto de actualizar algunos productos con la siguiente información, por favor confirme.|{1}Está a punto de actualizar un producto con la siguiente información, por favor confirme. |]1, Inf[Estás a punto de actualizar {{ itemsCount }} productos con la siguiente información, por favor confirme."
   step:
     select:
       label: Seleccione los productos


### PR DESCRIPTION
**PIM-10058** Added missing pipes for pluralization

**Description (for Contributor and Core Developer)**
Spanish translation message was missing `|` characters used to pluralize translation

![image](https://user-images.githubusercontent.com/7101819/132237241-0ce2e784-8245-41fa-9a34-b442a7f050f3.png)



