### PR TITLE
CXP-827: rename ACL API log channel

### DIFF
--- a/config/packages/monolog.yml
+++ b/config/packages/monolog.yml
@@ -1,2 +1,2 @@
 monolog:
-    channels: ['event_api', 'business_event', 'pim_api_product_acl']
+    channels: ['event_api', 'business_event', 'pim_api_acl']

--- a/config/packages/test/monolog.yml
+++ b/config/packages/test/monolog.yml
@@ -5,6 +5,6 @@ monolog:
           channels: ['!event', '!doctrine', '!event_api', '!business_event']
 
 services:
-    monolog.logger.pim_api_product_acl.test:
-        decorates: monolog.logger.pim_api_product_acl
+    monolog.logger.pim_api_acl.test:
+        decorates: monolog.logger.pim_api_acl
         class: Psr\Log\Test\TestLogger

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -73,7 +73,7 @@ services:
             - '@akeneo.pim.enrichment.use_cases.get_products_with_quality_scores'
             - '@pim_catalog.entity_with_family_variant.remove_parent_from_product'
             - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
-            - '@monolog.logger.pim_api_product_acl'
+            - '@monolog.logger.pim_api_acl'
             - '@oro_security.security_facade'
 
     pim_api.controller.product_model:
@@ -104,7 +104,7 @@ services:
             - '@pim_api.warmup_query_cache.dummy'
             - '@logger'
             - '%pim_api.configuration%'
-            - '@monolog.logger.pim_api_product_acl'
+            - '@monolog.logger.pim_api_acl'
             - '@oro_security.security_facade'
 
     pim_api.controller.category:

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -1010,7 +1010,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -65,7 +65,7 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
         $client->request('DELETE', 'api/rest/v1/products/foo');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -312,7 +312,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -927,7 +927,7 @@ JSON;
         $client->request('GET', 'api/rest/v1/products');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -327,7 +327,7 @@ JSON;
         $result = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
         $response = $result['http_response'];
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -1614,7 +1614,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/products/foo', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -972,7 +972,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/GetProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/GetProductModelEndToEnd.php
@@ -108,7 +108,7 @@ class GetProductModelEndToEnd extends ApiTestCase
         $client->request('GET', 'api/rest/v1/product-models/model-biker-jacket-leather');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
@@ -197,7 +197,7 @@ JSON;
         $client->request('GET', 'api/rest/v1/product-models');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -341,7 +341,7 @@ JSON;
         $result = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);
         $response = $result['http_response'];
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -1326,7 +1326,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_product_acl');
+        $logger = self::$container->get('monolog.logger.pim_api_acl');
         assert($logger instanceof TestLogger);
 
         $this->assertTrue(


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We are going to monitor other ACLs than Product's one with this channel.
Renaming the channel to be consistent.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
