### PR TITLE
Dirty fix to solve webp extension added to thumbnails

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/Ui/FileController.php
@@ -76,6 +76,7 @@ class FileController
         }
 
         try {
+            $this->removeWebPFromAcceptHeader($request);
             return $this->imagineController->filterAction($request, $filename, $filter);
         } catch (NotFoundHttpException | \RuntimeException $exception) {
             return $this->renderDefaultImage(FileTypes::IMAGE, $filter);
@@ -114,7 +115,24 @@ class FileController
      */
     public function cacheAction(Request $request, $path, $filter)
     {
+        $this->removeWebPFromAcceptHeader($request);
         return $this->imagineController->filterAction($request, $path, $filter);
+    }
+
+    private function removeWebPFromAcceptHeader(Request $request): void
+    {
+        $headerOriginalAcceptValues = explode(',', $request->headers->get('accept', ''));
+        $headerNewAcceptValues = [];
+        foreach($headerOriginalAcceptValues as $accept)
+        {
+            if($accept === 'image/webp')
+            {
+                continue;
+            }
+
+            $headerNewAcceptValues[] = $accept;
+        }
+        $request->headers->set('accept', implode(',', $headerNewAcceptValues));
     }
 
     /**


### PR DESCRIPTION
Thumbnails are generated with liip imagine bundle.

From a recent bump of the dependency, [if the browser supports the `image/webp` thanks to the `Accept` header](https://github.com/liip/LiipImagineBundle/blob/2.x/Controller/ImagineController.php#L176) in the request, then liip, will generate the thumbnail in this format and return the url with `.webp` suffix

The thumbnail url leads to 404 errors when requested by the browser.


This PR is a QUICK AND DIRTY FIX, please consider find a better solution to the problem.
This PR is just here in case of fire.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
