### PR TITLE
RAC-897: Fix cleanup-staging.js is not present in gh-pages the github action cannot be executed successfully

### DIFF
--- a/front-packages/akeneo-design-system/.github/workflows/deploy.yml
+++ b/front-packages/akeneo-design-system/.github/workflows/deploy.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Build storybook
         run: yarn run storybook:build
 
+      - name: Add cleanup stagging script
+        run: |
+          mkdir -p ./storybook-static/.github/workflows && \
+          cp ./.github/workflows/cleanup-staging.js ./storybook-static/.github/workflows/cleanup-staging.js
+
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/front-packages/akeneo-design-system/.github/workflows/deploy.yml
+++ b/front-packages/akeneo-design-system/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build storybook
         run: yarn run storybook:build
 
-      - name: Add cleanup stagging script
+      - name: Add cleanup staging script
         run: |
           mkdir -p ./storybook-static/.github/workflows && \
           cp ./.github/workflows/cleanup-staging.js ./storybook-static/.github/workflows/cleanup-staging.js


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually the gh-pages are not cleaned after merge: https://github.com/akeneo/akeneo-design-system/tree/gh-pages

In this PR : 
Fix the github action called "Cleanup unused staging envs" (https://github.com/akeneo/akeneo-design-system/runs/3642544224?check_suite_focus=true) the cleanup-staging.js script is not present in the branche gh-pages branch

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
