### PR TITLE
PIM-10118: Fix attribute option with numeric code not being translated when exported

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10118: Fix attribute option with numeric code not being translated when exported
+
 # 5.0.50 (2021-10-11)
 
 ## Bug fixes
@@ -123,11 +127,11 @@
 ## BC breaks
 
 - API-1557:
-    - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductCreatedAndUpdatedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
-    - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelCreatedAndUpdatedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
-    - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelRemovedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
-    - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductRemovedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
-    -  Public methods have been changed according to the new interface.
+  - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductCreatedAndUpdatedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
+  - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelCreatedAndUpdatedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
+  - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductModelRemovedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
+  - `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchProductRemovedEventSubscriber` implements `Akeneo\Pim\Enrichment\Bundle\EventSubscriber\BusinessEvent\DispatchBufferedPimEventSubscriberInterface`.
+  - Public methods have been changed according to the new interface.
 
 # 5.0.22 (2021-04-27)
 
@@ -227,7 +231,7 @@
 - PIM-9213: Fix tooltip hover on Ellipsis for Family Name on creating product
 - PIM-9184: API - Fix dbal query group by part for saas instance
 - PIM-9289: Display a correct error message when deleting a group or an association
-- PIM-9327: PDF generation header miss the product name when the attribute used as label is localizable 
+- PIM-9327: PDF generation header miss the product name when the attribute used as label is localizable
 - PIM-9324: Fix product grid not loading when asset used as main picture is deleted
 - PIM-9356: Fix external api endpoint for products with invalid quantified associations
 - PIM-9357: Make rules case-insensitive so it complies with family and attribute codes
@@ -308,7 +312,7 @@
 - CXP-493: Do not save products when they were not actually updated. In order to do so, the product now returns copies of
   its collections (values, categories, groups, associations and quantified associations). Practically, this means that such a collection cannot be directly
   updated "from outside" anymore (e.g: `$product->getCategories()->add($category)` **won't update the product anymore**,
-  you should now use `$product->addCategory($category)` to achieve it)  
+  you should now use `$product->addCategory($category)` to achieve it)
 - CXP-544: Do not save product models when they were not actually updated. As for products, the product model
   will now return copies of its collections (values, categories, associations and quantified associations)
 
@@ -328,51 +332,51 @@
 ## BC breaks
 
 - API-1140: Change $criteria format from `Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Repository\ExternalApi\AttributeRepository`
-    the new format is `[property: [['operator' => (string), 'value' => (mixed)]]]`.
+  the new format is `[property: [['operator' => (string), 'value' => (mixed)]]]`.
 
 ### Codebase
 
 - Change constructor of `Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader` to
-    - add `Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag`
+  - add `Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductModelController` to
-    - add `Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface $productEditDataFilter`
+  - add `Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface $productEditDataFilter`
 - Change constructor of `\Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ProductController` to
-    - add `Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts $getConnectorProductsWithOptions`
-    - add `Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
-    - add `GetProductsWithQualityScoresInterface $getProductsWithQualityScores`  
-    - add `Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface $removeParent`
+  - add `Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts $getConnectorProductsWithOptions`
+  - add `Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
+  - add `GetProductsWithQualityScoresInterface $getProductsWithQualityScores`
+  - add `Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface $removeParent`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\ProductController` to
-    - add `Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface $productEditDataFilter`
-    - add `Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface $removeParent`
+  - add `Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface $productEditDataFilter`
+  - add `Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface $removeParent`
 - Change constructor of `Akeneo\Pim\Structure\Component\Validator\Constraints\ValidMetricValidator` to
-    - remove `array $measures`
-    - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
+  - remove `array $measures`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
 - Change constructor of `Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\MeasureFamilyController` to
-    - remove `array $measures`
-    - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $legacyMeasurementProvider`
+  - remove `array $measures`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $legacyMeasurementProvider`
 - Change constructor of `Akeneo\Tool\Bundle\MeasureBundle\Controller\MeasuresController` to
-    - remove `array $measures`
-    - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
+  - remove `array $measures`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
 - Change constructor of `Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter` to
-    - remove `array $config`
-    - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
+  - remove `array $config`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $provider`
 - Change constructor of `Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager` to
-     - remove `array $config`
-     - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $legacyMeasurementProvider`
+  - remove `array $config`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider $legacyMeasurementProvider`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Localization\Presenter` to
-    - remove `Akeneo\Tool\Component\Localization\TranslatorProxy $translatorProxy`
-    - add `Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface $measurementFamilyRepository`
-    - add `Akeneo\Tool\Component\StorageUtils\Repository\BaseCachedObjectRepository $baseCachedObjectRepository`
-    - add `Psr\Log\LoggerInterface $logger`
+  - remove `Akeneo\Tool\Component\Localization\TranslatorProxy $translatorProxy`
+  - add `Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface $measurementFamilyRepository`
+  - add `Akeneo\Tool\Component\StorageUtils\Repository\BaseCachedObjectRepository $baseCachedObjectRepository`
+  - add `Psr\Log\LoggerInterface $logger`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\GroupNormalizer` to
-    - add `Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers`
+  - add `Akeneo\Pim\Enrichment\Component\Product\Query\GetGroupProductIdentifiers`
 - Change constructor of `Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute` to
-    - add `(string) $defaultMetricUnit`    
+  - add `(string) $defaultMetricUnit`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResultCursor` to add `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ElasticsearchResult $result`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductGrid\FetchProductAndProductModelRows` to add `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Facet\ProductAndProductsModelDocumentTypeFacetFactory $productAndProductsModelDocumentTypeFacetFactory`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Rows` to
-    - add `?int $totalProductCount`
-    - add `?int $totalProductModelCount`
+  - add `?int $totalProductCount`
+  - add `?int $totalProductModelCount`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductAndProductModelQueryBuilderWithSearchAggregatorFactory` to make not nullable the third parameter `Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductAndProductModelSearchAggregator $searchAggregator`
 - Change `Akeneo\Tool\Bundle\MeasureBundle\Manager\MeasureManager` to remove method `setMeasureConfig(array $config)`
 - Remove `Akeneo\Tool\Bundle\MeasureBundle\DependencyInjection\Configuration`
@@ -397,10 +401,10 @@
 - Rename `Akeneo\Tool\Bundle\MeasureBundle\Exception\UnknownFamilyMeasureException` as `Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException`
 - Rename `Akeneo\Tool\Bundle\MeasureBundle\Exception\UnknownMeasureException` as `Akeneo\Tool\Bundle\MeasureBundle\Exception\UnitNotFoundException`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\RefreshProductCommand` to
-    - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $productSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $productSaver`
-    - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $productModelSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $productModelSaver`
+  - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $productSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $productSaver`
+  - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $productModelSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $productModelSaver`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\RemoveCompletenessForChannelAndLocaleCommand` to
-    - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $channelSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $channelSaver`
+  - replace `Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface $channelSaver` by `Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface $channelSaver`
 - Add `getChannels()` and `getLabel()` methods in `Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface` interface
 - Change `addFieldSorter()` method of `Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface` to return `Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface`
 - The `Akeneo\Tool\Component\Api\Repository\ApiResourceRepositoryInterface` interface now also extends `Doctrine\Common\Persistence\ObjectRepository` interface
@@ -412,93 +416,94 @@
 - Change `Akeneo\Pim\Enrichment\Component\Product\Model\Group::getTranslation()` to return null or an instance of `Akeneo\Pim\Enrichment\Component\Product\Model\GroupTranslationInterface`
 - Change `Akeneo\Pim\Enrichment\Component\Category\Model\Category::getTranslation()` to return null or an instance of `Akeneo\Pim\Enrichment\Component\Category\Model\CategoryTranslationInterface`
 - Change `Akeneo\Pim\Enrichment\Component\Comment\Normalizer\Standard\CommentNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\Product\CollectionNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\Product\ValueNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\ProductModelNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Enrichment\Component\Product\Normalizer\Versioning\ProductNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeOptionNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Change `Akeneo\Pim\Structure\Component\Normalizer\InternalApi\AttributeOptionValueCollectionNormalizer` to implement `Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface` instead of `Symfony\Component\Serializer\SerializerAwareInterface`. That means:
-    - the `setSerializer()` method and the `$serializer` property are removed
-    - the `setNormalizer()` method and the `$normalizer` property are added
+  - the `setSerializer()` method and the `$serializer` property are removed
+  - the `setNormalizer()` method and the `$normalizer` property are added
 - Remove `Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ViolationNormalizer` class, it is replaced by `Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi\ConstraintViolationNormalizer`
 - Change `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface` to add `getId()` and `getIdentifier()` methods
 - Change constructor of `Akeneo\Pim\Structure\Bundle\Controller\InternalApi\AttributeGroupController` to replace `Doctrine\ORM\EntityRepository $attributeGroupRepo` by `Akeneo\Pim\Structure\Component\Repository\AttributeGroupRepositoryInterface $attributeGroupRepo`
 - Change `Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface` interface to add `getWithVariants()`
 - Change constructor of `Akeneo\Pim\Structure\Bundle\Query\InternalApi\AttributeGroup\Sql\FindAttributeCodesForAttributeGroup` to replace `Doctrine\DBAL\Driver\Connection $connection` by `Doctrine\DBAL\Connection $connection`
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface` to
-    - remove the `setFamilyId()` method
-    - extend the new `Akeneo\Tool\Component\StorageUtils\Model\StateUpdatedAware` interface (with `isDirty()` and `cleanup()` methods)
-- Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface` to extend the new `Akeneo\Tool\Component\StorageUtils\Model\StateUpdatedAware` interface (with `isDirty()` and `cleanup()` methods)    
+  - remove the `setFamilyId()` method
+  - extend the new `Akeneo\Tool\Component\StorageUtils\Model\StateUpdatedAware` interface (with `isDirty()` and `cleanup()` methods)
+- Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface` to extend the new `Akeneo\Tool\Component\StorageUtils\Model\StateUpdatedAware` interface (with `isDirty()` and `cleanup()` methods)
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct` to
-    - remove the `setFamilyId()` method
-    - remove the `$categoryIds` public property and  the `$familyId` and `$groupIds` protected properties
-    - add `isDirty()` and `cleanup()` methods 
+  - remove the `setFamilyId()` method
+  - remove the `$categoryIds` public property and the `$familyId` and `$groupIds` protected properties
+  - add `isDirty()` and `cleanup()` methods
 - Change the `Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface` to:
-    - remove the `findDatagridViewByAlias()` method
-    - rename the `getDatagridViewTypeByUser()` method to `getDatagridViewAliasesByUser()` and add type hint on the return (array)
-    - add type hint on the return of the `findDatagridViewBySearch()` method (`Doctrine\Common\Collections\Collection`)
+  - remove the `findDatagridViewByAlias()` method
+  - rename the `getDatagridViewTypeByUser()` method to `getDatagridViewAliasesByUser()` and add type hint on the return (array)
+  - add type hint on the return of the `findDatagridViewBySearch()` method (`Doctrine\Common\Collections\Collection`)
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Job\DeleteProductsAndProductModelsTasklet` to
-    - add `Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface $jobRepository`
+  - add `Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface $jobRepository`
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel` to add `isDirty()` and `cleanup()` methods
 - Move `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\WritableDirectory` to `Akeneo\Tool\Component\StorageUtils\Validator\Constraints\WritableDirectory`
 - Move `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\WritableDirectoryValidator` to `Akeneo\Tool\Component\StorageUtils\Validator\Constraints\WritableDirectoryValidator`
 - Change constructor of `Akeneo\Pim\Enrichment\Bundle\Command\CleanRemovedAttributesFromProductAndProductModelCommand` to
-    - add `\Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
-    - remove `\Akeneo\Pim\Enrichment\Component\Product\ValuesRemover\CleanValuesOfRemovedAttributesInterface $cleanValuesOfRemovedAttributes`
-    - add `\Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface $jobLauncher`
-    - add `\Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface $jobInstanceRepository`
-    - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute`
-    - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute`
-    - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface $countProductsAndProductModelsWithInheritedRemovedAttribute`
-    - add `\Symfony\Component\Routing\RouterInterface $router`
-    - add `string $pimUrl`
+
+  - add `\Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher`
+  - remove `\Akeneo\Pim\Enrichment\Component\Product\ValuesRemover\CleanValuesOfRemovedAttributesInterface $cleanValuesOfRemovedAttributes`
+  - add `\Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface $jobLauncher`
+  - add `\Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface $jobInstanceRepository`
+  - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute`
+  - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute`
+  - add `\Akeneo\Pim\Enrichment\Component\Product\Query\CountProductsAndProductModelsWithInheritedRemovedAttributeInterface $countProductsAndProductModelsWithInheritedRemovedAttribute`
+  - add `\Symfony\Component\Routing\RouterInterface $router`
+  - add `string $pimUrl`
 
 - Change the `Oro\Bundle\PimDataGridBundle\Controller\ProductExportController` class to remove the `getRequest()` method
 - Change signature of `createInversedAssociation()` from `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface`
-    - remove `AssociationInterface $association`
-    - add `string $associationTypeCode` and `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface $associatedEntity`
+  - remove `AssociationInterface $association`
+  - add `string $associationTypeCode` and `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface $associatedEntity`
 - Change signature of `removeInversedAssociation()` from `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface`
-    - remove `AssociationInterface $association`
-    - add `string $associationTypeCode` and `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface $associatedEntity`
+  - remove `AssociationInterface $association`
+  - add `string $associationTypeCode` and `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface $associatedEntity`
 - Update `Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithAssociationsInterface` interface:
-    - Remove method `setAssociations()`
-    - Remove method `getAssociationForType()`
-    - Remove method `getAssociationForTypeCode()`
-    - Add method `hasAssociationForTypeCode()`
-    - Add method `addAssociatedProduct()`
-    - Add method `removeAssociatedProduct()`
-    - Add method `getAssociatedProducts()`
-    - Add method `addAssociatedProductModel()`
-    - Add method `removeAssociatedProductModel()`
-    - Add method `getAssociatedProductModels()`
-    - Add method `addAssociatedGroup()`
-    - Add method `removeAssociatedGroup()`
-    - Add method `getAssociatedGroups()`
+  - Remove method `setAssociations()`
+  - Remove method `getAssociationForType()`
+  - Remove method `getAssociationForTypeCode()`
+  - Add method `hasAssociationForTypeCode()`
+  - Add method `addAssociatedProduct()`
+  - Add method `removeAssociatedProduct()`
+  - Add method `getAssociatedProducts()`
+  - Add method `addAssociatedProductModel()`
+  - Add method `removeAssociatedProductModel()`
+  - Add method `getAssociatedProductModels()`
+  - Add method `addAssociatedGroup()`
+  - Add method `removeAssociatedGroup()`
+  - Add method `getAssociatedGroups()`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Updater\Adder\AssociationFieldAdder`:
   - add argument `Akeneo\Pim\Structure\Component\Repository\AssociationTypeRepositoryInterface $associationTypeRepository`
   - add argument `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface $twoWayAssociationUpdater`
-- Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\AssociationFieldClearer`: add argument `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface $twoWayAssociationUpdater`   
+- Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Updater\Clearer\Field\AssociationFieldClearer`: add argument `Akeneo\Pim\Enrichment\Component\Product\Updater\TwoWayAssociationUpdaterInterface $twoWayAssociationUpdater`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Updater\Setter\AssociationFieldSetter`: add argument `Akeneo\Pim\Structure\Component\Repository\AssociationTypeRepositoryInterface $associationTypeRepository`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Factory\ReadValueCollectionFactory` to
-    - add `Psr\Log\LoggerInterface $logger`
+  - add `Psr\Log\LoggerInterface $logger`
 - Move `Akeneo\Channel\Component\Query\GetChannelCodeWithLocaleCodesInterface` to `Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface`
 - Remove `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\ImmutableVariantAxesValues`
 - Remove `Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\ImmutableVariantAxesValuesValidator`
 - Change constructor of `Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\Denormalizer\ProductProcessor` to add `Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\RemoveParentInterface $removeParent`
 - Change constructor of `Akeneo\Platform\Bundle\ImportExportBundle\Controller\Ui\JobTrackerController` to
-    - add `Psr\Log\LoggerInterface $logger`
+  - add `Psr\Log\LoggerInterface $logger`
 
 ### CLI commands
 
@@ -511,5 +516,5 @@ The following CLI commands have been deleted:
 - Update `akeneo_measure.manager` to use `akeneo_measure.provider.measurement_provider`
 - Update `akeneo_measure.controller.rest.measures` to use `akeneo_measure.provider.measurement_provider`
 - Update `legacy_pim_api.controller.measure_family` to use `akeneo_measure.provider.measurement_provider`
-- Rename `pim_api.controller.measure_family` to  `legacy_pim_api.controller.measure_family`
+- Rename `pim_api.controller.measure_family` to `legacy_pim_api.controller.measure_family`
 - Remove parameter `akeneo_measure.measures_config`

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
@@ -16,8 +16,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAt
 
 class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
 {
-    /** @var GetExistingAttributeOptionsWithValues */
-    private $getExistingAttributeOptionsWithValues;
+    private GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues;
 
     public function __construct(GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues)
     {
@@ -38,7 +37,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
 
         $result = [];
         foreach ($values as $valueIndex => $value) {
-            if (empty($value)) {
+            if (null === $value || '' === $value) {
                 $result[$valueIndex] = $value;
                 continue;
             }
@@ -63,7 +62,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
     {
         $optionKeys = [];
         foreach ($values as $value) {
-            if (empty($value)) {
+            if (null === $value || '' === $value) {
                 continue;
             }
             $optionCodes = explode(',', $value);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
@@ -15,8 +15,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAt
  */
 class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
 {
-    /** @var GetExistingAttributeOptionsWithValues */
-    private $getExistingAttributeOptionsWithValues;
+    private GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues;
 
     public function __construct(GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues)
     {
@@ -43,7 +42,7 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
 
         $result = [];
         foreach ($values as $valueIndex => $value) {
-            if (empty($value)) {
+            if (null === $value || '' === $value) {
                 $result[$valueIndex] = $value;
                 continue;
             }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
@@ -47,6 +47,28 @@ class MultiSelectTranslatorSpec extends ObjectBehavior
             ->shouldReturn(['rouge,jaune', 'purple', '']);
     }
 
+    function it_translates_multi_select_value_with_numeric_label(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $locale = 'fr_FR';
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                $this->optionKey('color', 'red'),
+                $this->optionKey('color', 'yellow'),
+                $this->optionKey('color', '0'),
+            ])
+            ->willReturn(
+                [
+                    $this->optionKey('color', 'red') => [$locale => 'rouge'],
+                    $this->optionKey('color', 'yellow') => [$locale => 'jaune'],
+                    $this->optionKey('color', '0') => [$locale => 'zero'],
+                ]
+            );
+
+        $this->translate('color', [], ['red,yellow', '0', ''], $locale)
+            ->shouldReturn(['rouge,jaune', 'zero', '']);
+    }
+
     function it_puts_the_option_code_between_brackets_when_the_option_does_have_a_translation(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
@@ -61,6 +61,32 @@ class SimpleSelectTranslatorSpec extends ObjectBehavior
         )->shouldReturn([$redTranslation, $yellowTranslation, $optionWithoutTranslation]);
     }
 
+    function it_translates_simple_select_value_with_numeric_label(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $locale = 'fr_FR';
+        $attributeCode = 'color';
+
+        $redOptionCode = '0';
+        $redOptionKey = $this->optionKey($attributeCode, $redOptionCode);
+        $redTranslation = 'zero';
+
+        $getExistingAttributeOptionsWithValues->fromAttributeCodeAndOptionCodes(
+            [$redOptionKey]
+        )->willReturn(
+            [
+                $redOptionKey => [$locale => $redTranslation],
+            ]
+        );
+
+        $this->translate(
+            $attributeCode,
+            [],
+            [$redOptionCode],
+            $locale
+        )->shouldReturn([$redTranslation]);
+    }
+
     function it_puts_the_option_code_between_brackets_when_the_option_does_have_a_translation(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Attribute option with `0` as code were not translated because a check with php `empty` was made on the value, and `empty('0')` returns true, so the translator was tricked into thinking the value was empty