### PR TITLE
Load the Migration Versions records before the fixtures

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -170,6 +170,8 @@ class DatabaseCommand extends Command
             $this->createNotMappedTables($output);
         }
 
+        $this->setLatestKnownMigration($input);
+
         if (false === $input->getOption('withoutFixtures')) {
             $this->eventDispatcher->dispatch(
                 new InstallerEvent($this->commandExecutor, null, [
@@ -190,8 +192,6 @@ class DatabaseCommand extends Command
 
         // TODO: Should be in an event subscriber
         $this->launchCommands();
-
-        $this->setLatestKnownMigration($input);
 
         return $this;
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR moves the setLatestKnownMigration method call before the fixtures loading.

Context information: In case the fixtures loading fails, for example, if the fixtures are inconsistent (for any reason), then the migration_versions table will be empty. It can cause the next saas upgrade process to fail if it appends before the migration_versions table records to be repaired.

So by loading the migration_versions records before the load of the fixtures we are sure the migration table is well filled and it will avoid the issue described above.

Thank you very much.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
