### PR TITLE
Update FamilyVariantNormalizer for PHP 7.4 support

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/FamilyVariantNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/FamilyVariantNormalizer.php
@@ -53,7 +53,7 @@ class FamilyVariantNormalizer implements NormalizerInterface, CacheableSupportsM
                 return $attribute->getLabel();
             }, $attributeSet->getAxes()->toArray());
 
-            $normalizedFamilyVariant['level_' . $attributeSet->getLevel()] = implode($axesLabels, ', ');
+            $normalizedFamilyVariant['level_' . $attributeSet->getLevel()] = implode(', ', $axesLabels);
         }
 
         return $normalizedFamilyVariant;


### PR DESCRIPTION
the old notation of implode throws deprecated warnings since 7.4 and with php 8 it will throw an error
https://www.php.net/manual/en/function.implode.php

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
