### PR TITLE
Run cypress in prod mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,11 +301,11 @@ jobs:
           name: Start containers
           command: |
             docker load -i php-pim-image.tar
-            APP_ENV=dev C='fpm mysql elasticsearch httpd object-storage pubsub-emulator' make up
+            APP_ENV=prod C='fpm mysql elasticsearch httpd object-storage pubsub-emulator' make up
             docker/wait_docker_up.sh
       - run:
           name: Install database
-          command: APP_ENV=dev O="--catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev" make database
+          command: APP_ENV=prod O="--catalog src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev" make database
       - run:
           name: Launch Cypress
           command: CYPRESS_defaultCommandTimeout=10000 CYPRESS_requestTimeout=15000 CYPRESS_responseTimeout=50000 make end-to-end-front


### PR DESCRIPTION
Running Cypress over a PIM in dev has two drawbacks:
- the app is slower
- we can have issues with selector because of the debug bar when targeting buttons for example