### PR TITLE
PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - CXP-838: Fix (Not)LocalizableAnd(Not)ScopableAttributeException catches
 - PIM-10029: Added an explicit class named container to inject additional content into sub-navigation panel
 - PIM-10067: Date value in calendar not set when none is selected
+- PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
@@ -26,7 +26,7 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
     private array $esQuery;
     private int $pageSize;
     private array $searchAfter;
-    private ?ResultInterface $result;
+    private ?ResultInterface $result = null;
 
     /**
      * @param Client                        $esClient

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
@@ -121,7 +121,7 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
     public function getResult(): ResultInterface
     {
         if (null === $this->result) {
-            $this->getNextIdentifiers([]);
+            $this->getNextIdentifiers($this->esQuery);
         }
 
         return $this->result;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR fix the following error: 
`Typed property Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Cursor::$result must not be accessed before initialization./srv/pim/src/Akeneo/Pim/Automation/RuleEngine/Bundle/Controller/InternalApi/GetImpactedProductCountController.php:70,/srv/pim/vendor/symfony/http-kernel/HttpKernel.php:158,/srv/pim/vendor/symfony/http-kernel/HttpKernel.php:80,/srv/pim/vendor/symfony/http-kernel/Kernel.php:201,/srv/pim/public/index.php:20{/code}`

When does this error happen ?

- Only on production because in production we call getResult without initialized $result. Before https://github.com/akeneo/pim-enterprise-dev/pull/11662. The cursor was initialized when counting `count($subjectSet->getSubjectsCursor())`  but now in production does not appear anymore do to `isInfoOrLowerSeverityLogger`

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
