### PR TITLE
CXP-871: fix how we catch marketplace errors in the front

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-apps.ts
@@ -10,7 +10,7 @@ export const useFetchApps = () => {
             headers: [['X-Requested-With', 'XMLHttpRequest']],
         });
         if (false === response.ok) {
-            throw new Error(`${response.status} ${response.statusText}`);
+            return Promise.reject(`${response.status} ${response.statusText}`);
         }
 
         return response.json();

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-extensions.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-extensions.ts
@@ -10,7 +10,7 @@ export const useFetchExtensions = () => {
             headers: [['X-Requested-With', 'XMLHttpRequest']],
         });
         if (false === response.ok) {
-            throw new Error(`${response.status} ${response.statusText}`);
+            return Promise.reject(`${response.status} ${response.statusText}`);
         }
 
         return response.json();

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
@@ -73,7 +73,7 @@ export const MarketplacePage: FC = () => {
 
             <PageContent>
                 {null === extensions || (null === apps && <MarketplaceIsLoading />)}
-                {(false === extensions || false === apps) && <UnreachableMarketplace />}
+                {false === extensions && false === apps && <UnreachableMarketplace />}
                 {false !== extensions && null !== extensions && false !== apps && null !== apps && (
                     <Marketplace extensions={extensions} apps={apps} />
                 )}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
@@ -73,7 +73,7 @@ export const MarketplacePage: FC = () => {
 
             <PageContent>
                 {null === extensions || (null === apps && <MarketplaceIsLoading />)}
-                {false === extensions && false === apps && <UnreachableMarketplace />}
+                {(false === extensions || false === apps) && <UnreachableMarketplace />}
                 {false !== extensions && null !== extensions && false !== apps && null !== apps && (
                     <Marketplace extensions={extensions} apps={apps} />
                 )}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When the marketplace is not available, like this afternoon, an expected error is thrown when trying to retrieve extensions.
Sadly, it was not correctly handled in the front.

In the following snippet, the setExtensions is only called when the Promise is rejected.
The exception we were throwing was thrown before the Promise of `response.json` was started so, it was not catched.
```
fetchExtensions()
            .then(setExtensions)
            .catch(() => setExtensions(false));
```

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
