### PR TITLE
PIM-10074: Add translation key for mass action selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@
 - PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized
 - PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
+- PIM-10074: Add translation key for mass action selection
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/form.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/form.js
@@ -80,6 +80,7 @@ define([
           previousLabel: __('pim_common.previous'),
           nextLabel: __('pim_common.next'),
           confirmLabel: __('pim_common.confirm'),
+          selectActionLabel: __('pim_datagrid.mass_action.default.select_action'),
           illustrationClass: step.getIllustrationClass(),
           __: __,
         })

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/mass-edit/form.html
@@ -63,7 +63,7 @@
         <div class="AknSteps">
             <div class="AknSteps-step AknSteps-step--checked">
                 <div class="AknSteps-stepCircle"></div>
-                Select action
+                <%- selectActionLabel %>
             </div>
             <% if (currentStep === 'choose') { %>
             <div class="AknSteps-step AknSteps-step--undefined">

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/translations/jsmessages.en_US.yml
@@ -60,6 +60,7 @@ pim_datagrid:
       success: Mass action performed
       error: Mass action was not performed
       no_items: Please, select items to perform mass action.
+      select_action: Select action
     quick_export:
       title: Quick Export
       success: Quick export has been launched


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Add a translation key for the former hardcoded "Select action" label on the mass action selection screen

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
