### PR TITLE
PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - PIM-10077: Fix the "product image" filter display (untranslatable values on languages other than english)
 - PIM-10078: Add sanity check on attribute options to avoid having an empty screen.
 - PIM-10074: Add translation key for mass action selection
+- PIM-10085: Fix product grid filters with multiple selectable values going out of screen when too many values are selected
 
 ## New features
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/text-filter.js
@@ -200,6 +200,9 @@ define([
         })
       );
       this._renderCriteria(this.$(this.criteriaSelector));
+      this.$el.on('change', () => {
+        this._updateCriteriaSelectorPosition();
+      });
 
       return this;
     },


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
This PR fixes a bug in the product grid for all filters that can be partially hidden due to the content (cf screenshot) and theirs position at the bottom at the filters list. This is the case for simple select, multi select, reference entities and assets attributes. To fix that, I called an already existing method to recalculate the position of the filter popin every time an item is added (or deleted) to the selected items.

The same method is already used when we scroll in the product grid's filters list, to recalculate the popin position.

![Screenshot from 2021-09-23 17-06-00](https://user-images.githubusercontent.com/1978756/134533141-adbbaacb-ddd4-4a2d-9513-ffb15bd6da10.png)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
