### PR TITLE
Fix Symfony debug dependency

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -2,7 +2,7 @@
 <?php
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 
 if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,6 @@
 <?php
 
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
 require dirname(__DIR__).'/config/bootstrap.php';


### PR DESCRIPTION
`Symfony\Component\Debug\Debug` is deprecated since Symfony 4.4 and no longer exist in Symfony 5. It should be replaced by `Symfony\Component\ErrorHandler\Debug`