### PR TITLE
PLG-638: Fix the version of LiipImagineBundle to 2.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "justinrainbow/json-schema": "^5.2",
         "league/flysystem": "^2.0",
         "league/flysystem-memory": "^2.0",
-        "liip/imagine-bundle": "^2.6.0",
+        "liip/imagine-bundle": "2.6.1",
         "monolog/monolog": "1.25.5",
         "ocramius/proxy-manager": "2.11.1",
         "oneup/flysystem-bundle": "^4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a30cabb21feed5f8e36e2a35af0034d0",
+    "content-hash": "142cfcbe19c9dfb762cd7c3e4157c79e",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
The last version of LiipImagineBundle forces the generation of thumbnail in webp format. This update breaks thumbnail generation in both Growth Edition and Enterprise Edition. Thumbnail url are automatically suffixed with the `.webp` file extension. That causes `404 Not Found` errors when we load thumbnails in the web browser (Product list and product edition form pages)

This pull request fix the version of LiipImagineBundle to `2.6.1` to avoid unexpected upgrade of the lib in other editions.

[LiipImagineBundle documentation](https://github.com/liip/LiipImagineBundle/blob/2.x/Resources/doc/basic-usage.rst#use-webp-if-supported)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
