### PR TITLE
PIM-10062: compute default value for missing filter in sequential edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,6 @@
 - PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized
 - PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
-<<<<<<< HEAD
 - PIM-10074: Add translation key for mass action selection
 - PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected
 - PIM-10062: Suppress warning in datadog,  When missing 'dataScope' value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,9 +107,13 @@
 - PIM-10071: Fix fatal error in case of Cursor::getResults is called without been initialized
 - PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
+<<<<<<< HEAD
 - PIM-10074: Add translation key for mass action selection
 - PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected
 - PIM-10062: Suppress warning in datadog,  When missing 'dataScope' value.
+=======
+- PIM-10062: Suppress PHP warning when missing 'dataScope' value.
+>>>>>>> Update CHANGELOG.md
 
 ## New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,7 @@
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
 - PIM-10074: Add translation key for mass action selection
 - PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected
-- PIM-10062: Suppress warning in datadog,  When missing 'dataScope' value.
-=======
 - PIM-10062: Suppress PHP warning when missing 'dataScope' value.
->>>>>>> Update CHANGELOG.md
 
 ## New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
 - PIM-10074: Add translation key for mass action selection
 - PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected
+- PIM-10062: Suppress warning in datadog,  When missing 'dataScope' value.
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/SequentialEditController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/SequentialEditController.php
@@ -35,8 +35,6 @@ class SequentialEditController
     protected UserContext $userContext;
 
     /**
-     * @param MassActionParametersParser $parameterParser
-     * @param GridFilterAdapterInterface $filterAdapter
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
      */
     public function __construct(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/SequentialEditController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/SequentialEditController.php
@@ -32,18 +32,18 @@ class SequentialEditController
     protected $pqbFactory;
 
     /**
-     * @param MassActionParametersParser          $parameterParser
-     * @param GridFilterAdapterInterface          $filterAdapter
+     * @param MassActionParametersParser $parameterParser
+     * @param GridFilterAdapterInterface $filterAdapter
      * @param ProductQueryBuilderFactoryInterface $pqbFactory
      */
     public function __construct(
-        MassActionParametersParser $parameterParser,
-        GridFilterAdapterInterface $filterAdapter,
+        MassActionParametersParser          $parameterParser,
+        GridFilterAdapterInterface          $filterAdapter,
         ProductQueryBuilderFactoryInterface $pqbFactory
     ) {
-        $this->parameterParser      = $parameterParser;
-        $this->filterAdapter        = $filterAdapter;
-        $this->pqbFactory           = $pqbFactory;
+        $this->parameterParser = $parameterParser;
+        $this->filterAdapter = $filterAdapter;
+        $this->pqbFactory = $pqbFactory;
     }
 
     /**
@@ -62,8 +62,10 @@ class SequentialEditController
 
         $cursor = $this->getProductsCursor($filters, [
             'locale' => $parameters['dataLocale'],
-            'scope'  => $parameters['dataScope']['value'],
-            'sort'   => $parameters['sort']
+            'scope' => isset($parameters['dataScope'])
+                ? $parameters['dataScope']['value']
+                : null,
+            'sort' => $parameters['sort']
         ]);
 
         while ($cursor->valid() && $cursor->key() < self::MAX_PRODUCT_COUNT) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -237,6 +237,7 @@ services:
             - '@oro_datagrid.mass_action.parameters_parser'
             - '@pim_datagrid.adapter.oro_to_pim_grid_filter'
             - '@pim_enrich.query.product_and_product_model_query_sequential_edit_builder_factory'
+            - '@pim_user.context.user'
 
     pim_enrich.controller.rest.value:
         public: true

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/internal_api/sequential_edit.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/internal_api/sequential_edit.yml
@@ -1,4 +1,4 @@
 pim_enrich_sequential_edit_rest_get_ids:
     path: '/'
     defaults: { _controller: pim_enrich.controller.rest.sequential_edit:getIdsAction }
-    methods: [GET]
+    methods: [POST]

--- a/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/MassAction/MassActionParametersParser.php
@@ -31,9 +31,9 @@ class MassActionParametersParser
 
         $actionName = $request->get('actionName');
         $gridName = $request->get('gridName');
-        $dataLocale = $request->query->get('dataLocale');
+        $dataLocale = $request->get('dataLocale');
         $dataScope = isset($filters['scope']) ? $filters['scope'] : null;
-        $gridParams = $request->query->get($request->get('gridName'));
+        $gridParams = $request->get($gridName);
         $sort = isset($gridParams['_sort_by']) ? $gridParams['_sort_by'] : null;
 
         return [

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
@@ -46,7 +46,6 @@ define([
               __('pim_enrich.entity.product.module.sequential_edit.item_limit', {count: response.total})
             );
           }
-          dev.mk;
 
           if (0 === response.total) {
             messenger.notify('error', __('pim_enrich.entity.product.module.sequential_edit.empty'));

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
@@ -34,7 +34,7 @@ define([
 
       return $.ajax({
         url: Routing.generate('pim_enrich_sequential_edit_rest_get_ids'),
-        method: "POST",
+        method: 'POST',
         data: params,
       })
         .then(response => {
@@ -46,6 +46,7 @@ define([
               __('pim_enrich.entity.product.module.sequential_edit.item_limit', {count: response.total})
             );
           }
+          dev.mk;
 
           if (0 === response.total) {
             messenger.notify('error', __('pim_enrich.entity.product.module.sequential_edit.empty'));

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/sequential-edit-action.js
@@ -34,6 +34,7 @@ define([
 
       return $.ajax({
         url: Routing.generate('pim_enrich_sequential_edit_rest_get_ids'),
+        method: "POST",
         data: params,
       })
         .then(response => {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->
a proactive correction on a error log received in datadog. 
probably du to get url above 2048 char with query string param.

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
