### PR TITLE
CXP-886: Display the Permissions tab

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -87,6 +87,7 @@ akeneo_connectivity.connection:
                 not_found: App not found
                 tabs:
                     settings: Settings
+                    permissions: Permissions
                 settings:
                     authorizations:
                         title: authorizations

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -9,6 +9,7 @@ import {UserButtons} from '../../../shared/user';
 import {ConnectedAppSettings} from './ConnectedAppSettings';
 import {useSessionStorageState} from '@akeneo-pim-community/shared';
 import {ConnectedAppPermissions} from './ConnectedAppPermissions';
+import {usePermissionFormRegistry} from '../../../shared/permission-form-registry';
 
 type Props = {
     connectedApp: ConnectedApp;
@@ -23,6 +24,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
     const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
     const generateMediaUrl = useMediaUrlGenerator();
+    const permissionFormRegistry = usePermissionFormRegistry();
     const [activeTab, setActiveTab] = useSessionStorageState(settingsTabName, 'pim_connectedApp_activeTab');
     const [isCurrent, switchTo] = useTabBar(activeTab);
 
@@ -55,15 +57,17 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                     >
                         {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')}
                     </TabBar.Tab>
-                    <TabBar.Tab
-                        isActive={isCurrent(permissionsTabName)}
-                        onClick={() => {
-                            setActiveTab(permissionsTabName);
-                            switchTo(permissionsTabName);
-                        }}
-                    >
-                        {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')}
-                    </TabBar.Tab>
+                    {permissionFormRegistry.countProviders() > 0 && (
+                        <TabBar.Tab
+                            isActive={isCurrent(permissionsTabName)}
+                            onClick={() => {
+                                setActiveTab(permissionsTabName);
+                                switchTo(permissionsTabName);
+                            }}
+                        >
+                            {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')}
+                        </TabBar.Tab>
+                    )}
                 </TabBar>
 
                 {isCurrent(settingsTabName) && <ConnectedAppSettings connectedApp={connectedApp} />}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -1,5 +1,5 @@
 import React, {FC} from 'react';
-import {Breadcrumb, TabBar} from 'akeneo-design-system';
+import {Breadcrumb, TabBar, useTabBar} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
 import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
@@ -7,10 +7,15 @@ import {useMediaUrlGenerator} from '../../../settings/use-media-url-generator';
 import {PageContent, PageHeader} from '../../../common';
 import {UserButtons} from '../../../shared/user';
 import {ConnectedAppSettings} from './ConnectedAppSettings';
+import {useSessionStorageState} from '@akeneo-pim-community/shared';
+import {ConnectedAppPermissions} from './ConnectedAppPermissions';
 
 type Props = {
     connectedApp: ConnectedApp;
 };
+
+const settingsTabName = '#connected-app-tab-settings';
+const permissionsTabName = '#connected-app-tab-permissions';
 
 export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
     const translate = useTranslate();
@@ -18,6 +23,8 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
     const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
     const generateMediaUrl = useMediaUrlGenerator();
+    const [activeTab, setActiveTab] = useSessionStorageState(settingsTabName, 'pim_connectedApp_activeTab');
+    const [isCurrent, switchTo] = useTabBar(activeTab);
 
     const breadcrumb = (
         <Breadcrumb>
@@ -39,12 +46,29 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
 
             <PageContent>
                 <TabBar moreButtonTitle='More'>
-                    <TabBar.Tab isActive>
+                    <TabBar.Tab
+                        isActive={isCurrent(settingsTabName)}
+                        onClick={() => {
+                            setActiveTab(settingsTabName);
+                            switchTo(settingsTabName);
+                        }}
+                    >
                         {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')}
+                    </TabBar.Tab>
+                    <TabBar.Tab
+                        isActive={isCurrent(permissionsTabName)}
+                        onClick={() => {
+                            setActiveTab(permissionsTabName);
+                            switchTo(permissionsTabName);
+                        }}
+                    >
+                        {translate('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')}
                     </TabBar.Tab>
                 </TabBar>
 
-                <ConnectedAppSettings connectedApp={connectedApp} />
+                {isCurrent(settingsTabName) && <ConnectedAppSettings connectedApp={connectedApp} />}
+
+                {isCurrent(permissionsTabName) && <ConnectedAppPermissions connectedApp={connectedApp} />}
             </PageContent>
         </>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppPermissions.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppPermissions.tsx
@@ -1,0 +1,10 @@
+import React, {FC} from 'react';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
+
+type Props = {
+    connectedApp: ConnectedApp;
+};
+
+export const ConnectedAppPermissions: FC<Props> = ({connectedApp}) => {
+    return <>permissions</>;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry-context.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry-context.ts
@@ -3,4 +3,5 @@ import {PermissionFormRegistry} from './permission-form-registry.interface';
 
 export const PermissionFormRegistryContext = createContext<PermissionFormRegistry>({
     all: () => Promise.resolve([]),
+    countProviders: () => 0,
 });

--- a/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/shared/permission-form-registry/permission-form-registry.interface.ts
@@ -9,4 +9,5 @@ export interface PermissionFormProvider<T> {
 
 export interface PermissionFormRegistry {
     all: () => Promise<PermissionFormProvider<any>[]>;
+    countProviders: () => number;
 }

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -26,13 +26,62 @@ jest.mock('@src/connect/components/ConnectedApp/ConnectedAppPermissions', () => 
     ConnectedAppPermissions: jest.fn(() => null),
 }));
 
+let countRegistryProviders = 0;
+
+jest.mock('@src/shared/permission-form-registry/use-permission-form-registry', () => ({
+    ...jest.requireActual('@src/shared/permission-form-registry/use-permission-form-registry'),
+    usePermissionFormRegistry: () => {
+        return {
+            all: jest.fn(() => null),
+            countProviders: jest.fn(() => countRegistryProviders),
+        };
+    },
+}));
+
 beforeEach(() => {
     fetchMock.resetMocks();
     historyMock.reset();
     jest.clearAllMocks();
 });
 
-test('The connected app container renders', () => {
+test('The connected app container renders without permissions tab', () => {
+    countRegistryProviders = 0;
+
+    const connectedApp = {
+        id: '12345',
+        name: 'App A',
+        scopes: ['scope1', 'scope2'],
+        connection_code: 'some_connection_code',
+        logo: 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+        author: 'Author A',
+        categories: ['e-commerce', 'print'],
+        certified: false,
+        partner: null,
+    };
+
+    renderWithProviders(<ConnectedAppContainer connectedApp={connectedApp} />);
+
+    expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
+    expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
+    expect(screen.queryAllByText('App A')).toHaveLength(2);
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')
+    ).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')
+    ).not.toBeInTheDocument();
+    expect(ConnectedAppSettings).toHaveBeenCalledWith(
+        {
+            connectedApp: connectedApp,
+        },
+        {}
+    );
+    expect(ConnectedAppPermissions).not.toHaveBeenCalled();
+});
+
+test('The connected app container renders with permissions tab', () => {
+    countRegistryProviders = 2;
+
     const connectedApp = {
         id: '12345',
         name: 'App A',

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -1,20 +1,29 @@
 import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
-import {screen} from '@testing-library/react';
+import {act, screen} from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../../test-utils';
 import {ConnectedAppContainer} from '@src/connect/components/ConnectedApp/ConnectedAppContainer';
 import {ConnectedAppSettings} from '@src/connect/components/ConnectedApp/ConnectedAppSettings';
-import {TabBar} from 'akeneo-design-system';
+import {ConnectedAppPermissions} from '@src/connect/components/ConnectedApp/ConnectedAppPermissions';
+import userEvent from '@testing-library/user-event';
+
+type EntryCallback = (entries: {isIntersecting: boolean}[]) => void;
+let entryCallback: EntryCallback | undefined = undefined;
+const intersectionObserverMock = (callback: EntryCallback) => ({
+    observe: jest.fn(() => (entryCallback = callback)),
+    unobserve: jest.fn(),
+});
+window.IntersectionObserver = jest.fn().mockImplementation(intersectionObserverMock);
 
 jest.mock('@src/connect/components/ConnectedApp/ConnectedAppSettings', () => ({
     ...jest.requireActual('@src/connect/components/ConnectedApp/ConnectedAppSettings'),
     ConnectedAppSettings: jest.fn(() => null),
 }));
 
-jest.mock('akeneo-design-system', () => ({
-    ...jest.requireActual('akeneo-design-system'),
-    TabBar: jest.fn(() => null),
+jest.mock('@src/connect/components/ConnectedApp/ConnectedAppPermissions', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApp/ConnectedAppPermissions'),
+    ConnectedAppPermissions: jest.fn(() => null),
 }));
 
 beforeEach(() => {
@@ -41,8 +50,27 @@ test('The connected app container renders', () => {
     expect(screen.queryByText('pim_menu.tab.connect')).toBeInTheDocument();
     expect(screen.queryByText('pim_menu.item.connected_apps')).toBeInTheDocument();
     expect(screen.queryAllByText('App A')).toHaveLength(2);
-    expect(TabBar).toHaveBeenCalledTimes(1);
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.settings')
+    ).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')
+    ).toBeInTheDocument();
     expect(ConnectedAppSettings).toHaveBeenCalledWith(
+        {
+            connectedApp: connectedApp,
+        },
+        {}
+    );
+    expect(ConnectedAppPermissions).not.toHaveBeenCalled();
+
+    act(() => {
+        userEvent.click(
+            screen.getByText('akeneo_connectivity.connection.connect.connected_apps.edit.tabs.permissions')
+        );
+    });
+
+    expect(ConnectedAppPermissions).toHaveBeenCalledWith(
         {
             connectedApp: connectedApp,
         },

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.test.ts
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.test.ts
@@ -36,3 +36,28 @@ test('it can retrieve the list of registered providers', async () => {
         {module_that_should_be_imported: 'module/d'},
     ]);
 });
+
+test('it can count the number of registered providers', () => {
+    PermissionFormRegistry.setModuleConfig({
+        providers: {
+            d: {
+                module: 'module/d',
+                order: 20,
+            },
+            c: {
+                module: 'module/c',
+                order: 10,
+            },
+            a: {
+                module: 'module/a',
+            },
+            b: {
+                module: 'module/b',
+            },
+        },
+    });
+
+    const countProviders = PermissionFormRegistry.countProviders();
+
+    expect(countProviders).toEqual(4);
+});

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/src/registry/PermissionFormRegistry.ts
@@ -40,6 +40,11 @@ const PermissionFormRegistry = {
             })
         );
     },
+    countProviders: (): number => {
+        const providers = _config.providers || [];
+
+        return Object.keys(providers).length
+    },
 };
 
 export default PermissionFormRegistry;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In EE, if the user has the role `Manage apps`, after an App has been activated, he can access to a tab displaying permissions of the App. In order to display the tab only in EE, we base the condition onto whether or not the count of registry providers is greater than 0.

![image](https://user-images.githubusercontent.com/4290650/135122815-a801f7cd-6fee-480e-8c90-0b80c719836e.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
