### PR TITLE
PIM-10063: make query builder case insensitive for attribute filter

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validation/attribute.yml
@@ -100,7 +100,7 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
             - Length:
                 max: 255
             - Regex:
-                pattern: /^(?!(id|iD|Id|ID|associationTypes|categories|categoryId|completeness|enabled|(?i)\bfamily\b|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type|attributes)$)/
+                pattern: /^(?!(id|associationTypes|categories|categoryId|completeness|enabled|(?i)\bfamily\b|groups|associations|products|scope|treeId|values|category|parent|label|(.)*_(products|groups)|entity_type|attributes)$)/i
                 message: This code is not available
             - Regex:
                 pattern: /^[^\n]+$/D

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
@@ -78,6 +78,24 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertCount(0, $productsNotFound);
     }
 
+    public function testAddAnAttributeFilterIsCaseInsensitive(): void
+    {
+        $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        $pqb->addFilter('family', Operators::IN_LIST, ['familyA']);
+        $pqb->addFilter('A_FILE', Operators::STARTS_WITH, 'aken');
+        $pqb->addFilter('a_localizable_IMAGE', Operators::CONTAINS, 'akeneo', ['locale' => 'en_US']);
+        $pqb->addFilter('a_regexp', Operators::CONTAINS, '+', ['locale' => 'en_US']);
+        $pqb->addFilter(
+            'a_SCOPABLE_price',
+            Operators::GREATER_THAN,
+            ['amount' => 13, 'currency' => 'USD'],
+            ['scope' => 'ecommerce']
+        );
+
+        $productsFound = $pqb->execute();
+        $this->assertCount(1, $productsFound);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -178,10 +196,7 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
         );
     }
 
-    /**
-     * @return ProductQueryBuilderInterface
-     */
-    protected function createPQBWithoutFamilyFilter()
+    protected function createPQBWithoutFamilyFilter(): ProductQueryBuilderInterface
     {
         $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
         $pqb->addFilter('a_file', Operators::STARTS_WITH, 'aken');
@@ -203,10 +218,7 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
         return $pqb;
     }
 
-    /**
-     * @return ProductQueryBuilderInterface
-     */
-    protected function createPQBWithoutaLocalizedAndScopableTextAreaFilter()
+    protected function createPQBWithoutaLocalizedAndScopableTextAreaFilter(): ProductQueryBuilderInterface
     {
         $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
         $pqb->addFilter('family', Operators::IN_LIST, ['familyA']);
@@ -223,10 +235,7 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
         return $pqb;
     }
 
-    /**
-     * @return ProductQueryBuilderInterface
-     */
-    protected function createPQBWithoutACategoriesFilter()
+    protected function createPQBWithoutACategoriesFilter(): ProductQueryBuilderInterface
     {
         $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
         $pqb->addFilter(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelQueryBuilderFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductAndProductModelQueryBuilderFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductAndProductModelQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
+use Prophecy\Argument;
 
 class ProductAndProductModelQueryBuilderFactorySpec extends ObjectBehavior
 {
@@ -20,6 +21,7 @@ class ProductAndProductModelQueryBuilderFactorySpec extends ObjectBehavior
         CursorFactoryInterface $cursorFactory,
         ProductQueryBuilderOptionsResolverInterface $optionsResolver
     ) {
+        $optionsResolver->resolve(Argument::any())->willReturn([]);
         $this->beConstructedWith(
             ProductAndProductModelQueryBuilder::class,
             $attributeRepository,

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductQueryBuilderFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/ProductQueryBuilderFactorySpec.php
@@ -23,6 +23,7 @@ class ProductQueryBuilderFactorySpec extends ObjectBehavior
         CursorFactoryInterface $cursorFactory,
         ProductQueryBuilderOptionsResolverInterface $optionsResolver
     ) {
+        $optionsResolver->resolve(Argument::any())->willReturn([]);
         $this->beConstructedWith(
             ProductQueryBuilder::class,
             $attRepository,

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductModelQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductModelQueryBuilderSpec.php
@@ -2,24 +2,23 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Query;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\AbstractEntityWithValuesQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FilterRegistryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductModelQueryBuilder;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderOptionsResolverInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\AttributeSorterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\SorterRegistryInterface;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FilterRegistryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderOptionsResolverInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\SorterRegistryInterface;
-use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Prophecy\Argument;
 
 class ProductModelQueryBuilderSpec extends ObjectBehavior
@@ -128,6 +127,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $this->setQueryBuilder($searchQb);
         $repository->findOneByIdentifier('sku')->willReturn($attribute);
         $attribute->getCode()->willReturn('sku');
+        $filterRegistry->getFieldFilter('sku', '=')->willReturn(null);
         $filterRegistry->getAttributeFilter($attribute, '=')->willReturn($filter);
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
@@ -156,6 +156,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $name->setLocalizable(false);
 
         $repository->findOneByIdentifier('name')->willReturn($name);
+        $filterRegistry->getFieldFilter('name', 'EMPTY')->willReturn(null);
         $filterRegistry->getAttributeFilter($name, 'EMPTY')->willReturn($textFilter);
         $repository->findOneByIdentifier('family')->willReturn(null);
         $filterRegistry->getFieldFilter('family', 'NOT EMPTY')->willReturn($familyFilter);
@@ -372,6 +373,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
         $repository->findOneByIdentifier('bar')->willReturn($attribute);
+        $filterRegistry->getFieldFilter('bar', 'IN LIST')->willReturn(null);
         $filterRegistry->getAttributeFilter($attribute, 'IN LIST')->willReturn($filterAttribute);
 
         $this->addFilter('id', '=', '42', []);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductQueryBuilderSpec.php
@@ -119,6 +119,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
     ) {
         $repository->findOneByIdentifier('sku')->willReturn($attribute);
         $attribute->getCode()->willReturn('sku');
+        $filterRegistry->getFieldFilter('sku', '=')->willReturn(null);
         $filterRegistry->getAttributeFilter($attribute, '=')->willReturn($filter);
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
@@ -148,6 +149,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
         $name->setLocalizable(false);
 
         $repository->findOneByIdentifier('name')->willReturn($name);
+        $filterRegistry->getFieldFilter('name', 'EMPTY')->willReturn(null);
         $filterRegistry->getAttributeFilter($name, 'EMPTY')->willReturn($textFilter);
         $repository->findOneByIdentifier('family')->willReturn(null);
         $filterRegistry->getFieldFilter('family', 'NOT EMPTY')->willReturn($familyFilter);
@@ -313,6 +315,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
         $attribute->isScopable()->willReturn(true);
         $attribute->isLocalizable()->willReturn(true);
         $repository->findOneByIdentifier('bar')->willReturn($attribute);
+        $filterRegistry->getFieldFilter('bar', 'IN LIST')->willReturn(null);
         $filterRegistry->getAttributeFilter($attribute, 'IN LIST')->willReturn($filterAttribute);
 
         $this->addFilter('id', '=', '42', []);

--- a/tests/back/Pim/Structure/Integration/Attribute/Validation/NonAvailableAttributeCodeIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Validation/NonAvailableAttributeCodeIntegration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\Attribute\Validation;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+
+class NonAvailableAttributeCodeIntegration extends AbstractAttributeTestCase
+{
+    public function test_create_an_attribute_with_an_available_code_is_possible()
+    {
+        $attribute = $this->createAttributeByCode('new_attribute');
+        $violations = $this->validateAttribute($attribute);
+
+        $this->assertCount(0, $violations);
+    }
+
+    public function test_create_an_attribute_with_a_non_available_code_is_not_possible()
+    {
+        $attribute = $this->createAttributeByCode('categories');
+        $violations = $this->validateAttribute($attribute);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('This code is not available', $violations->get(0)->getMessage());
+    }
+
+    public function test_create_an_attribute_with_a_non_available_code_in_different_case_is_not_possible()
+    {
+        $attribute = $this->createAttributeByCode('CATEgories');
+        $violations = $this->validateAttribute($attribute);
+
+        $this->assertCount(1, $violations);
+        $this->assertSame('This code is not available', $violations->get(0)->getMessage());
+    }
+
+    private function createAttributeByCode(string $attributeCode): AttributeInterface
+    {
+        $attribute = $this->createAttribute();
+
+        $this->updateAttribute($attribute, [
+            'code' => $attributeCode,
+            'type' => 'pim_catalog_text',
+            'group' => 'attributeGroupA'
+        ]);
+        $this->saveAttribute($attribute);
+
+        return $attribute;
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Before the query builder was case sensitive . That means if the attribute code is `test` we cannot filter on `TEST`.  
It was like that because we can create some attribute with code like `CATEGORIES`, `FAMILIES`, ... So when a filter is added on `categories` we cannot know if this refers to the system filter or the attribute filter.  
Having the PQB case sensitive provides some bad UX, as the PIM is case insensitive almost everywhere, and not here.  

Now the PQB is case insensitive. To do that:
- now we forbid the creation of attribute with `CATEGORIES` code. So the conflict could not happen
- Our SAAS environments does not have attribute like that, so there is no conflict with the existent attribute
- the PQB is now simplified, and we can even save a query if we add a system filter

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
