### PR TITLE
SDS-20187: fix wrong check before saving consolidated product scores

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ConsolidateProductScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ConsolidateProductScores.php
@@ -46,7 +46,7 @@ class ConsolidateProductScores
             $productsScores[] = new ProductScores($productId, $this->clock->getCurrentTime(), $scores);
         }
 
-        if (!empty($scores)) {
+        if (!empty($productsScores)) {
             $this->productScoreRepository->saveAll($productsScores);
         }
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Check if the list of product scores is not empty before saving it

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
