### PR TITLE
TIP-1541: add a front and back cache layer on dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
                       docker save -o php-pim-image.tar akeneo/pim-php-dev:master
       - run:
           name: Setup tests results folder and log folder
-          command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
+          command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.cache/Cypress ~/.composer
       - run:
             name: Creating cache key for JS and PHP dependencies
             command: |
@@ -956,4 +956,6 @@ commands:
           command: |
             wget https://github.com/mikefarah/yq/releases/download/3.3.1/yq_linux_386
             sudo mv yq_linux_386 /usr/local/bin/yq
+            echo "e7fa464149a450d068311a244f403757408a745b  /usr/local/bin/yq" > /tmp/checksum
+            sha1sum -c /tmp/checksum
             sudo chmod +x /usr/local/bin/yq

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,14 +108,24 @@ jobs:
           name: Setup tests results folder and log folder
           command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
       - run:
+            name: Creating cache key for JS and PHP dependencies
+            command: |
+                cat yarn.lock > ~/front-dependency.hash && date +%F >> ~/front-dependency.hash
+                cat composer.json > ~/back-dependency.hash && date +%F >> ~/back-dependency.hash
+      - restore_cache:
+            name: Restore cache - yarn and Cypress dependency cache
+            keys:
+                - frontend-dependency-cache-{{ checksum "~/front-dependency.hash" }}
+      - restore_cache:
+            name: Restore cache - composer dependency cache
+            keys:
+                - backend-dependency-cache-{{ checksum "~/back-dependency.hash" }}
+      - run:
           name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
           command: |
               sudo chown -R 1000:1000 ../project
               sudo chown -R 1000:1000 ~/.composer
-              sudo chown -R 1000:1000 ~/.cache/yarn
-      - run:
-          name: Change owner on project dir after restoring cache
-          command: sudo chown -R 1000:1000 ../project
+              sudo chown -R 1000:1000 ~/.cache/
       - run:
           name: Install back and front dependencies
           command: make dependencies
@@ -163,7 +173,17 @@ jobs:
           command: make javascript-dev
       - run:
             name: Change owner on project dir after installing when there is no cache
-            command: sudo chmod -R 777 ../project
+            command: sudo chmod -R 777 ../project ~/.cache ~/.composer
+      - save_cache:
+            name: Save fontend dependency cache
+            paths:
+                - ~/.cache
+            key: frontend-dependency-cache-{{ checksum "~/front-dependency.hash" }}
+      - save_cache:
+            name: Save backend dependency cache
+            paths:
+                - ~/.composer
+            key: backend-dependency-cache-{{ checksum "~/back-dependency.hash" }}
       - persist_to_workspace:
           root: ~/
           paths:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,9 +42,11 @@ services:
     image: 'akeneo/node:12'
     environment:
       YARN_CACHE_FOLDER: '/home/node/.yarn'
+      CYPRESS_CACHE_FOLDER: '/home/node/.cypress'
     volumes:
       - './:/srv/pim'
       - '${HOST_YARN_CACHE_FOLDER:-~/.cache/yarn}:/home/node/.yarn'
+      - '${HOST_CYPRESS_CACHE_FOLDER:-~/.cache/Cypress}:/home/node/.cypress'
     working_dir: '/srv/pim'
     networks:
       - 'pim'


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Gain: ~2m30 for building PIM dev

The front and back cache layers were removed during the rework of the CI to launch the EE edition. It was existing in 4.0.
It was a different approach: node_modules and vendor were cached directly.

Such approach is not recommended with `yarn`, and same for composer. Instead, it's recommended to store in cache the global cache dependency directory and let the package manager to do its stuff. It is `.composer` for PHP and `.cache/.yarn` for JS.

Also, there is another cache: Cypress. It is very costly to build the package both in **local** and in the **CI**, because this cache is not mount in docker (and also not persisted as cache on the CI). 


**Note 1**: the cache key `package.json` is not necessary perfect due to the various workspaces, etc. As it's not mandatory to have all dependencies in this cache, it's not an issue. 

**Note** 2: this cache is forced to be rebuilt every day, to mitigate the issue of missing dependencies in the cache due to a change in a workspace.

**Note 3**: I added also a security check when downloading `yq` (see https://about.codecov.io/security-update/) 

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
