### PR TITLE
BH-681: Fixes Twig deprecated classes

### DIFF
--- a/src/Akeneo/Channel/.php_cd.php
+++ b/src/Akeneo/Channel/.php_cd.php
@@ -16,7 +16,7 @@ $rules = [
         'Akeneo\Tool',
         'Akeneo\Channel',
         'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
-        'Twig_Environment',
+        'Twig\Environment',
 
         // TIP-939: Remove filter system for permissions
         'Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface',

--- a/src/Akeneo/Channel/.php_cd.php
+++ b/src/Akeneo/Channel/.php_cd.php
@@ -16,7 +16,7 @@ $rules = [
         'Akeneo\Tool',
         'Akeneo\Channel',
         'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
-        'Twig\Environment',
+        'Twig',
 
         // TIP-939: Remove filter system for permissions
         'Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface',

--- a/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
+++ b/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
@@ -4,7 +4,10 @@ namespace Akeneo\Channel\Bundle\Twig;
 
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Symfony\Component\Intl;
-use Twig_Environment;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to render locales from twig templates
@@ -13,7 +16,7 @@ use Twig_Environment;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class LocaleExtension extends \Twig_Extension
+class LocaleExtension extends AbstractExtension
 {
     /** @var UserContext */
     protected $userContext;
@@ -32,10 +35,10 @@ class LocaleExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('locale_code', [$this, 'currentLocaleCode']),
-            new \Twig_SimpleFunction('locale_label', [$this, 'localeLabel']),
-            new \Twig_SimpleFunction('currency_symbol', [$this, 'currencySymbol']),
-            new \Twig_SimpleFunction('currency_label', [$this, 'currencyLabel'])
+            new TwigFunction('locale_code', [$this, 'currentLocaleCode']),
+            new TwigFunction('locale_label', [$this, 'localeLabel']),
+            new TwigFunction('currency_symbol', [$this, 'currencySymbol']),
+            new TwigFunction('currency_label', [$this, 'currencyLabel'])
         ];
     }
 
@@ -45,7 +48,7 @@ class LocaleExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter(
+            new TwigFilter(
                 'flag',
                 [$this, 'flag'],
                 [
@@ -116,14 +119,14 @@ class LocaleExtension extends \Twig_Extension
     /**
      * Returns the flag icon for a locale with its country as long label or short code
      *
-     * @param Twig_Environment $environment
+     * @param Environment      $environment
      * @param string           $code
      * @param bool             $short
      * @param string           $translateIn
      *
      * @return string
      */
-    public function flag(Twig_Environment $environment, $code, $short = true, $translateIn = null)
+    public function flag(Environment $environment, $code, $short = true, $translateIn = null)
     {
         return $environment->render(
             '@PimUI/Locale/_flag.html.twig',

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -31,7 +31,7 @@ $rules = [
         'Oro\Bundle\PimDataGridBundle',
         // TODO: dependencies related to the front end, remove twig screens
         'Twig_SimpleFunction', // used by the category tree
-        'Twig_Extension', // used by Twig extensions
+        'Twig\Extension\AbstractExtension',
         'Twig\Environment', // used by Twig extensions
 
         // Event API

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -30,9 +30,7 @@ $rules = [
         'Oro\Bundle\DataGridBundle',
         'Oro\Bundle\PimDataGridBundle',
         // TODO: dependencies related to the front end, remove twig screens
-        'Twig_SimpleFunction', // used by the category tree
-        'Twig\Extension\AbstractExtension',
-        'Twig\Environment', // used by Twig extensions
+        'Twig',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Twig/AttributeExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Twig/AttributeExtension.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Twig;
 
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to manage attribute from twig templates
@@ -14,7 +13,7 @@ use Twig_SimpleFunction;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AttributeExtension extends Twig_Extension
+class AttributeExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -22,7 +21,7 @@ class AttributeExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('contains_han_characters', [$this, 'containsHanCharacters']),
+            new TwigFunction('contains_han_characters', [$this, 'containsHanCharacters']),
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Twig/CategoryExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Twig/CategoryExtension.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Counter\CategoryItemsCounterInterf
 use Akeneo\Pim\Enrichment\Bundle\Doctrine\ORM\Counter\CategoryItemsCounterRegistryInterface;
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Doctrine\Common\Collections\Collection;
-use Twig_SimpleFunction;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to render category from twig templates
@@ -15,7 +15,7 @@ use Twig_SimpleFunction;
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CategoryExtension extends \Twig_Extension
+class CategoryExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var CategoryItemsCounterRegistryInterface */
     protected $categoryItemsCounter;
@@ -35,12 +35,12 @@ class CategoryExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('children_response', [$this, 'childrenResponse']),
-            new Twig_SimpleFunction('children_tree_response', [$this, 'childrenTreeResponse']),
-            new Twig_SimpleFunction('list_categories_response', [$this, 'listCategoriesResponse']),
-            new Twig_SimpleFunction('list_trees_response', [$this, 'listTreesResponse']),
-            new Twig_SimpleFunction('exceeds_products_limit_for_removal', [$this, 'exceedsProductsLimitForRemoval']),
-            new Twig_SimpleFunction('get_products_limit_for_removal', [$this, 'getProductsLimitForRemoval']),
+            new TwigFunction('children_response', [$this, 'childrenResponse']),
+            new TwigFunction('children_tree_response', [$this, 'childrenTreeResponse']),
+            new TwigFunction('list_categories_response', [$this, 'listCategoriesResponse']),
+            new TwigFunction('list_trees_response', [$this, 'listTreesResponse']),
+            new TwigFunction('exceeds_products_limit_for_removal', [$this, 'exceedsProductsLimitForRemoval']),
+            new TwigFunction('get_products_limit_for_removal', [$this, 'getProductsLimitForRemoval']),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
@@ -4,6 +4,7 @@ namespace Akeneo\Platform\Bundle\AnalyticsBundle\Twig;
 
 use Akeneo\Platform\VersionProviderInterface;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to detect if update notification is enabled and to provide the url to fetch the last patch
@@ -12,7 +13,7 @@ use Oro\Bundle\ConfigBundle\Config\ConfigManager;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class UpdateExtension extends \Twig_Extension
+class UpdateExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var ConfigManager */
     protected $configManager;
@@ -32,8 +33,8 @@ class UpdateExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('is_last_patch_enabled', [$this, 'isLastPatchEnabled']),
-            new \Twig_SimpleFunction('get_update_server_url', [$this, 'getUpdateServerUrl']),
+            new TwigFunction('is_last_patch_enabled', [$this, 'isLastPatchEnabled']),
+            new TwigFunction('get_update_server_url', [$this, 'getUpdateServerUrl']),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
@@ -4,6 +4,7 @@ namespace Akeneo\Platform\Bundle\NotificationBundle\Twig;
 
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\Repository\UserNotificationRepositoryInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to provide the number of unread user notifications
@@ -12,7 +13,7 @@ use Akeneo\UserManagement\Bundle\Context\UserContext;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class NotificationExtension extends \Twig_Extension
+class NotificationExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var UserNotificationRepositoryInterface */
     protected $repository;
@@ -38,7 +39,7 @@ class NotificationExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('notification_count', [$this, 'countNotifications'])
+            new TwigFunction('notification_count', [$this, 'countNotifications'])
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
@@ -4,6 +4,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Platform\Bundle\UIBundle\Resolver\LocaleResolver;
 use Akeneo\Tool\Component\Localization\Presenter\PresenterInterface;
+use Twig\TwigFilter;
 
 /**
  * Twig extension to present localized data
@@ -12,7 +13,7 @@ use Akeneo\Tool\Component\Localization\Presenter\PresenterInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AttributeExtension extends \Twig_Extension
+class AttributeExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var PresenterInterface */
     protected $datePresenter;
@@ -44,8 +45,8 @@ class AttributeExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('datetime_presenter', [$this, 'datetimePresenter'], ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('date_presenter', [$this, 'datePresenter'], ['is_safe' => ['html']]),
+            new TwigFilter('datetime_presenter', [$this, 'datetimePresenter'], ['is_safe' => ['html']]),
+            new TwigFilter('date_presenter', [$this, 'datePresenter'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
+use Twig\TwigFunction;
 
 /**
  * CSP twig extension.
@@ -13,7 +14,7 @@ use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ContentSecurityPolicyExtension extends \Twig_Extension
+class ContentSecurityPolicyExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var ScriptNonceGenerator */
     private $scriptNonceGenerator;
@@ -29,7 +30,7 @@ class ContentSecurityPolicyExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('js_nonce', [$this, 'getScriptNonce']),
+            new TwigFunction('js_nonce', [$this, 'getScriptNonce']),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Platform\Bundle\UIBundle\Provider\ExternalJavascriptDependenciesProvider;
+use Twig\TwigFunction;
 
-final class ExternalJavascriptDependenciesExtension extends \Twig_Extension
+final class ExternalJavascriptDependenciesExtension extends \Twig\Extension\AbstractExtension
 {
     private ExternalJavascriptDependenciesProvider $dependenciesProvider;
 
@@ -21,7 +22,7 @@ final class ExternalJavascriptDependenciesExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('external_javascript_dependencies', [$this, 'getExternalJavascriptDependencies'], ['is_safe' => ['html']]),
+            new TwigFunction('external_javascript_dependencies', [$this, 'getExternalJavascriptDependencies'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/LocaleExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/LocaleExtension.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\TwigFilter;
+
 /**
  * Twig extension to present locales
  *
@@ -9,7 +11,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class LocaleExtension extends \Twig_Extension
+class LocaleExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -17,7 +19,7 @@ class LocaleExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('pretty_locale_name', [$this, 'prettyLocaleName'], ['is_safe' => ['html']]),
+            new TwigFilter('pretty_locale_name', [$this, 'prettyLocaleName'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/Node/PlaceholderNode.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/Node/PlaceholderNode.php
@@ -6,6 +6,7 @@ use \Twig_Node_Expression_Constant;
 use \Twig_Node_Expression_Function;
 use \Twig_Node_Include;
 use \Twig_Node_Print;
+use Twig\Node\Node;
 
 class PlaceholderNode extends \Twig_Node
 {
@@ -68,12 +69,12 @@ class PlaceholderNode extends \Twig_Node
                     // {{ render(controller('Bundle:Directory:controllerAction', { action: attributes })) }}
                     $controllerFunctionExpression = new Twig_Node_Expression_Function(
                         'controller',
-                        new \Twig_Node([$expression, $attributes]),
+                        new Node([$expression, $attributes]),
                         $this->lineno
                     );
                     $renderFunctionExpression = new Twig_Node_Expression_Function(
                         'render',
-                        new \Twig_Node(['uri' => $controllerFunctionExpression]),
+                        new Node(['uri' => $controllerFunctionExpression]),
                         $this->lineno
                     );
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Doctrine\Common\Util\ClassUtils;
+use Twig\TwigFilter;
 
 /**
  * Twig filter to get entity FQCN
@@ -11,7 +12,7 @@ use Doctrine\Common\Util\ClassUtils;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ObjectClassExtension extends \Twig_Extension
+class ObjectClassExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -19,7 +20,7 @@ class ObjectClassExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('class', array($this, 'getClass')),
+            new TwigFilter('class', array($this, 'getClass')),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/StyleExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/StyleExtension.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\TwigFilter;
+
 /**
  * Some presentation filters
  *
@@ -9,7 +11,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class StyleExtension extends \Twig_Extension
+class StyleExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -17,7 +19,7 @@ class StyleExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter('highlight', [$this, 'highlight'])
+            new TwigFilter('highlight', [$this, 'highlight'])
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
@@ -4,6 +4,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Tool\Component\Console\CommandLauncher;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\TwigFunction;
 
 /**
  * Translations twig extension.
@@ -15,7 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class TranslationsExtension extends \Twig_Extension
+class TranslationsExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var CommandLauncher */
     protected $commandLauncher;
@@ -41,7 +42,7 @@ class TranslationsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('get_translations_file', [$this, 'getTranslationsFile'])
+            new TwigFunction('get_translations_file', [$this, 'getTranslationsFile'])
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
@@ -4,7 +4,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Platform\Bundle\UIBundle\Twig\Parser\PlaceholderTokenParser;
 
-class UiExtension extends \Twig_Extension
+class UiExtension extends \Twig\Extension\AbstractExtension
 {
     protected $placeholders;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
 use Akeneo\Platform\VersionProviderInterface;
+use Twig\TwigFunction;
 
 /**
  * Extension to display version of the Akeneo
@@ -11,7 +12,7 @@ use Akeneo\Platform\VersionProviderInterface;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VersionExtension extends \Twig_Extension
+class VersionExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var VersionProviderInterface */
     private $versionProvider;
@@ -27,7 +28,7 @@ class VersionExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('version', [$this, 'version']),
+            new TwigFunction('version', [$this, 'version']),
         ];
     }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
@@ -5,6 +5,7 @@ namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementInterface;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementRegistry;
 use Twig\Environment;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to display view elements
@@ -13,7 +14,7 @@ use Twig\Environment;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ViewElementExtension extends \Twig_Extension
+class ViewElementExtension extends \Twig\Extension\AbstractExtension
 {
     protected ViewElementRegistry $registry;
     protected Environment $templating;
@@ -32,12 +33,12 @@ class ViewElementExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'view_elements',
                 [$this, 'renderViewElements'],
                 ['needs_context' => true, 'is_safe' => ['html']]
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'view_element_aliases',
                 [$this, 'getViewElementAliases'],
                 ['needs_context' => true, 'is_safe' => ['html']]

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
@@ -6,6 +6,7 @@ use Akeneo\Tool\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Email\SenderAddress;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Twig\Environment;
 
 /**
  * Notify Job execution result by mail
@@ -16,47 +17,17 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class MailNotifier implements Notifier
 {
-    /**
-     * @var BatchLogHandler
-     */
-    protected $logger;
+    protected BatchLogHandler $logger;
+    protected TokenStorageInterface $tokenStorage;
+    protected Environment $twig;
+    protected \Swift_Mailer $mailer;
+    protected string $mailerUrl;
+    protected ?string $recipientEmail = null;
 
-    /**
-     * @var TokenStorageInterface
-     */
-    protected $tokenStorage;
-
-    /**
-     * @var \Twig_Environment
-     */
-    protected $twig;
-
-    /**
-     * @var \Swift_Mailer
-     */
-    protected $mailer;
-
-    /**
-     * @var string
-     */
-    protected $mailerUrl;
-
-    /**
-     * @var string
-     */
-    protected $recipientEmail;
-
-    /**
-     * @param BatchLogHandler       $logger
-     * @param TokenStorageInterface $tokenStorage
-     * @param \Twig_Environment     $twig
-     * @param \Swift_Mailer         $mailer
-     * @param string                $mailerUrl
-     */
     public function __construct(
         BatchLogHandler $logger,
         TokenStorageInterface $tokenStorage,
-        \Twig_Environment $twig,
+        Environment $twig,
         \Swift_Mailer $mailer,
         string $mailerUrl
     ) {

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -56,6 +56,7 @@ $rules = [
         'FOS\OAuthServerBundle\Entity\ClientManager', // used by API client controller
         'OAuth2\OAuth2', // used by API client controller
         'Swift_Mailer',
+        'Twig\TwigFunction',
         'Oro\Bundle\DataGridBundle\Extension\Action\Actions\NavigateAction',
 
         // TIP-1007: Clean VisibilityChecker system

--- a/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
+++ b/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
@@ -3,6 +3,7 @@
 namespace Akeneo\UserManagement\Bundle\Twig;
 
 use Symfony\Component\Yaml\Yaml;
+use Twig\TwigFunction;
 
 /**
  * Twig extension to provide acl groups
@@ -11,7 +12,7 @@ use Symfony\Component\Yaml\Yaml;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AclGroupsExtension extends \Twig_Extension
+class AclGroupsExtension extends \Twig\Extension\AbstractExtension
 {
     /** @var array */
     protected $bundles;
@@ -30,8 +31,8 @@ class AclGroupsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('acl_groups', [$this, 'getAclGroups']),
-            new \Twig_SimpleFunction('acl_group_names', [$this, 'getAclGroupNames']),
+            new TwigFunction('acl_groups', [$this, 'getAclGroups']),
+            new TwigFunction('acl_group_names', [$this, 'getAclGroupNames']),
         ];
     }
 

--- a/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
+++ b/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
@@ -3,8 +3,9 @@
 namespace Oro\Bundle\ConfigBundle\Twig;
 
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Twig\TwigFunction;
 
-class ConfigExtension extends \Twig_Extension
+class ConfigExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @var ConfigManager
@@ -24,7 +25,7 @@ class ConfigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('oro_config_value', [$this, 'getUserValue']),
+            new TwigFunction('oro_config_value', [$this, 'getUserValue']),
         ];
     }
 

--- a/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
@@ -3,10 +3,9 @@
 namespace Oro\Bundle\DataGridBundle\Twig;
 
 use Oro\Bundle\DataGridBundle\Datagrid\MetadataParser;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\TwigFunction;
 
-class MetadataExtension extends Twig_Extension
+class MetadataExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @param ContainerInterface $container
@@ -22,8 +21,8 @@ class MetadataExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('oro_datagrid_data', [$this->metadataParser, 'getGridData']),
-            new Twig_SimpleFunction('oro_datagrid_metadata', [$this->metadataParser, 'getGridMetadata'])
+            new TwigFunction('oro_datagrid_data', [$this->metadataParser, 'getGridData']),
+            new TwigFunction('oro_datagrid_metadata', [$this->metadataParser, 'getGridMetadata'])
         ];
     }
 }

--- a/src/Oro/Bundle/FilterBundle/Twig/AbstractExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Twig/AbstractExtension.php
@@ -2,7 +2,7 @@
 
 namespace Oro\Bundle\FilterBundle\Twig;
 
-abstract class AbstractExtension extends \Twig_Extension
+abstract class AbstractExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * Extension name

--- a/src/Oro/Bundle/FilterBundle/Twig/RenderHeaderExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Twig/RenderHeaderExtension.php
@@ -2,6 +2,8 @@
 
 namespace Oro\Bundle\FilterBundle\Twig;
 
+use Twig\TwigFunction;
+
 class RenderHeaderExtension extends AbstractExtension
 {
     /**
@@ -25,12 +27,12 @@ class RenderHeaderExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'oro_filter_render_header_javascript',
                 [$this, 'renderHeaderJavascript'],
                 $this->defaultFunctionOptions
             ),
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'oro_filter_render_header_stylesheet',
                 [$this, 'renderHeaderStylesheet'],
                 $this->defaultFunctionOptions

--- a/src/Oro/Bundle/FilterBundle/Twig/RenderLayoutExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Twig/RenderLayoutExtension.php
@@ -4,6 +4,8 @@ namespace Oro\Bundle\FilterBundle\Twig;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 use Symfony\Component\Form\FormView;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
 class RenderLayoutExtension extends AbstractExtension
 {
@@ -23,7 +25,7 @@ class RenderLayoutExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'oro_filter_render_filter_javascript',
                 [$this, 'renderFilterJavascript'],
                 $this->defaultFunctionOptions
@@ -69,7 +71,7 @@ class RenderLayoutExtension extends AbstractExtension
     public function getFilters()
     {
         return [
-            new \Twig_SimpleFilter(
+            new TwigFilter(
                 'oro_filter_choices',
                 [$this, 'getChoices']
             )

--- a/src/Oro/Bundle/PimDataGridBundle/Twig/FilterExtension.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Twig/FilterExtension.php
@@ -5,8 +5,8 @@ namespace Oro\Bundle\PimDataGridBundle\Twig;
 use Oro\Bundle\DataGridBundle\Datagrid\Manager;
 use Oro\Bundle\PimDataGridBundle\Datagrid\Configuration\ConfiguratorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
-use Twig_Extension;
-use Twig_SimpleFunction;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Add some functions about datagrid filters
@@ -15,19 +15,17 @@ use Twig_SimpleFunction;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class FilterExtension extends Twig_Extension
+class FilterExtension extends AbstractExtension
 {
-    /** @var Manager */
-    private $datagridManager;
+    private Manager $datagridManager;
+    private ConfiguratorInterface $filtersConfigurator;
+    private TranslatorInterface $translator;
 
-    /** @var ConfiguratorInterface */
-    private $filtersConfigurator;
-
-    /** @var TranslatorInterface */
-    private $translator;
-
-    public function __construct(Manager $datagridManager, ConfiguratorInterface $filtersConfigurator, TranslatorInterface $translator)
-    {
+    public function __construct(
+        Manager               $datagridManager,
+        ConfiguratorInterface $filtersConfigurator,
+        TranslatorInterface   $translator
+    ) {
         $this->datagridManager = $datagridManager;
         $this->filtersConfigurator = $filtersConfigurator;
         $this->translator = $translator;
@@ -39,7 +37,7 @@ class FilterExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('filter_label', [$this, 'filterLabel']),
+            new TwigFunction('filter_label', [$this, 'filterLabel']),
         ];
     }
 
@@ -59,8 +57,6 @@ class FilterExtension extends Twig_Extension
             return null;
         }
 
-        $label = $this->translator->trans($label);
-
-        return $label;
+        return $this->translator->trans($label);
     }
 }

--- a/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
+++ b/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
@@ -3,8 +3,9 @@
 namespace Oro\Bundle\SecurityBundle\Twig;
 
 use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Twig\TwigFunction;
 
-class OroSecurityExtension extends \Twig_Extension
+class OroSecurityExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @var SecurityFacade
@@ -27,7 +28,7 @@ class OroSecurityExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('resource_granted', [$this, 'checkResourceIsGranted']),
+            new TwigFunction('resource_granted', [$this, 'checkResourceIsGranted']),
         ];
     }
 

--- a/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
+++ b/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
@@ -5,6 +5,7 @@ namespace Specification\Akeneo\Channel\Bundle\Twig;
 use Akeneo\Channel\Component\Model\LocaleInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use PhpSpec\ObjectBehavior;
+use Twig\Node\Node;
 
 class LocaleExtensionSpec extends ObjectBehavior
 {
@@ -65,7 +66,7 @@ class LocaleExtensionSpec extends ObjectBehavior
 
     function getMatchers(): array
     {
-        $filterArgs = new \Twig_Node();
+        $filterArgs = new Node();
 
         return [
             'haveTwigMethod' => function ($subject, $name, $method) {

--- a/tests/back/Platform/Specification/Bundle/UIBundle/Twig/ViewElementExtensionSpec.php
+++ b/tests/back/Platform/Specification/Bundle/UIBundle/Twig/ViewElementExtensionSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementRegistry;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Twig\Environment;
+use Twig\Node\Node;
 
 class ViewElementExtensionSpec extends ObjectBehavior
 {
@@ -191,7 +192,7 @@ class ViewElementExtensionSpec extends ObjectBehavior
                         return $function instanceof \Twig_SimpleFunction &&
                             $function->getName() === $name &&
                             $function->needsContext() === $needsContext &&
-                            $function->getSafe(new \Twig_Node()) === $safe;
+                            $function->getSafe(new Node()) === $safe;
                     }
                 );
 


### PR DESCRIPTION
Twig_* classes will be deprecated in Twig v3 that we will use with Symfony 5.