### PR TITLE
EXB-1046: Don't delete channel used in Shared Catalogs export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@
 - PIM-10092: Display an error message when trying to delete a category tree linked to a channel
 - PIM-10116: Fix filter bar not being sticky on Measurement & Attribute groups page
 - PIM-10030: use POST method to fetch product data grid data to avoid http 414 error
+- EXB-1046: Don't delete a channel used in an "Export to Shared Catalogs" export profile
 
 ## New features
 

--- a/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/queries.yml
@@ -23,6 +23,7 @@ services:
                 - '%pim_connector.job_name.xlsx_product_model_export%'
                 - '%pim_connector.job_name.csv_product_export%'
                 - '%pim_connector.job_name.csv_product_model_export%'
+                - 'akeneo_shared_catalog'
 
     pimee_security.query.get_all_viewable_locales_for_user:
         class: 'Akeneo\Channel\Bundle\Query\Sql\SqlGetAllViewableLocalesForUser'


### PR DESCRIPTION
**Description**

Deleting a channel in the PIM is blocked if this channel is used in a product export or import.
However, the "Export to Shared Catalogs" job is not handled by this rule, and it is still possible to delete a channel used in this export profile, rendering the export unusable.

This PR adds the `akeneo_shared_catalog` export profile to the list of jobs that can block a channel removal.

**Definition Of Done**

- [ ] ~Tests~
- [ ] ~Migration & Installer~
- [ ] PM Validation (Story)~
- [x] Changelog (maintenance bug fixes)
- [ ] ~Tech Doc~
