### PR TITLE
PIM-10101: Fix incorrect count of families selection in the family grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 - PIM-10095: Fix API error when providing an integer for the identifier or code when patching products or models
 - CVE-2021-3807: Bump ansi-regex from 5.0.0 to 5.0.1 in /front-packages/shared
 - CVE-2021-23343: Bump path-parse from 1.0.6 to 1.0.7 in /front-packages/shared
+- PIM-10101: Fix incorrect count of families selection in the family grid
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
@@ -48,7 +48,7 @@ extensions:
         targetZone: filters
 
     pim-family-index-mass-actions:
-        module: pim/grid/mass-actions
+        module: pim/family/grid/mass-actions
         parent: pim-family-index
         targetZone: bottom-panel
         config:

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -990,6 +990,7 @@ config:
     pim/grid/category-switcher: pimui/js/product/grid/category-switcher
     pim/grid/mass-actions:      pimui/js/grid/mass-actions
     pim/product/grid/mass-actions: pimui/js/product/grid/mass-actions.ts
+    pim/family/grid/mass-actions: pimui/js/family/grid/mass-actions.ts
 
     # Category tree
     pim/grid/category-tree:      pimui/js/product/grid/category-tree

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/grid/mass-actions.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/grid/mass-actions.ts
@@ -1,0 +1,18 @@
+const BaseForm = require('pim/grid/mass-actions');
+
+class MassActions extends BaseForm {
+  countEntities() {
+    let count = this.count;
+    if (this.datagrid) {
+      const selectionState = this.datagrid.getSelectionState();
+      count = Object.keys(this.datagrid.getSelectionState().selectedModels).length;
+      if (!selectionState.inset) {
+        count = this.collection.state.totalRecords - Object.keys(selectionState.selectedModels).length;
+      }
+    }
+
+    return count;
+  }
+}
+
+export = MassActions;

--- a/src/Oro/Bundle/PimDataGridBundle/Adapter/OroToPimGridFilterAdapter.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Adapter/OroToPimGridFilterAdapter.php
@@ -51,6 +51,10 @@ class OroToPimGridFilterAdapter implements GridFilterAdapterInterface
      */
     protected function adaptDefaultGrid(array $parameters): array
     {
+        if (isset($parameters['inset']) && true === $parameters['inset']) {
+            $parameters['filters'] = [];
+        }
+
         $items = $this->massActionDispatcher->dispatch($parameters);
 
         foreach ($items as &$object) {

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Adapter/OroToPimGridFilterAdapterSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Adapter/OroToPimGridFilterAdapterSpec.php
@@ -5,6 +5,7 @@ namespace spec\Oro\Bundle\PimDataGridBundle\Adapter;
 use PhpSpec\ObjectBehavior;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Prophecy\Argument;
 
 class OroToPimGridFilterAdapterSpec extends ObjectBehavior
 {
@@ -47,13 +48,23 @@ class OroToPimGridFilterAdapterSpec extends ObjectBehavior
         FamilyInterface $family1,
         FamilyInterface $family2
     ) {
-        $massActionDispatcher->dispatch(['gridName' => 'family-grid'])->willReturn([$family1, $family2]);
+        $parameters = [
+            'gridName' => 'family-grid',
+            'inset'    => true,
+            'filters'  => ['myfilter' => 'value'],
+        ];
+
+        $massActionDispatcher->dispatch([
+            'gridName' => 'family-grid',
+            'inset'    => true,
+            'filters'  => [],
+        ])->willReturn([$family1, $family2]);
         $family1->getId()->willReturn(45);
         $family2->getId()->willReturn(70);
 
-        $massActionDispatcher->getRawFilters(['gridName' => 'family-grid'])->shouldNotBeCalled();
+        $massActionDispatcher->getRawFilters(Argument::any())->shouldNotBeCalled();
 
-        $this->adapt(['gridName' => 'family-grid'])->shouldReturn([[
+        $this->adapt($parameters)->shouldReturn([[
             'field'    => 'id',
             'operator' => 'IN',
             'value'    => [45, 70],


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
This PR fixes 2 issues in the family datagrid when we add families to the selection in multiple steps. For example add the first family, then search for a second one, add it to the selection (first issue : the counter at the bottom of the screen displayed 1 selected family) and then launch the bulk action (second issue : only one family was displayed as selected in the bulk action modal. 

The first issue was a frontend issue, already fixed for the product grid in this PR : https://github.com/akeneo/pim-community-dev/pull/15032. I fixed it the same way for the families.

The second issue was on the backend side : the selected families were used as filters to retrieve the family entities, but the search filter was too, so the 2 filters combined always returned the last selected family(ies). In this case, we want only the selected families to be used as filters. Fortunately those 2 issues was already fixed for the product grid, in a dedicated stack though (https://github.com/akeneo/pim-community-dev/blob/master/src/Oro/Bundle/PimDataGridBundle/Adapter/OroToPimGridFilterAdapter.php#L36 / https://github.com/akeneo/pim-community-dev/blob/master/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php#L104). So I simply applied the same logic for the other grids.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
