### PR TITLE
PurgeableVersionList no longer keeps every version if it is asked to keep none

### DIFF
--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/PurgeableVersionList.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/PurgeableVersionList.php
@@ -46,11 +46,9 @@ final class PurgeableVersionList implements \Countable
 
     public function keep(array $versionIds): self
     {
-        if (empty($versionIds)) {
-            return $this;
+        if (!empty($versionIds)) {
+            $versionIds = array_values(array_intersect($this->versionIds, $versionIds));
         }
-
-        $versionIds = array_values(array_intersect($this->versionIds, $versionIds));
 
         return new self($this->resourceName, $versionIds);
     }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/Purger/KeepLastVersionPurgerAdvisorSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/Purger/KeepLastVersionPurgerAdvisorSpec.php
@@ -39,4 +39,13 @@ class KeepLastVersionPurgerAdvisorSpec extends ObjectBehavior
 
         $this->isPurgeable($versionList)->shouldBeLike(new PurgeableVersionList('resource_name', [1, 2, 3]));
     }
+
+    function it_returns_no_version_when_all_are_last_version(
+        SqlGetAllButLastVersionIdsByIdsQuery $sqlGetAllButLastVersionIdsByIdsQuery
+    ) {
+        $versionList = new PurgeableVersionList('resource_name', [1, 2, 3, 4]);
+        $sqlGetAllButLastVersionIdsByIdsQuery->execute([1, 2, 3, 4])->willReturn([]);
+
+        $this->isPurgeable($versionList)->shouldBeLike(new PurgeableVersionList('resource_name', []));
+    }
 }


### PR DESCRIPTION
If the PurgeableVersionList::keep method is called with an empty list of versions, instead of keeping no versions at all, it keeps all of them.

This means that when the version purge command is run, if at one point the KeepLastVersionPurgerAdvisor is called with versions that all are the latest of their entity, they all get removed instead of being kept.