### PR TITLE
CXP-840 Confirm App Wizard with steps

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -63,6 +63,9 @@ akeneo_connectivity.connection:
             unreachable: We can't reach the marketplace, please come back later.
             scroll_to_top: Scroll to the top
         apps:
+            flash:
+                permissions_error.title: 'Permissions on {{ entity }} could not be saved.'
+                permissions_error.description: Please check the App permission settings.
             wizard:
                 title: Connect
                 action:
@@ -84,8 +87,6 @@ akeneo_connectivity.connection:
                 flash:
                     success: App successfully configured.
                     error: Sorry, an error occurred while connecting the App.
-                    permissions_error.title: 'Permissions on {{ entity }} could not be saved.'
-                    permissions_error.description: Please check the App permission settings.
                 permission:
                     helper: If you need help please check our article
                     helper_link: How to set-up app permissions?

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -84,6 +84,8 @@ akeneo_connectivity.connection:
                 flash:
                     success: App successfully configured.
                     error: Sorry, an error occurred while connecting the App.
+                    permissions_error.title: 'Permissions on {{ entity }} could not be saved.'
+                    permissions_error.description: Please check the App permission settings.
                 permission:
                     helper: If you need help please check our article
                     helper_link: How to set-up app permissions?

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-confirm-authorization.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-confirm-authorization.ts
@@ -3,6 +3,7 @@ import {useCallback} from 'react';
 
 interface ConfirmReturn {
     appId: string;
+    userGroup: string;
 }
 
 type hookType = (clientId: string) => () => Promise<ConfirmReturn>;

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/notify/notify.interface.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/notify/notify.interface.ts
@@ -5,4 +5,4 @@ export enum NotificationLevel {
     ERROR = 'error',
 }
 
-export type Notify = (level: NotificationLevel, message: string) => void;
+export type Notify = (level: NotificationLevel, message: string, title?: {titleMessage: string}) => void;

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
@@ -2,9 +2,10 @@ import {ReactNode} from 'react';
 
 export interface PermissionFormProvider<T> {
     key: string;
+    label: string;
     renderForm: (onChange: (state: T) => void, initialState: T | undefined) => ReactNode;
     renderSummary: (state: T) => ReactNode;
-    save: (role: string, state: T) => boolean;
+    save: (userGroup: string, state: T) => Promise<boolean>;
 }
 
 export interface PermissionFormRegistry {

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
@@ -5,7 +5,7 @@ export interface PermissionFormProvider<T> {
     label: string;
     renderForm: (onChange: (state: T) => void, initialState: T | undefined) => ReactNode;
     renderSummary: (state: T) => ReactNode;
-    save: (userGroup: string, state: T) => Promise<boolean>;
+    save: (userGroup: string, state: T) => Promise<void>;
 }
 
 export interface PermissionFormRegistry {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizardWithSteps/AppWizardWithSteps.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizardWithSteps/AppWizardWithSteps.test.tsx
@@ -1,14 +1,20 @@
 import React, {useEffect} from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import {act, screen, waitForElement} from '@testing-library/react';
+import {act, screen, wait, waitForElement} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {historyMock, mockFetchResponses, MockFetchResponses, renderWithProviders} from '../../../../test-utils';
 import {AppWizardWithSteps, PermissionsType} from '@src/connect/components/AppWizardWithSteps/AppWizardWithSteps';
-import {PermissionFormProvider} from '@src/shared/permission-form-registry';
+import {PermissionFormProvider, PermissionFormRegistryContext} from '@src/shared/permission-form-registry';
+import {NotificationLevel, NotifyContext} from '@src/shared/notify';
+
+const notify = jest.fn();
+const providerSave = jest.fn();
 
 beforeEach(() => {
     fetchMock.resetMocks();
     historyMock.reset();
+    notify.mockClear();
+    providerSave.mockClear();
 });
 
 jest.mock('@src/connect/components/AppWizardWithSteps/Authorizations', () => ({
@@ -24,7 +30,13 @@ type PermissionsProps = {
 jest.mock('@src/connect/components/AppWizardWithSteps/Permissions', () => ({
     Permissions: ({permissions, setPermissions}: PermissionsProps) => {
         const handleClick = () => {
-            setPermissions({data: 'hello world!'});
+            setPermissions({
+                data: 'hello world!',
+                formProvider1: 'formProviderData1',
+                formProvider2: 'formProviderData2',
+                formProvider3: 'formProviderData3',
+                formProvider4: 'formProviderData4',
+            });
         };
 
         return (
@@ -132,6 +144,208 @@ test('The wizard renders steps and is able to navigate between steps', async () 
     assertAuthorizationsScreen();
 });
 
+test('The wizard notifies of the error on app confirm ', async () => {
+    const clientId = '8d8a7dc1-0827-4cc9-9ae5-577c6419230b';
+    const fetchAppWizardDataResponses: MockFetchResponses = {
+        [`akeneo_connectivity_connection_apps_rest_get_wizard_data?clientId=${clientId}`]: {
+            json: {
+                appName: 'MyApp',
+                appLogo: '',
+                scopeMessages: [],
+            },
+        },
+        [`akeneo_connectivity_connection_apps_rest_confirm_authorization?clientId=${clientId}`]: {
+            status: 400,
+            json: '',
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchAppWizardDataResponses,
+    });
+
+    renderWithProviders(
+        <NotifyContext.Provider value={notify}>
+            <AppWizardWithSteps clientId={clientId} />
+        </NotifyContext.Provider>
+    );
+
+    await navigateToSummaryAndClickConfirm();
+
+    await wait(() => expect(notify).toHaveBeenCalledTimes(1));
+
+    expect(notify).toBeCalledWith(
+        NotificationLevel.ERROR,
+        'akeneo_connectivity.connection.connect.apps.wizard.flash.error'
+    );
+});
+
+test('The wizard saves app and permissions on confirm', async () => {
+    const clientId = '8d8a7dc1-0827-4cc9-9ae5-577c6419230b';
+    const appUserGroup = 'AppUserGroup';
+
+    mockFetchResponses({
+        [`akeneo_connectivity_connection_apps_rest_get_wizard_data?clientId=${clientId}`]: {
+            json: {
+                appName: 'MyApp',
+                appLogo: '',
+                scopeMessages: [],
+            },
+        },
+        [`akeneo_connectivity_connection_apps_rest_confirm_authorization?clientId=${clientId}`]: {
+            json: {
+                userGroup: appUserGroup,
+            },
+        },
+    });
+
+    const providers = [
+        {
+            key: 'formProvider1',
+            label: 'formProviderLabel1',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+        {
+            key: 'formProvider2',
+            label: 'formProviderLabel2',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+    ];
+    const registry = {all: () => Promise.resolve(providers)};
+
+    renderWithProviders(
+        <NotifyContext.Provider value={notify}>
+            <PermissionFormRegistryContext.Provider value={registry}>
+                <AppWizardWithSteps clientId={clientId} />
+            </PermissionFormRegistryContext.Provider>
+        </NotifyContext.Provider>
+    );
+
+    await navigateToSummaryAndClickConfirm();
+
+    await wait(() => {
+        expect(notify).toHaveBeenCalledTimes(1);
+        expect(providerSave).toHaveBeenCalledTimes(2);
+    });
+
+    expect(notify).toBeCalledWith(
+        NotificationLevel.SUCCESS,
+        'akeneo_connectivity.connection.connect.apps.wizard.flash.success'
+    );
+
+    expect(providerSave).toHaveBeenNthCalledWith(1, appUserGroup, 'formProviderData1');
+    expect(providerSave).toHaveBeenNthCalledWith(2, appUserGroup, 'formProviderData2');
+});
+
+test('The wizard saves app but have some failing permissions on confirm', async () => {
+    const clientId = '8d8a7dc1-0827-4cc9-9ae5-577c6419230b';
+    const appUserGroup = 'AppUserGroup';
+
+    mockFetchResponses({
+        [`akeneo_connectivity_connection_apps_rest_get_wizard_data?clientId=${clientId}`]: {
+            json: {
+                appName: 'MyApp',
+                appLogo: '',
+                scopeMessages: [],
+            },
+        },
+        [`akeneo_connectivity_connection_apps_rest_confirm_authorization?clientId=${clientId}`]: {
+            json: {
+                userGroup: appUserGroup,
+            },
+        },
+    });
+
+    providerSave
+        .mockResolvedValue(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(undefined)
+        .mockImplementationOnce(() => {
+            throw new Error('testError');
+        });
+
+    const providers = [
+        {
+            key: 'formProvider1',
+            label: 'formProviderLabel1',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+        {
+            key: 'formProvider2',
+            label: 'formProviderLabel2',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+        {
+            key: 'formProvider3',
+            label: 'formProviderLabel3',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+        {
+            key: 'formProvider4',
+            label: 'formProviderLabel4',
+            renderForm: () => null,
+            renderSummary: () => null,
+            save: providerSave,
+        },
+    ];
+    const registry = {all: () => Promise.resolve(providers)};
+
+    renderWithProviders(
+        <NotifyContext.Provider value={notify}>
+            <PermissionFormRegistryContext.Provider value={registry}>
+                <AppWizardWithSteps clientId={clientId} />
+            </PermissionFormRegistryContext.Provider>
+        </NotifyContext.Provider>
+    );
+
+    await navigateToSummaryAndClickConfirm();
+
+    await wait(() => {
+        expect(notify).toHaveBeenCalledTimes(3);
+        expect(providerSave).toHaveBeenCalledTimes(4);
+    });
+
+    expect(notify).toHaveBeenNthCalledWith(
+        1,
+        NotificationLevel.ERROR,
+        'akeneo_connectivity.connection.connect.apps.flash.permissions_error.description',
+        {
+            titleMessage:
+                'akeneo_connectivity.connection.connect.apps.flash.permissions_error.title?entity=formProviderLabel3',
+        }
+    );
+    expect(notify).toHaveBeenNthCalledWith(
+        2,
+        NotificationLevel.ERROR,
+        'akeneo_connectivity.connection.connect.apps.flash.permissions_error.description',
+        {
+            titleMessage:
+                'akeneo_connectivity.connection.connect.apps.flash.permissions_error.title?entity=formProviderLabel4',
+        }
+    );
+    expect(notify).toHaveBeenNthCalledWith(
+        3,
+        NotificationLevel.SUCCESS,
+        'akeneo_connectivity.connection.connect.apps.wizard.flash.success'
+    );
+
+    expect(providerSave).toHaveBeenNthCalledWith(1, appUserGroup, 'formProviderData1');
+    expect(providerSave).toHaveBeenNthCalledWith(2, appUserGroup, 'formProviderData2');
+    expect(providerSave).toHaveBeenNthCalledWith(3, appUserGroup, 'formProviderData3');
+    expect(providerSave).toHaveBeenNthCalledWith(4, appUserGroup, 'formProviderData4');
+});
+
 const assertAuthorizationsScreen = () => {
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.action.allow_and_next')
@@ -179,4 +393,26 @@ const assertPermissionsSummaryScreen = () => {
     expect(screen.queryByText('authorizations-component')).not.toBeInTheDocument();
     expect(screen.queryByText('permissions-component', {exact: false})).not.toBeInTheDocument();
     expect(screen.queryByText('permissions-summary-component hello world!')).toBeInTheDocument();
+};
+
+const navigateToSummaryAndClickConfirm = async () => {
+    await waitForElement(() => screen.getByAltText('MyApp'));
+
+    act(() => {
+        userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.apps.wizard.action.allow_and_next'));
+    });
+
+    expect(screen.queryByText('permissions-component')).toBeInTheDocument();
+    act(() => {
+        userEvent.click(screen.getByTestId('set-permissions'));
+    });
+
+    act(() => {
+        userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.apps.wizard.action.next'));
+    });
+    assertPermissionsSummaryScreen();
+
+    act(() => {
+        userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.apps.wizard.action.confirm'));
+    });
 };

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizardWithSteps/Permissions.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizardWithSteps/Permissions.test.tsx
@@ -19,9 +19,10 @@ test('The permissions step renders with the providers from the registry', done =
     const providers = [
         {
             key: 'test',
+            label: 'testLabel',
             renderForm: (_onChange: any, initialState: any) => <div>test form {initialState.print}</div>,
             renderSummary: () => null,
-            save: () => true,
+            save: () => Promise.resolve(),
         },
     ];
 

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
@@ -15,7 +15,7 @@ export interface PermissionFormProvider<T> {
     label: string;
     renderForm: (onChange: (state: T) => void, initialState: T | undefined) => ReactNode;
     renderSummary: (state: T) => ReactNode;
-    save: (userGroup: string, state: T) => Promise<boolean>;
+    save: (userGroup: string, state: T) => Promise<void>;
 }
 
 let _config: ModuleConfig = {

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
@@ -12,9 +12,10 @@ type ModuleConfig = {
 
 export interface PermissionFormProvider<T> {
     key: string;
+    label: string;
     renderForm: (onChange: (state: T) => void, initialState: T | undefined) => ReactNode;
     renderSummary: (state: T) => ReactNode;
-    save: (role: string, state: T) => boolean;
+    save: (userGroup: string, state: T) => Promise<boolean>;
 }
 
 let _config: ModuleConfig = {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Added confirm handling for App Wizard with steps
Sends confirm App request then sequentially saves each form provider