### PR TITLE
RAC-879: Clean remove attribute maintenance command does not unblacklisted attributes

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -4,26 +4,23 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Command;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Structure\Bundle\Event\AttributeEvents;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute\FindBlacklistedAttributesCodesInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
-use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Oro\Bundle\PimDataGridBundle\Normalizer\IdEncoder;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\Process\Process;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\User\User;
 
@@ -50,6 +47,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     private CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute;
     private CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute;
     private CountProductsAndProductModelsWithInheritedRemovedAttributeInterface $countProductsAndProductModelsWithInheritedRemovedAttribute;
+    private FindBlacklistedAttributesCodesInterface $findBlacklistedAttributesCodes;
     private RouterInterface $router;
     private string $pimUrl;
 
@@ -64,6 +62,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute,
         CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute,
         CountProductsAndProductModelsWithInheritedRemovedAttributeInterface $countProductsAndProductModelsWithInheritedRemovedAttribute,
+        FindBlacklistedAttributesCodesInterface $findBlacklistedAttributesCodes,
         RouterInterface $router,
         string $pimUrl
     ) {
@@ -81,6 +80,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         $this->countProductsAndProductModelsWithInheritedRemovedAttribute = $countProductsAndProductModelsWithInheritedRemovedAttribute;
         $this->router = $router;
         $this->pimUrl = $pimUrl;
+        $this->findBlacklistedAttributesCodes = $findBlacklistedAttributesCodes;
     }
 
     /**
@@ -90,7 +90,13 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     {
         $this
             ->setDescription('Removes all values of deleted attributes on all products and product models')
-            ->addArgument('attributes', InputArgument::OPTIONAL | InputArgument::IS_ARRAY);
+            ->addArgument('attributes', InputArgument::OPTIONAL | InputArgument::IS_ARRAY)
+            ->addOption(
+                'all',
+                null,
+                InputOption::VALUE_NONE,
+                'If defined, all blacklisted attributes will be processed.'
+            );
     }
 
     /**
@@ -101,98 +107,50 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Clean removed attributes values');
 
-        $attributeCodes = $input->getArgument('attributes');
+        $shouldCleanAll = $input->getOption('all');
+        $attributeCodesToClean = $input->getArgument('attributes');
+        $allBlacklistedAttributeCodes = $this->findBlacklistedAttributesCodes->all();
 
-        if (!empty($attributeCodes)) {
-            $this->launchCleanRemovedAttributeJob($io, $attributeCodes);
+
+        if ($shouldCleanAll && !empty($attributeCodesToClean)) {
+            $io->writeln('<error>You cannot specify attribute codes when using the --all option.</error>');
+
+            return 1;
+        }
+
+        if (!$shouldCleanAll && empty($attributeCodesToClean)) {
+            $io->writeln(
+                '<info>Please specify a list of attribute codes to clean or use the --all option to process all blacklisted attributes.</info>'
+            );
+            $io->writeln('<info>Nothing to do.</info>');
+
+            return 1;
+        }
+
+        if (!$this->checkBlacklistedAttributeCodesToCleanAllExist(
+            $io,
+            $attributeCodesToClean,
+            $allBlacklistedAttributeCodes
+        )) {
+            return 0;
+        }
+
+        if ($shouldCleanAll) {
+            if (empty($allBlacklistedAttributeCodes)) {
+                $io->writeln('<info>There was no blacklisted attributes to process.</info>');
+                $io->writeln('<info>Nothing to do.</info>');
+
+                return 0;
+            }
+
+            $this->launchCleanRemovedAttributeJob($io, $allBlacklistedAttributeCodes);
 
             return 0;
         }
 
-        $answer = $io->confirm(
-            'This command will remove all values of deleted attributes on all products and product models' . "\n" .
-                'Do you want to proceed?',
-            true
-        );
-
-        if (!$answer) {
-            $io->text('That\'s ok, see you!');
-
-            return 0;
-        }
-
-        $io->text([
-            'Ok, let\'s go!',
-            '(If you see warnings appearing in the console output, it\'s totally normal as ',
-            'the goal of the command is to avoid those warnings in the future)'
-        ]);
-        $io->newLine(2);
-
-        $products = $this->getProducts($this->productQueryBuilderFactory);
-
-        $progressBar = new ProgressBar($output, count($products));
-
-        $env = $input->getOption('env');
-        $this->cleanProducts($products, $progressBar, $this->productBatchSize, $this->entityManagerClearer, $env, $this->kernelRootDir);
-        $io->newLine();
-        $io->text(sprintf('%d products well cleaned', $products->count()));
-
-        $this->eventDispatcher->dispatch(AttributeEvents::POST_CLEAN);
+        $this->launchCleanRemovedAttributeJob($io, $attributeCodesToClean);
 
         return 0;
-    }
-
-    /**
-     * Get products
-     */
-    private function getProducts(ProductQueryBuilderFactoryInterface $pqbFactory): CursorInterface
-    {
-        $pqb = $pqbFactory->create();
-
-        return $pqb->execute();
-    }
-
-    /**
-     * Iterate over given products to launch clean commands
-     */
-    private function cleanProducts(
-        CursorInterface $products,
-        ProgressBar $progressBar,
-        int $productBatchSize,
-        EntityManagerClearerInterface $cacheClearer,
-        string $env,
-        string $rootDir
-    ): void {
-        $progressBar->start();
-        $productIds = [];
-
-        $productToCleanCount = 0;
-        foreach ($products as $product) {
-            $productIds[] = IdEncoder::encode($product instanceof ProductModel ? 'product_model' : 'product', $product->getId());
-            $productToCleanCount++;
-            if (0 === $productToCleanCount % $productBatchSize) {
-                $this->launchCleanTask($productIds, $env, $rootDir);
-                $cacheClearer->clear();
-                $productIds = [];
-
-                $progressBar->advance($productBatchSize);
-            }
-        }
-        if (count($productIds) > 0) {
-            $this->launchCleanTask($productIds, $env, $rootDir);
-        }
-
-        $progressBar->finish();
-    }
-
-    /**
-     * Launches the clean command on given ids
-     */
-    private function launchCleanTask(array $productIds, string $env, string $rootDir)
-    {
-        $process = new Process([sprintf('%s/../bin/console', $rootDir), 'pim:product:refresh', sprintf('--env=%s', $env), implode(',', $productIds)]);
-        $process->setTimeout(null);
-        $process->run();
     }
 
     /**
@@ -202,18 +160,22 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     {
         $countProducts = $this->countProductsWithRemovedAttribute->count($attributeCodes);
         $countProductModels = $this->countProductModelsWithRemovedAttribute->count($attributeCodes);
-        $countProductVariants = $this->countProductsAndProductModelsWithInheritedRemovedAttribute->count($attributeCodes);
+        $countProductVariants = $this->countProductsAndProductModelsWithInheritedRemovedAttribute->count(
+            $attributeCodes
+        );
 
         $confirmMessage = sprintf(
-            "This command will launch a job to remove the values of the attributes:\n" .
-                "%s\n" .
-                " This will update:\n" .
-                " - %d product model(s) (and %d product variant(s))\n" .
-                " - %d product(s)\n" .
-                " Do you want to proceed?",
-            implode(array_map(function (string $attributeCode) {
-                return sprintf(" - %s\n", $attributeCode);
-            }, $attributeCodes)),
+            "This command will launch a job to remove the values of the attributes:\n".
+            "%s\n".
+            " This will update:\n".
+            " - %d product model(s) (and %d product variant(s))\n".
+            " - %d product(s)\n".
+            " Do you want to proceed?",
+            implode(
+                array_map(function (string $attributeCode) {
+                    return sprintf(" - %s\n", $attributeCode);
+                }, $attributeCodes)
+            ),
             $countProductModels,
             $countProductVariants,
             $countProducts
@@ -227,7 +189,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
 
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier(self::JOB_NAME);
         $jobExecution = $this->jobLauncher->launch($jobInstance, new User(UserInterface::SYSTEM_USER_NAME, null), [
-            'attribute_codes' => $attributeCodes
+            'attribute_codes' => $attributeCodes,
         ]);
 
         $jobUrl = sprintf(
@@ -236,9 +198,29 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
             $this->router->generate(self::JOB_TRACKER_ROUTE, ['id' => $jobExecution->getId()])
         );
 
-        $io->text(sprintf(
-            'The cleaning removed attribute values job has been launched, you can follow its progression here: %s',
-            $jobUrl
-        ));
+        $io->text(
+            sprintf(
+                'The cleaning removed attribute values job has been launched, you can follow its progression here: %s',
+                $jobUrl
+            )
+        );
+
+        $this->eventDispatcher->dispatch(AttributeEvents::POST_CLEAN);
+    }
+
+    private function checkBlacklistedAttributeCodesToCleanAllExist(
+        SymfonyStyle $io,
+        array $attributeCodesToClean,
+        array $allBlacklistedAttributeCodes
+    ): bool {
+        $nonExistingBlacklistedAttributeCodes = array_diff($attributeCodesToClean, $allBlacklistedAttributeCodes);
+        if (!empty($nonExistingBlacklistedAttributeCodes)) {
+            $io->writeln('<error>The following attribute codes do not exist in the Blacklist:</error>');
+            $io->listing($nonExistingBlacklistedAttributeCodes);
+
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
@@ -17,6 +17,7 @@ services:
             - '@akeneo.pim.enrichment.product.query.count_products_with_removed_attribute'
             - '@akeneo.pim.enrichment.product.query.count_product_models_with_removed_attribute'
             - '@akeneo.pim.enrichment.product.query.count_products_and_product_models_with_inherited_removed_attribute'
+            - '@akeneo.pim.structure.query.find_blacklisted_attribute_codes'
             - '@router'
             - '%env(AKENEO_PIM_URL)%'
         tags:

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/FindBlacklistedAttributesCodes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/FindBlacklistedAttributesCodes.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute\FindBlacklistedAttributesCodesInterface;
+use Doctrine\DBAL\Connection;
+
+final class FindBlacklistedAttributesCodes implements FindBlacklistedAttributesCodesInterface
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function all(): array
+    {
+        $sql = <<<SQL
+        SELECT attribute_code FROM pim_catalog_attribute_blacklist;
+SQL;
+
+        $statement = $this->connection->executeQuery($sql);
+
+        return $statement->fetchAll(\PDO::FETCH_COLUMN);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -112,6 +112,11 @@ services:
         arguments:
             - '@database_connection'
 
+    akeneo.pim.structure.query.find_blacklisted_attribute_codes:
+        class: Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\FindBlacklistedAttributesCodes
+        arguments:
+            - '@database_connection'
+
     akeneo.pim.structure.query.get_blacklisted_attribute_job_execution_id:
         class: Akeneo\Pim\Structure\Bundle\Query\InternalApi\Attribute\GetBlacklistedAttributeJobExecutionId
         arguments:

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/FindBlacklistedAttributesCodesInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/FindBlacklistedAttributesCodesInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute;
+
+interface FindBlacklistedAttributesCodesInterface
+{
+    /** @return string[] */
+    public function all(): array;
+}

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/FindBlacklistedAttributeCodesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/FindBlacklistedAttributeCodesIntegration.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\Attribute\Query;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute\FindBlacklistedAttributesCodesInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+final class FindBlacklistedAttributeCodesIntegration extends TestCase
+{
+    private FindBlacklistedAttributesCodesInterface $findBlackListedAttributeCodes;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->findBlackListedAttributeCodes = $this->get('akeneo.pim.structure.query.find_blacklisted_attribute_codes');
+    }
+
+    public function test_it_returns_empty_if_there_is_no_blacklisted_attribute_codes(): void
+    {
+        $actual = $this->findBlackListedAttributeCodes->all();
+        self::assertEmpty($actual);
+    }
+
+    public function test_it_returns_all_blacklisted_attribute_codes(): void
+    {
+        $blacklistedAttributeCodes = ['description', 'image', 'EAN'];
+        $this->createBlacklistedAttributeCodes($blacklistedAttributeCodes);
+
+        $actual = $this->findBlackListedAttributeCodes->all();
+
+        self::assertEqualsCanonicalizing($blacklistedAttributeCodes, $actual);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    /**
+     * @param array $blacklistedAttributeCodes
+     */
+    private function createBlacklistedAttributeCodes(array $blacklistedAttributeCodes): void
+    {
+        $values = implode(
+            ',',
+            array_map(static fn(string $attributeCode) => sprintf("('%s')", $attributeCode), $blacklistedAttributeCodes)
+        );
+        $insertBlackListedAttributeCodesQuery = <<<SQL
+        INSERT INTO `pim_catalog_attribute_blacklist` (`attribute_code`)
+        VALUES $values;
+        SQL;
+
+        /** @var Connection $connection */
+        $connection = $this->get('database_connection');
+        $connection->executeUpdate($insertBlackListedAttributeCodesQuery);
+    }
+}

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/GetBlacklistedAttributeJobExecutionIdIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/GetBlacklistedAttributeJobExecutionIdIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Structure\Integration\Family;
+namespace AkeneoTest\Pim\Structure\Integration\Attribute\Query;
 
 use Akeneo\Pim\Structure\Bundle\Manager\AttributeCodeBlacklister;
 use Akeneo\Pim\Structure\Bundle\Query\InternalApi\Attribute\GetBlacklistedAttributeJobExecutionId;

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/IsAttributeCodeBlacklistedIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/IsAttributeCodeBlacklistedIntegration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AkeneoTest\Pim\Structure\Integration\Family;
+namespace AkeneoTest\Pim\Structure\Integration\Attribute\Query;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/IsThereAtLeastOneAttributeConfiguredWithMeasurementFamilyIntegration.php
@@ -3,7 +3,6 @@
 namespace AkeneoTest\Pim\Structure\Integration\Attribute\Query;
 
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\IsThereAtLeastOneAttributeConfiguredWithMeasurementFamily;
-use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Rework the clean attribute command by:
- Removing the possiblity to "refresh" all the catalog products
- Add the possibility to run a clean job for all blacklisted attributes at once with the --all option.
- Checks if the given attribute codes are indeed blacklisted otherwise, explains the user that the given attribute code does not exist in the blacklist.

<img width="877" alt="Screen Shot 2021-09-29 at 17 19 03" src="https://user-images.githubusercontent.com/1826473/135298807-5b248e95-1448-49b2-b794-eb0dcc15ab09.png">


**Definition Of Done (for Core Developer only)**

- [x] Tests
