### PR TITLE
PIM-10103: Fix JS error on attribute options when DQI is disabled

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/AttributeOptionsContextProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/AttributeOptionsContextProvider.tsx
@@ -39,7 +39,10 @@ type Props = {
   attributeOptionsQualityFetcher?: undefined | (() => Promise<SpellcheckEvaluation> | null);
 };
 
-const mergeAttributeOptionsEvaluation = (attributeOptions: AttributeOption[], evaluation: SpellcheckEvaluation | null) => {
+const mergeAttributeOptionsEvaluation = (
+  attributeOptions: AttributeOption[],
+  evaluation: SpellcheckEvaluation | null
+) => {
   if (!evaluation) {
     return attributeOptions;
   }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
EE PR : https://github.com/akeneo/pim-enterprise-dev/pull/11967

This PR fixes a bug that occurs on attribute options screen when DQI is disabled, that can happen only in EE. The evaluation fetcher returned a JSON like `{"code":404,"message":"Feature \"data_quality_insights\" is not enabled."}` with a HTTP error code 404 and it was not handled well because we expects a JSON that contains a valid evaluation (we simply forgot to handle this use case). So to fix this error, I return null in the fetcher (see EE PR) when the backend does not return a 200 and I handle the null in the JS code.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
