### PR TITLE
PIM-10096: Reload PEF main image on channel switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - CVE-2021-3777: Bump tmpl from 1.0.4 to 1.0.5
 - CVE-2021-23343: Bump path-parse from 1.0.6 to 1.0.7
 - GHSA-6fc8-4gx4-v693: Bump ws from 7.4.5 to 7.5.5
+- PIM-10096: Reload PEF main image on channel switching
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/main-image.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/main-image.ts
@@ -5,6 +5,7 @@ const Routing = require('routing');
 class MainImage extends BaseMainImage {
   configure() {
     this.listenTo(this.getRoot(), 'pim_enrich:form:locale_switcher:change', this.render.bind(this));
+    this.listenTo(this.getRoot(), 'pim_enrich:form:scope_switcher:change', this.render.bind(this));
     this.listenTo(this.getRoot(), 'pim_enrich:form:entity:update_state', this.render.bind(this));
 
     return BaseMainImage.prototype.configure.apply(this, arguments);


### PR DESCRIPTION
When the main image of a product is on an attribute of type asset collection, the image can be different for the current locale and channel.

The problem has been fixed for the locale switching here https://github.com/akeneo/pim-community-dev/pull/14202/
But not for the channel switching