### PR TITLE
CXP-749: Display app authorization (tab Settings)

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Repository/ConnectedAppRepositoryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Repository/ConnectedAppRepositoryInterface.php
@@ -14,6 +14,7 @@ interface ConnectedAppRepositoryInterface
 {
     public function create(ConnectedApp $app): void;
     public function findOneById(string $appId): ?ConnectedApp;
+    public function findOneByConnectionCode(string $connectionCode): ?ConnectedApp;
     /**
      * @return ConnectedApp[]
      */

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/ConfirmAuthorizationAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/ConfirmAuthorizationAction.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetAllConnectedAppScopeMessagesAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetAllConnectedAppScopeMessagesAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Repository\ConnectedAppRepositoryInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Akeneo\Tool\Bundle\ApiBundle\Security\ScopeMapper;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class GetAllConnectedAppScopeMessagesAction
+{
+    private FeatureFlag $featureFlag;
+    private SecurityFacade $security;
+    private ConnectedAppRepositoryInterface $connectedAppRepository;
+    private ScopeMapper $scopeMapper;
+
+    public function __construct(
+        FeatureFlag $featureFlag,
+        SecurityFacade $security,
+        ConnectedAppRepositoryInterface $connectedAppRepository,
+        ScopeMapper $scopeMapper
+    ) {
+        $this->featureFlag = $featureFlag;
+        $this->security = $security;
+        $this->connectedAppRepository = $connectedAppRepository;
+        $this->scopeMapper = $scopeMapper;
+    }
+
+    public function __invoke(Request $request, string $connectionCode): Response
+    {
+        if (!$this->featureFlag->isEnabled()) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        if (!$this->security->isGranted('akeneo_connectivity_connection_manage_apps')) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $connectedApp = $this->connectedAppRepository->findOneByConnectionCode($connectionCode);
+
+        if (null === $connectedApp) {
+            throw new NotFoundHttpException("Connected app with connection code $connectionCode does not exist.");
+        }
+
+        $scopeMessages = $this->scopeMapper->getMessages($connectedApp->getScopes());
+
+        return new JsonResponse($scopeMessages);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppAction.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Repository\ConnectedAppRepositoryInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class GetConnectedAppAction
+{
+    private FeatureFlag $featureFlag;
+    private SecurityFacade $security;
+    private ConnectedAppRepositoryInterface $connectedAppRepository;
+
+    public function __construct(
+        FeatureFlag $featureFlag,
+        SecurityFacade $security,
+        ConnectedAppRepositoryInterface $connectedAppRepository
+    ) {
+        $this->featureFlag = $featureFlag;
+        $this->security = $security;
+        $this->connectedAppRepository = $connectedAppRepository;
+    }
+
+    public function __invoke(Request $request, string $connectionCode): Response
+    {
+        if (!$this->featureFlag->isEnabled()) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        if (!$this->security->isGranted('akeneo_connectivity_connection_manage_apps')) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $connectedApp = $this->connectedAppRepository->findOneByConnectionCode($connectionCode);
+
+        if (null === $connectedApp) {
+            throw new NotFoundHttpException("Connected app with connection code $connectionCode does not exist.");
+        }
+
+        return new JsonResponse($connectedApp->normalize());
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
@@ -95,17 +95,17 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
     }
 
     /**
-     * @param array<array{
-     *  id: string,
-     *  name: string,
-     *  scopes: string[],
-     *  connection_code: string,
-     *  logo: string,
-     *  author: string,
-     *  categories: string[],
-     *  certified: bool,
-     *  partner: ?string,
-     * }> $dataRow
+     * @param array{
+     *    id: string,
+     *    name: string,
+     *    scopes: string,
+     *    connection_code: string,
+     *    logo: string,
+     *    author: string,
+     *    categories: string,
+     *    certified: bool,
+     *    partner: ?string,
+     * } $dataRow
      */
     private function denormalizeRow(array $dataRow): ConnectedApp
     {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
@@ -32,20 +32,10 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
 
         $dataRows = $this->dbalConnection->executeQuery($selectSQL)->fetchAll();
 
-        $connectedApps = [];
-        foreach ($dataRows as $dataRow) {
-            $connectedApps[] = new ConnectedApp(
-                $dataRow['id'],
-                $dataRow['name'],
-                \json_decode($dataRow['scopes'], true),
-                $dataRow['connection_code'],
-                $dataRow['logo'],
-                $dataRow['author'],
-                \json_decode($dataRow['categories'], true),
-                (bool) $dataRow['certified'],
-                $dataRow['partner']
-            );
-        }
+        $connectedApps = array_map(
+            fn ($dataRow) => $this->denormalizeRow($dataRow),
+            $dataRows
+        );
 
         return $connectedApps;
     }
@@ -88,17 +78,47 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
 
         $dataRow = $this->dbalConnection->executeQuery($selectQuery, ['id' => $appId])->fetch();
 
-        return $dataRow ?
-            new ConnectedApp(
-                $dataRow['id'],
-                $dataRow['name'],
-                \json_decode($dataRow['scopes'], true),
-                $dataRow['connection_code'],
-                $dataRow['logo'],
-                $dataRow['author'],
-                \json_decode($dataRow['categories'], true),
-                (bool) $dataRow['certified'],
-                $dataRow['partner']
-            ) : null;
+        return $dataRow ? $this->denormalizeRow($dataRow) : null;
+    }
+
+    public function findOneByConnectionCode(string $connectionCode): ?ConnectedApp
+    {
+        $selectQuery = <<<SQL
+        SELECT id, name, logo, author, partner,categories, scopes, certified, connection_code
+        FROM akeneo_connectivity_connected_app
+        WHERE connection_code = :connectionCode
+        SQL;
+
+        $dataRow = $this->dbalConnection->executeQuery($selectQuery, ['connectionCode' => $connectionCode])->fetch();
+
+        return $dataRow ? $this->denormalizeRow($dataRow) : null;
+    }
+
+    /**
+     * @param array<array{
+     *  id: string,
+     *  name: string,
+     *  scopes: string[],
+     *  connection_code: string,
+     *  logo: string,
+     *  author: string,
+     *  categories: string[],
+     *  certified: bool,
+     *  partner: ?string,
+     * }> $dataRow
+     */
+    private function denormalizeRow(array $dataRow): ConnectedApp
+    {
+        return new ConnectedApp(
+            $dataRow['id'],
+            $dataRow['name'],
+            \json_decode($dataRow['scopes'], true),
+            $dataRow['connection_code'],
+            $dataRow['logo'],
+            $dataRow['author'],
+            \json_decode($dataRow['categories'], true),
+            (bool) $dataRow['certified'],
+            $dataRow['partner']
+        );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -114,3 +114,20 @@ services:
             - '@akeneo_connectivity.connection.marketplace_activate.feature'
             - '@oro_security.security_facade'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository'
+
+    akeneo_connectivity.connection.internal_api.controller.apps.get_connected_app:
+        public: true
+        class: 'Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetConnectedAppAction'
+        arguments:
+            - '@akeneo_connectivity.connection.marketplace_activate.feature'
+            - '@oro_security.security_facade'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository'
+
+    akeneo_connectivity.connection.internal_api.controller.apps.connected_app.get_all_scope_messages:
+        public: true
+        class: 'Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetAllConnectedAppScopeMessagesAction'
+        arguments:
+            - '@akeneo_connectivity.connection.marketplace_activate.feature'
+            - '@oro_security.security_facade'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository'
+            - '@pim_api.security.scope_mapper'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
@@ -40,7 +40,7 @@ config:
                 akeneo_connectivity_connection_connect_connected_apps:
                     module: pim/controller/connectivity/connection/connect/connected-apps
                     aclResourceId: akeneo_connectivity_connection_manage_apps
-                akeneo_connectivity_connection_connect_connected_apps_any:
+                akeneo_connectivity_connection_connect_connected_apps_edit:
                     module: pim/controller/connectivity/connection/connect/connected-apps
                     aclResourceId: akeneo_connectivity_connection_manage_apps
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
@@ -40,6 +40,9 @@ config:
                 akeneo_connectivity_connection_connect_connected_apps:
                     module: pim/controller/connectivity/connection/connect/connected-apps
                     aclResourceId: akeneo_connectivity_connection_manage_apps
+                akeneo_connectivity_connection_connect_connected_apps_any:
+                    module: pim/controller/connectivity/connection/connect/connected-apps
+                    aclResourceId: akeneo_connectivity_connection_manage_apps
 
     paths:
         pim/controller/connectivity/connection/connect/apps: akeneoconnectivityconnection/js/controller/apps.tsx

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -116,7 +116,7 @@ akeneo_connectivity_connection_settings_any:
 akeneo_connectivity_connection_connect_connected_apps:
     path: '/connect/connected-apps'
 
-akeneo_connectivity_connection_connect_connected_apps_any:
-    path: '/connect/connected-apps/{any}'
+akeneo_connectivity_connection_connect_connected_apps_edit:
+    path: '/connect/connected-apps/{connectionCode}'
     requirements:
-        any: .*
+        connectionCode: '[a-zA-Z0-9_-]+'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -115,3 +115,8 @@ akeneo_connectivity_connection_settings_any:
 ## Connected Apps
 akeneo_connectivity_connection_connect_connected_apps:
     path: '/connect/connected-apps'
+
+akeneo_connectivity_connection_connect_connected_apps_any:
+    path: '/connect/connected-apps/{any}'
+    requirements:
+        any: .*

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
@@ -13,9 +13,9 @@ akeneo_connectivity_connection_apps_rest_confirm_authorization:
     controller: akeneo_connectivity.connection.apps.controller.apps.confirm_authorization
     methods: [POST]
 
-akeneo_connectivity_connection_apps_rest_get_all_connected_apps:
-    path: '/connected-apps'
-    controller: akeneo_connectivity.connection.internal_api.controller.apps.get_all_connected_apps
+akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages:
+    path: '/connected-apps/{connectionCode}/scope-messages'
+    controller: akeneo_connectivity.connection.internal_api.controller.apps.connected_app.get_all_scope_messages
     methods: [GET]
 
 akeneo_connectivity_connection_apps_rest_get_connected_app:
@@ -23,7 +23,7 @@ akeneo_connectivity_connection_apps_rest_get_connected_app:
     controller: akeneo_connectivity.connection.internal_api.controller.apps.get_connected_app
     methods: [GET]
 
-akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages:
-    path: '/connected-apps/{connectionCode}/scope-messages'
-    controller: akeneo_connectivity.connection.internal_api.controller.apps.connected_app.get_all_scope_messages
+akeneo_connectivity_connection_apps_rest_get_all_connected_apps:
+    path: '/connected-apps'
+    controller: akeneo_connectivity.connection.internal_api.controller.apps.get_all_connected_apps
     methods: [GET]

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
@@ -17,3 +17,13 @@ akeneo_connectivity_connection_apps_rest_get_all_connected_apps:
     path: '/connected-apps'
     controller: akeneo_connectivity.connection.internal_api.controller.apps.get_all_connected_apps
     methods: [GET]
+
+akeneo_connectivity_connection_apps_rest_get_connected_app:
+    path: '/connected-apps/{connectionCode}'
+    controller: akeneo_connectivity.connection.internal_api.controller.apps.get_connected_app
+    methods: [GET]
+
+akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages:
+    path: '/connected-apps/{connectionCode}/scope-messages'
+    controller: akeneo_connectivity.connection.internal_api.controller.apps.connected_app.get_all_scope_messages
+    methods: [GET]

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -37,7 +37,7 @@ pim_title:
     akeneo_connectivity_connection_webhook_event_logs: Event logs
     akeneo_connectivity_connection_settings_redirect: Connections
     akeneo_connectivity_connection_connect_connected_apps: Apps
-    akeneo_connectivity_connection_connect_connected_apps_any: App settings
+    akeneo_connectivity_connection_connect_connected_apps_edit: App settings
 
 akeneo_connectivity.connection:
     connect:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -37,6 +37,7 @@ pim_title:
     akeneo_connectivity_connection_webhook_event_logs: Event logs
     akeneo_connectivity_connection_settings_redirect: Connections
     akeneo_connectivity_connection_connect_connected_apps: Apps
+    akeneo_connectivity_connection_connect_connected_apps_any: App settings
 
 akeneo_connectivity.connection:
     connect:
@@ -82,6 +83,16 @@ akeneo_connectivity.connection:
                     manage_app: Manage app
                 flash:
                     error: Sorry, an error occured while fetching the connected apps list.
+            edit:
+                not_found: App not found
+                tabs:
+                    settings: Settings
+                settings:
+                    authorizations:
+                        title: authorizations
+                        information: 'To know more about app authorizations, check out our {{ link }}.'
+                        information_link_anchor: Help Center article
+                        no_scope: No specific authorizations have been requested.
         apps:
             wizard:
                 title: Connect

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppScopeMessagesActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppScopeMessagesActionEndToEnd.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Apps\InternalApi;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class GetAllConnectedAppScopeMessagesActionEndToEnd extends WebTestCase
+{
+    private FakeFeatureFlag $featureFlagMarketplaceActivate;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->featureFlagMarketplaceActivate = $this->get('akeneo_connectivity.connection.marketplace_activate.feature');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_throws_not_found_exception_with_feature_flag_disabled(): void
+    {
+        $this->featureFlagMarketplaceActivate->disable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/scope-messages'
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_redirects_on_missing_xmlhttprequest_header(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/scope-messages'
+        );
+
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        assert($response instanceof RedirectResponse);
+        Assert::assertEquals('/', $response->getTargetUrl());
+    }
+
+    public function test_it_throws_access_denied_exception_with_missing_acl(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->removeAclFromRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/scope-messages',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function test_it_throws_not_found_exception_with_wrong_connection_code(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/scope-messages',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_gets_all_connected_app_scope_messages(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->getConnectionLoader()->createConnection('connectionCodeA', 'Connector A', FlowType::DATA_DESTINATION, false);
+        $this->getConnectedAppLoader()->createConnectedApp(
+            '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+            'App A',
+            ['write_association_types'],
+            'connectionCodeA',
+            'http://www.example.com/path/to/logo/a',
+            'author A',
+            ['category A1', 'category A2'],
+            false,
+            'partner A'
+        );
+
+        $expectedResult = [
+            [
+                'icon' => 'association_types',
+                'type' => 'edit',
+                'entities' => 'association_types',
+            ]
+        ];
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/scope-messages',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+        $result = \json_decode($response->getContent(), true);
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        Assert::assertEquals($expectedResult, $result);
+    }
+
+    private function getConnectionLoader(): ConnectionLoader
+    {
+        return $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+    }
+
+    private function getConnectedAppLoader(): ConnectedAppLoader
+    {
+        return $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-class GetAllConnectedAppsEndToEnd extends WebTestCase
+class GetAllConnectedAppsActionEndToEnd extends WebTestCase
 {
     private FakeFeatureFlag $featureFlagMarketplaceActivate;
 
@@ -101,7 +101,6 @@ class GetAllConnectedAppsEndToEnd extends WebTestCase
             'author B',
             ['category B1'],
             true,
-            null,
             null
         );
 
@@ -115,8 +114,7 @@ class GetAllConnectedAppsEndToEnd extends WebTestCase
             'author A',
             ['category A1', 'category A2'],
             false,
-            'partner A',
-            'http://www.example.com/path/to/app/a'
+            'partner A'
         );
 
         $expectedResult = [

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\back\tests\EndToEnd\Apps\InternalApi;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class GetConnectedAppActionEndToEnd extends WebTestCase
+{
+    private FakeFeatureFlag $featureFlagMarketplaceActivate;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->featureFlagMarketplaceActivate = $this->get('akeneo_connectivity.connection.marketplace_activate.feature');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_throws_not_found_exception_with_feature_flag_disabled(): void
+    {
+        $this->featureFlagMarketplaceActivate->disable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA'
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_redirects_on_missing_xmlhttprequest_header(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA'
+        );
+
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        assert($response instanceof RedirectResponse);
+        Assert::assertEquals('/', $response->getTargetUrl());
+    }
+
+    public function test_it_throws_access_denied_exception_with_missing_acl(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->removeAclFromRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function test_it_throws_not_found_exception_with_wrong_connection_code(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_gets_connected_app(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->getConnectionLoader()->createConnection('connectionCodeB', 'Connector B', FlowType::DATA_DESTINATION, false);
+        $this->getConnectedAppLoader()->createConnectedApp(
+            '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+            'App B',
+            ['scope B1', 'scope B2'],
+            'connectionCodeB',
+            'http://www.example.com/path/to/logo/b',
+            'author B',
+            ['category B1'],
+            true,
+            null
+        );
+
+        $this->getConnectionLoader()->createConnection('connectionCodeA', 'Connector A', FlowType::DATA_DESTINATION, false);
+        $this->getConnectedAppLoader()->createConnectedApp(
+            '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+            'App A',
+            ['scope A1'],
+            'connectionCodeA',
+            'http://www.example.com/path/to/logo/a',
+            'author A',
+            ['category A1', 'category A2'],
+            false,
+            'partner A'
+        );
+
+        $expectedResult = [
+            'id' => '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+            'name' => 'App A',
+            'scopes' => ['scope A1'],
+            'connection_code' => 'connectionCodeA',
+            'logo' => 'http://www.example.com/path/to/logo/a',
+            'author' => 'author A',
+            'categories' => ['category A1', 'category A2'],
+            'certified' => false,
+            'partner' => 'partner A',
+        ];
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+        $result = \json_decode($response->getContent(), true);
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        Assert::assertEquals($expectedResult, $result);
+    }
+
+    private function getConnectionLoader(): ConnectionLoader
+    {
+        return $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+    }
+
+    private function getConnectedAppLoader(): ConnectedAppLoader
+    {
+        return $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/DbalConnectedAppRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/DbalConnectedAppRepositoryIntegration.php
@@ -105,7 +105,7 @@ class DbalConnectedAppRepositoryIntegration extends TestCase
 
         $retrievedApp = $this->repository->findOneByConnectionCode('bynder');
 
-            Assert::assertEquals(serialize($createdApp), serialize($retrievedApp));
+        Assert::assertEquals(serialize($createdApp), serialize($retrievedApp));
     }
 
     public function test_it_finds_all_ordered_by_name()

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/DbalConnectedAppRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/DbalConnectedAppRepositoryIntegration.php
@@ -86,6 +86,28 @@ class DbalConnectedAppRepositoryIntegration extends TestCase
         Assert::assertEquals(serialize($createdApp), serialize($retrievedApp));
     }
 
+    public function test_it_can_retrieve_an_app_by_connection_code(): void
+    {
+        $this->connectionLoader->createConnection('bynder', 'Bynder', FlowType::OTHER, false);
+
+        $createdApp = new ConnectedApp(
+            '86d603e6-ec67-45fa-bd79-aa8b2f649e12',
+            'my app',
+            ['foo', 'bar'],
+            'bynder',
+            'app logo',
+            'app author',
+            ['e-commerce'],
+            false,
+            'akeneo'
+        );
+        $this->repository->create($createdApp);
+
+        $retrievedApp = $this->repository->findOneByConnectionCode('bynder');
+
+            Assert::assertEquals(serialize($createdApp), serialize($retrievedApp));
+    }
+
     public function test_it_finds_all_ordered_by_name()
     {
         $this->connectionLoader->createConnection('connectionCodeB', 'Connector B', FlowType::DATA_DESTINATION, false);

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/ScopeListContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/ScopeListContainer.tsx
@@ -52,10 +52,7 @@ export const ScopeListContainer: FC<Props> = ({appName, scopeMessages}) => {
             </Helper>
             {0 === scopeMessages.length ? (
                 <ScopeItem key='0'>
-                    <CheckRoundIcon
-                        size={24}
-                        title={translate('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')}
-                    />
+                    <CheckRoundIcon size={24} />
                     {translate('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')}
                 </ScopeItem>
             ) : (

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/ScopeListContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/ScopeListContainer.tsx
@@ -2,7 +2,7 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {getColor, getFontSize, Link, CheckRoundIcon} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
-import {ScopeItem, ScopeList} from '../ScopeList';
+import {ScopeList} from '../ScopeList';
 import ScopeMessage from '../../../model/Apps/scope-message';
 
 const AppTitle = styled.h2`
@@ -20,6 +20,21 @@ const Helper = styled.div`
     line-height: 18px;
     margin: 17px 0 19px 0;
     width: 280px;
+`;
+
+const NoScope = styled.div`
+    color: ${getColor('grey', 140)};
+    font-size: ${getFontSize('bigger')};
+    font-weight: normal;
+    line-height: 21px;
+    margin-bottom: 13px;
+    display: flex;
+    align-items: center;
+
+    & > svg {
+        margin-right: 10px;
+        color: ${getColor('grey', 100)};
+    }
 `;
 
 interface Props {
@@ -51,10 +66,10 @@ export const ScopeListContainer: FC<Props> = ({appName, scopeMessages}) => {
                 </Link>
             </Helper>
             {0 === scopeMessages.length ? (
-                <ScopeItem key='0'>
+                <NoScope>
                     <CheckRoundIcon size={24} />
                     {translate('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')}
-                </ScopeItem>
+                </NoScope>
             ) : (
                 <ScopeList scopeMessages={scopeMessages} />
             )}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -1,17 +1,12 @@
 import React, {FC} from 'react';
-import {Breadcrumb, CheckRoundIcon, Helper, SectionTitle, TabBar} from 'akeneo-design-system';
+import {Breadcrumb, TabBar} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
-import styled from 'styled-components';
-import {ConnectedApp} from '../../../model/connected-app';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
 import {useMediaUrlGenerator} from '../../../settings/use-media-url-generator';
 import {PageContent, PageHeader} from '../../../common';
 import {UserButtons} from '../../../shared/user';
-import {ScopeItem, ScopeList} from '../ScopeList';
-
-const ScopeListContainer = styled.div`
-  margin: 10px 20px;
-`;
+import {ConnectedAppSettings} from './ConnectedAppSettings';
 
 type Props = {
     connectedApp: ConnectedApp;
@@ -23,33 +18,13 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
     const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
     const generateMediaUrl = useMediaUrlGenerator();
-    // connectedApp.scopes = [
-    //     {
-    //         icon: 'catalog_structure',
-    //         type: 'view',
-    //         entities: 'catalog_structure'
-    //     },
-    //     {
-    //         icon: 'attribute_options',
-    //         type: 'view',
-    //         entities: 'attribute_options'
-    //     },
-    //     {
-    //         icon: 'categories',
-    //         type: 'edit',
-    //         entities: 'categories'
-    //     }
-    // ];
+
     const breadcrumb = (
         <Breadcrumb>
             <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
             <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
             <Breadcrumb.Step>{connectedApp.name}</Breadcrumb.Step>
         </Breadcrumb>
-    );
-
-    const informationLinkAnchor = translate(
-        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information_link_anchor'
     );
 
     return (
@@ -69,29 +44,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                     </TabBar.Tab>
                 </TabBar>
 
-                <SectionTitle>
-                    <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
-                </SectionTitle>
-                <Helper level='info'>
-                    <div
-                        dangerouslySetInnerHTML={{
-                            __html: translate(
-                                'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
-                                {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
-                            ),
-                        }}
-                    />
-                </Helper>
-                <ScopeListContainer>
-                    {0 === connectedApp.scopes.length ? (
-                        <ScopeItem key='0' fontSize='default'>
-                            <CheckRoundIcon size={24} />
-                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
-                        </ScopeItem>
-                    ) : (
-                        <ScopeList scopeMessages={connectedApp.scopes} itemFontSize='default' />
-                    )}
-                </ScopeListContainer>
+                <ConnectedAppSettings connectedApp={connectedApp}/>
             </PageContent>
         </>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -44,7 +44,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                     </TabBar.Tab>
                 </TabBar>
 
-                <ConnectedAppSettings connectedApp={connectedApp}/>
+                <ConnectedAppSettings connectedApp={connectedApp} />
             </PageContent>
         </>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -1,0 +1,98 @@
+import React, {FC} from 'react';
+import {Breadcrumb, CheckRoundIcon, Helper, SectionTitle, TabBar} from 'akeneo-design-system';
+import {useTranslate} from '../../../shared/translate';
+import styled from 'styled-components';
+import {ConnectedApp} from '../../../model/connected-app';
+import {useRouter} from '../../../shared/router/use-router';
+import {useMediaUrlGenerator} from '../../../settings/use-media-url-generator';
+import {PageContent, PageHeader} from '../../../common';
+import {UserButtons} from '../../../shared/user';
+import {ScopeItem, ScopeList} from '../ScopeList';
+
+const ScopeListContainer = styled.div`
+  margin: 10px 20px;
+`;
+
+type Props = {
+    connectedApp: ConnectedApp;
+};
+
+export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
+    const translate = useTranslate();
+    const generateUrl = useRouter();
+    const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
+    const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
+    const generateMediaUrl = useMediaUrlGenerator();
+    // connectedApp.scopes = [
+    //     {
+    //         icon: 'catalog_structure',
+    //         type: 'view',
+    //         entities: 'catalog_structure'
+    //     },
+    //     {
+    //         icon: 'attribute_options',
+    //         type: 'view',
+    //         entities: 'attribute_options'
+    //     },
+    //     {
+    //         icon: 'categories',
+    //         type: 'edit',
+    //         entities: 'categories'
+    //     }
+    // ];
+    const breadcrumb = (
+        <Breadcrumb>
+            <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
+            <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
+            <Breadcrumb.Step>{connectedApp.name}</Breadcrumb.Step>
+        </Breadcrumb>
+    );
+
+    const informationLinkAnchor = translate(
+        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information_link_anchor'
+    );
+
+    return (
+        <>
+            <PageHeader
+                breadcrumb={breadcrumb}
+                userButtons={<UserButtons />}
+                imageSrc={generateMediaUrl(connectedApp.logo, 'thumbnail')}
+            >
+                {connectedApp.name}
+            </PageHeader>
+
+            <PageContent>
+                <TabBar moreButtonTitle='More'>
+                    <TabBar.Tab isActive>
+                        {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')}
+                    </TabBar.Tab>
+                </TabBar>
+
+                <SectionTitle>
+                    <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
+                </SectionTitle>
+                <Helper level='info'>
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: translate(
+                                'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
+                                {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
+                            ),
+                        }}
+                    />
+                </Helper>
+                <ScopeListContainer>
+                    {0 === connectedApp.scopes.length ? (
+                        <ScopeItem key='0' fontSize='default'>
+                            <CheckRoundIcon size={24} />
+                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
+                        </ScopeItem>
+                    ) : (
+                        <ScopeList scopeMessages={connectedApp.scopes} itemFontSize='default' />
+                    )}
+                </ScopeListContainer>
+            </PageContent>
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
@@ -25,6 +25,7 @@ const SkeletonTabBar = styled.div`
     border-radius: 5px;
     margin-bottom: 10px;
 `;
+
 const SkeletonContent = styled.div`
     height: 400px;
     animation: ${loadingBreath} 2s infinite;
@@ -48,7 +49,7 @@ export const ConnectedAppContainerIsLoading: FC = () => {
         <Breadcrumb>
             <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
             <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
-            <Breadcrumb.Step>...</Breadcrumb.Step>
+            <Breadcrumb.Step>{' '}</Breadcrumb.Step>
         </Breadcrumb>
     );
 
@@ -58,9 +59,7 @@ export const ConnectedAppContainerIsLoading: FC = () => {
                 breadcrumb={breadcrumb}
                 userButtons={<UserButtons />}
                 imageSrc={defaultImageUrl}
-            >
-                ...
-            </PageHeader>
+            />
 
             <PageContent>
                 <SkeletonTabBar />

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
@@ -1,0 +1,71 @@
+import React, {FC} from 'react';
+import {Breadcrumb} from 'akeneo-design-system';
+import {useTranslate} from '../../../shared/translate';
+import styled, {keyframes} from 'styled-components';
+import {PageContent, PageHeader} from '../../../common';
+import {UserButtons} from '../../../shared/user';
+import {useRouter} from '../../../shared/router/use-router';
+import defaultImageUrl from '../../../common/assets/illustrations/NewAPI.svg';
+
+const loadingBreath = keyframes`
+    0%{background-position:0% 50%}
+    50%{background-position:100% 50%}
+    100%{background-position:0% 50%}
+`;
+
+const SkeletonTabBar = styled.div`
+    height: 44px;
+    animation: ${loadingBreath} 2s infinite;
+    content: '';
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: linear-gradient(270deg, #fdfdfd, #eee);
+    background-size: 400% 400%;
+    border-radius: 5px;
+    margin-bottom: 10px;
+`;
+const SkeletonContent = styled.div`
+    height: 400px;
+    animation: ${loadingBreath} 2s infinite;
+    content: '';
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: linear-gradient(270deg, #fdfdfd, #eee);
+    background-size: 400% 400%;
+    border-radius: 5px;
+    margin-bottom: 20px;
+`;
+
+export const ConnectedAppContainerIsLoading: FC = () => {
+    const translate = useTranslate();
+    const generateUrl = useRouter();
+    const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
+    const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
+
+    const breadcrumb = (
+        <Breadcrumb>
+            <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
+            <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
+            <Breadcrumb.Step>...</Breadcrumb.Step>
+        </Breadcrumb>
+    );
+
+    return (
+        <>
+            <PageHeader
+                breadcrumb={breadcrumb}
+                userButtons={<UserButtons />}
+                imageSrc={defaultImageUrl}
+            >
+                ...
+            </PageHeader>
+
+            <PageContent>
+                <SkeletonTabBar />
+                <SkeletonContent />
+            </PageContent>
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainerIsLoading.tsx
@@ -49,17 +49,13 @@ export const ConnectedAppContainerIsLoading: FC = () => {
         <Breadcrumb>
             <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
             <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
-            <Breadcrumb.Step>{' '}</Breadcrumb.Step>
+            <Breadcrumb.Step> </Breadcrumb.Step>
         </Breadcrumb>
     );
 
     return (
         <>
-            <PageHeader
-                breadcrumb={breadcrumb}
-                userButtons={<UserButtons />}
-                imageSrc={defaultImageUrl}
-            />
+            <PageHeader breadcrumb={breadcrumb} userButtons={<UserButtons />} imageSrc={defaultImageUrl} />
 
             <PageContent>
                 <SkeletonTabBar />

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppScopeListIsLoading.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppScopeListIsLoading.tsx
@@ -8,7 +8,7 @@ const loadingBreath = keyframes`
 `;
 
 const ScopeListContainer = styled.div`
-  margin: 10px 20px;
+    margin: 10px 20px;
 `;
 
 const SkeletonScopeListItem = styled.div`

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppScopeListIsLoading.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppScopeListIsLoading.tsx
@@ -1,0 +1,35 @@
+import React, {FC} from 'react';
+import styled, {keyframes} from 'styled-components';
+
+const loadingBreath = keyframes`
+    0%{background-position:0% 50%}
+    50%{background-position:100% 50%}
+    100%{background-position:0% 50%}
+`;
+
+const ScopeListContainer = styled.div`
+  margin: 10px 20px;
+`;
+
+const SkeletonScopeListItem = styled.div`
+    height: 24px;
+    animation: ${loadingBreath} 2s infinite;
+    content: '';
+    top: 0px;
+    left: 0px;
+    width: 100%;
+    background: linear-gradient(270deg, #fdfdfd, #eee);
+    background-size: 400% 400%;
+    border-radius: 5px;
+    margin-bottom: 13px;
+`;
+
+export const ConnectedAppScopeListIsLoading: FC = () => {
+    return (
+        <ScopeListContainer>
+            <SkeletonScopeListItem />
+            <SkeletonScopeListItem />
+            <SkeletonScopeListItem />
+        </ScopeListContainer>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
@@ -10,7 +10,7 @@ import {useFeatureFlags} from '../../../shared/feature-flags';
 import {ConnectedAppScopeListIsLoading} from './ConnectedAppScopeListIsLoading';
 
 const ScopeListContainer = styled.div`
-  margin: 10px 20px;
+    margin: 10px 20px;
 `;
 
 type Props = {
@@ -41,14 +41,20 @@ export const ConnectedAppSettings: FC<Props> = ({connectedApp}) => {
     return (
         <>
             <SectionTitle>
-                <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
+                <SectionTitle.Title>
+                    {translate(
+                        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title'
+                    )}
+                </SectionTitle.Title>
             </SectionTitle>
             <Helper level='info'>
                 <div
                     dangerouslySetInnerHTML={{
                         __html: translate(
                             'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
-                            {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
+                            {
+                                link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`, // eslint-disable-line max-len
+                            }
                         ),
                     }}
                 />
@@ -60,7 +66,9 @@ export const ConnectedAppSettings: FC<Props> = ({connectedApp}) => {
                     {0 === connectedAppScopeMessages.length ? (
                         <ScopeItem key='0' fontSize='default'>
                             <CheckRoundIcon size={24} />
-                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
+                            {translate(
+                                'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope'
+                            )}
                         </ScopeItem>
                     ) : (
                         <ScopeList scopeMessages={connectedAppScopeMessages} itemFontSize='default' />

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
@@ -1,9 +1,9 @@
 import React, {FC, useEffect, useState} from 'react';
-import {CheckRoundIcon, Helper, SectionTitle} from 'akeneo-design-system';
+import {CheckRoundIcon, getColor, getFontSize, Helper, SectionTitle} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
 import styled from 'styled-components';
 import {ConnectedApp} from '../../../model/Apps/connected-app';
-import {ScopeItem, ScopeList} from '../ScopeList';
+import {ScopeList} from '../ScopeList';
 import ScopeMessage from '../../../model/Apps/scope-message';
 import {useFetchConnectedAppScopeMessages} from '../../hooks/use-fetch-connected-app-scope-messages';
 import {useFeatureFlags} from '../../../shared/feature-flags';
@@ -11,6 +11,21 @@ import {ConnectedAppScopeListIsLoading} from './ConnectedAppScopeListIsLoading';
 
 const ScopeListContainer = styled.div`
     margin: 10px 20px;
+`;
+
+const NoScope = styled.div`
+    color: ${getColor('grey', 140)};
+    font-size: ${getFontSize('default')};
+    font-weight: normal;
+    line-height: 21px;
+    margin-bottom: 13px;
+    display: flex;
+    align-items: center;
+
+    & > svg {
+        margin-right: 10px;
+        color: ${getColor('grey', 100)};
+    }
 `;
 
 type Props = {
@@ -64,12 +79,12 @@ export const ConnectedAppSettings: FC<Props> = ({connectedApp}) => {
             {false !== connectedAppScopeMessages && null !== connectedAppScopeMessages && (
                 <ScopeListContainer>
                     {0 === connectedAppScopeMessages.length ? (
-                        <ScopeItem key='0' fontSize='default'>
+                        <NoScope>
                             <CheckRoundIcon size={24} />
                             {translate(
                                 'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope'
                             )}
-                        </ScopeItem>
+                        </NoScope>
                     ) : (
                         <ScopeList scopeMessages={connectedAppScopeMessages} itemFontSize='default' />
                     )}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppSettings.tsx
@@ -1,0 +1,72 @@
+import React, {FC, useEffect, useState} from 'react';
+import {CheckRoundIcon, Helper, SectionTitle} from 'akeneo-design-system';
+import {useTranslate} from '../../../shared/translate';
+import styled from 'styled-components';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
+import {ScopeItem, ScopeList} from '../ScopeList';
+import ScopeMessage from '../../../model/Apps/scope-message';
+import {useFetchConnectedAppScopeMessages} from '../../hooks/use-fetch-connected-app-scope-messages';
+import {useFeatureFlags} from '../../../shared/feature-flags';
+import {ConnectedAppScopeListIsLoading} from './ConnectedAppScopeListIsLoading';
+
+const ScopeListContainer = styled.div`
+  margin: 10px 20px;
+`;
+
+type Props = {
+    connectedApp: ConnectedApp;
+};
+
+export const ConnectedAppSettings: FC<Props> = ({connectedApp}) => {
+    const translate = useTranslate();
+    const featureFlag = useFeatureFlags();
+    const fetchConnectedAppScopeMessages = useFetchConnectedAppScopeMessages(connectedApp.connection_code);
+    const [connectedAppScopeMessages, setConnectedAppScopeMessages] = useState<ScopeMessage[] | null | false>(null);
+
+    useEffect(() => {
+        if (!featureFlag.isEnabled('marketplace_activate')) {
+            setConnectedAppScopeMessages(false);
+            return;
+        }
+
+        fetchConnectedAppScopeMessages()
+            .then(setConnectedAppScopeMessages)
+            .catch(() => setConnectedAppScopeMessages(false));
+    }, [fetchConnectedAppScopeMessages]);
+
+    const informationLinkAnchor = translate(
+        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information_link_anchor'
+    );
+
+    return (
+        <>
+            <SectionTitle>
+                <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
+            </SectionTitle>
+            <Helper level='info'>
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html: translate(
+                            'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
+                            {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
+                        ),
+                    }}
+                />
+            </Helper>
+
+            {null === connectedAppScopeMessages && <ConnectedAppScopeListIsLoading />}
+            {false !== connectedAppScopeMessages && null !== connectedAppScopeMessages && (
+                <ScopeListContainer>
+                    {0 === connectedAppScopeMessages.length ? (
+                        <ScopeItem key='0' fontSize='default'>
+                            <CheckRoundIcon size={24} />
+                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
+                        </ScopeItem>
+                    ) : (
+                        <ScopeList scopeMessages={connectedAppScopeMessages} itemFontSize='default' />
+                    )}
+                </ScopeListContainer>
+            )}
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -102,10 +102,9 @@ type Props = {
 const ConnectedAppCard: FC<Props> = ({item}) => {
     const translate = useTranslate();
     const generateUrl = useRouter();
-    const connectedAppUrl = `#${generateUrl(
-        'akeneo_connectivity_connection_connect_connected_apps_any',
-        {any: item.connection_code}
-    )}`;
+    const connectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_any', {
+        any: item.connection_code,
+    })}`;
 
     return (
         <CardContainer>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -2,7 +2,7 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {getColor, getFontSize, Button} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
-import {ConnectedApp} from '../../../model/connected-app';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
 
 const Grid = styled.section`

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import {getColor, getFontSize, Button} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
 import {ConnectedApp} from '../../../model/connected-app';
+import {useRouter} from '../../../shared/router/use-router';
 
 const Grid = styled.section`
     margin: 20px 0;
@@ -100,6 +101,11 @@ type Props = {
 
 const ConnectedAppCard: FC<Props> = ({item}) => {
     const translate = useTranslate();
+    const generateUrl = useRouter();
+    const connectedAppUrl = `#${generateUrl(
+        'akeneo_connectivity_connection_connect_connected_apps_any',
+        {any: item.connection_code}
+    )}`;
 
     return (
         <CardContainer>
@@ -116,7 +122,7 @@ const ConnectedAppCard: FC<Props> = ({item}) => {
                 {item.categories.length > 0 && <Tag>{item.categories[0]}</Tag>}
             </TextInformation>
             <Actions>
-                <Button ghost level='tertiary' href='#'>
+                <Button ghost level='tertiary' href={connectedAppUrl}>
                     {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.manage_app')}
                 </Button>
             </Actions>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -102,8 +102,8 @@ type Props = {
 const ConnectedAppCard: FC<Props> = ({item}) => {
     const translate = useTranslate();
     const generateUrl = useRouter();
-    const connectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_any', {
-        any: item.connection_code,
+    const connectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_edit', {
+        connectionCode: item.connection_code,
     })}`;
 
     return (

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
@@ -4,7 +4,7 @@ import {useTranslate} from '../../../shared/translate';
 import styled from 'styled-components';
 import {useDisplayScrollTopButton} from '../../../shared/scroll/hooks/useDisplayScrollTopButton';
 import findScrollParent from '../../../shared/scroll/utils/findScrollParent';
-import {ConnectedApp} from '../../../model/connected-app';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useFeatureFlags} from '../../../shared/feature-flags';
 import ConnectedAppsContainerHelper from './ConnectedAppsContainerHelper';
 import {ConnectedAppCard} from './ConnectedAppCard';

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
@@ -17,9 +17,11 @@ import {
 } from 'akeneo-design-system';
 import ScopeMessage from '../../model/Apps/scope-message';
 
-export const ScopeItem = styled('li')<{fontSize?: keyof FontSize} & AkeneoThemedProps>`
+export const ScopeItem = styled.li.attrs((props: {fontSize?: keyof FontSize} & AkeneoThemedProps) => ({
+    fontSize: props.fontSize || 'bigger',
+}))`
     color: ${getColor('grey', 140)};
-    font-size: ${({fontSize}) => (fontSize && getFontSize(fontSize)) || getFontSize('bigger')};
+    font-size: ${props => getFontSize(props.fontSize)};
     font-weight: normal;
     line-height: 21px;
     margin-bottom: 13px;

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
@@ -17,7 +17,7 @@ import ScopeMessage from '../../model/Apps/scope-message';
 
 export const ScopeItem = styled.li`
     color: ${getColor('grey', 140)};
-    font-size: ${getFontSize('bigger')};
+    font-size: ${props => (props.fontSize && getFontSize(props.fontSize)) || getFontSize('bigger')};
     font-weight: normal;
     line-height: 21px;
     margin-bottom: 13px;
@@ -42,9 +42,10 @@ const iconsMap: {[key: string]: React.ElementType} = {
 
 interface Props {
     scopeMessages: ScopeMessage[];
+    itemFontSize?: string;
 }
 
-export const ScopeList: FC<Props> = ({scopeMessages}) => {
+export const ScopeList: FC<Props> = ({scopeMessages, itemFontSize}) => {
     const translate = useTranslate();
 
     return (
@@ -56,7 +57,7 @@ export const ScopeList: FC<Props> = ({scopeMessages}) => {
                 const Icon = iconsMap[scopeMessage.icon] ?? CheckRoundIcon;
 
                 return (
-                    <ScopeItem key={key}>
+                    <ScopeItem key={key} fontSize={itemFontSize}>
                         <Icon title={entities} size={24} />
                         <div
                             dangerouslySetInnerHTML={{

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
@@ -12,12 +12,15 @@ import {
     ProductIcon,
     ShopIcon,
     CheckRoundIcon,
+    AkeneoThemedProps,
+    FontSize,
 } from 'akeneo-design-system';
 import ScopeMessage from '../../model/Apps/scope-message';
 
-export const ScopeItem = styled.li`
+
+export const ScopeItem = styled('li')<{fontSize?: keyof FontSize} & AkeneoThemedProps>`
     color: ${getColor('grey', 140)};
-    font-size: ${props => (props.fontSize && getFontSize(props.fontSize)) || getFontSize('bigger')};
+    font-size: ${({fontSize}) => (fontSize && getFontSize(fontSize)) || getFontSize('bigger')};
     font-weight: normal;
     line-height: 21px;
     margin-bottom: 13px;

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ScopeList.tsx
@@ -17,7 +17,6 @@ import {
 } from 'akeneo-design-system';
 import ScopeMessage from '../../model/Apps/scope-message';
 
-
 export const ScopeItem = styled('li')<{fontSize?: keyof FontSize} & AkeneoThemedProps>`
     color: ${getColor('grey', 140)};
     font-size: ${({fontSize}) => (fontSize && getFontSize(fontSize)) || getFontSize('bigger')};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-scope-messages.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-scope-messages.ts
@@ -1,8 +1,8 @@
 import {useRoute} from '../../shared/router';
 import {useCallback} from 'react';
 
-export const useFetchConnectedApp = (connectionCode: string) => {
-    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_connected_app', {connectionCode: connectionCode});
+export const useFetchConnectedAppScopeMessages = (connectionCode: string) => {
+    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages', {connectionCode: connectionCode});
 
     return useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-scope-messages.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-scope-messages.ts
@@ -2,7 +2,9 @@ import {useRoute} from '../../shared/router';
 import {useCallback} from 'react';
 
 export const useFetchConnectedAppScopeMessages = (connectionCode: string) => {
-    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages', {connectionCode: connectionCode});
+    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages', {
+        connectionCode: connectionCode,
+    });
 
     return useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
@@ -2,7 +2,9 @@ import {useRoute} from '../../shared/router';
 import {useCallback} from 'react';
 
 export const useFetchConnectedApp = (connectionCode: string) => {
-    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_connected_app', {connectionCode: connectionCode});
+    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_connected_app', {
+        connectionCode: connectionCode,
+    });
 
     return useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
@@ -1,0 +1,55 @@
+export const useFetchConnectedApp = () => {
+    // @todo fetch real connected app from backend
+
+    return new Promise((resolve, reject) => {
+        setTimeout(function () {
+            resolve({
+                id: '12345',
+                name: 'App name',
+                scopes: [
+                    {
+                        icon: 'catalog_structure',
+                        type: 'view',
+                        entities: 'catalog_structure'
+                    },
+                    {
+                        icon: 'attribute_options',
+                        type: 'view',
+                        entities: 'attribute_options'
+                    },
+                    {
+                        icon: 'categories',
+                        type: 'edit',
+                        entities: 'categories'
+                    },
+                    {
+                        icon: 'channel_localization',
+                        type: 'edit',
+                        entities: 'channel_localization'
+                    },
+                    {
+                        icon: 'channel_settings',
+                        type: 'edit',
+                        entities: 'channel_settings'
+                    },
+                    {
+                        icon: 'association_types',
+                        type: 'delete',
+                        entities: 'association_types'
+                    },
+                    {
+                        icon: 'products',
+                        type: 'delete',
+                        entities: 'products'
+                    },
+                ],
+                connection_code: 'connectionCode',
+                logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+                author: 'Author A',
+                categories: ['e-commerce', 'print'],
+                certified: false,
+                partner: null,
+            });
+        }, 800);
+    });
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app.ts
@@ -1,7 +1,7 @@
-export const useFetchConnectedApp = () => {
+export const useFetchConnectedApp = (connectionCode: string) => {
     // @todo fetch real connected app from backend
 
-    return new Promise((resolve, reject) => {
+    return () => new Promise((resolve, reject) => {
         setTimeout(function () {
             resolve({
                 id: '12345',

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
@@ -36,9 +36,7 @@ export const ConnectedAppPage: FC = () => {
                     code={404}
                 />
             )}
-            {false !== connectedApp && null !== connectedApp && (
-                <ConnectedAppContainer connectedApp={connectedApp} />
-            )}
+            {false !== connectedApp && null !== connectedApp && <ConnectedAppContainer connectedApp={connectedApp} />}
         </>
     );
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
@@ -1,0 +1,110 @@
+import React, {FC, useEffect, useState} from 'react';
+import {Breadcrumb, CheckRoundIcon, Helper, SectionTitle, TabBar} from 'akeneo-design-system';
+import {useTranslate} from '../../shared/translate';
+import {PageContent, PageHeader} from '../../common';
+import {UserButtons} from '../../shared/user';
+import {useRouter} from '../../shared/router/use-router';
+import {useFeatureFlags} from '../../shared/feature-flags';
+import {useParams} from 'react-router';
+import {useMediaUrlGenerator} from '../../settings/use-media-url-generator';
+import {useFetchConnectedApp} from '../hooks/use-fetch-connected-app';
+import {ConnectedApp} from '../../model/connected-app';
+import {FullScreenError} from '@akeneo-pim-community/shared';
+import {ScopeItem, ScopeList} from '../components/ScopeList';
+import styled from 'styled-components';
+
+const ScopeListContainer = styled.div`
+  margin: 10px 20px;
+`;
+
+export const ConnectedAppPage: FC = () => {
+    const translate = useTranslate();
+    const featureFlag = useFeatureFlags();
+    const {connectionCode} = useParams<{connectionCode: string}>();
+    const generateUrl = useRouter();
+    const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
+    const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
+    const generateMediaUrl = useMediaUrlGenerator();
+    const fetchConnectedApp = useFetchConnectedApp();
+    const [connectedApp, setConnectedApp] = useState<ConnectedApp | null | false>(null);
+
+    useEffect(() => {
+        if (!featureFlag.isEnabled('marketplace_activate')) {
+            setConnectedApp(false);
+            return;
+        }
+
+        fetchConnectedApp
+            .then(setConnectedApp)
+            .catch(() => setConnectedApp(false));
+    }, [fetchConnectedApp]);
+
+    if (false === connectedApp) {
+        return (
+            <FullScreenError
+                title={translate('error.exception', {status_code: '404'})}
+                message={translate('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')}
+                code={404}
+            />
+        );
+    }
+
+    const breadcrumb = (connectedApp &&
+        <Breadcrumb>
+            <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
+            <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
+            <Breadcrumb.Step>{connectedApp.name}</Breadcrumb.Step>
+        </Breadcrumb>
+    );
+
+    const informationLinkAnchor = translate(
+        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information_link_anchor'
+    );
+
+    return (connectedApp &&
+        <>
+            <PageHeader
+                breadcrumb={breadcrumb}
+                userButtons={<UserButtons />}
+                imageSrc={generateMediaUrl(connectedApp.logo, 'thumbnail')}
+            >
+                {connectedApp.name}
+            </PageHeader>
+
+            <PageContent>
+                <TabBar moreButtonTitle={'More'}>
+                    <TabBar.Tab isActive={true}>
+                        {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')}
+                    </TabBar.Tab>
+                </TabBar>
+
+                <SectionTitle>
+                    <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
+                </SectionTitle>
+                <Helper level='info'>
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: translate(
+                                'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
+                                {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
+                            ),
+                        }}
+                    />
+                </Helper>
+                <ScopeListContainer>
+                    {0 === connectedApp.scopes.length ? (
+                        <ScopeItem key='0' fontSize='default'>
+                            <CheckRoundIcon
+                                size={24}
+                                title={translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
+                            />
+                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
+                        </ScopeItem>
+                    ) : (
+                        <ScopeList scopeMessages={connectedApp.scopes} itemFontSize='default' />
+                    )}
+                </ScopeListContainer>
+            </PageContent>
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
@@ -1,31 +1,20 @@
 import React, {FC, useEffect, useState} from 'react';
-import {Breadcrumb, CheckRoundIcon, Helper, SectionTitle, TabBar} from 'akeneo-design-system';
 import {useTranslate} from '../../shared/translate';
-import {PageContent, PageHeader} from '../../common';
-import {UserButtons} from '../../shared/user';
 import {useRouter} from '../../shared/router/use-router';
 import {useFeatureFlags} from '../../shared/feature-flags';
-import {useParams} from 'react-router';
-import {useMediaUrlGenerator} from '../../settings/use-media-url-generator';
 import {useFetchConnectedApp} from '../hooks/use-fetch-connected-app';
 import {ConnectedApp} from '../../model/connected-app';
 import {FullScreenError} from '@akeneo-pim-community/shared';
-import {ScopeItem, ScopeList} from '../components/ScopeList';
-import styled from 'styled-components';
-
-const ScopeListContainer = styled.div`
-  margin: 10px 20px;
-`;
+import {ConnectedAppContainerIsLoading} from '../components/ConnectedApp/ConnectedAppContainerIsLoading';
+import {ConnectedAppContainer} from '../components/ConnectedApp/ConnectedAppContainer';
+import {useParams} from 'react-router-dom';
 
 export const ConnectedAppPage: FC = () => {
     const translate = useTranslate();
     const featureFlag = useFeatureFlags();
-    const {connectionCode} = useParams<{connectionCode: string}>();
     const generateUrl = useRouter();
-    const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
-    const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
-    const generateMediaUrl = useMediaUrlGenerator();
-    const fetchConnectedApp = useFetchConnectedApp();
+    const {connectionCode} = useParams<{connectionCode: string}>();
+    const fetchConnectedApp = useFetchConnectedApp(connectionCode);
     const [connectedApp, setConnectedApp] = useState<ConnectedApp | null | false>(null);
 
     useEffect(() => {
@@ -34,77 +23,24 @@ export const ConnectedAppPage: FC = () => {
             return;
         }
 
-        fetchConnectedApp
+        fetchConnectedApp()
             .then(setConnectedApp)
             .catch(() => setConnectedApp(false));
     }, [fetchConnectedApp]);
 
-    if (false === connectedApp) {
-        return (
-            <FullScreenError
-                title={translate('error.exception', {status_code: '404'})}
-                message={translate('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')}
-                code={404}
-            />
-        );
-    }
-
-    const breadcrumb = (connectedApp &&
-        <Breadcrumb>
-            <Breadcrumb.Step href={dashboardHref}>{translate('pim_menu.tab.connect')}</Breadcrumb.Step>
-            <Breadcrumb.Step href={connectedAppsListHref}>{translate('pim_menu.item.connected_apps')}</Breadcrumb.Step>
-            <Breadcrumb.Step>{connectedApp.name}</Breadcrumb.Step>
-        </Breadcrumb>
-    );
-
-    const informationLinkAnchor = translate(
-        'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information_link_anchor'
-    );
-
-    return (connectedApp &&
+    return (
         <>
-            <PageHeader
-                breadcrumb={breadcrumb}
-                userButtons={<UserButtons />}
-                imageSrc={generateMediaUrl(connectedApp.logo, 'thumbnail')}
-            >
-                {connectedApp.name}
-            </PageHeader>
-
-            <PageContent>
-                <TabBar moreButtonTitle={'More'}>
-                    <TabBar.Tab isActive={true}>
-                        {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')}
-                    </TabBar.Tab>
-                </TabBar>
-
-                <SectionTitle>
-                    <SectionTitle.Title>{translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.title')}</SectionTitle.Title>
-                </SectionTitle>
-                <Helper level='info'>
-                    <div
-                        dangerouslySetInnerHTML={{
-                            __html: translate(
-                                'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
-                                {link: `<a href='https://help.akeneo.com/pim/serenity/articles/how-to-connect-my-pim-with-apps.html#all-editions-authorization-step' target='_blank'>${informationLinkAnchor}</a>`}
-                            ),
-                        }}
-                    />
-                </Helper>
-                <ScopeListContainer>
-                    {0 === connectedApp.scopes.length ? (
-                        <ScopeItem key='0' fontSize='default'>
-                            <CheckRoundIcon
-                                size={24}
-                                title={translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
-                            />
-                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')}
-                        </ScopeItem>
-                    ) : (
-                        <ScopeList scopeMessages={connectedApp.scopes} itemFontSize='default' />
-                    )}
-                </ScopeListContainer>
-            </PageContent>
+            {null === connectedApp && <ConnectedAppContainerIsLoading />}
+            {false === connectedApp && (
+                <FullScreenError
+                    title={translate('error.exception', {status_code: '404'})}
+                    message={translate('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')}
+                    code={404}
+                />
+            )}
+            {false !== connectedApp && null !== connectedApp && (
+                <ConnectedAppContainer connectedApp={connectedApp} />
+            )}
         </>
     );
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppPage.tsx
@@ -1,9 +1,8 @@
 import React, {FC, useEffect, useState} from 'react';
 import {useTranslate} from '../../shared/translate';
-import {useRouter} from '../../shared/router/use-router';
 import {useFeatureFlags} from '../../shared/feature-flags';
 import {useFetchConnectedApp} from '../hooks/use-fetch-connected-app';
-import {ConnectedApp} from '../../model/connected-app';
+import {ConnectedApp} from '../../model/Apps/connected-app';
 import {FullScreenError} from '@akeneo-pim-community/shared';
 import {ConnectedAppContainerIsLoading} from '../components/ConnectedApp/ConnectedAppContainerIsLoading';
 import {ConnectedAppContainer} from '../components/ConnectedApp/ConnectedAppContainer';
@@ -12,7 +11,6 @@ import {useParams} from 'react-router-dom';
 export const ConnectedAppPage: FC = () => {
     const translate = useTranslate();
     const featureFlag = useFeatureFlags();
-    const generateUrl = useRouter();
     const {connectionCode} = useParams<{connectionCode: string}>();
     const fetchConnectedApp = useFetchConnectedApp(connectionCode);
     const [connectedApp, setConnectedApp] = useState<ConnectedApp | null | false>(null);

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
@@ -6,7 +6,7 @@ import {UserButtons} from '../../shared/user';
 import {useRouter} from '../../shared/router/use-router';
 import {ConnectedAppsContainerIsLoading} from '../components/ConnectedApps/ConnectedAppsContainerIsLoading';
 import {ConnectedAppsContainer} from '../components/ConnectedApps/ConnectedAppsContainer';
-import {ConnectedApp} from '../../model/connected-app';
+import {ConnectedApp} from '../../model/Apps/connected-app';
 import {useFetchConnectedApps} from '../hooks/use-fetch-connected-apps';
 import {useFeatureFlags} from '../../shared/feature-flags';
 import {NotificationLevel, useNotify} from '../../shared/notify';

--- a/src/Akeneo/Connectivity/Connection/front/src/infrastructure/ConnectedApps.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/infrastructure/ConnectedApps.tsx
@@ -3,12 +3,20 @@ import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 import {AkeneoThemeProvider} from './akeneo-theme-provider';
 import {withDependencies} from './dependencies-provider';
 import {ConnectedAppsListPage} from '../connect/pages/ConnectedAppsListPage';
+import {ConnectedAppPage} from '../connect/pages/ConnectedAppPage';
 
 export const ConnectedApps = withDependencies(() => (
     <StrictMode>
         <AkeneoThemeProvider>
             <Router>
-                <ConnectedAppsListPage />
+                <Switch>
+                    <Route path='/connect/connected-apps/:connectionCode'>
+                        <ConnectedAppPage />
+                    </Route>
+                    <Route path='/connect/connected-apps'>
+                        <ConnectedAppsListPage />
+                    </Route>
+                </Switch>
             </Router>
         </AkeneoThemeProvider>
     </StrictMode>

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
@@ -1,7 +1,7 @@
 export type ConnectedApp = {
     id: string;
     name: string;
-    scopes: any;
+    scopes: string[];
     connection_code: string;
     logo: string;
     author: string;

--- a/src/Akeneo/Connectivity/Connection/front/src/model/connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/connected-app.ts
@@ -1,7 +1,7 @@
 export type ConnectedApp = {
     id: string;
     name: string;
-    scopes: string[];
+    scopes: any;
     connection_code: string;
     logo: string;
     author: string;

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
@@ -34,12 +34,7 @@ test('The scope list renders with scopes', () => {
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.helper')
     ).toBeInTheDocument();
-    expect(ScopeList).toHaveBeenCalledWith(
-        {
-            scopeMessages: scopes,
-        },
-        {}
-    );
+    expect(ScopeList).toHaveBeenCalledWith({scopeMessages: scopes}, {});
 });
 
 test('The scope list still renders with unknown scopes', () => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
@@ -36,7 +36,7 @@ test('The scope list renders with scopes', () => {
     ).toBeInTheDocument();
     expect(ScopeList).toHaveBeenCalledWith(
         {
-            scopeMessages: scopes
+            scopeMessages: scopes,
         },
         {}
     );
@@ -68,5 +68,7 @@ test('The scope list renders without scopes', () => {
         })
     ).toBeInTheDocument();
     expect(ScopeList).not.toHaveBeenCalled();
-    expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')
+    ).toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/ScopeListContainer.test.tsx
@@ -4,15 +4,17 @@ import {screen} from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../../test-utils';
 import {ScopeListContainer} from '@src/connect/components/AppWizard/ScopeListContainer';
+import {ScopeList} from '@src/connect/components/ScopeList';
 
 beforeEach(() => {
     fetchMock.resetMocks();
     historyMock.reset();
+    jest.clearAllMocks();
 });
 
 jest.mock('@src/connect/components/ScopeList', () => ({
-    ScopeList: () => <div>ScopeListComponent</div>,
-    ScopeItem: () => <div>ScopeItemComponent</div>,
+    ...jest.requireActual('@src/connect/components/ScopeList'),
+    ScopeList: jest.fn(() => null),
 }));
 
 test('The scope list renders with scopes', () => {
@@ -32,7 +34,12 @@ test('The scope list renders with scopes', () => {
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.helper')
     ).toBeInTheDocument();
-    expect(screen.queryByText('ScopeListComponent')).toBeInTheDocument();
+    expect(ScopeList).toHaveBeenCalledWith(
+        {
+            scopeMessages: scopes
+        },
+        {}
+    );
 });
 
 test('The scope list still renders with unknown scopes', () => {
@@ -49,7 +56,7 @@ test('The scope list still renders with unknown scopes', () => {
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.helper')
     ).toBeInTheDocument();
-    expect(screen.queryByText('ScopeListComponent')).toBeInTheDocument();
+    expect(ScopeList).toHaveBeenCalledWith({scopeMessages: scopes}, {});
 });
 
 test('The scope list renders without scopes', () => {
@@ -60,6 +67,6 @@ test('The scope list renders without scopes', () => {
             exact: false,
         })
     ).toBeInTheDocument();
-    expect(screen.queryByText('ScopeItemComponent')).toBeInTheDocument();
-    expect(screen.queryByText('ScopeListComponent')).not.toBeInTheDocument();
+    expect(ScopeList).not.toHaveBeenCalled();
+    expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.wizard.authorize.no_scope')).toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -4,12 +4,12 @@ import {screen} from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../../test-utils';
 import {ConnectedAppContainer} from '@src/connect/components/ConnectedApp/ConnectedAppContainer';
-import {ScopeList} from '@src/connect/components/ScopeList';
+import {ConnectedAppSettings} from '@src/connect/components/ConnectedApp/ConnectedAppSettings';
 import {TabBar} from 'akeneo-design-system';
 
-jest.mock('@src/connect/components/ScopeList', () => ({
-    ...jest.requireActual('@src/connect/components/ScopeList'),
-    ScopeList: jest.fn(() => null),
+jest.mock('@src/connect/components/ConnectedApp/ConnectedAppSettings', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApp/ConnectedAppSettings'),
+    ConnectedAppSettings: jest.fn(() => null),
 }));
 
 jest.mock('akeneo-design-system', () => ({
@@ -23,19 +23,11 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-test('The connected app container renders with scopes', async () => {
-    const scopes = [
-        {
-            icon: 'catalog_structure',
-            type: 'view',
-            entities: 'catalog_structure'
-        },
-    ];
-
+test('The connected app container renders', async () => {
     const connectedApp = {
         id: '12345',
         name: 'App A',
-        scopes: scopes,
+        scopes: ['scope1', 'scope2'],
         connection_code: 'some_connection_code',
         logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
         author: 'Author A',
@@ -50,40 +42,10 @@ test('The connected app container renders with scopes', async () => {
     expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
     expect(screen.queryAllByText('App A')).toHaveLength(2);
     expect(TabBar).toHaveBeenCalledTimes(1);
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
-    ).toBeInTheDocument();
-    expect(ScopeList).toHaveBeenCalledWith(
+    expect(ConnectedAppSettings).toHaveBeenCalledWith(
         {
-            scopeMessages: scopes,
-            itemFontSize: 'default'
+            connectedApp: connectedApp
         },
         {}
     );
-});
-
-test('The connected app container renders without scopes', () => {
-    const connectedApp = {
-        id: '12345',
-        name: 'App A',
-        scopes: [],
-        connection_code: 'some_connection_code',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
-        author: 'Author A',
-        categories: ['e-commerce', 'print'],
-        certified: false,
-        partner: null,
-    };
-
-    renderWithProviders(<ConnectedAppContainer connectedApp={connectedApp} />);
-
-    expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
-    expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
-    expect(screen.queryAllByText('App A')).toHaveLength(2);
-    expect(TabBar).toHaveBeenCalledTimes(1);
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
-    ).toBeInTheDocument();
-    expect(ScopeList).not.toHaveBeenCalled();
-    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -23,13 +23,13 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-test('The connected app container renders', async () => {
+test('The connected app container renders', () => {
     const connectedApp = {
         id: '12345',
         name: 'App A',
         scopes: ['scope1', 'scope2'],
         connection_code: 'some_connection_code',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        logo: 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
         author: 'Author A',
         categories: ['e-commerce', 'print'],
         certified: false,
@@ -44,7 +44,7 @@ test('The connected app container renders', async () => {
     expect(TabBar).toHaveBeenCalledTimes(1);
     expect(ConnectedAppSettings).toHaveBeenCalledWith(
         {
-            connectedApp: connectedApp
+            connectedApp: connectedApp,
         },
         {}
     );

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -5,16 +5,19 @@ import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../../test-utils';
 import {ConnectedAppContainer} from '@src/connect/components/ConnectedApp/ConnectedAppContainer';
 import {ConnectedAppSettings} from '@src/connect/components/ConnectedApp/ConnectedAppSettings';
-import {TabBar} from 'akeneo-design-system';
+
+// to make Tab usable with jest
+type EntryCallback = (entries: {isIntersecting: boolean}[]) => void;
+let entryCallback: EntryCallback | undefined = undefined;
+const intersectionObserverMock = (callback: EntryCallback) => ({
+    observe: jest.fn(() => (entryCallback = callback)),
+    unobserve: jest.fn(),
+});
+window.IntersectionObserver = jest.fn().mockImplementation(intersectionObserverMock);
 
 jest.mock('@src/connect/components/ConnectedApp/ConnectedAppSettings', () => ({
     ...jest.requireActual('@src/connect/components/ConnectedApp/ConnectedAppSettings'),
     ConnectedAppSettings: jest.fn(() => null),
-}));
-
-jest.mock('akeneo-design-system', () => ({
-    ...jest.requireActual('akeneo-design-system'),
-    TabBar: jest.fn(() => null),
 }));
 
 beforeEach(() => {
@@ -41,11 +44,8 @@ test('The connected app container renders', () => {
     expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
     expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
     expect(screen.queryAllByText('App A')).toHaveLength(2);
-    expect(TabBar).toHaveBeenCalledTimes(1);
-    expect(ConnectedAppSettings).toHaveBeenCalledWith(
-        {
-            connectedApp: connectedApp,
-        },
-        {}
-    );
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')
+    ).toBeInTheDocument();
+    expect(ConnectedAppSettings).toHaveBeenCalledWith({connectedApp: connectedApp}, {});
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {screen} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import {renderWithProviders, historyMock} from '../../../../test-utils';
+import {ConnectedAppContainer} from '@src/connect/components/ConnectedApp/ConnectedAppContainer';
+import {ScopeList} from '@src/connect/components/ScopeList';
+import {TabBar} from 'akeneo-design-system';
+
+jest.mock('@src/connect/components/ScopeList', () => ({
+    ...jest.requireActual('@src/connect/components/ScopeList'),
+    ScopeList: jest.fn(() => null),
+}));
+
+jest.mock('akeneo-design-system', () => ({
+    ...jest.requireActual('akeneo-design-system'),
+    TabBar: jest.fn(() => null),
+}));
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
+
+test('The connected app container renders with scopes', async () => {
+    const scopes = [
+        {
+            icon: 'catalog_structure',
+            type: 'view',
+            entities: 'catalog_structure'
+        },
+    ];
+
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: scopes,
+        connection_code: 'some_connection_code',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    renderWithProviders(<ConnectedAppContainer connectedApp={connectedApp} />);
+
+    expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
+    expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
+    expect(screen.queryAllByText('App A')).toHaveLength(2);
+    expect(TabBar).toHaveBeenCalledTimes(1);
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    ).toBeInTheDocument();
+    expect(ScopeList).toHaveBeenCalledWith(
+        {
+            scopeMessages: scopes,
+            itemFontSize: 'default'
+        },
+        {}
+    );
+});
+
+test('The connected app container renders without scopes', () => {
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: [],
+        connection_code: 'some_connection_code',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    renderWithProviders(<ConnectedAppContainer connectedApp={connectedApp} />);
+
+    expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
+    expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
+    expect(screen.queryAllByText('App A')).toHaveLength(2);
+    expect(TabBar).toHaveBeenCalledTimes(1);
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    ).toBeInTheDocument();
+    expect(ScopeList).not.toHaveBeenCalled();
+    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {screen, wait, waitForElement} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import {renderWithProviders, historyMock, MockFetchResponses, mockFetchResponses} from '../../../../test-utils';
+import {ScopeList} from '@src/connect/components/ScopeList';
+import {ConnectedAppSettings} from '@src/connect/components/ConnectedApp/ConnectedAppSettings';
+
+jest.mock('@src/shared/feature-flags/use-feature-flags', () => ({
+    ...jest.requireActual('@src/shared/feature-flags/use-feature-flags'),
+    useFeatureFlags: jest.fn(() => {
+        return {
+            isEnabled: () => true,
+        };
+    }),
+}));
+
+jest.mock('@src/connect/components/ScopeList', () => ({
+    ...jest.requireActual('@src/connect/components/ScopeList'),
+    ScopeList: jest.fn(() => null),
+}));
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
+
+test('The connected settings renders with scopes', async () => {
+    const scopes = [
+        {
+            icon: 'catalog_structure',
+            type: 'view',
+            entities: 'catalog_structure'
+        },
+    ];
+
+    const fetchConnectedAppScopeMessagesResponses: MockFetchResponses = {
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code': {
+            json: scopes,
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchConnectedAppScopeMessagesResponses,
+    });
+
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: ['scope 1'],
+        connection_code: 'some_connection_code',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    renderWithProviders(<ConnectedAppSettings connectedApp={connectedApp} />);
+    await wait(() => expect(ScopeList).toHaveBeenCalledTimes(1));
+
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    ).toBeInTheDocument();
+    expect(ScopeList).toHaveBeenCalledWith(
+        {
+            scopeMessages: scopes,
+            itemFontSize: 'default'
+        },
+        {}
+    );
+});
+
+test('The connected app settings renders without scopes', async () => {
+    const fetchConnectedAppScopeMessagesResponses: MockFetchResponses = {
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code': {
+            json: [],
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchConnectedAppScopeMessagesResponses,
+    });
+
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: [],
+        connection_code: 'some_connection_code',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    renderWithProviders(<ConnectedAppSettings connectedApp={connectedApp} />);
+    await waitForElement(() => screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope'));
+
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    ).toBeInTheDocument();
+    expect(ScopeList).not.toHaveBeenCalled();
+    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
@@ -31,14 +31,15 @@ test('The connected settings renders with scopes', async () => {
         {
             icon: 'catalog_structure',
             type: 'view',
-            entities: 'catalog_structure'
+            entities: 'catalog_structure',
         },
     ];
 
     const fetchConnectedAppScopeMessagesResponses: MockFetchResponses = {
-        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code': {
-            json: scopes,
-        },
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code':
+            {
+                json: scopes,
+            },
     };
 
     mockFetchResponses({
@@ -50,7 +51,7 @@ test('The connected settings renders with scopes', async () => {
         name: 'App A',
         scopes: ['scope 1'],
         connection_code: 'some_connection_code',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        logo: 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
         author: 'Author A',
         categories: ['e-commerce', 'print'],
         certified: false,
@@ -61,12 +62,15 @@ test('The connected settings renders with scopes', async () => {
     await wait(() => expect(ScopeList).toHaveBeenCalledTimes(1));
 
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
+            {exact: false}
+        )
     ).toBeInTheDocument();
     expect(ScopeList).toHaveBeenCalledWith(
         {
             scopeMessages: scopes,
-            itemFontSize: 'default'
+            itemFontSize: 'default',
         },
         {}
     );
@@ -74,9 +78,10 @@ test('The connected settings renders with scopes', async () => {
 
 test('The connected app settings renders without scopes', async () => {
     const fetchConnectedAppScopeMessagesResponses: MockFetchResponses = {
-        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code': {
-            json: [],
-        },
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=some_connection_code':
+            {
+                json: [],
+            },
     };
 
     mockFetchResponses({
@@ -88,7 +93,7 @@ test('The connected app settings renders without scopes', async () => {
         name: 'App A',
         scopes: [],
         connection_code: 'some_connection_code',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        logo: 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
         author: 'Author A',
         categories: ['e-commerce', 'print'],
         certified: false,
@@ -96,11 +101,20 @@ test('The connected app settings renders without scopes', async () => {
     };
 
     renderWithProviders(<ConnectedAppSettings connectedApp={connectedApp} />);
-    await waitForElement(() => screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope'));
+    await waitForElement(() =>
+        screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')
+    );
 
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information',
+            {exact: false}
+        )
     ).toBeInTheDocument();
     expect(ScopeList).not.toHaveBeenCalled();
-    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
+    expect(
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope'
+        )
+    ).toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-scope-messages.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-scope-messages.test.tsx
@@ -7,14 +7,15 @@ test('it fetches the connected app scope messages', async () => {
         {
             icon: 'channel_settings',
             type: 'edit',
-            entities: 'channel_settings'
+            entities: 'channel_settings',
         },
     ];
 
     mockFetchResponses({
-        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=connectionCodeA': {
-            json: expectedScopeMessages,
-        },
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=connectionCodeA':
+            {
+                json: expectedScopeMessages,
+            },
     });
     const {result} = renderHook(() => useFetchConnectedAppScopeMessages('connectionCodeA'));
     const scopeMessages = await result.current();

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-scope-messages.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-scope-messages.test.tsx
@@ -1,0 +1,23 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {mockFetchResponses} from '../../../test-utils';
+import {useFetchConnectedAppScopeMessages} from '@src/connect/hooks/use-fetch-connected-app-scope-messages';
+
+test('it fetches the connected app scope messages', async () => {
+    const expectedScopeMessages = [
+        {
+            icon: 'channel_settings',
+            type: 'edit',
+            entities: 'channel_settings'
+        },
+    ];
+
+    mockFetchResponses({
+        'akeneo_connectivity_connection_apps_rest_get_all_connected_app_scope_messages?connectionCode=connectionCodeA': {
+            json: expectedScopeMessages,
+        },
+    });
+    const {result} = renderHook(() => useFetchConnectedAppScopeMessages('connectionCodeA'));
+    const scopeMessages = await result.current();
+
+    expect(scopeMessages).toStrictEqual(expectedScopeMessages);
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app.test.tsx
@@ -1,0 +1,27 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {mockFetchResponses} from '../../../test-utils';
+import {useFetchConnectedApp} from '@src/connect/hooks/use-fetch-connected-app';
+
+test('it fetches the connected app', async () => {
+    const expectedConnectedApp = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'App A',
+        scopes: ['scope A1'],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.test/path/to/logo/a',
+        author: 'author A',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+    };
+
+    mockFetchResponses({
+        'akeneo_connectivity_connection_apps_rest_get_connected_app?connectionCode=connectionCodeA': {
+            json: expectedConnectedApp,
+        },
+    });
+    const {result} = renderHook(() => useFetchConnectedApp('connectionCodeA'));
+    const connectedApp = await result.current();
+
+    expect(connectedApp).toStrictEqual(expectedConnectedApp);
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {screen, wait, waitForElement} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import {renderWithProviders, historyMock, MockFetchResponses, mockFetchResponses} from '../../../test-utils';
+import {ConnectedAppPage} from '@src/connect/pages/ConnectedAppPage';
+import {ConnectedAppContainer} from '@src/connect/components/ConnectedApp/ConnectedAppContainer';
+
+jest.mock('@src/shared/feature-flags/use-feature-flags', () => ({
+    ...jest.requireActual('@src/shared/feature-flags/use-feature-flags'),
+    useFeatureFlags: jest.fn().mockReturnValue({isEnabled: () => true}),
+}));
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useParams: jest.fn().mockReturnValue({connectionCode: 'some_connection_code'}),
+}));
+
+jest.mock('@src/connect/components/ConnectedApp/ConnectedAppContainer', () => ({
+    ConnectedAppContainer: jest.fn(() => null),
+}));
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
+
+test('The connected app page renders with some scopes', async () => {
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: [
+            {
+                icon: 'catalog_structure',
+                type: 'view',
+                entities: 'catalog_structure'
+            },
+        ],
+        connection_code: 'some_connection_code',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    const fetchConnectedAppResponses: MockFetchResponses = {
+        'akeneo_connectivity_connection_apps_rest_get_connected_app?connectionCode=some_connection_code': {
+            json: connectedApp,
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchConnectedAppResponses,
+    });
+
+    renderWithProviders(<ConnectedAppPage />);
+    await wait(() => expect(ConnectedAppContainer).toHaveBeenCalledTimes(1));
+
+    expect(ConnectedAppContainer).toHaveBeenCalledWith({connectedApp: connectedApp}, {});
+
+
+    // await waitForElement(() => screen.getAllByText('App A'));
+    //
+    // expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
+    // expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
+    // expect(screen.queryAllByText('App A')).toHaveLength(2);
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')).toBeInTheDocument();
+    // expect(
+    //     screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    // ).toBeInTheDocument();
+    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.view', {exact: false})).toHaveLength(2);
+    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.edit', {exact: false})).toHaveLength(3);
+    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.delete', {exact: false})).toHaveLength(2);
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.catalog_structure')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.attribute_options')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.categories')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_localization')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_settings')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.association_types')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.products')).toBeInTheDocument();
+});
+
+test('The connected app page renders without scopes', async () => {
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: [],
+        connection_code: 'connectionCode',
+        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    const fetchConnectedAppResponses: MockFetchResponses = {
+        'akeneo_connectivity_connection_apps_rest_get_connected_app?connectionCode=some_connection_code': {
+            json: connectedApp,
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchConnectedAppResponses,
+    });
+
+    renderWithProviders(<ConnectedAppPage />);
+    await wait(() => expect(ConnectedAppContainer).toHaveBeenCalledTimes(1));
+
+    expect(ConnectedAppContainer).toHaveBeenCalledWith({connectedApp: connectedApp}, {});
+
+
+    // await waitForElement(() => screen.getAllByText('App A'));
+    //
+    // expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
+    // expect(screen.queryAllByText('pim_menu.item.connected_apps')).toHaveLength(2);
+    // expect(screen.queryAllByText('App A')).toHaveLength(2);
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')).toBeInTheDocument();
+    // expect(
+    //     screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
+    // ).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.view', {exact: false})).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.edit', {exact: false})).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.delete', {exact: false})).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.catalog_structure')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.attribute_options')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.categories')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_localization')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_settings')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.association_types')).not.toBeInTheDocument();
+    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.products')).not.toBeInTheDocument();
+});
+
+test('The connected app page renders with internal api errors', async () => {
+    const fetchConnectedAppResponses: MockFetchResponses = {
+        'akeneo_connectivity_connection_apps_rest_get_connected_app?connectionCode=some_connection_code': {
+            reject: true,
+            json: {},
+        },
+    };
+
+    mockFetchResponses({
+        ...fetchConnectedAppResponses,
+    });
+
+    renderWithProviders(<ConnectedAppPage />);
+    await waitForElement(() => screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found'));
+
+    expect(screen.queryByText('error.exception', {exact: false})).toBeInTheDocument();
+    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')).toBeInTheDocument();
+    expect(ConnectedAppContainer).not.toHaveBeenCalled();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-test('The connected app page renders with some scopes', async () => {
+test('The connected app page renders with a connected app', async () => {
     const connectedApp = {
         id: '12345',
         name: 'App A',
@@ -59,78 +59,6 @@ test('The connected app page renders with some scopes', async () => {
     await wait(() => expect(ConnectedAppContainer).toHaveBeenCalledTimes(1));
 
     expect(ConnectedAppContainer).toHaveBeenCalledWith({connectedApp: connectedApp}, {});
-
-
-    // await waitForElement(() => screen.getAllByText('App A'));
-    //
-    // expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
-    // expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
-    // expect(screen.queryAllByText('App A')).toHaveLength(2);
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')).toBeInTheDocument();
-    // expect(
-    //     screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
-    // ).toBeInTheDocument();
-    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.view', {exact: false})).toHaveLength(2);
-    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.edit', {exact: false})).toHaveLength(3);
-    // expect(screen.queryAllByText('akeneo_connectivity.connection.connect.apps.scope.type.delete', {exact: false})).toHaveLength(2);
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.catalog_structure')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.attribute_options')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.categories')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_localization')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_settings')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.association_types')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.products')).toBeInTheDocument();
-});
-
-test('The connected app page renders without scopes', async () => {
-    const connectedApp = {
-        id: '12345',
-        name: 'App A',
-        scopes: [],
-        connection_code: 'connectionCode',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
-        author: 'Author A',
-        categories: ['e-commerce', 'print'],
-        certified: false,
-        partner: null,
-    };
-
-    const fetchConnectedAppResponses: MockFetchResponses = {
-        'akeneo_connectivity_connection_apps_rest_get_connected_app?connectionCode=some_connection_code': {
-            json: connectedApp,
-        },
-    };
-
-    mockFetchResponses({
-        ...fetchConnectedAppResponses,
-    });
-
-    renderWithProviders(<ConnectedAppPage />);
-    await wait(() => expect(ConnectedAppContainer).toHaveBeenCalledTimes(1));
-
-    expect(ConnectedAppContainer).toHaveBeenCalledWith({connectedApp: connectedApp}, {});
-
-
-    // await waitForElement(() => screen.getAllByText('App A'));
-    //
-    // expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
-    // expect(screen.queryAllByText('pim_menu.item.connected_apps')).toHaveLength(2);
-    // expect(screen.queryAllByText('App A')).toHaveLength(2);
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')).toBeInTheDocument();
-    // expect(
-    //     screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.information', {exact: false})
-    // ).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.settings.authorizations.no_scope')).toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.view', {exact: false})).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.edit', {exact: false})).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.type.delete', {exact: false})).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.catalog_structure')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.attribute_options')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.categories')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_localization')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.channel_settings')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.association_types')).not.toBeInTheDocument();
-    // expect(screen.queryByText('akeneo_connectivity.connection.connect.apps.scope.entities.products')).not.toBeInTheDocument();
 });
 
 test('The connected app page renders with internal api errors', async () => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppPage.test.tsx
@@ -34,11 +34,11 @@ test('The connected app page renders with a connected app', async () => {
             {
                 icon: 'catalog_structure',
                 type: 'view',
-                entities: 'catalog_structure'
+                entities: 'catalog_structure',
             },
         ],
         connection_code: 'some_connection_code',
-        logo: 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        logo: 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
         author: 'Author A',
         categories: ['e-commerce', 'print'],
         certified: false,
@@ -74,9 +74,13 @@ test('The connected app page renders with internal api errors', async () => {
     });
 
     renderWithProviders(<ConnectedAppPage />);
-    await waitForElement(() => screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found'));
+    await waitForElement(() =>
+        screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')
+    );
 
     expect(screen.queryByText('error.exception', {exact: false})).toBeInTheDocument();
-    expect(screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.not_found')
+    ).toBeInTheDocument();
     expect(ConnectedAppContainer).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If the user has the role `Manage apps`, after an App has been activated, he can access to a page dedicated to the App and it will display a tab Settings in the App menu containing all permissions granted to the App.

![image](https://user-images.githubusercontent.com/4290650/134700696-ecb64295-5d62-49b0-927c-e1cc72e798c9.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
