### PR TITLE
TIP-1542: add cache on Dockerfile and front package dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,9 +77,9 @@ jobs:
         is_ee_built:
             type: boolean
             default: true
-        path_to_dsm:
+        path_to_front_packages:
             type: string
-            default: front-packages/akeneo-design-system
+            default: front-packages
     machine:
       image: ubuntu-2004:202101-01
     steps:
@@ -90,12 +90,27 @@ jobs:
           command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
       - when:
             condition: << parameters.is_ee_built >>
+
             steps:
+              - run:
+                  name: Creating hash key for PHP Docker image
+                  command: |
+                      find Dockerfile docker/ -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/php-docker-image.hash
+                      date +%F >> ~/php-docker-image.hash
+              - restore_cache:
+                  name: Restore PHP docker image cache
+                  key: php-docker-image-{{ checksum "~/php-docker-image.hash" }}
               - run:
                   name: Build the latest EE Docker images
                   command: |
-                      make php-image-dev
-                      docker save -o php-pim-image.tar akeneo/pim-dev/php:7.4
+                      ls php-pim-image.tar && docker load -i php-pim-image.tar
+                      ls php-pim-image.tar || make php-image-dev
+                      ls php-pim-image.tar || docker save -o php-pim-image.tar akeneo/pim-dev/php:7.4
+              - save_cache:
+                  name: Save PHP docker image cache
+                  key: php-docker-image-{{ checksum "~/php-docker-image.hash" }}
+                  paths:
+                      - php-pim-image.tar
       - unless:
             condition: << parameters.is_ee_built >>
             steps:
@@ -123,20 +138,12 @@ jobs:
       - run:
           name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
           command: |
-              sudo chown -R 1000:1000 ../project
-              sudo chown -R 1000:1000 ~/.composer
-              sudo chown -R 1000:1000 ~/.cache/
+              sudo chown -R 1000:1000 ../project ~/.composer ~/.cache/
       - run:
           name: Install back and front dependencies
           command: make dependencies
           environment:
             YARN_REGISTRY: "http://registry.yarnpkg.com"
-      - run:
-          name: Check PIM requirements
-          command: |
-              C='mysql elasticsearch' make up
-              docker/wait_docker_up.sh
-              make check-requirements
       - run:
           name: Install assets
           command: make assets
@@ -145,26 +152,27 @@ jobs:
           command: make css
       - run:
           name: Create hash for front packages
+          # Adding date allows to invalidate the cache each new day, adding front package path avoid conflict between CE build and EE build
           command: |
-            find << parameters.path_to_dsm >>  -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/akeneo-design-system.hash
-            date +%F >> ~/akeneo-design-system.hash
+              find << parameters.path_to_front_packages >>/akeneo-design-system -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/akeneo-design-system.hash
+              find << parameters.path_to_front_packages >>/measurement -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/measurement.hash
+              find << parameters.path_to_front_packages >>/shared -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/shared.hash
+              echo "$(date +%F) << parameters.path_to_front_packages >>" | tee -a ~/akeneo-design-system.hash ~/measurement.hash ~/shared.hash
       - run:
-          name: Set DSM directory owner to circleci
-          command: sudo chown -R 1001:1001 << parameters.path_to_dsm >>
+          name: Set front package directories owner to circleci
+          command: sudo chown -R 1001:1001 << parameters.path_to_front_packages >>
       - restore_cache:
-          name: Restore DSM cache
-          key: dsm-lib-{{ checksum "~/akeneo-design-system.hash" }}
+            name: Restore front package DSM cache
+            key: front-packages-dsm-{{ checksum "~/akeneo-design-system.hash" }}
+      - restore_cache:
+            name: Restore front package measurement cache
+            key: front-packages-measurement-{{ checksum "~/measurement.hash" }}
+      - restore_cache:
+            name: Restore front package Shared cache
+            key: front-packages-shared-{{ checksum "~/shared.hash" }}
       - run:
-          name: Set DSM directory owner to docker
-          command: sudo chown -R 1000:1000 << parameters.path_to_dsm >>
-      - run:
-          name: Build DSM
-          command: ls << parameters.path_to_dsm >>/lib 1> /dev/null 2>&1 || make dsm
-      - save_cache:
-          name: Save DSM cache
-          key: dsm-lib-{{ checksum "~/akeneo-design-system.hash" }}
-          paths:
-            - << parameters.path_to_dsm >>/lib
+          name: Set font package directories owner to docker
+          command: sudo chown -R 1000:1000 << parameters.path_to_front_packages >>
       - run:
           name: Build front-packages
           command: make front-packages
@@ -184,6 +192,21 @@ jobs:
             paths:
                 - ~/.composer
             key: backend-dependency-cache-{{ checksum "~/back-dependency.hash" }}
+      - save_cache:
+            name: Save front package DSM cache
+            key: front-packages-dsm-{{ checksum "~/akeneo-design-system.hash" }}
+            paths:
+                - << parameters.path_to_front_packages >>/akeneo-design-system/
+      - save_cache:
+            name: Save front package measurement cache
+            key: front-packages-measurement-{{ checksum "~/measurement.hash" }}
+            paths:
+                - << parameters.path_to_front_packages >>/measurement/
+      - save_cache:
+            name: Save front package Shared cache
+            key: front-packages-shared-{{ checksum "~/shared.hash" }}
+            paths:
+                - << parameters.path_to_front_packages >>/shared/
       - persist_to_workspace:
           root: ~/
           paths:
@@ -741,7 +764,7 @@ workflows:
                 requires:
                     - ready_to_build?
           - build_dev:
-                path_to_dsm: vendor/akeneo/pim-community-dev/front-packages/akeneo-design-system
+                path_to_front_packages: vendor/akeneo/pim-community-dev/front-packages
                 requires:
                     - checkout_ee
           - build_prod:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

**Put front packages in cache to speed up compilation time**

DSM was rebuilt during `make front-packages`, even if a cache of the DSM already exists. Indeed, only the `lib` directory was put in the cache. `yarn` was not able to detect that the build is up to date with the source.

A solution would be to have a different behavior between `make front-packages` in the CI and in local. But it defeats the purpose of why we used `make` initially (reproducibility). 

The best option is to put in cache the whole front package. Indeed, yarn does not rebuild the package if it's already built thanks to the file `tsconfig.build.tsbuildinfo`. 

It can be applied for every front packages.

**Put dockerfile in cache**

PHP Docker image is rebuilt in each PR, even if the Dockerfile or `docker/` didn't change (probably 95% of the PR). To avoid that, the image is in cache now for `build_dev` **only**.

**Speed gain**

Docker cache: 1 min
Front package cache: 2m30 (could be slightly improved with `makefile` parallelisation later on with `make -j`)

Note: because the build job is the same between CE and EE in CE repository, tailored export is not cached (it would add complexity).

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
