### PR TITLE
PIM-10138: Fix Add attribute dropdown being hidden when bulk editing Assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@
 - PIM-10090: Fix missing cache clearing during family variant changes computing
 - PIM-10048: fix memory leak in search product models by family variant query
 - PIM-10115: Connections domain blacklist should deny local ip
+- PIM-10138: Fix Add attribute dropdown being hidden when bulk editing Assets
 - PIM-10129: Fix error 414 with a long filter list when launching a bulk action and quick export
 
 ## New features

--- a/front-packages/akeneo-design-system/src/components/Modal/Modal.tsx
+++ b/front-packages/akeneo-design-system/src/components/Modal/Modal.tsx
@@ -21,7 +21,7 @@ const ModalContainer = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: 2000;
+  z-index: 1800;
   overflow: hidden;
   padding: 20px 80px;
   box-sizing: border-box;


### PR DESCRIPTION
There has been an update of the z-index of the Dropdown component to put it below the Select & MultiSelect inputs, but it should also be above the z-index of the Modal component

Order is

- Modal (1800)
- Dropdown (1900)
- Inputs (2000)
