### PR TITLE
CXP-872: Add a default_permissions column to the user group table

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
@@ -14,6 +14,11 @@ Akeneo\UserManagement\Component\Model\Group:
             unique: true
             nullable: false
             lenght: 30
+        defaultPermissions:
+            column: default_permissions
+            type: json
+            unique: false
+            nullable: true
     manyToMany:
         roles:
             targetEntity: Akeneo\UserManagement\Component\Model\Role

--- a/src/Akeneo/UserManagement/Component/Model/Group.php
+++ b/src/Akeneo/UserManagement/Component/Model/Group.php
@@ -21,6 +21,8 @@ class Group implements GroupInterface
     /** @var ArrayCollection */
     protected $roles;
 
+    protected ?array $defaultPermissions = null;
+
     /**
      * @param string $name [optional] Group name
      */
@@ -156,6 +158,16 @@ class Group implements GroupInterface
                 '$roles must be an instance of Doctrine\Common\Collections\Collection or an array'
             );
         }
+    }
+
+    public function getDefaultPermissions(): ?array
+    {
+        return $this->defaultPermissions;
+    }
+
+    public function setDefaultPermissions(array $defaultPermissions): void
+    {
+        $this->defaultPermissions = $defaultPermissions;
     }
 
     /**

--- a/src/Akeneo/UserManagement/Component/Model/Group.php
+++ b/src/Akeneo/UserManagement/Component/Model/Group.php
@@ -160,11 +160,17 @@ class Group implements GroupInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getDefaultPermissions(): ?array
     {
         return $this->defaultPermissions;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function setDefaultPermissions(array $defaultPermissions): void
     {
         $this->defaultPermissions = $defaultPermissions;

--- a/src/Akeneo/UserManagement/Component/Model/GroupInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/GroupInterface.php
@@ -81,7 +81,13 @@ interface GroupInterface
      */
     public function setRoles($roles): void;
 
+    /**
+     * @return array<string, bool>
+     */
     public function getDefaultPermissions(): ?array;
 
+    /**
+     * @param array<string, bool> $defaultPermissions
+     */
     public function setDefaultPermissions(array $defaultPermissions): void;
 }

--- a/src/Akeneo/UserManagement/Component/Model/GroupInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/GroupInterface.php
@@ -80,4 +80,8 @@ interface GroupInterface
      * @throws \InvalidArgumentException
      */
     public function setRoles($roles): void;
+
+    public function getDefaultPermissions(): ?array;
+
+    public function setDefaultPermissions(array $defaultPermissions): void;
 }

--- a/tests/back/UserManagement/Integration/Bundle/Export/ExportUserGroupIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/Export/ExportUserGroupIntegration.php
@@ -46,10 +46,10 @@ final class ExportUserGroupIntegration extends TestCase
     {
         $expectedCsv = <<<CSV
 name
-All
 "IT support"
 Manager
 Redactor
+All
 
 CSV;
         $csv = $this->jobLauncher->launchExport(static::CSV_EXPORT_JOB_CODE, null, []);

--- a/upgrades/schema/Version_6_0_20210917103700_add_user_group_default_permissions.php
+++ b/upgrades/schema/Version_6_0_20210917103700_add_user_group_default_permissions.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_6_0_20210917103700_add_user_group_default_permissions extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE oro_access_group ADD default_permissions JSON NULL DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

For the Activate App feature, we want to be able to configure default permissions to an user group (since each app will have a dedicated user group).

Basically, we add a new JSON column, `{[key: string]: boolean}` where different features in EE are able to add dynamically setup default values for their permissions.
Example:
```
{"attribute_group_view": true, "asset_familly_view": true}
```

See the PR in EE for examples: https://github.com/akeneo/pim-enterprise-dev/pull/11815/files

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
