### PR TITLE
RAC: Fix --remove-orphans typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ pim-prod:
 
 .PHONY: up
 up:
-	$(DOCKER_COMPOSE) up -d --remove-orphan ${C}
+	$(DOCKER_COMPOSE) up -d --remove-orphans ${C}
 
 .PHONY: down
 down:

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -108,7 +108,7 @@ endif
 
 .PHONY: up
 up:
-	docker-compose up -d --remove-orphan
+	docker-compose up -d --remove-orphans
 
 .PHONY: down
 down:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The correct spelling of the `--remove-orphans` flag is plural, see: https://docs.docker.com/compose/reference/down/
<img width="649" alt="image" src="https://user-images.githubusercontent.com/3492179/134302597-75ac45ba-a966-49c7-8ba1-a9da932dee9a.png">

On docker-compose v2, using it without the `s` will not work:

<img width="658" alt="image" src="https://user-images.githubusercontent.com/3492179/134302819-485f4f04-88f2-416c-820c-a31831c1aba1.png">


