### PR TITLE
PLG-334: Remove useless code in catalog-volume-monitoring

### DIFF
--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -44,36 +44,6 @@ parameters:
     events_api_debug_elasticsearch_index_configuration_file:
         - "%pim_ce_dev_src_folder_location%/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml"
 
-    # these parameters indicate the advisable limitations of the PIM in term of volume
-    # if your volume of data exceeds these limits, it can impact the performance
-    average_max_attributes_per_family_limit: 125
-    average_max_localizable_attributes_per_family_limit: -1
-    average_max_scopable_attributes_per_family_limit: -1
-    average_max_localizable_and_scopable_attributes_per_family_limit: -1
-    average_max_product_values_per_family_limit: -1
-    average_max_options_per_attribute_limit: 145
-    average_max_product_values_limit: -1
-    average_max_product_model_values_limit: -1
-    average_max_categories_in_one_category_limit: 120
-    average_max_category_levels_limit: 5
-    count_attributes_limit: 600
-    count_useable_as_grid_filter_attributes_limit: -1
-    count_categories_limit: 5000
-    count_category_trees_limit: 4
-    count_channels_limit: 3
-    count_families_limit: 120
-    count_locales_limit: 9
-    count_localizable_and_scopable_attributes_limit: 65
-    count_localizable_attributes_limit: 125
-    count_scopable_attributes_limit: 65
-    count_products_limit: 180000
-    count_product_models_limit: -1
-    count_variant_products_limit: -1
-    count_product_values_limit: -1
-    count_product_model_values_limit: -1
-    count_product_and_product_model_values_limit: -1
-    count_users_limit: -1
-
     index_list_changed_total_field_limit:
         - '%env(APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME)%'
     # url to request to fetch announcements in the communication panel

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductModels.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductModels.php
@@ -20,13 +20,9 @@ class CountProductModels implements CountQuery
     /** @var Client */
     private $client;
 
-    /** @var int */
-    private $limit;
-
-    public function __construct(Client $client, int $limit)
+    public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->limit = $limit;
     }
 
     public function fetch(): CountVolume
@@ -46,6 +42,6 @@ class CountProductModels implements CountQuery
         ];
         $result = $this->client->count($query);
 
-        return new CountVolume((int)$result['count'], $this->limit, self::VOLUME_NAME);
+        return new CountVolume((int)$result['count'], self::VOLUME_NAME);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProducts.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProducts.php
@@ -20,13 +20,9 @@ class CountProducts implements CountQuery
     /** @var Client */
     private $client;
 
-    /** @var int */
-    private $limit;
-
-    public function __construct(Client $client, int $limit)
+    public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->limit = $limit;
     }
 
     public function fetch(): CountVolume
@@ -46,6 +42,6 @@ class CountProducts implements CountQuery
         ];
         $result = $this->client->count($query);
 
-        return new CountVolume((int)$result['count'], $this->limit, self::VOLUME_NAME);
+        return new CountVolume((int)$result['count'], self::VOLUME_NAME);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountVariantProducts.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountVariantProducts.php
@@ -20,13 +20,9 @@ class CountVariantProducts implements CountQuery
     /** @var Client */
     private $client;
 
-    /** @var int */
-    private $limit;
-
-    public function __construct(Client $client, int $limit)
+    public function __construct(Client $client)
     {
         $this->client = $client;
-        $this->limit = $limit;
     }
 
     public function fetch(): CountVolume
@@ -51,6 +47,6 @@ class CountVariantProducts implements CountQuery
         ];
         $result = $this->client->count($query);
 
-        return new CountVolume((int)$result['count'], $this->limit, self::VOLUME_NAME);
+        return new CountVolume((int)$result['count'], self::VOLUME_NAME);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxOptionsPerAttribute.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxOptionsPerAttribute.php
@@ -22,17 +22,12 @@ class AggregatedAverageMaxOptionsPerAttribute implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -51,7 +46,7 @@ SQL;
         $maxValue = isset($sqlResult['max']) ? (int) $sqlResult['max'] : 0;
         $averageValue = isset($sqlResult['average']) ? (int) $sqlResult['average'] : 0;
 
-        $volume = new AverageMaxVolumes($maxValue, $averageValue, $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes($maxValue, $averageValue, self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxProductAndProductModelValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxProductAndProductModelValues.php
@@ -22,17 +22,12 @@ class AggregatedAverageMaxProductAndProductModelValues implements AverageMaxQuer
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -64,6 +59,6 @@ SQL;
         $maxValue = isset($sqlResult['max']) ? (int) $sqlResult['max'] : 0;
         $averageValue = isset($sqlResult['average']) ? (int) $sqlResult['average'] : 0;
 
-        return new AverageMaxVolumes($maxValue, $averageValue, $this->limit, self::VOLUME_NAME);
+        return new AverageMaxVolumes($maxValue, $averageValue, self::VOLUME_NAME);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedCountProductAndProductModelValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedCountProductAndProductModelValues.php
@@ -22,17 +22,12 @@ class AggregatedCountProductAndProductModelValues implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     public function fetch(): CountVolume
@@ -45,6 +40,6 @@ SQL;
         $sqlResult = $this->connection->executeQuery($sql)->fetchAssociative();
         $volumeValue = isset($sqlResult['value']) ? (int) $sqlResult['value'] : 0;
 
-        return new CountVolume($volumeValue, $this->limit, self::VOLUME_NAME);
+        return new CountVolume($volumeValue, self::VOLUME_NAME);
     }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxAttributesPerFamily.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxAttributesPerFamily.php
@@ -20,16 +20,12 @@ class AverageMaxAttributesPerFamily implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -48,7 +44,7 @@ class AverageMaxAttributesPerFamily implements AverageMaxQuery
             ) a
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoriesInOneCategory.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoriesInOneCategory.php
@@ -20,16 +20,12 @@ class AverageMaxCategoriesInOneCategory implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -49,7 +45,7 @@ class AverageMaxCategoriesInOneCategory implements AverageMaxQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoryLevels.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoryLevels.php
@@ -20,17 +20,12 @@ class AverageMaxCategoryLevels implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -46,7 +41,7 @@ class AverageMaxCategoryLevels implements AverageMaxQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamily.php
@@ -20,17 +20,12 @@ class AverageMaxLocalizableAndScopableAttributesPerFamily implements AverageMaxQ
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -50,7 +45,7 @@ class AverageMaxLocalizableAndScopableAttributesPerFamily implements AverageMaxQ
             ) as attr;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamily.php
@@ -20,17 +20,12 @@ class AverageMaxLocalizableAttributesPerFamily implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -50,7 +45,7 @@ class AverageMaxLocalizableAttributesPerFamily implements AverageMaxQuery
             ) as attr;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxOptionsPerAttribute.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxOptionsPerAttribute.php
@@ -21,16 +21,12 @@ class AverageMaxOptionsPerAttribute implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -54,7 +50,7 @@ class AverageMaxOptionsPerAttribute implements AverageMaxQuery
             ) as opa
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductModelValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductModelValues.php
@@ -20,17 +20,12 @@ class AverageMaxProductModelValues implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -46,7 +41,7 @@ class AverageMaxProductModelValues implements AverageMaxQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new AverageMaxVolumes((int)$result['max'], (int)$result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int)$result['max'], (int)$result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValues.php
@@ -20,16 +20,12 @@ class AverageMaxProductValues implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -45,7 +41,7 @@ class AverageMaxProductValues implements AverageMaxQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamily.php
@@ -20,17 +20,12 @@ class AverageMaxProductValuesPerFamily implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -74,7 +69,7 @@ class AverageMaxProductValuesPerFamily implements AverageMaxQuery
             ) as a
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamily.php
@@ -20,17 +20,12 @@ class AverageMaxScopableAttributesPerFamily implements AverageMaxQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -50,7 +45,7 @@ class AverageMaxScopableAttributesPerFamily implements AverageMaxQuery
             ) as attr;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], $this->limit, self::VOLUME_NAME);
+        $volume = new AverageMaxVolumes((int) $result['max'], (int) $result['average'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountAttributes.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountAttributes.php
@@ -20,16 +20,12 @@ class CountAttributes implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -42,7 +38,7 @@ class CountAttributes implements CountQuery
             FROM pim_catalog_attribute;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategories.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategories.php
@@ -20,16 +20,12 @@ class CountCategories implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -42,7 +38,7 @@ class CountCategories implements CountQuery
             FROM pim_catalog_category
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoryTrees.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoryTrees.php
@@ -20,16 +20,12 @@ class CountCategoryTrees implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -43,7 +39,7 @@ class CountCategoryTrees implements CountQuery
             WHERE lvl = 0;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountChannels.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountChannels.php
@@ -20,16 +20,12 @@ class CountChannels implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -42,7 +38,7 @@ class CountChannels implements CountQuery
             FROM pim_catalog_channel;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountFamilies.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountFamilies.php
@@ -20,16 +20,12 @@ class CountFamilies implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -42,7 +38,7 @@ class CountFamilies implements CountQuery
             FROM pim_catalog_family;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocales.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocales.php
@@ -20,16 +20,12 @@ class CountLocales implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -43,7 +39,7 @@ class CountLocales implements CountQuery
             WHERE is_activated = 1;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAndScopableAttributes.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAndScopableAttributes.php
@@ -20,16 +20,12 @@ class CountLocalizableAndScopableAttributes implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -43,7 +39,7 @@ class CountLocalizableAndScopableAttributes implements CountQuery
             WHERE is_localizable = 1 AND is_scopable = 1;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAttributes.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAttributes.php
@@ -20,16 +20,12 @@ class CountLocalizableAttributes implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -43,7 +39,7 @@ class CountLocalizableAttributes implements CountQuery
             WHERE is_localizable = 1 AND is_scopable = 0;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductModelValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductModelValues.php
@@ -22,17 +22,12 @@ class CountProductModelValues implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -46,7 +41,7 @@ class CountProductModelValues implements CountQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new CountVolume((int) $result['sum_product_model_values'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['sum_product_model_values'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductValues.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductValues.php
@@ -20,17 +20,12 @@ class CountProductValues implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int        $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -44,7 +39,7 @@ class CountProductValues implements CountQuery
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
 
-        $volume = new CountVolume((int) $result['sum_product_values'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['sum_product_values'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountScopableAttributes.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountScopableAttributes.php
@@ -20,16 +20,12 @@ class CountScopableAttributes implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -43,7 +39,7 @@ class CountScopableAttributes implements CountQuery
             WHERE is_localizable = 0 AND is_scopable = 1;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributes.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributes.php
@@ -20,17 +20,12 @@ class CountUseableAsGridFilterAttributes implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -44,7 +39,7 @@ class CountUseableAsGridFilterAttributes implements CountQuery
             WHERE useable_as_grid_filter = 1;
 SQL;
         $result = $this->connection->executeQuery($sql)->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUsers.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUsers.php
@@ -21,17 +21,12 @@ class CountUsers implements CountQuery
     /** @var Connection */
     private $connection;
 
-    /** @var int */
-    private $limit;
-
     /**
      * @param Connection $connection
-     * @param int $limit
      */
-    public function __construct(Connection $connection, int $limit)
+    public function __construct(Connection $connection)
     {
         $this->connection = $connection;
-        $this->limit = $limit;
     }
 
     /**
@@ -46,7 +41,7 @@ WHERE oro_user.user_type = :type
 SQL;
 
         $result = $this->connection->executeQuery($sql, ['type' => User::TYPE_USER])->fetchAssociative();
-        $volume = new CountVolume((int) $result['count'], $this->limit, self::VOLUME_NAME);
+        $volume = new CountVolume((int) $result['count'], self::VOLUME_NAME);
 
         return $volume;
     }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/queries.yml
@@ -3,7 +3,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_attributes_per_family_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query }
 
@@ -11,25 +10,21 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxScopableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_scopable_attributes_per_family_limit%'
 
     pim_volume_monitoring.persistence.query.average_max_localizable_attributes_per_family:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_localizable_attributes_per_family_limit%'
 
     pim_volume_monitoring.persistence.query.average_max_localizable_and_scopable_attributes_per_family:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxLocalizableAndScopableAttributesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_localizable_and_scopable_attributes_per_family_limit%'
 
     pim_volume_monitoring.persistence.query.average_max_options_per_attribute:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxOptionsPerAttribute'
         arguments:
             - '@database_connection'
-            - '%average_max_options_per_attribute_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query_to_aggregate }
 
@@ -37,7 +32,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AggregatedAverageMaxOptionsPerAttribute'
         arguments:
             - '@database_connection'
-            - '%average_max_options_per_attribute_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query }
 
@@ -45,7 +39,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValues'
         arguments:
             - '@database_connection'
-            - '%average_max_product_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query_to_aggregate }
 
@@ -53,7 +46,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductModelValues'
         arguments:
             - '@database_connection'
-            - '%average_max_product_model_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query_to_aggregate }
 
@@ -61,7 +53,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AggregatedAverageMaxProductAndProductModelValues'
         arguments:
             - '@database_connection'
-            - '%average_max_product_model_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.average_max_query }
 
@@ -69,25 +60,21 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxProductValuesPerFamily'
         arguments:
             - '@database_connection'
-            - '%average_max_product_values_per_family_limit%'
 
     pim_volume_monitoring.persistence.query.average_max_categories_in_one_category:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxCategoriesInOneCategory'
         arguments:
             - '@database_connection'
-            - '%average_max_categories_in_one_category_limit%'
 
     pim_volume_monitoring.persistence.query.average_max_category_levels:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AverageMaxCategoryLevels'
         arguments:
             - '@database_connection'
-            - '%average_max_category_levels_limit%'
 
     pim_volume_monitoring.persistence.query.count_attributes:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountAttributes'
         arguments:
             - '@database_connection'
-            - '%count_attributes_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -95,13 +82,11 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUseableAsGridFilterAttributes'
         arguments:
             - '@database_connection'
-            - '%count_useable_as_grid_filter_attributes_limit%'
 
     pim_volume_monitoring.persistence.query.count_categories:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountCategories'
         arguments:
             - '@database_connection'
-            - '%count_categories_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -109,7 +94,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountCategoryTrees'
         arguments:
             - '@database_connection'
-            - '%count_category_trees_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -117,7 +101,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountChannels'
         arguments:
             - '@database_connection'
-            - '%count_channels_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -125,7 +108,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountFamilies'
         arguments:
             - '@database_connection'
-            - '%count_families_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -133,7 +115,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountLocales'
         arguments:
             - '@database_connection'
-            - '%count_locales_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -141,7 +122,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountLocalizableAndScopableAttributes'
         arguments:
             - '@database_connection'
-            - '%count_localizable_and_scopable_attributes_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -149,7 +129,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountLocalizableAttributes'
         arguments:
             - '@database_connection'
-            - '%count_localizable_attributes_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -157,7 +136,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountScopableAttributes'
         arguments:
             - '@database_connection'
-            - '%count_scopable_attributes_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -165,7 +143,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Elasticsearch\CountProducts'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '%count_products_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
             - { name: pim_volume_monitoring.persistence.count_query_to_aggregate }
@@ -174,7 +151,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Elasticsearch\CountProductModels'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '%count_product_models_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
             - { name: pim_volume_monitoring.persistence.count_query_to_aggregate }
@@ -183,7 +159,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Elasticsearch\CountVariantProducts'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
-            - '%count_variant_products_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -191,7 +166,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountProductValues'
         arguments:
             - '@database_connection'
-            - '%count_product_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query_to_aggregate }
 
@@ -199,7 +173,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountProductModelValues'
         arguments:
             - '@database_connection'
-            - '%count_product_model_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query_to_aggregate }
 
@@ -207,7 +180,6 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\AggregatedCountProductAndProductModelValues'
         arguments:
             - '@database_connection'
-            - '%count_product_and_product_model_values_limit%'
         tags:
             - { name: pim_volume_monitoring.persistence.count_query }
 
@@ -215,4 +187,3 @@ services:
         class: 'Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Persistence\Query\Sql\CountUsers'
         arguments:
             - '@database_connection'
-            - '%count_users_limit%'

--- a/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizer.php
+++ b/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizer.php
@@ -28,7 +28,6 @@ class AverageMaxVolumesNormalizer
                     'average' => $data->getAverageVolume(),
                     'max' => $data->getMaxVolume(),
                 ],
-                'has_warning' => $data->hasWarning(),
                 'type' => self::VOLUME_TYPE
             ]
         ];

--- a/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizer.php
+++ b/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizer.php
@@ -24,7 +24,6 @@ class CountVolumeNormalizer
         $data = [
             $data->getVolumeName() => [
                 'value' => $data->getVolume(),
-                'has_warning' => $data->hasWarning(),
                 'type' => self::VOLUME_TYPE
             ]
         ];

--- a/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumes.php
+++ b/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumes.php
@@ -22,23 +22,13 @@ class AverageMaxVolumes
     /** @var int */
     private $averageVolume;
 
-    /** @var int*/
-    private $limit;
-
     /** @var string */
     private $volumeName;
 
-    /**
-     * @param int    $maxVolume
-     * @param int    $averageVolume
-     * @param int    $limit
-     * @param string $volumeName
-     */
-    public function __construct(int $maxVolume, int $averageVolume, int $limit, string $volumeName)
+    public function __construct(int $maxVolume, int $averageVolume, string $volumeName)
     {
         $this->maxVolume = $maxVolume;
         $this->averageVolume = $averageVolume;
-        $this->limit = $limit;
         $this->volumeName = $volumeName;
     }
 
@@ -55,10 +45,5 @@ class AverageMaxVolumes
     public function getVolumeName(): string
     {
         return $this->volumeName;
-    }
-
-    public function hasWarning(): bool
-    {
-        return $this->limit >= 0 && $this->maxVolume > $this->limit;
     }
 }

--- a/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolume.php
+++ b/src/Akeneo/Platform/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolume.php
@@ -16,21 +16,16 @@ class CountVolume
     /** @var int */
     private $volume;
 
-    /** @var int*/
-    private $limit;
-
     /** @var string */
     private $volumeName;
 
     /**
      * @param int    $volume
-     * @param int    $limit
      * @param string $volumeName
      */
-    public function __construct(int $volume, int $limit, string $volumeName)
+    public function __construct(int $volume, string $volumeName)
     {
         $this->volume = $volume;
-        $this->limit = $limit;
         $this->volumeName = $volumeName;
     }
 
@@ -42,10 +37,5 @@ class CountVolume
     public function getVolumeName(): string
     {
         return $this->volumeName;
-    }
-
-    public function hasWarning(): bool
-    {
-        return $this->limit >= 0 && $this->volume > $this->limit;
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/AttributeContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/AttributeContext.php
@@ -37,16 +37,6 @@ final class AttributeContext implements Context
     }
 
     /**
-     * @Given the limit of the number of attributes is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfAttributesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of attributes is :numberOfAttributes
      *
      * @param int $numberOfAttributes
@@ -56,25 +46,5 @@ final class AttributeContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfAttributes, $volumes['count_attributes']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of attributes is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_attributes']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of attributes is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_attributes']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/AttributePerFamilyContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/AttributePerFamilyContext.php
@@ -59,24 +59,4 @@ final class AttributePerFamilyContext implements Context
 
         Assert::eq($volumes['average_max_attributes_per_family']['value']['max'], $number);
     }
-
-    /**
-     * @Given the limit of the number of attributes per family is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
-     * @Then the report warns the users that the number of attributes per family is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfAttributesPerFamilyIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['average_max_attributes_per_family']['has_warning']);
-    }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryContext.php
@@ -37,16 +37,6 @@ final class CategoryContext implements Context
     }
 
     /**
-     * @Given the limit of the number of categories is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfCategoriesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of categories is :numberOfCategories
      *
      * @param int $numberOfCategories
@@ -56,25 +46,5 @@ final class CategoryContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfCategories, $volumes['count_categories']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of categories is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfCategoriesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_categories']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of categories is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfCategoriesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_categories']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryInOneCategoryContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryInOneCategoryContext.php
@@ -37,16 +37,6 @@ final class CategoryInOneCategoryContext implements Context
     }
 
     /**
-     * @Given the limit of the number of category in one category is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfCategoryInOneCategoryIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the maximum of category in one category is :maxOfCategoryInOneCategory
      *
      * @param int $maxOfCategoryInOneCategory

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryLevelContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryLevelContext.php
@@ -37,16 +37,6 @@ final class CategoryLevelContext implements Context
     }
 
     /**
-     * @Given the limit of the number of category levels is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfCategoryLevelsIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the maximum of category levels is :maxOfCategoryLevels
      *
      * @param int $maxOfCategoryLevels

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryTreeContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/CategoryTreeContext.php
@@ -37,16 +37,6 @@ final class CategoryTreeContext implements Context
     }
 
     /**
-     * @Given the limit of the number of category trees is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfCategoryTreesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of category trees is :numberOfCategoryTrees
      *
      * @param int $numberOfCategoryTrees
@@ -56,25 +46,5 @@ final class CategoryTreeContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfCategoryTrees, $volumes['count_category_trees']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of category trees is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfCategoryTreesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_category_trees']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of category trees is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfCategoryTreesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_category_trees']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ChannelContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ChannelContext.php
@@ -37,16 +37,6 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @Given the limit of the number of channels is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfChannelsIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of channels is :numberOfChannels
      *
      * @param int $numberOfChannels
@@ -56,25 +46,5 @@ final class ChannelContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfChannels, $volumes['count_channels']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of channels is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfChannelsIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_channels']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of channels is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfChannelsIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_channels']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/FamilyContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/FamilyContext.php
@@ -37,16 +37,6 @@ final class FamilyContext implements Context
     }
 
     /**
-     * @Given the limit of the number of families is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfFamiliesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of families is :numberOfFamilies
      *
      * @param int $numberOfFamilies
@@ -56,25 +46,5 @@ final class FamilyContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfFamilies, $volumes['count_families']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of families is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfFamiliesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_families']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of families is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfFamiliesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_families']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocaleContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocaleContext.php
@@ -37,16 +37,6 @@ final class LocaleContext implements Context
     }
 
     /**
-     * @Given the limit of the number of locales is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfLocalesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of locales is :numberOfLocales
      *
      * @param int $numberOfLocales
@@ -56,25 +46,5 @@ final class LocaleContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfLocales, $volumes['count_locales']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of locales is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfLocalesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_locales']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of locales is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfLocalesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_locales']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocalizableAndScopableAttributeContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocalizableAndScopableAttributeContext.php
@@ -37,16 +37,6 @@ final class LocalizableAndScopableAttributeContext implements Context
     }
 
     /**
-     * @Given the limit of the number of localizable and scopable attributes is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfLocalizableAndScopableAttributesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of localizable and scopable attributes is :number
      *
      * @param int $number
@@ -56,25 +46,5 @@ final class LocalizableAndScopableAttributeContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($number, $volumes['count_localizable_and_scopable_attributes']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of localizable and scopable attributes is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfLocalizableAndScopableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_localizable_and_scopable_attributes']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of localizable and scopable attributes is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfLocalizableAndScopableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_localizable_and_scopable_attributes']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocalizableAttributeContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/LocalizableAttributeContext.php
@@ -37,16 +37,6 @@ final class LocalizableAttributeContext implements Context
     }
 
     /**
-     * @Given the limit of the number of localizable attributes is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfLocalizableAttributesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of localizable attributes is :numberOfLocalizableAttributes
      *
      * @param int $numberOfLocalizableAttributes
@@ -56,25 +46,5 @@ final class LocalizableAttributeContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfLocalizableAttributes, $volumes['count_localizable_attributes']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of localizable attributes is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberOfLocalizableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_localizable_attributes']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of localizable attributes is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberOfLocalizableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_localizable_attributes']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ProductContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ProductContext.php
@@ -37,16 +37,6 @@ final class ProductContext implements Context
     }
 
     /**
-     * @Given the limit of the number of products is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfProductsIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of products is :numberOfProducts
      *
      * @param int $numberOfProducts
@@ -56,25 +46,5 @@ final class ProductContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfProducts, $volumes['count_products']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of products is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_products']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of products is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_products']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ScopableAttributeContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/ScopableAttributeContext.php
@@ -37,16 +37,6 @@ final class ScopableAttributeContext implements Context
     }
 
     /**
-     * @Given the limit of the number of scopable attributes is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfScopableAttributesIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of scopable attributes is :numberOfScopableAttributes
      *
      * @param int $numberOfScopableAttributes
@@ -56,25 +46,5 @@ final class ScopableAttributeContext implements Context
         $volumes = $this->reportContext->getVolumes();
 
         Assert::eq($numberOfScopableAttributes, $volumes['count_scopable_attributes']['value']);
-    }
-
-    /**
-     * @Then the report warns the users that the number of scopable attributes is high
-     */
-    public function theReportWarnsTheUsersThatTheNumberScopableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::true($volumes['count_scopable_attributes']['has_warning']);
-    }
-
-    /**
-     * @Then the report does not warn the users that the number of scopable attributes is high
-     */
-    public function theReportDoesNotWarnTheUsersThatTheNumberScopableAttributesIsHigh(): void
-    {
-        $volumes = $this->reportContext->getVolumes();
-
-        Assert::false($volumes['count_scopable_attributes']['has_warning']);
     }
 }

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/UserContext.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Context/UserContext.php
@@ -37,16 +37,6 @@ final class UserContext implements Context
     }
 
     /**
-     * @Given the limit of the number of users is set to :limit
-     *
-     * @param int $limit
-     */
-    public function theLimitOfTheNumberOfUsersIsSetTo(int $limit): void
-    {
-        $this->inMemoryQuery->setLimit($limit);
-    }
-
-    /**
      * @Then the report returns that the number of users is :numberOfUsers
      *
      * @param int $numberOfUsers

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Persistence/Query/InMemory/InMemoryAverageMaxQuery.php
@@ -14,9 +14,6 @@ use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\ReadModel\AverageMa
  */
 class InMemoryAverageMaxQuery implements AverageMaxQuery
 {
-    /** @var int */
-    private $limit;
-
     /** @var string */
     private $volumeName;
 
@@ -29,7 +26,6 @@ class InMemoryAverageMaxQuery implements AverageMaxQuery
     public function __construct(string $volumeName)
     {
         $this->volumeName = $volumeName;
-        $this->limit = -1;
     }
 
     /**
@@ -40,7 +36,7 @@ class InMemoryAverageMaxQuery implements AverageMaxQuery
         $averageVolume = empty($this->values) ? 0 : intval(array_sum($this->values) / count($this->values));
         $maxVolume =  empty($this->values) ? 0 : max($this->values);
 
-        return new AverageMaxVolumes($maxVolume, $averageVolume, $this->limit, $this->volumeName);
+        return new AverageMaxVolumes($maxVolume, $averageVolume, $this->volumeName);
     }
 
     /**

--- a/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Persistence/Query/InMemory/InMemoryCountQuery.php
+++ b/tests/back/Platform/Acceptance/CatalogVolumeMonitoring/Persistence/Query/InMemory/InMemoryCountQuery.php
@@ -17,9 +17,6 @@ class InMemoryCountQuery implements CountQuery
     /** @var int */
     private $volume;
 
-    /** @var int*/
-    private $limit;
-
     /** @var string */
     private $volumeName;
 
@@ -30,7 +27,6 @@ class InMemoryCountQuery implements CountQuery
     {
         $this->volumeName = $volumeName;
         $this->volume = -1;
-        $this->limit = -1;
     }
 
     /**
@@ -38,7 +34,7 @@ class InMemoryCountQuery implements CountQuery
      */
     public function fetch(): CountVolume
     {
-        return new CountVolume($this->volume, $this->limit, $this->volumeName);
+        return new CountVolume($this->volume, $this->volumeName);
     }
 
     /**
@@ -47,13 +43,5 @@ class InMemoryCountQuery implements CountQuery
     public function setVolume(int $volume): void
     {
         $this->volume = $volume;
-    }
-
-    /**
-     * @param int $limit
-     */
-    public function setLimit(int $limit): void
-    {
-        $this->limit = $limit;
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedAverageMaxOptionsPerAttributeIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedAverageMaxOptionsPerAttributeIntegration.php
@@ -35,6 +35,5 @@ class AggregatedAverageMaxOptionsPerAttributeIntegration extends TestCase
         $this->assertEquals('average_max_options_per_attribute', $volume->getVolumeName());
         $this->assertEquals(23, $volume->getMaxVolume());
         $this->assertEquals(15, $volume->getAverageVolume());
-        $this->assertFalse($volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedAverageMaxProductAndProductModelValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedAverageMaxProductAndProductModelValuesIntegration.php
@@ -49,6 +49,5 @@ class AggregatedAverageMaxProductAndProductModelValuesIntegration extends TestCa
         $this->assertEquals('average_max_product_and_product_model_values', $volume->getVolumeName());
         $this->assertEquals(23, $volume->getMaxVolume());
         $this->assertEquals(14, $volume->getAverageVolume());
-        $this->assertFalse($volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedCountProductAndProductModelValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AggregatedCountProductAndProductModelValuesIntegration.php
@@ -28,6 +28,5 @@ class AggregatedCountProductAndProductModelValuesIntegration extends TestCase
 
         $this->assertEquals('count_product_and_product_model_values', $volume->getVolumeName());
         $this->assertEquals(58, $volume->getVolume());
-        $this->assertFalse($volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxAttributesPerFamilyIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxAttributesPerFamilyIntegration.php
@@ -21,7 +21,6 @@ class AverageMaxAttributesPerFamilyIntegration extends QueryTestCase
         Assert::assertEquals(8, $volume->getMaxVolume());
         Assert::assertEquals(5, $volume->getAverageVolume());
         Assert::assertEquals('average_max_attributes_per_family', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxCategoriesInOneCategoryIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxCategoriesInOneCategoryIntegration.php
@@ -22,7 +22,6 @@ class AverageMaxCategoriesInOneCategoryIntegration extends QueryTestCase
         Assert::assertEquals(6, $volume->getMaxVolume());
         Assert::assertEquals(5, $volume->getAverageVolume());
         Assert::assertEquals('average_max_categories_in_one_category', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration.php
@@ -21,7 +21,6 @@ class AverageMaxLocalizableAndScopableAttributesPerFamilyIntegration extends Que
         Assert::assertEquals(80, $volume->getMaxVolume());
         Assert::assertEquals(40, $volume->getAverageVolume());
         Assert::assertEquals('average_max_localizable_and_scopable_attributes_per_family', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxLocalizableAttributesPerFamilyIntegration.php
@@ -21,7 +21,6 @@ class AverageMaxLocalizableAttributesPerFamilyIntegration extends QueryTestCase
         Assert::assertEquals(30, $volume->getMaxVolume());
         Assert::assertEquals(17, $volume->getAverageVolume());
         Assert::assertEquals('average_max_localizable_attributes_per_family', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxOptionsPerAttributeIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxOptionsPerAttributeIntegration.php
@@ -22,7 +22,6 @@ class AverageMaxOptionsPerAttributeIntegration extends QueryTestCase
         Assert::assertEquals(8, $volume->getMaxVolume());
         Assert::assertEquals(5, $volume->getAverageVolume());
         Assert::assertEquals('average_max_options_per_attribute', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxProductModelValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxProductModelValuesIntegration.php
@@ -19,7 +19,6 @@ class AverageMaxProductModelValuesIntegration extends QueryTestCase
         $this->assertEquals(6, $volume->getMaxVolume());
         $this->assertEquals(5, $volume->getAverageVolume());
         $this->assertEquals('average_max_product_model_values', $volume->getVolumeName());
-        $this->assertFalse($volume->hasWarning());
     }
 
     public function testGetAverageAndMaximumNumberOfProductModelValuesDoesNotTakeAccountOfProductValues()
@@ -34,6 +33,5 @@ class AverageMaxProductModelValuesIntegration extends QueryTestCase
        $this->assertEquals(6, $volume->getMaxVolume());
        $this->assertEquals(5, $volume->getAverageVolume());
        $this->assertEquals('average_max_product_model_values', $volume->getVolumeName());
-       $this->assertFalse($volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxProductValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxProductValuesIntegration.php
@@ -21,7 +21,6 @@ class AverageMaxProductValuesIntegration extends QueryTestCase
         Assert::assertEquals(6, $volume->getMaxVolume());
         Assert::assertEquals(5, $volume->getAverageVolume());
         Assert::assertEquals('average_max_product_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     public function testGetAverageAndMaximumNumberOfProductValuesDoesNotTakeAccountOfProductModelValues()
@@ -36,6 +35,5 @@ class AverageMaxProductValuesIntegration extends QueryTestCase
         Assert::assertEquals(6, $volume->getMaxVolume());
         Assert::assertEquals(5, $volume->getAverageVolume());
         Assert::assertEquals('average_max_product_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/AverageMaxScopableAttributesPerFamilyIntegration.php
@@ -21,7 +21,6 @@ class AverageMaxScopableAttributesPerFamilyIntegration extends QueryTestCase
         Assert::assertEquals(84, $volume->getMaxVolume());
         Assert::assertEquals(40, $volume->getAverageVolume());
         Assert::assertEquals('average_max_scopable_attributes_per_family', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountAttributesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountAttributesIntegration.php
@@ -18,7 +18,6 @@ class CountAttributesIntegration extends QueryTestCase
 
         Assert::assertEquals(8, $volume->getVolume());
         Assert::assertEquals('count_attributes', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountCategoriesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountCategoriesIntegration.php
@@ -19,7 +19,6 @@ class CountCategoriesIntegration extends QueryTestCase
         //in minimal catalog we have one category
         Assert::assertEquals(9, $volume->getVolume());
         Assert::assertEquals('count_categories', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountCategoryTreesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountCategoryTreesIntegration.php
@@ -21,7 +21,6 @@ class CountCategoryTreesIntegration extends QueryTestCase
         //in minimal catalogue we have one root category
         Assert::assertEquals(4, $volume->getVolume());
         Assert::assertEquals('count_category_trees', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountChannelsIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountChannelsIntegration.php
@@ -19,7 +19,6 @@ class CountChannelsIntegration extends QueryTestCase
         //in minimal catalogue we have one channel
         Assert::assertEquals(5, $volume->getVolume());
         Assert::assertEquals('count_channels', $volume->getVolumeName());
-        Assert::assertEquals(true, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountFamiliesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountFamiliesIntegration.php
@@ -18,7 +18,6 @@ class CountFamiliesIntegration extends QueryTestCase
 
         Assert::assertEquals(4, $volume->getVolume());
         Assert::assertEquals('count_families', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalesIntegration.php
@@ -22,7 +22,6 @@ class CountLocalesIntegration extends QueryTestCase
 
         Assert::assertEquals(3, $volume->getVolume());
         Assert::assertEquals('count_locales', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalizableAndScopableAttributesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalizableAndScopableAttributesIntegration.php
@@ -20,6 +20,5 @@ class CountLocalizableAndScopableAttributesIntegration extends QueryTestCase
 
         Assert::assertEquals(3, $volume->getVolume());
         Assert::assertEquals('count_localizable_and_scopable_attributes', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalizableAttributesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountLocalizableAttributesIntegration.php
@@ -20,6 +20,5 @@ class CountLocalizableAttributesIntegration extends QueryTestCase
 
         Assert::assertEquals(4, $volume->getVolume());
         Assert::assertEquals('count_localizable_attributes', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductModelValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductModelValuesIntegration.php
@@ -19,7 +19,6 @@ class CountProductModelValuesIntegration extends QueryTestCase
 
         Assert::assertEquals(10, $volume->getVolume());
         Assert::assertEquals('count_product_model_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     public function testGetCountOfProductValuesDoesNotCountProductValues()
@@ -33,6 +32,5 @@ class CountProductModelValuesIntegration extends QueryTestCase
 
         Assert::assertEquals(10, $volume->getVolume());
         Assert::assertEquals('count_product_model_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductModelsIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductModelsIntegration.php
@@ -23,7 +23,6 @@ class CountProductModelsIntegration extends QueryTestCase
 
         Assert::assertEquals(4, $volume->getVolume());
         Assert::assertEquals('count_product_models', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductValuesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductValuesIntegration.php
@@ -19,7 +19,6 @@ class CountProductValuesIntegration extends QueryTestCase
 
         Assert::assertEquals(10, $volume->getVolume());
         Assert::assertEquals('count_product_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     public function testGetCountOfProductValuesDoesNotCountProductModelValues()
@@ -33,6 +32,5 @@ class CountProductValuesIntegration extends QueryTestCase
 
         Assert::assertEquals(10, $volume->getVolume());
         Assert::assertEquals('count_product_values', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductsIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountProductsIntegration.php
@@ -18,7 +18,6 @@ class CountProductsIntegration extends QueryTestCase
 
         Assert::assertEquals(8, $volume->getVolume());
         Assert::assertEquals('count_products', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountScopableAttributesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountScopableAttributesIntegration.php
@@ -20,6 +20,5 @@ class CountScopableAttributesIntegration extends QueryTestCase
 
         Assert::assertEquals(5, $volume->getVolume());
         Assert::assertEquals('count_scopable_attributes', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 }

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUseableAsGridFilterAttributesIntegration.php
@@ -18,7 +18,6 @@ class CountUseableAsGridFilterAttributesIntegration extends QueryTestCase
 
         Assert::assertEquals(5, $volume->getVolume());
         Assert::assertEquals('count_useable_as_grid_filter_attributes', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountUsersIntegration.php
@@ -21,7 +21,6 @@ class CountUsersIntegration extends QueryTestCase
 
         Assert::assertEquals(4, $volume->getVolume());
         Assert::assertEquals('count_users', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     /**

--- a/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountVariantProductsIntegration.php
+++ b/tests/back/Platform/Integration/CatalogVolumeMonitoring/Persistence/Query/CountVariantProductsIntegration.php
@@ -18,7 +18,6 @@ class CountVariantProductsIntegration extends QueryTestCase
 
         Assert::assertEquals(8, $volume->getVolume());
         Assert::assertEquals('count_variant_products', $volume->getVolumeName());
-        Assert::assertEquals(false, $volume->hasWarning());
     }
 
     private function createVariantProducts(int $numberOfVariantProducts) : void

--- a/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollectorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/AttributeDataCollectorSpec.php
@@ -57,16 +57,16 @@ class AttributeDataCollectorSpec extends ObjectBehavior
         $localizableAndScopableAttributePerFamilyAverageMaxQuery,
         $attributePerFamilyAverageMaxQuery
     ) {
-        $attributeCountQuery->fetch()->willReturn(new CountVolume(1000, -1, 'count_attributes'));
-        $localizableAttributeCountQuery->fetch()->willReturn(new CountVolume(33, -1, 'count_localizable_attributes'));
-        $scopableAttributeCountQuery->fetch()->willReturn(new CountVolume(40, -1, 'count_scopable_attributes'));
-        $localizableAndScopableAttributeCountQuery->fetch()->willReturn(new CountVolume(64, -1, 'count_localizable_and_scopable_attributes'));
-        $useableAsGridFilterAttributeCountQuery->fetch()->willReturn(new CountVolume(12, -1, 'count_useable_as_grid_filter_attributes'));
+        $attributeCountQuery->fetch()->willReturn(new CountVolume(1000, 'count_attributes'));
+        $localizableAttributeCountQuery->fetch()->willReturn(new CountVolume(33, 'count_localizable_attributes'));
+        $scopableAttributeCountQuery->fetch()->willReturn(new CountVolume(40, 'count_scopable_attributes'));
+        $localizableAndScopableAttributeCountQuery->fetch()->willReturn(new CountVolume(64, 'count_localizable_and_scopable_attributes'));
+        $useableAsGridFilterAttributeCountQuery->fetch()->willReturn(new CountVolume(12, 'count_useable_as_grid_filter_attributes'));
 
-        $localizableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12, 7, -1, 'average_max_localizable_attributes_per_family'));
-        $scopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(13, 9, -1, 'average_max_scopable_attributes_per_family'));
-        $localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(10, 7, -1, 'average_max_localizable_and_scopable_attributes_per_family'));
-        $attributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(20, 15, -1, 'avg_number_attributes_per_family'));
+        $localizableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12, 7,'average_max_localizable_attributes_per_family'));
+        $scopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(13, 9,'average_max_scopable_attributes_per_family'));
+        $localizableAndScopableAttributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(10, 7, 'average_max_localizable_and_scopable_attributes_per_family'));
+        $attributePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(20, 15, 'avg_number_attributes_per_family'));
 
         $this->collect()->shouldReturn([
             'nb_attributes' => 1000,

--- a/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/DBDataCollectorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/AnalyticsBundle/DataCollector/DBDataCollectorSpec.php
@@ -92,21 +92,21 @@ class DBDataCollectorSpec extends ObjectBehavior
         IsDemoCatalogQuery $isDemoCatalogQuery,
         ActiveEventSubscriptionCountQuery $activeEventSubscriptionCountQuery
     ) {
-        $channelCountQuery->fetch()->willReturn(new CountVolume(3, -1, 'count_channels'));
-        $productCountQuery->fetch()->willReturn(new CountVolume(1121, -1, 'count_products'));
-        $localeCountQuery->fetch()->willReturn(new CountVolume(3, -1, 'count_locales'));
-        $familyCountQuery->fetch()->willReturn(new CountVolume(14, -1, 'count_families'));
-        $attributeCountQuery->fetch()->willReturn(new CountVolume(110, -1, 'count_attributes'));
-        $userCountQuery->fetch()->willReturn(new CountVolume(5, -1, 'count_users'));
-        $productModelCountQuery->fetch()->willReturn(new CountVolume(123, -1, 'count_product_models'));
-        $variantProductCountQuery->fetch()->willReturn(new CountVolume(89, -1, 'count_variant_products'));
-        $categoryCountQuery->fetch()->willReturn(new CountVolume(250, -1, 'count_categories'));
-        $categoryTreeCountQuery->fetch()->willReturn(new CountVolume(3, -1, 'count_category_trees'));
-        $categoriesInOneCategoryAverageMax->fetch()->willReturn(new AverageMaxVolumes(25,2, -1, 'average_max_categories_in_one_category'));
-        $categoryLevelsAverageMax->fetch()->willReturn(new AverageMaxVolumes(6, 4, -1, 'average_max_category_levels'));
-        $productValueCountQuery->fetch()->willReturn(new CountVolume(254897, -1, 'count_product_values'));
-        $productValueAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(8,7, -1, 'average_max_product_values'));
-        $productValuePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12,10, -1, 'average_max_product_values_per_family'));
+        $channelCountQuery->fetch()->willReturn(new CountVolume(3, 'count_channels'));
+        $productCountQuery->fetch()->willReturn(new CountVolume(1121, 'count_products'));
+        $localeCountQuery->fetch()->willReturn(new CountVolume(3, 'count_locales'));
+        $familyCountQuery->fetch()->willReturn(new CountVolume(14, 'count_families'));
+        $attributeCountQuery->fetch()->willReturn(new CountVolume(110, 'count_attributes'));
+        $userCountQuery->fetch()->willReturn(new CountVolume(5, 'count_users'));
+        $productModelCountQuery->fetch()->willReturn(new CountVolume(123, 'count_product_models'));
+        $variantProductCountQuery->fetch()->willReturn(new CountVolume(89, 'count_variant_products'));
+        $categoryCountQuery->fetch()->willReturn(new CountVolume(250, 'count_categories'));
+        $categoryTreeCountQuery->fetch()->willReturn(new CountVolume(3, 'count_category_trees'));
+        $categoriesInOneCategoryAverageMax->fetch()->willReturn(new AverageMaxVolumes(25,2, 'average_max_categories_in_one_category'));
+        $categoryLevelsAverageMax->fetch()->willReturn(new AverageMaxVolumes(6, 4, 'average_max_category_levels'));
+        $productValueCountQuery->fetch()->willReturn(new CountVolume(254897, 'count_product_values'));
+        $productValueAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(8,7, 'average_max_product_values'));
+        $productValuePerFamilyAverageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(12,10, 'average_max_product_values_per_family'));
         $emailDomains->fetch()->willReturn('example.com,other-example.com');
         $apiConnectionCount->fetch()->willReturn([
             'data_source' => ['tracked' => 0, 'untracked' => 0],

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductModelsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductModelsSpec.php
@@ -29,6 +29,6 @@ class CountProductModelsSpec extends ObjectBehavior
     function it_gets_the_products_volume(Client $client)
     {
         $client->count(Argument::type('array'))->shouldBeCalled()->willReturn(['count' => 7]);
-        $this->fetch()->shouldBeLike(new CountVolume(7, 10, 'count_product_models'));
+        $this->fetch()->shouldBeLike(new CountVolume(7, 'count_product_models'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountProductsSpec.php
@@ -29,6 +29,6 @@ class CountProductsSpec extends ObjectBehavior
     function it_gets_the_products_volume(Client $client)
     {
         $client->count(Argument::type('array'))->shouldBeCalled()->willReturn(['count' => 75]);
-        $this->fetch()->shouldBeLike(new CountVolume(75, 100, 'count_products'));
+        $this->fetch()->shouldBeLike(new CountVolume(75, 'count_products'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountVariantProductsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Elasticsearch/CountVariantProductsSpec.php
@@ -29,6 +29,6 @@ class CountVariantProductsSpec extends ObjectBehavior
     function it_gets_the_products_volume(Client $client)
     {
         $client->count(Argument::type('array'))->shouldBeCalled()->willReturn(['count' => 33]);
-        $this->fetch()->shouldBeLike(new CountVolume(33, 50, 'count_variant_products'));
+        $this->fetch()->shouldBeLike(new CountVolume(33, 'count_variant_products'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxOptionsPerAttributeSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxOptionsPerAttributeSpec.php
@@ -43,7 +43,7 @@ class AggregatedAverageMaxOptionsPerAttributeSpec extends ObjectBehavior
             ]
         );
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(12, 7, 10, 'average_max_options_per_attribute'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(12, 7, 'average_max_options_per_attribute'));
     }
 
     function it_fetches_a_average_max_with_empty_values_if_no_aggregated_volume_has_been_found(
@@ -57,6 +57,6 @@ class AggregatedAverageMaxOptionsPerAttributeSpec extends ObjectBehavior
         $statement->executeQuery()->shouldBeCalled()->willReturn($result);
         $result->fetchAssociative()->willReturn(null);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 10, 'average_max_options_per_attribute'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 'average_max_options_per_attribute'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxProductAndProductModelValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedAverageMaxProductAndProductModelValuesSpec.php
@@ -39,7 +39,7 @@ class AggregatedAverageMaxProductAndProductModelValuesSpec extends ObjectBehavio
             ]
         );
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(12, 7, 10, 'average_max_product_and_product_model_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(12, 7, 'average_max_product_and_product_model_values'));
     }
 
     function it_fetches_an_average_max_with_empty_values_if_no_aggregated_volume_has_been_found(
@@ -49,6 +49,6 @@ class AggregatedAverageMaxProductAndProductModelValuesSpec extends ObjectBehavio
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(null);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 10, 'average_max_product_and_product_model_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 'average_max_product_and_product_model_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedCountProductAndProductModelValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AggregatedCountProductAndProductModelValuesSpec.php
@@ -35,7 +35,7 @@ class AggregatedCountProductAndProductModelValuesSpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['value' => 123]);
 
-        $this->fetch()->shouldBeLike(new CountVolume(123, 30, 'count_product_and_product_model_values'));
+        $this->fetch()->shouldBeLike(new CountVolume(123, 'count_product_and_product_model_values'));
     }
 
     function it_fetches_a_count_volume_with_an_empty_value_if_no_aggregated_volume_has_been_found(Connection $connection, Result $statement)
@@ -43,6 +43,6 @@ class AggregatedCountProductAndProductModelValuesSpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(null);
 
-        $this->fetch()->shouldBeLike(new CountVolume(0, 30, 'count_product_and_product_model_values'));
+        $this->fetch()->shouldBeLike(new CountVolume(0, 'count_product_and_product_model_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxAttributesPerFamilySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxAttributesPerFamilySpec.php
@@ -34,6 +34,6 @@ class AverageMaxAttributesPerFamilySpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 12, 'average_max_attributes_per_family'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_attributes_per_family'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoriesInOneCategorySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoriesInOneCategorySpec.php
@@ -34,6 +34,6 @@ class AverageMaxCategoriesInOneCategorySpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, -1, 'average_max_categories_in_one_category'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_categories_in_one_category'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoryLevelsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxCategoryLevelsSpec.php
@@ -34,6 +34,6 @@ class AverageMaxCategoryLevelsSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, -1, 'average_max_category_levels'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_category_levels'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamilySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAndScopableAttributesPerFamilySpec.php
@@ -35,7 +35,7 @@ class AverageMaxLocalizableAndScopableAttributesPerFamilySpec extends ObjectBeha
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '5', 'max' => '10']);
         $this->fetch()->shouldBeLike(
-            new AverageMaxVolumes(10, 5, 15, 'average_max_localizable_and_scopable_attributes_per_family')
+            new AverageMaxVolumes(10, 5, 'average_max_localizable_and_scopable_attributes_per_family')
         );
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamilySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxLocalizableAttributesPerFamilySpec.php
@@ -34,6 +34,6 @@ class AverageMaxLocalizableAttributesPerFamilySpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '5', 'max' => '13']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(13, 5, 14, 'average_max_localizable_attributes_per_family'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(13, 5, 'average_max_localizable_attributes_per_family'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxOptionsPerAttributeSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxOptionsPerAttributeSpec.php
@@ -34,6 +34,6 @@ class AverageMaxOptionsPerAttributeSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 12, 'average_max_options_per_attribute'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_options_per_attribute'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductModelValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductModelValuesSpec.php
@@ -35,7 +35,7 @@ class AverageMaxProductModelValuesSpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 12, 'average_max_product_model_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_product_model_values'));
     }
 
     function it_gets_average_and_max_volume_of_an_empty_catalog(Connection $connection, Result $statement)
@@ -43,6 +43,6 @@ class AverageMaxProductModelValuesSpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => null, 'max' => null]);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 12, 'average_max_product_model_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 'average_max_product_model_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamilySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesPerFamilySpec.php
@@ -34,7 +34,7 @@ class AverageMaxProductValuesPerFamilySpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '5', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 5, 100, 'average_max_product_values_per_family'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 5, 'average_max_product_values_per_family'));
     }
 
     function it_gets_average_and_max_volume_of_an_empty_catalog(Connection $connection, Result $statement)
@@ -42,6 +42,6 @@ class AverageMaxProductValuesPerFamilySpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => null, 'max' => null]);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 100, 'average_max_product_values_per_family'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 'average_max_product_values_per_family'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxProductValuesSpec.php
@@ -34,7 +34,7 @@ class AverageMaxProductValuesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '4', 'max' => '10']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 12, 'average_max_product_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(10, 4, 'average_max_product_values'));
     }
 
     function it_gets_average_and_max_volume_of_an_empty_catalog(Connection $connection, Result $statement)
@@ -42,6 +42,6 @@ class AverageMaxProductValuesSpec extends ObjectBehavior
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => null, 'max' => null]);
 
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 12, 'average_max_product_values'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(0, 0, 'average_max_product_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamilySpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/AverageMaxScopableAttributesPerFamilySpec.php
@@ -34,6 +34,6 @@ class AverageMaxScopableAttributesPerFamilySpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['average' => '5', 'max' => '11']);
-        $this->fetch()->shouldBeLike(new AverageMaxVolumes(11, 5, 14, 'average_max_scopable_attributes_per_family'));
+        $this->fetch()->shouldBeLike(new AverageMaxVolumes(11, 5, 'average_max_scopable_attributes_per_family'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountAttributesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountAttributesSpec.php
@@ -34,6 +34,6 @@ class CountAttributesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_attributes'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_attributes'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoriesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoriesSpec.php
@@ -34,6 +34,6 @@ class CountCategoriesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_categories'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_categories'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoryTreesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountCategoryTreesSpec.php
@@ -34,6 +34,6 @@ class CountCategoryTreesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_category_trees'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_category_trees'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountChannelsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountChannelsSpec.php
@@ -34,6 +34,6 @@ class CountChannelsSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_channels'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_channels'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountFamiliesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountFamiliesSpec.php
@@ -34,6 +34,6 @@ class CountFamiliesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_families'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_families'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalesSpec.php
@@ -33,6 +33,6 @@ class CountLocalesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_locales'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_locales'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAndScopableAttributesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAndScopableAttributesSpec.php
@@ -34,6 +34,6 @@ class CountLocalizableAndScopableAttributesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_localizable_and_scopable_attributes'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_localizable_and_scopable_attributes'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAttributesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountLocalizableAttributesSpec.php
@@ -34,6 +34,6 @@ class CountLocalizableAttributesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_localizable_attributes'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_localizable_attributes'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductModelValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductModelValuesSpec.php
@@ -34,6 +34,6 @@ class CountProductModelValuesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['sum_product_model_values' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_product_model_values'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_product_model_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductValuesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountProductValuesSpec.php
@@ -34,6 +34,6 @@ class CountProductValuesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['sum_product_values' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_product_values'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_product_values'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountScopableAttributesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountScopableAttributesSpec.php
@@ -33,6 +33,6 @@ class CountScopableAttributesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '4']);
-        $this->fetch()->shouldBeLike(new CountVolume(4, 12, 'count_scopable_attributes'));
+        $this->fetch()->shouldBeLike(new CountVolume(4, 'count_scopable_attributes'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributesSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUseableAsGridFilterAttributesSpec.php
@@ -34,6 +34,6 @@ class CountUseableAsGridFilterAttributesSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'))->willReturn($statement);
         $statement->fetchAssociative()->willReturn(['count' => '7']);
-        $this->fetch()->shouldBeLike(new CountVolume(7, 14, 'count_useable_as_grid_filter_attributes'));
+        $this->fetch()->shouldBeLike(new CountVolume(7, 'count_useable_as_grid_filter_attributes'));
     }
 }

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUsersSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Persistence/Query/Sql/CountUsersSpec.php
@@ -35,6 +35,6 @@ class CountUsersSpec extends ObjectBehavior
     {
         $connection->executeQuery(Argument::type('string'), ['type' => User::TYPE_USER])->willReturn($result);
         $result->fetchAssociative()->willReturn(['count' => '25']);
-        $this->fetch()->shouldBeLike(new CountVolume(25, -1, 'count_users'));
+        $this->fetch()->shouldBeLike(new CountVolume(25, 'count_users'));
     }
 }

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizerSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/AverageMaxVolumesNormalizerSpec.php
@@ -17,14 +17,13 @@ class AverageMaxVolumesNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_average_and_max_volumes()
     {
-        $volumes = new AverageMaxVolumes(10, 6, 14, 'volume_name');
+        $volumes = new AverageMaxVolumes(10, 6, 'volume_name');
         $this->normalize($volumes)->shouldReturn([
             'volume_name' => [
                 'value' => [
                     'average' => 6,
                     'max' => 10,
                 ],
-                'has_warning' => false,
                 'type' => 'average_max'
             ]
         ]);

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizerSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/CountVolumeNormalizerSpec.php
@@ -17,11 +17,10 @@ class CountVolumeNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_count_volume()
     {
-        $volumes = new CountVolume(10, 8, 'volume_name');
+        $volumes = new CountVolume(10, 'volume_name');
         $this->normalize($volumes)->shouldReturn([
             'volume_name' => [
                 'value' => 10,
-                'has_warning' => true,
                 'type' => 'count'
             ]
         ]);

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/VolumesSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Normalizer/VolumesSpec.php
@@ -52,7 +52,6 @@ class VolumesSpec extends ObjectBehavior
         $countVolumeNormalizer->normalize($countVolume1)->willReturn([
             'count_volume_1' => [
                 'value' => 10,
-                'has_warning' => true,
                 'type' => 'count'
             ]
         ]);
@@ -60,7 +59,6 @@ class VolumesSpec extends ObjectBehavior
         $countVolumeNormalizer->normalize($countVolume2)->willReturn([
             'count_volume_2' => [
                 'value' => 12,
-                'has_warning' => false,
                 'type' => 'count'
             ]
         ]);
@@ -68,7 +66,6 @@ class VolumesSpec extends ObjectBehavior
         $averageVolumeNormalizer->normalize($averageMaxVolumes)->willReturn([
             'average_max_volume' => [
                 'value' => ['average' => 4, 'max' => 10],
-                'has_warning' => false,
                 'type' => 'average_max'
             ]
         ]);
@@ -76,17 +73,14 @@ class VolumesSpec extends ObjectBehavior
         $this->volumes()->shouldReturn([
             'count_volume_1' => [
                 'value' => 10,
-                'has_warning' => true,
                 'type' => 'count'
             ],
             'count_volume_2' => [
                 'value' => 12,
-                'has_warning' => false,
                 'type' => 'count'
             ],
             'average_max_volume' => [
                 'value' => ['average' => 4, 'max' => 10],
-                'has_warning' => false,
                 'type' => 'average_max'
             ],
         ]);

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumesSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/ReadModel/AverageMaxVolumesSpec.php
@@ -11,7 +11,7 @@ class AverageMaxVolumesSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith(10, 6, 8, 'volume_name');
+        $this->beConstructedWith(10, 6, 'volume_name');
     }
 
     function it_is_initializable()
@@ -32,17 +32,5 @@ class AverageMaxVolumesSpec extends ObjectBehavior
     function it_has_volume_name()
     {
         $this->getVolumeName()->shouldReturn('volume_name');
-    }
-
-    function it_has_warning()
-    {
-        $this->hasWarning()->shouldReturn(true);
-    }
-
-    function it_does_not_have_warning_if_the_limit_is_lower_than_zero()
-    {
-        $this->beConstructedWith(10, 6, -1, 'volume_name');
-
-        $this->hasWarning()->shouldReturn(false);
     }
 }

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolumeSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/ReadModel/CountVolumeSpec.php
@@ -11,7 +11,7 @@ class CountVolumeSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith(10, 6, 'volume_name');
+        $this->beConstructedWith(10, 'volume_name');
     }
     function it_is_initializable()
     {
@@ -26,17 +26,5 @@ class CountVolumeSpec extends ObjectBehavior
     function it_has_volume_name()
     {
         $this->getVolumeName()->shouldReturn('volume_name');
-    }
-
-    function it_has_warning()
-    {
-        $this->hasWarning()->shouldReturn(true);
-    }
-
-    function it_does_not_have_warning_if_the_limit_is_lower_than_zero()
-    {
-        $this->beConstructedWith(10, -1, 'volume_name');
-
-        $this->hasWarning()->shouldReturn(false);
     }
 }

--- a/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Service/VolumeAggregationSpec.php
+++ b/tests/back/Platform/Specification/Component/CatalogVolumeMonitoring/Volume/Service/VolumeAggregationSpec.php
@@ -40,9 +40,9 @@ class VolumeAggregationSpec extends ObjectBehavior
         $countQuery2,
         $averageMaxQuery
     ) {
-        $countQuery1->fetch()->willReturn(new CountVolume(11, 20, 'count_volume_1'));
-        $countQuery2->fetch()->willReturn(new CountVolume(7, 10, 'count_volume_2'));
-        $averageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(42, 34, -1, 'average_max_volume'));
+        $countQuery1->fetch()->willReturn(new CountVolume(11, 'count_volume_1'));
+        $countQuery2->fetch()->willReturn(new CountVolume(7, 'count_volume_2'));
+        $averageMaxQuery->fetch()->willReturn(new AverageMaxVolumes(42, 34, 'average_max_volume'));
 
         $aggregatedVolumeRepository->add(Argument::that(function (AggregatedVolume $aggregatedVolume) {
             return 'count_volume_1' === $aggregatedVolume->getVolumeName()

--- a/tests/features/platform/volume-monitoring/monitor_attribute_per_family_volume.feature
+++ b/tests/features/platform/volume-monitoring/monitor_attribute_per_family_volume.feature
@@ -10,11 +10,3 @@ Feature: Monitor catalog volume
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the average number of attributes per family is 7
     And the report returns that the maximum number of attributes per family is 10
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of attributes per family is high
-    Given a family with 8 attributes
-    And a family with 2 attributes
-    And the limit of the number of attributes per family is set to 6
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of attributes per family is high

--- a/tests/features/platform/volume-monitoring/monitor_attributes.feature
+++ b/tests/features/platform/volume-monitoring/monitor_attributes.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of attributes
     Given a catalog with 99 attributes
-    And the limit of the number of attributes is set to 100
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of attributes is 99
-    And the report does not warn the users that the number of attributes is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of attributes is high
-    Given a catalog with 101 attributes
-    And the limit of the number of attributes is set to 100
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of attributes is high

--- a/tests/features/platform/volume-monitoring/monitor_categories.feature
+++ b/tests/features/platform/volume-monitoring/monitor_categories.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of categories
     Given a catalog with 5 categories
-    And the limit of the number of categories is set to 6
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of categories is 5
-    And the report does not warn the users that the number of categories is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of categories is high
-    Given a catalog with 6 categories
-    And the limit of the number of categories is set to 5
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of categories is high

--- a/tests/features/platform/volume-monitoring/monitor_category_trees.feature
+++ b/tests/features/platform/volume-monitoring/monitor_category_trees.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of category trees
     Given a catalog with 3 category trees
-    And the limit of the number of category trees is set to 5
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of category trees is 3
-    And the report does not warn the users that the number of category trees is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of category trees is high
-    Given a catalog with 6 category trees
-    And the limit of the number of category trees is set to 5
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of category trees is high

--- a/tests/features/platform/volume-monitoring/monitor_channels.feature
+++ b/tests/features/platform/volume-monitoring/monitor_channels.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of channels
     Given a catalog with 5 channels
-    And the limit of the number of channels is set to 6
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of channels is 5
-    And the report does not warn the users that the number of channels is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of channels is high
-    Given a catalog with 6 channels
-    And the limit of the number of channels is set to 5
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of channels is high

--- a/tests/features/platform/volume-monitoring/monitor_families.feature
+++ b/tests/features/platform/volume-monitoring/monitor_families.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of families
     Given a catalog with 10 families
-    And the limit of the number of families is set to 11
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of families is 10
-    And the report does not warn the users that the number of families is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of families is high
-    Given a catalog with 11 families
-    And the limit of the number of families is set to 10
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of families is high

--- a/tests/features/platform/volume-monitoring/monitor_locales.feature
+++ b/tests/features/platform/volume-monitoring/monitor_locales.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of locales
     Given a catalog with 5 locales
-    And the limit of the number of locales is set to 6
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of locales is 5
-    And the report does not warn the users that the number of locales is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of locales is high
-    Given a catalog with 6 locales
-    And the limit of the number of locales is set to 5
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of locales is high

--- a/tests/features/platform/volume-monitoring/monitor_localizable_and_scopable_attributes.feature
+++ b/tests/features/platform/volume-monitoring/monitor_localizable_and_scopable_attributes.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of localizable and scopable attributes
     Given a catalog with 20 localizable and scopable attributes
-    And the limit of the number of localizable and scopable attributes is set to 21
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of localizable and scopable attributes is 20
-    And the report does not warn the users that the number of localizable and scopable attributes is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of localizable and scopable attributes is high
-    Given a catalog with 21 localizable and scopable attributes
-    And the limit of the number of localizable and scopable attributes is set to 20
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of localizable and scopable attributes is high

--- a/tests/features/platform/volume-monitoring/monitor_localizable_attributes.feature
+++ b/tests/features/platform/volume-monitoring/monitor_localizable_attributes.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of localizable attributes
     Given a catalog with 20 localizable attributes
-    And the limit of the number of localizable attributes is set to 21
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of localizable attributes is 20
-    And the report does not warn the users that the number of localizable attributes is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of localizable attributes is high
-    Given a catalog with 21 localizable attributes
-    And the limit of the number of localizable attributes is set to 20
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of localizable attributes is high

--- a/tests/features/platform/volume-monitoring/monitor_products.feature
+++ b/tests/features/platform/volume-monitoring/monitor_products.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of products
     Given a catalog with 10 products
-    And the limit of the number of products is set to 11
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of products is 10
-    And the report does not warn the users that the number of products is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of products is high
-    Given a catalog with 11 products
-    And the limit of the number of products is set to 10
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of products is high

--- a/tests/features/platform/volume-monitoring/monitor_scopable_attributes.feature
+++ b/tests/features/platform/volume-monitoring/monitor_scopable_attributes.feature
@@ -6,14 +6,5 @@ Feature: Monitor catalog volume
   @acceptance-back
   Scenario: Monitor the number of scopable attributes
     Given a catalog with 20 scopable attributes
-    And the limit of the number of scopable attributes is set to 21
     When the administrator user asks for the catalog volume monitoring report
     Then the report returns that the number of scopable attributes is 20
-    And the report does not warn the users that the number of scopable attributes is high
-
-  @acceptance-back
-  Scenario: Warn the user administrator when the maximum number of scopable attributes is high
-    Given a catalog with 21 scopable attributes
-    And the limit of the number of scopable attributes is set to 20
-    When the administrator user asks for the catalog volume monitoring report
-    Then the report warns the users that the number of scopable attributes is high


### PR DESCRIPTION
Following the removing of the warnings in the Catalog Volume Monitoring, the use of limits and warnings in the counters became useless.
cf https://github.com/akeneo/pim-community-dev/pull/15587