### PR TITLE
PIM-10030: use POST method to fetch product data grid data to avoid http 414 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 - PIM-10100: Added a product & product model indexation step for setAttributeRequirements job
 - PIM-10092: Display an error message when trying to delete a category tree linked to a channel
 - PIM-10116: Fix filter bar not being sticky on Measurement & Attribute groups page
+- PIM-10030: use POST method to fetch product data grid data to avoid http 414 error
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -13,6 +13,7 @@ datagrid:
             extraKeys:
                 - totalProducts
                 - totalProductModels
+            fetchMethod: POST
         source:
             acl_resource:      pim_enrich_product_index
             type:              pim_datasource_product

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/table.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/grid/table.js
@@ -247,7 +247,7 @@ define([
 
       this.getRoot().trigger('datagrid:getParams', params);
 
-      return $.get(Routing.generate(datagridLoadUrl, params), this.loadDataGrid.bind(this));
+      return $.post(Routing.generate(datagridLoadUrl, {alias: params.alias}), params, this.loadDataGrid.bind(this));
     },
 
     /**

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/routing/datagrid.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/routing/datagrid.yml
@@ -1,7 +1,7 @@
 pim_datagrid_load:
     path: /{alias}/load
     defaults: { _controller: pim_datagrid.controller.datagrid:loadAction }
-    methods: ['GET']
+    methods: ['GET', 'POST']
 
 pim_datagrid_productgrid_attributes_filters:
     path: /product-grid/attributes-filters

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/pageable-collection.js
@@ -119,6 +119,8 @@ define(['underscore', 'backbone', 'backbone/pageable-collection', 'oro/app'], fu
         this.meta = models.meta;
       }
 
+      this.fetchMethod = options.fetchMethod || 'GET';
+
       _.extend(this.queryParams, {
         currentPage: this.inputName + '[_pager][_page]',
         pageSize: this.inputName + '[_pager][_per_page]',
@@ -400,14 +402,17 @@ define(['underscore', 'backbone', 'backbone/pageable-collection', 'oro/app'], fu
 
       // set up query params
       var url = options.url || _.result(this, 'url') || '';
-      var qsi = url.indexOf('?');
-      if (qsi != -1) {
-        _.extend(data, app.unpackFromQueryString(url.slice(qsi + 1)));
-        url = url.slice(0, qsi);
+      if ('GET' === this.fetchMethod) {
+        var qsi = url.indexOf('?');
+        if (qsi != -1) {
+          _.extend(data, app.unpackFromQueryString(url.slice(qsi + 1)));
+          url = url.slice(0, qsi);
+        }
       }
 
       options.url = url;
       options.data = data;
+      options.type = this.fetchMethod;
 
       data = this.processQueryParams(data, state);
       data = this.processFiltersParams(data, state);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Sometimes, users encountered an 414 http error when trying to filters with a large range of values because of too long url.
This PR replace the GET search call with a POST search call.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Changelog (maintenance bug fixes)
