### PR TITLE
PIM-10073: [Backport] DQI de-activation on attribute group is not fully taken into account

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-10060: Impossible to edit products in a new tab/window from a right click on the product grid
+- PIM-10073: [Backport PIM-9671] DQI de-activation on attribute group is not fully taken into account
 
 # 5.0.46 (2021-09-03)
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/context/AttributeGroupsStatusContext.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/context/AttributeGroupsStatusContext.tsx
@@ -1,0 +1,28 @@
+import React, {createContext, FC, useContext} from 'react';
+import {AttributeGroupsStatusCollection, useFetchAllAttributeGroupsStatus} from '../../infrastructure/hooks';
+
+type AttributeGroupsStatusContextState = {
+  load: () => void;
+  status: AttributeGroupsStatusCollection;
+};
+
+const AttributeGroupsStatusContext = createContext<AttributeGroupsStatusContextState>({
+  load: () => {},
+  status: {},
+});
+
+AttributeGroupsStatusContext.displayName = 'AttributeGroupsStatusContext';
+
+const useAttributeGroupsStatusContext = () => {
+  return useContext(AttributeGroupsStatusContext);
+};
+
+const AttributeGroupsStatusProvider: FC = ({children}) => {
+  const {load, status} = useFetchAllAttributeGroupsStatus();
+
+  return (
+    <AttributeGroupsStatusContext.Provider value={{load, status}}>{children}</AttributeGroupsStatusContext.Provider>
+  );
+};
+
+export {AttributeGroupsStatusProvider, useAttributeGroupsStatusContext, AttributeGroupsStatusContext};

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/context/index.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/context/index.ts
@@ -1,0 +1,1 @@
+export * from './AttributeGroupsStatusContext';

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/index.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/index.ts
@@ -1,1 +1,2 @@
 export * from './component';
+export * from './context';

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/AttributeGroup/index.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/AttributeGroup/index.ts
@@ -1,0 +1,3 @@
+export * from './useFetchAllAttributeGroupsStatus';
+export * from './useAttributeGroupState';
+export * from './useProductEvaluatedAttributeGroups';

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/AttributeGroup/useFetchAllAttributeGroupsStatus.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/AttributeGroup/useFetchAllAttributeGroupsStatus.ts
@@ -1,0 +1,21 @@
+import {useCallback, useState} from 'react';
+import {fetchAllAttributeGroupsDqiStatus} from '../../fetcher';
+
+export type AttributeGroupsStatusCollection = {
+  [code: string]: boolean;
+};
+
+const useFetchAllAttributeGroupsStatus = () => {
+  const [status, setStatus] = useState<AttributeGroupsStatusCollection>({});
+  const load = useCallback(async () => {
+    const response = await fetchAllAttributeGroupsDqiStatus();
+    setStatus(response);
+  }, [setStatus]);
+
+  return {
+    status,
+    load,
+  };
+};
+
+export {useFetchAllAttributeGroupsStatus};

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/index.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/infrastructure/hooks/index.ts
@@ -7,9 +7,10 @@ import useProduct from './ProductEditForm/useProduct';
 import {useFetchProductQualityScore} from './ProductEditForm/useFetchProductQualityScore';
 import usePageContext from './ProductEditForm/usePageContext';
 import useProductEvaluation from './ProductEditForm/useProductEvaluation';
-import {useProductEvaluatedAttributeGroups} from './AttributeGroup/useProductEvaluatedAttributeGroups';
 import {useFetchKeyIndicators} from './Dashboard/useFetchKeyIndicators';
-import {useFetchQualityScoreEvolution, RawScoreEvolutionData} from './Dashboard/useFetchQualityScoreEvolution';
+import {RawScoreEvolutionData, useFetchQualityScoreEvolution} from './Dashboard/useFetchQualityScoreEvolution';
+
+export * from './AttributeGroup';
 
 export {
   useFetchDqiDashboardData,
@@ -21,7 +22,6 @@ export {
   useFetchProductQualityScore,
   usePageContext,
   useProductEvaluation,
-  useProductEvaluatedAttributeGroups,
   useFetchKeyIndicators,
   useFetchQualityScoreEvolution,
   RawScoreEvolutionData,

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/front/unit/infrastructure/hooks/AttributeGroup/useFetchAllAttributeGroupsStatus.unit.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/front/unit/infrastructure/hooks/AttributeGroup/useFetchAllAttributeGroupsStatus.unit.ts
@@ -1,0 +1,30 @@
+import {fetchAllAttributeGroupsDqiStatus} from '@akeneo-pim-community/data-quality-insights/src/infrastructure/fetcher/AttributeGroup/attributeGroupDqiStatusFetcher';
+import {renderHook, act} from '@testing-library/react-hooks';
+import {useFetchAllAttributeGroupsStatus} from '@akeneo-pim-community/data-quality-insights/src/infrastructure/hooks';
+
+jest.mock(
+  '@akeneo-pim-community/data-quality-insights/src/infrastructure/fetcher/AttributeGroup/attributeGroupDqiStatusFetcher'
+);
+
+describe('useFetchAllAttributeGroupsStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('it loads all attribute groups status for DQI', async () => {
+    fetchAllAttributeGroupsDqiStatus.mockResolvedValueOnce({erp: true, technical: true, marketing: true});
+
+    const {result} = renderHook(() => useFetchAllAttributeGroupsStatus());
+
+    expect(result.current.status).toEqual({});
+
+    await act(async () => result.current.load());
+
+    expect(result.current.status).toEqual({erp: true, technical: true, marketing: true});
+  });
+});


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport of PIM-9671: 
https://github.com/akeneo/pim-enterprise-dev/pull/10360
https://github.com/akeneo/pim-community-dev/pull/13888

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
