### PR TITLE
PIM-10107: Hide add quantified association button when ACL is not granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
 - CVE-2021-23343: Bump path-parse from 1.0.6 to 1.0.7 in /front-packages/shared
 - PIM-10094: Increase product grid filters limit display in user settings
 - PIM-10101: Fix incorrect count of families selection in the family grid
+- PIM-10107: Hide add quantified association button when ACL is not granted
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
@@ -10,6 +10,7 @@ import {
   useTranslate,
   useNotify,
   NotificationLevel,
+  useSecurity,
 } from '@akeneo-pim-community/shared';
 import {
   Row,
@@ -79,6 +80,7 @@ const QuantifiedAssociations = ({
   onAssociationsChange,
 }: QuantifiedAssociationsProps) => {
   const translate = useTranslate();
+  const {isGranted} = useSecurity();
   const notify = useNotify();
   const [rowCollection, setRowCollection] = useState<Row[]>(
     quantifiedAssociationToRowCollection(quantifiedAssociations, errors)
@@ -96,6 +98,7 @@ const QuantifiedAssociations = ({
   );
   const filteredCollectionWithProducts = collectionWithProducts.filter(filterOnLabelOrIdentifier(searchValue));
   const inputRef = useRef<HTMLInputElement>(null);
+  const shouldDisplayAddButton = !isCompact && isGranted('pim_enrich_associations_edit');
 
   useAutoFocus(inputRef);
 
@@ -168,7 +171,7 @@ const QuantifiedAssociations = ({
           )}
         </Search.ResultCount>
       </Search>
-      {!isCompact && (
+      {shouldDisplayAddButton && (
         <Buttons>
           <Button level="secondary" onClick={handleAdd}>
             {translate('pim_enrich.entity.product.module.associations.add_associations')}


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The ACL "add association to a product" was not taken into account when displaying the add button
