### PR TITLE
PIM-10095: Fix API error when providing an integer for the identifier…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - CVE-2021-23358: Bump underscore from 1.8.3 to 1.12.1
 - GHSA-6fc8-4gx4-v693: Bump ws from 7.4.5 to 7.5.5 (yarn.lock and front-packages/share/yarn.lock)
 - CVE-2021-23364: Bump browserslist from 4.16.4 to 4.16.6 in /front-packages/shared
+- PIM-10095: Fix API error when providing an integer for the identifier or code when patching products or models
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -435,6 +435,14 @@ class ProductController
     {
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
+        if (!\is_string($code)) {
+            $message = 'The identifier field requires a string.';
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products__code_',
+                sprintf('%s Check the expected format on the API documentation.', $message)
+            );
+        }
+
         $data = $this->getDecodedContent($request->getContent());
 
         try {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -176,9 +176,17 @@ class ProductModelController
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
         $data = $this->getDecodedContent($request->getContent());
+        if (isset($data['code']) && !\is_string($data['code'])) {
+            $message = 'The code field requires a string.';
+            throw new DocumentedHttpException(
+                Documentation::URL . 'post_product_models',
+                sprintf('%s Check the expected format on the API documentation.', $message)
+            );
+        }
+
         $productModel = $this->factory->create();
 
-        $this->updateProductModel($productModel, $data, 'post_product_model');
+        $this->updateProductModel($productModel, $data, 'post_product_models');
         $this->validateProductModel($productModel);
         $this->saver->save($productModel);
 
@@ -201,6 +209,14 @@ class ProductModelController
 
         $data = $this->getDecodedContent($request->getContent());
         $data['code'] = array_key_exists('code', $data) ? $data['code'] : $code;
+
+        if (!\is_string($data['code'])) {
+            $message = 'The code field requires a string.';
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_product_models__code_',
+                sprintf('%s Check the expected format on the API documentation.', $message)
+            );
+        }
 
         $productModel = $this->productModelRepository->findOneByIdentifier($code);
         $isCreation = null === $productModel;

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -184,6 +184,7 @@ JSON;
             'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
             'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
             'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
+            'invalid_identifier_datatype' => '{"identifier":123456}'
         ];
 
         $data =
@@ -198,6 +199,7 @@ ${line['line_too_long_4']}
 ${line['line_too_long_5']}
 ${line['line_too_long_6']}
 ${line['invalid_json_4']}
+${line['invalid_identifier_datatype']}
 JSON;
 
         $expectedContent =
@@ -212,6 +214,7 @@ JSON;
 {"line":8,"status_code":413,"message":"Line is too long."}
 {"line":9,"status_code":413,"message":"Line is too long."}
 {"line":10,"status_code":400,"message":"Invalid json message received"}
+{"line":11,"identifier":123456,"status_code":422,"message":"The identifier field requires a string. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products__code_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -190,7 +190,7 @@ JSON;
   "message": "The parent is not a product model of the family variant \"familyVariantA2\" but belongs to the family \"familyVariantA1\". Check the expected format on the API documentation.",
   "_links": {
     "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+      "href": "http://api.akeneo.com/api-reference.html#post_product_models"
     }
   }
 }
@@ -232,7 +232,7 @@ JSON;
   "message": "Property \"family_variant\" does not expect an empty value. Check the expected format on the API documentation.",
   "_links": {
     "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+      "href": "http://api.akeneo.com/api-reference.html#post_product_models"
     }
   }
 }
@@ -275,7 +275,7 @@ JSON;
   "message": "Property \"family_variant\" does not expect an empty value. Check the expected format on the API documentation.",
   "_links": {
     "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+      "href": "http://api.akeneo.com/api-reference.html#post_product_models"
     }
   }
 }
@@ -381,7 +381,7 @@ JSON;
     "message": "Property \"parent\" expects a valid parent code. The new parent of the product model must be a root product model, \"tshirt_sub_product_model\" given. Check the expected format on the API documentation.",
     "_links": {
         "documentation": {
-            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_model"
+            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_models"
         }
     }
 }
@@ -485,7 +485,7 @@ JSON;
   "message": "The parent is not a product model of the family variant \"familyVariantA2\" but belongs to the family \"familyVariantA1\". Check the expected format on the API documentation.",
   "_links": {
     "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+      "href": "http://api.akeneo.com/api-reference.html#post_product_models"
     }
   }
 }
@@ -615,7 +615,7 @@ JSON;
   "message": "Property \"a_simple_select\" expects an array with the key \"scope\". Check the expected format on the API documentation.",
   "_links": {
     "documentation": {
-      "href": "http://api.akeneo.com/api-reference.html#post_product_model"
+      "href": "http://api.akeneo.com/api-reference.html#post_product_models"
     }
   }
 }
@@ -864,7 +864,7 @@ JSON;
     "message": "Property \"associations\" expects a valid product model identifier. The product model does not exist, \"a_non_exiting_product_model\" given. Check the expected format on the API documentation.",
     "_links": {
         "documentation": {
-            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_model"
+            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_models"
         }
     }
 }
@@ -897,7 +897,7 @@ JSON;
     "message": "The family \"non_matching_family\" does not match the family of the variant \"familyVariantA1\". Check the expected format on the API documentation.",
     "_links": {
         "documentation": {
-            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_model"
+            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_models"
         }
     }
 }
@@ -932,7 +932,7 @@ JSON;
     "message": "Property \"associations\" expects a valid product identifier. The product does not exist, \"a_non_exiting_product\" given. Check the expected format on the API documentation.",
     "_links": {
         "documentation": {
-            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_model"
+            "href": "http:\/\/api.akeneo.com\/api-reference.html#post_product_models"
         }
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -300,7 +300,7 @@ JSON;
         $this->assertSame($expectedContent, $response['content']);
     }
 
-    public function testErrorWhenCodeIsMissing()
+    public function testErrorWhenCodeIsMissingOrInvalid()
     {
         $data =
             <<<JSON
@@ -309,6 +309,7 @@ JSON;
     {"code": ""}
     {"code": " "}
     {}
+    {"code":123456}
 JSON;
 
         $expectedContent =
@@ -318,6 +319,7 @@ JSON;
 {"line":3,"status_code":422,"message":"Code is missing."}
 {"line":4,"status_code":422,"message":"Code is missing."}
 {"line":5,"status_code":422,"message":"Code is missing."}
+{"line":6,"code":123456,"status_code":422,"message":"The code field requires a string. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_product_models__code_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductModelEndToEnd.php
@@ -52,7 +52,7 @@ JSON;
             'message' => 'Property "quantified_associations" expects an array with valid data, association type code should be a string. Check the expected format on the API documentation.',
             '_links' => [
                 'documentation' => [
-                    'href' => 'http://api.akeneo.com/api-reference.html#post_product_model'
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_product_models'
                 ],
             ],
         ];


### PR DESCRIPTION
… or code when patching products or models

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Fixes a 500 error thrown when trying to patch products or models via the API and providing a number for the "code" or "identifier" properties in the JSON body, because we falsely assumed they were strings. (a TypeError was thrown)  

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
