### PR TITLE
CXP-938: Fix issues with Activate OAuth

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/AuthorizeAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/AuthorizeAction.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller;
 
+use Akeneo\Connectivity\Connection\Application\Apps\AppAuthorizationSessionInterface;
 use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationCommand;
 use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationHandler;
+use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AppConfirmation;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequest;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query\GetAppConfirmationQueryInterface;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\RedirectUriWithAuthorizationCodeGeneratorInterface;
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,15 +27,24 @@ class AuthorizeAction
     private RequestAppAuthorizationHandler $handler;
     private RouterInterface $router;
     private FeatureFlag $featureFlag;
+    private AppAuthorizationSessionInterface $appAuthorizationSession;
+    private GetAppConfirmationQueryInterface $getAppConfirmationQuery;
+    private RedirectUriWithAuthorizationCodeGeneratorInterface $redirectUriWithAuthorizationCodeGenerator;
 
     public function __construct(
         RequestAppAuthorizationHandler $handler,
         RouterInterface $router,
-        FeatureFlag $featureFlag
+        FeatureFlag $featureFlag,
+        AppAuthorizationSessionInterface $appAuthorizationSession,
+        GetAppConfirmationQueryInterface $getAppConfirmationQuery,
+        RedirectUriWithAuthorizationCodeGeneratorInterface $redirectUriWithAuthorizationCodeGenerator
     ) {
         $this->handler = $handler;
         $this->router = $router;
         $this->featureFlag = $featureFlag;
+        $this->appAuthorizationSession = $appAuthorizationSession;
+        $this->getAppConfirmationQuery = $getAppConfirmationQuery;
+        $this->redirectUriWithAuthorizationCodeGenerator = $redirectUriWithAuthorizationCodeGenerator;
     }
 
     public function __invoke(Request $request): Response
@@ -40,8 +53,10 @@ class AuthorizeAction
             throw new NotFoundHttpException();
         }
 
+        $clientId = $request->query->get('client_id', '');
+
         $command = new RequestAppAuthorizationCommand(
-            $request->query->get('client_id', ''),
+            $clientId,
             $request->query->get('response_type', ''),
             $request->query->get('scope', ''),
             $request->query->get('redirect_uri', ''),
@@ -56,8 +71,28 @@ class AuthorizeAction
             ]));
         }
 
+        // Check if the App is already authorized
+        $appConfirmation = $this->getAppConfirmationQuery->execute($clientId);
+        if (null !== $appConfirmation) {
+            return $this->createAuthorizedResponse($appConfirmation);
+        }
+
         return new RedirectResponse('/#' . $this->router->generate('akeneo_connectivity_connection_connect_apps_authorize', [
             'client_id' => $command->getClientId(),
         ]));
+    }
+
+    private function createAuthorizedResponse(AppConfirmation $appConfirmation): Response
+    {
+        $clientId = $appConfirmation->getAppId();
+
+        $appAuthorization = $this->appAuthorizationSession->getAppAuthorization($clientId);
+        if (null === $appAuthorization) {
+            throw new \LogicException('There is no active app authorization in session');
+        }
+
+        $redirectUrl = $this->redirectUriWithAuthorizationCodeGenerator->generate($appAuthorization, $appConfirmation);
+
+        return new RedirectResponse($redirectUrl);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateAccessToken.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateAccessToken.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth;
 
 use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateAccessTokenInterface;
-use OAuth2\IOAuth2;
 use OAuth2\IOAuth2GrantCode;
 use OAuth2\Model\IOAuth2AuthCode;
-use OAuth2\OAuth2;
 
 /**
  * @author    Willy Mesnage <willy.mesnage@akeneo.com>
@@ -17,18 +15,18 @@ use OAuth2\OAuth2;
  */
 class CreateAccessToken implements CreateAccessTokenInterface
 {
-    private IOAuth2 $auth2;
     private IOAuth2GrantCode $storage;
     private ClientProviderInterface $clientProvider;
+    private RandomCodeGeneratorInterface $randomCodeGenerator;
 
     public function __construct(
-        IOAuth2 $auth2,
         IOAuth2GrantCode $storage,
-        ClientProviderInterface $clientProvider
+        ClientProviderInterface $clientProvider,
+        RandomCodeGeneratorInterface $randomCodeGenerator
     ) {
-        $this->auth2 = $auth2;
         $this->storage = $storage;
         $this->clientProvider = $clientProvider;
+        $this->randomCodeGenerator = $randomCodeGenerator;
     }
 
     /**
@@ -46,8 +44,17 @@ class CreateAccessToken implements CreateAccessTokenInterface
         if (null === $authCode) {
             throw new \InvalidArgumentException('Unknown authorization code.');
         }
-        $this->auth2->setVariable(OAuth2::CONFIG_ACCESS_LIFETIME, null);
 
-        return $this->auth2->createAccessToken($client, $authCode->getData());
+        $token = $this->randomCodeGenerator->generate();
+
+        /* @phpstan-ignore-next-line */
+        $this->storage->createAccessToken($token, $client, $authCode->getData(), null);
+
+        $this->storage->markAuthCodeAsUsed($code);
+
+        return [
+            'access_token' => $token,
+            'token_type' => 'bearer',
+        ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidator.php
@@ -6,6 +6,7 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation;
 
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AccessTokenRequest;
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApiInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -17,10 +18,14 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class CodeChallengeMustBeValidValidator extends ConstraintValidator
 {
     private WebMarketplaceApiInterface $webMarketplaceApi;
+    private FeatureFlag $fakeAppsFeatureFlag;
 
-    public function __construct(WebMarketplaceApiInterface $webMarketplaceApi)
-    {
+    public function __construct(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+        FeatureFlag $fakeAppsFeatureFlag
+    ) {
         $this->webMarketplaceApi = $webMarketplaceApi;
+        $this->fakeAppsFeatureFlag = $fakeAppsFeatureFlag;
     }
 
     public function validate($value, Constraint $constraint)
@@ -37,6 +42,10 @@ class CodeChallengeMustBeValidValidator extends ConstraintValidator
                     get_debug_type($value)
                 )
             );
+        }
+
+        if (true === $this->fakeAppsFeatureFlag->isEnabled()) {
+            return;
         }
 
         $codeChallengeIsValid = $this->webMarketplaceApi->validateCodeChallenge(

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidator.php
@@ -48,6 +48,13 @@ class CodeChallengeMustBeValidValidator extends ConstraintValidator
             return;
         }
 
+        if (empty($value->getClientId())
+            || empty($value->getCodeIdentifier())
+            || empty($value->getCodeChallenge())
+        ) {
+            return;
+        }
+
         $codeChallengeIsValid = $this->webMarketplaceApi->validateCodeChallenge(
             $value->getClientId(),
             $value->getCodeIdentifier(),

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
@@ -67,6 +67,6 @@ services:
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\CreateAccessToken:
         arguments:
-            - '@fos_oauth_server.server'
             - '@fos_oauth_server.storage.default'
             - '@akeneo_connectivity.connection.service.apps.client_provider'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\RandomCodeGenerator'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -89,6 +89,9 @@ services:
             - '@Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationHandler'
             - '@router'
             - '@akeneo_connectivity.connection.marketplace_activate.feature'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetAppConfirmationQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\RedirectUriWithAuthorizationCodeGenerator'
 
     akeneo_connectivity.connection.public.controller.apps.token:
         public: true

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -9,7 +9,7 @@ akeneo_connectivity_connection_connect_apps_v1_authorize:
 akeneo_connectivity_connection_connect_apps_v1_token:
   path: '/connect/apps/v1/oauth2/token'
   controller: akeneo_connectivity.connection.public.controller.apps.token
-  methods: [ GET ]
+  methods: [ POST ]
 
 # Internal API
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -67,5 +67,6 @@ services:
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation\CodeChallengeMustBeValidValidator:
         arguments:
             - '@akeneo_connectivity.connection.marketplace.web_marketplace_api'
+            - '@akeneo_connectivity.connection.marketplace_fake_apps.feature'
         tags:
             - { name: validator.constraint_validator }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/AuthorizeEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/AuthorizeEndToEnd.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Tests\EndToEnd\Apps;
 
+use Akeneo\Connectivity\Connection\Application\Apps\Command\CreateAppWithAuthorizationCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\CreateAppWithAuthorizationHandler;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationHandler;
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
 use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider;
@@ -25,6 +29,8 @@ class AuthorizeEndToEnd extends WebTestCase
     private FakeFeatureFlag $featureFlagMarketplaceActivate;
     private ClientProvider $clientProvider;
     private SessionInterface $session;
+    private RequestAppAuthorizationHandler $appAuthorizationHandler;
+    private CreateAppWithAuthorizationHandler $createAppWithAuthorizationHandler;
 
     protected function setUp(): void
     {
@@ -34,6 +40,8 @@ class AuthorizeEndToEnd extends WebTestCase
         $this->featureFlagMarketplaceActivate = $this->get('akeneo_connectivity.connection.marketplace_activate.feature');
         $this->clientProvider = $this->get('akeneo_connectivity.connection.service.apps.client_provider');
         $this->session = $this->get('session');
+        $this->appAuthorizationHandler = $this->get(RequestAppAuthorizationHandler::class);
+        $this->createAppWithAuthorizationHandler = $this->get(CreateAppWithAuthorizationHandler::class);
         $this->loadAppsFixtures();
     }
 
@@ -91,6 +99,40 @@ class AuthorizeEndToEnd extends WebTestCase
             'redirect_uri' => 'http://shopware.example.com/callback',
             'state' => 'foo',
         ], json_decode($authorizationInSession, true));
+    }
+
+    public function test_it_is_redirected_to_the_app_when_already_authorized(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+        $app = App::fromWebMarketplaceValues($this->webMarketplaceApi->getApp('90741597-54c5-48a1-98da-a68e7ee0a715'));
+        $this->clientProvider->findOrCreateClient($app);
+        $this->appAuthorizationHandler->handle(new RequestAppAuthorizationCommand(
+            '90741597-54c5-48a1-98da-a68e7ee0a715',
+            'code',
+            'write_catalog_structure delete_products read_association_types',
+            'http://anyurl.test'
+        ));
+        $this->createAppWithAuthorizationHandler->handle(new CreateAppWithAuthorizationCommand(
+            '90741597-54c5-48a1-98da-a68e7ee0a715'
+        ));
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/connect/apps/v1/authorize',
+            [
+                'client_id' => '90741597-54c5-48a1-98da-a68e7ee0a715',
+                'response_type' => 'code',
+                'redirect_uri' => 'http://shopware.example.com/callback',
+                'state' => 'foo',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FOUND, $this->client->getResponse()->getStatusCode());
+        assert($response instanceof RedirectResponse);
+        Assert::matchesRegularExpression('^http:\/\/shopware\.example\.com\/callback\?code=[a-zA-Z0-9@=]+&state=foo$');
     }
 
     private function loadAppsFixtures(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/RequestAccessTokenActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/RequestAccessTokenActionEndToEnd.php
@@ -39,7 +39,7 @@ class RequestAccessTokenActionEndToEnd extends WebTestCase
 
         $this->featureFlagMarketplaceActivate->enable();
         $this->client->request(
-            'GET',
+            'POST',
             '/connect/apps/v1/oauth2/token',
             [
                 'client_id' => $this->clientId,
@@ -66,7 +66,7 @@ class RequestAccessTokenActionEndToEnd extends WebTestCase
 
         $this->featureFlagMarketplaceActivate->enable();
         $this->client->request(
-            'GET',
+            'POST',
             '/connect/apps/v1/oauth2/token',
             [
                 // No client_id

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Validation/AccessTokenRequestValidationIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Validation/AccessTokenRequestValidationIntegration.php
@@ -126,6 +126,7 @@ class AccessTokenRequestValidationIntegration extends WebTestCase
         $this->clientProvider = $this->get('akeneo_connectivity.connection.service.apps.client_provider');
         $this->appAuthorizationHandler = $this->get(RequestAppAuthorizationHandler::class);
         $this->clientId = '90741597-54c5-48a1-98da-a68e7ee0a715';
+        $this->get('akeneo_connectivity.connection.marketplace_fake_apps.feature')->disable();
         $this->loadAppsFixtures();
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidatorSpec.php
@@ -7,6 +7,7 @@ namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation;
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AccessTokenRequest;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation\CodeChallengeMustBeValid;
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApiInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Validator\Constraint;
@@ -18,9 +19,11 @@ class CodeChallengeMustBeValidValidatorSpec extends ObjectBehavior
 {
     public function let(
         WebMarketplaceApiInterface $webMarketplaceApi,
+        FeatureFlag $fakeAppsFeatureFlag,
         ExecutionContextInterface $context
     ): void {
-        $this->beConstructedWith($webMarketplaceApi);
+        $this->beConstructedWith($webMarketplaceApi, $fakeAppsFeatureFlag);
+        $fakeAppsFeatureFlag->isEnabled()->willReturn(false);
         $this->initialize($context);
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Validation/CodeChallengeMustBeValidValidatorSpec.php
@@ -70,6 +70,23 @@ class CodeChallengeMustBeValidValidatorSpec extends ObjectBehavior
         $this->validate($value, $constraint);
     }
 
+    public function it_skips_the_validator_if_a_value_is_empty(
+        CodeChallengeMustBeValid $constraint,
+        AccessTokenRequest $value,
+        WebMarketplaceApiInterface $webMarketplaceApi,
+        ExecutionContextInterface $context
+    ): void {
+        $value->getClientId()->willReturn('');
+        $value->getCodeIdentifier()->willReturn('');
+        $value->getCodeChallenge()->willReturn('');
+
+        $webMarketplaceApi->validateCodeChallenge(Argument::cetera())->shouldNotBeCalled();
+
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate($value, $constraint);
+    }
+
     public function it_adds_a_violation_when_the_code_challenge_is_refused(
         CodeChallengeMustBeValid $constraint,
         AccessTokenRequest $value,

--- a/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
+++ b/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
@@ -32,4 +32,4 @@ Feature: Activate an OAuth2 client application in the PIM
       | pim_api_attribute_group_edit | false   |
       | pim_api_family_edit          | false   |
       | pim_api_family_variant_edit  | false   |
-    And it has an API token
+    And it has an authorization code


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Issues:**

- With the previous version, an expiration date was attributed to the token with `time() + null`, which mean that the token was expiring immediately ...
- When using fake apps, don't check the code challenge in the marketplace
- When validating a token request, don't call the marketplace if any of `code_challenge` & `code_identifier` are empty, it will fail anyway on the `NotBlank`.
- the endpoint for requesting a token should be `POST`, not `GET`

**Bonus:**

- I've implemented the last step of the behat scenario
- When an app is already authorized, skip the wizard and redirect directly with the Authorization Code. *This is a workaround waiting for the proper re-activation feature*.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
