### PR TITLE
PLG-472: Improve rounding key indicators extremities

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
@@ -46,8 +46,9 @@ final class KeyIndicator
     public function getRatioGood(): int
     {
         $total = $this->totalGood + $this->totalToImprove;
+        $ratio = $total === 0 ? 0 : intval(round($this->totalGood / $total * 100));
 
-        return $total === 0 ? 0 : intval(round($this->totalGood / $total * 100));
+        return $this->roundRatioExtremities($ratio);
     }
 
     public function isEmpty(): bool
@@ -68,5 +69,20 @@ final class KeyIndicator
             'totalToImprove' => $this->totalToImprove,
             'extraData' => $this->extraData,
         ];
+    }
+
+    /**
+     * Round ratio extremities to avoid having 100% while there's at least one item to improve
+     * And to avoid having 0% while there's at least one good item
+     */
+    private function roundRatioExtremities(int $ratio): int
+    {
+        if (100 === $ratio && $this->totalToImprove > 0) {
+            return 99;
+        } elseif (0 === $ratio && $this->totalGood > 0) {
+            return 1;
+        }
+
+        return $ratio;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Domain/Model/Read/KeyIndicatorSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Domain/Model/Read/KeyIndicatorSpec.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use PhpSpec\ObjectBehavior;
+
+final class KeyIndicatorSpec extends ObjectBehavior
+{
+    public function it_calculates_the_ratio_of_good_items()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 51, 149, []);
+
+        $this->getRatioGood()->shouldReturn(26);
+    }
+
+    public function it_calculates_the_ratio_of_only_good_items()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 42, 0, []);
+
+        $this->getRatioGood()->shouldReturn(100);
+    }
+
+    public function it_calculates_the_ratio_of_no_good_items()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 0, 77, []);
+
+        $this->getRatioGood()->shouldReturn(0);
+    }
+
+    public function it_rounds_down_the_right_extremity()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 999, 1, []);
+
+        $this->getRatioGood()->shouldReturn(99);
+    }
+
+    public function it_rounds_up_the_left_extremity()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 1, 999, []);
+
+        $this->getRatioGood()->shouldReturn(1);
+    }
+
+    public function it_determines_if_the_key_indicator_is_empty()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 0, 0, []);
+
+        $this->isEmpty()->shouldReturn(true);
+        $this->getRatioGood()->shouldReturn(0);
+    }
+
+    public function it_determines_if_the_key_indicator_is_not_empty()
+    {
+        $this->beConstructedWith(new KeyIndicatorCode('good_enrichment'), 1, 0, []);
+
+        $this->isEmpty()->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
Round ratio extremities to avoid having 100% while there's at least one entity to improve and to avoid having 0% while there's at least one good entity.