### PR TITLE
Parametrize directory permissions in BatchLogHandler

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Monolog/Handler/BatchLogHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Monolog/Handler/BatchLogHandler.php
@@ -17,6 +17,9 @@ class BatchLogHandler extends StreamHandler
     /** @var string */
     protected $filename;
 
+    /** @var int */
+    protected $directoryPermissions;
+
     /** @var string */
     protected $logDir;
 
@@ -32,6 +35,7 @@ class BatchLogHandler extends StreamHandler
         $bubble = true,
         $filePermission = null,
         $useLocking = false,
+        $directoryPermissions = 0755,
         $logDir
     ) {
         $this->level = $level;
@@ -40,6 +44,7 @@ class BatchLogHandler extends StreamHandler
         $this->url = null;
         $this->filePermission = $filePermission;
         $this->useLocking = $useLocking;
+        $this->directoryPermissions = $directoryPermissions;
         $this->logDir = $logDir;
     }
 
@@ -90,7 +95,7 @@ class BatchLogHandler extends StreamHandler
         }
 
         if (!is_dir(dirname($this->url))) {
-            mkdir(dirname($this->url), 0755, true);
+            mkdir(dirname($this->url), $this->directoryPermissions, true);
         }
 
         parent::write($record);

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -56,6 +56,7 @@ services:
             - true
             - null
             - false
+            - 0755
             - '%kernel.logs_dir%/batch'
 
     akeneo_batch.set_job_execution_log_file_subscriber:


### PR DESCRIPTION
Hi,

Some of our dev servers make use of group file system permissions so multiple user accounts can work on a project.

When executing batch jobs in CLI, Akeneo creates the `var/batch/XYZ` folder with hardcoded `0755` permissions, and we are not able to run the batch deamon due to file permission errors.

This patch adds a simple parameter to `BatchLogHandler` to parametrize the hardcoded permissions, allowing us to override it with a compiler pass or a similar technique.

Thanks!

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
