### PR TITLE
CXP-891 Updated confirm authorization endpoint

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetConnectedAppIdAndUserGroupQueryInterface
+{
+    /**
+     * @return array{appId:string, userGroup:string}|null $appIdAndUserGroup
+     */
+    public function execute(string $appPublicId): ?array;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryInterface.php
@@ -11,7 +11,7 @@ namespace Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query;
 interface GetConnectedAppIdAndUserGroupQueryInterface
 {
     /**
-     * @return array{appId:string, userGroup:string}|null $appIdAndUserGroup
+     * @return array{appId:string, userGroup:string}|null $marketplaceAppId
      */
-    public function execute(string $appPublicId): ?array;
+    public function execute(string $marketplaceAppId): ?array;
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQuery.php
@@ -20,7 +20,10 @@ class GetConnectedAppIdAndUserGroupQuery implements GetConnectedAppIdAndUserGrou
         $this->connection = $connection;
     }
 
-    public function execute(string $appPublicId): ?array
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(string $marketplaceAppId): ?array
     {
         $query = <<<SQL
 SELECT akeneo_connectivity_connected_app.id as appId, oro_access_group.name as userGroup
@@ -29,10 +32,13 @@ JOIN akeneo_connectivity_connection on pim_api_client.id = akeneo_connectivity_c
 JOIN akeneo_connectivity_connected_app on akeneo_connectivity_connection.code = akeneo_connectivity_connected_app.connection_code
 JOIN oro_user_access_group on akeneo_connectivity_connection.user_id = oro_user_access_group.user_id
 JOIN oro_access_group on oro_user_access_group.group_id = oro_access_group.id
-WHERE pim_api_client.marketplace_public_app_id = :id AND oro_access_group.name != 'All'
+WHERE pim_api_client.marketplace_public_app_id = :marketplace_public_app_id
+AND oro_access_group.name != 'All'
 SQL;
 
-        $stmt = $this->connection->executeQuery($query, ['id' => $appPublicId]);
+        $stmt = $this->connection->executeQuery($query, [
+            'marketplace_public_app_id' => $marketplaceAppId,
+        ]);
         $row = $stmt->fetch();
 
         return false === $row ? null : $row;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query\GetConnectedAppIdAndUserGroupQueryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetConnectedAppIdAndUserGroupQuery implements GetConnectedAppIdAndUserGroupQueryInterface
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function execute(string $appPublicId): ?array
+    {
+        $selectQuery = <<<SQL
+SELECT acca.id, oag.name
+FROM pim_api_client pac
+JOIN akeneo_connectivity_connection acc on pac.id = acc.client_id
+JOIN akeneo_connectivity_connected_app acca on acc.code = acca.connection_code
+JOIN oro_user_access_group ouag on acc.user_id = ouag.user_id
+JOIN oro_access_group oag on ouag.group_id = oag.id
+WHERE pac.marketplace_public_app_id = :id AND oag.name != 'All'
+SQL;
+        $resultRow = $this->connection->executeQuery($selectQuery, ['id' => $appPublicId])->fetch() ?: null;
+
+        return null !== $resultRow ? [
+            'appId' => $resultRow['id'],
+            'userGroup' => $resultRow['name'],
+        ] : null;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
@@ -45,4 +45,8 @@ services:
         arguments:
             - '@database_connection'
 
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetConnectedAppIdAndUserGroupQuery:
+        arguments:
+            - '@database_connection'
+
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Normalizer\ViolationListNormalizer: ~

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -102,7 +102,7 @@ services:
         arguments:
             - '@Akeneo\Connectivity\Connection\Application\Apps\Command\CreateAppWithAuthorizationHandler'
             - '@akeneo_connectivity.connection.marketplace_activate.feature'
-            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetConnectedAppIdAndUserGroupQuery'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Normalizer\ViolationListNormalizer'
             - '@oro_security.security_facade'
             - '@logger'

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/ConfirmAuthorizationEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/ConfirmAuthorizationEndToEnd.php
@@ -137,6 +137,8 @@ class ConfirmAuthorizationEndToEnd extends WebTestCase
         Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
         Assert::assertArrayHasKey('appId', $responseContent, 'Response missing appId');
         Assert::assertIsString($responseContent['appId']);
+        Assert::assertArrayHasKey('userGroup', $responseContent, 'Response missing userGroup');
+        Assert::assertIsString($responseContent['userGroup']);
     }
 
     private function loadAppsFixtures(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/GetConnectedAppIdAndUserGroupQueryIntegration.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence\Query;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnection;
+use Akeneo\Connectivity\Connection\Domain\Apps\Model\ConnectedApp;
+use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetConnectedAppIdAndUserGroupQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\User\Internal\CreateUser;
+use Akeneo\Connectivity\Connection\Infrastructure\User\Internal\CreateUserGroup;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetConnectedAppIdAndUserGroupQueryIntegration extends TestCase
+{
+    private DbalConnectedAppRepository $repository;
+    private GetConnectedAppIdAndUserGroupQuery $query;
+    private CreateConnection $createConnection;
+    private ClientProvider $clientProvider;
+    private CreateUserGroup $createUserGroup;
+    private CreateUser $createUser;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->repository = $this->get(DbalConnectedAppRepository::class);
+        $this->query = $this->get(GetConnectedAppIdAndUserGroupQuery::class);
+        $this->createConnection = $this->get(CreateConnection::class);
+        $this->clientProvider = $this->get('akeneo_connectivity.connection.service.apps.client_provider');
+        $this->createUserGroup = $this->get('akeneo_connectivity.connection.service.user.create_user_group');
+        $this->createUser = $this->get('akeneo_connectivity.connection.service.user.create_user');
+
+        $this->createConnectedApp('appA');
+        $this->createConnectedApp('appB');
+    }
+
+    private function createConnectedApp(string $appPublicId): void
+    {
+        $group = $this->createUserGroup->execute('userGroup_' . $appPublicId);
+
+        $user = $this->createUser->execute(
+            'username_' . $appPublicId,
+            'firstname_' . $appPublicId,
+            'lastname_' . $appPublicId,
+            [$group->getName()]
+        );
+
+        $client = $this->clientProvider->findOrCreateClient(App::fromWebMarketplaceValues([
+            'id' => $appPublicId,
+            'name' => 'testName',
+            'logo' => 'testLogo',
+            'author' => 'testAuthor',
+            'url' => 'testUrl',
+            'categories' => [],
+            'activate_url' => 'testUrl',
+            'callback_url' => 'testUrl',
+        ]));
+
+        $this->createConnection->execute(
+            'connectionCode_' . $appPublicId,
+            'Connector_' . $appPublicId,
+            FlowType::OTHER,
+            $client->getId(),
+            $user->id()
+        );
+
+        $this->repository->create(new ConnectedApp(
+            'connectedAppId_' . $appPublicId,
+            'App',
+            [],
+            'connectionCode_' . $appPublicId,
+            'http://www.example.com/path/to/logo',
+            'author',
+            [],
+            false,
+            'partner'
+        ));
+    }
+
+    public function connectedAppIdAndUserGroupDataProvider(): array
+    {
+        return [
+            'appA id and user group is returned ' => [
+                'expected' => [
+                    'appId' => 'connectedAppId_appA',
+                    'userGroup' => 'userGroup_appA'
+                ],
+                'publicAppId' => 'appA',
+            ],
+            'appB id and user group is returned ' => [
+                'expected' => [
+                    'appId' => 'connectedAppId_appB',
+                    'userGroup' => 'userGroup_appB'
+                ],
+                'publicAppId' => 'appB',
+            ],
+            'null returned on an unknown public app id' => [
+                'expected' => null,
+                'publicAppId' => 'unknown app id',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider connectedAppIdAndUserGroupDataProvider
+     */
+    public function test_it_returns_connected_app_id_and_its_user_group(?array $expected, string $publicAppId)
+    {
+        $appIdAndCode = $this->query->execute($publicAppId);
+
+        $this->assertEquals($expected, $appIdAndCode);
+    }
+}


### PR DESCRIPTION
Updated confirm authorization endpoint

**Description (for Contributor and Core Developer)**

The App Wizard requires a user group name to save permissions via form providers
So these changes updates Confirm authorization endpoint to return an id as well as user group name (that was created for the app)