### PR TITLE
- PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
 - PIM-10029: Added an explicit class named container to inject additional content into sub-navigation panel
 - PIM-10067: Date value in calendar not set when none is selected
 - PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized
+- PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)
 
 ## New features
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -156,8 +156,8 @@ akeneo_data_quality_insights:
         filter_value:
             good: Good
             to_improve: To improve
-            yes: Yes
-            no: No
+            "yes": "Yes"
+            "no": "No"
 
 pim_title:
     akeneo_data_quality_insights_dashboard: Data Quality Insights


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

YAML: Keys like "yes" or "no" evaluate to true and false by Crowdin.
In order to use the strings 'yes' and 'no' as keys, I needed to wrap them with quotes.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
