### PR TITLE
PIM-464: the catalog parameter is required for enterprise edition when the post_load_fixture

### DIFF
--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -292,6 +292,7 @@ class FixturesLoader implements FixturesLoaderInterface
             $this->eventDispatcher->dispatch(
                 new InstallerEvent(null, $jobInstance->getCode(), [
                     'job_name' => $jobInstance->getJobName(),
+                    'catalog' => 'minimal',
                 ]),
                 InstallerEvents::POST_LOAD_FIXTURE
             );


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

The catalog parameter is required for trial edition when installer events are triggered. We define the catalog name during the installation of the required jobs during the initialization of integration tests
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
