### PR TITLE
PIM-10140: Update liip_imagine config to handle .webp thumbnails

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
         "justinrainbow/json-schema": "^5.2",
         "league/flysystem": "^2.0",
         "league/flysystem-memory": "^2.0",
-        "liip/imagine-bundle": "2.6.1",
+        "liip/imagine-bundle": "^2.7.0",
         "monolog/monolog": "1.25.5",
         "ocramius/proxy-manager": "2.11.1",
         "oneup/flysystem-bundle": "^4.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "142cfcbe19c9dfb762cd7c3e4157c79e",
+    "content-hash": "f862c5fbf37dfa770de4d395938bd37e",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -3799,19 +3799,20 @@
         },
         {
             "name": "liip/imagine-bundle",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipImagineBundle.git",
-                "reference": "00f3ccfccb33834b44f82c17cca80bfd83882bb3"
+                "reference": "f815b7b664fe2b0023048affdbb61225a0393ec4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/00f3ccfccb33834b44f82c17cca80bfd83882bb3",
-                "reference": "00f3ccfccb33834b44f82c17cca80bfd83882bb3",
+                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/f815b7b664fe2b0023048affdbb61225a0393ec4",
+                "reference": "f815b7b664fe2b0023048affdbb61225a0393ec4",
                 "shasum": ""
             },
             "require": {
+                "ext-mbstring": "*",
                 "imagine/imagine": "^1.2.4",
                 "php": "^7.1|^8.0",
                 "symfony/filesystem": "^3.4|^4.3|^5.0",
@@ -3825,16 +3826,20 @@
             "require-dev": {
                 "amazonwebservices/aws-sdk-for-php": "^1.0",
                 "aws/aws-sdk-php": "^2.4",
-                "doctrine/cache": "^1.1",
+                "doctrine/cache": "^1.11|^2.0",
                 "doctrine/persistence": "^1.3|^2.0",
                 "enqueue/enqueue-bundle": "^0.9|^0.10",
                 "ext-gd": "*",
                 "league/flysystem": "^1.0|^2.0",
+                "phpstan/phpstan": "^0.12.64",
+                "psr/cache": "^1.0|^2.0|^3.0",
                 "psr/log": "^1.0",
                 "symfony/browser-kit": "^3.4|^4.3|^5.0",
+                "symfony/cache": "^3.4|^4.3|^5.0",
                 "symfony/console": "^3.4|^4.3|^5.0",
                 "symfony/dependency-injection": "^3.4|^4.3|^5.0",
                 "symfony/form": "^3.4|^4.3|^5.0",
+                "symfony/messenger": "^4.3|^5.0",
                 "symfony/phpunit-bridge": "^5.2",
                 "symfony/templating": "^3.4|^4.3|^5.0",
                 "symfony/validator": "^3.4|^4.3|^5.0",
@@ -3853,6 +3858,7 @@
                 "ext-mongodb": "required for mongodb components",
                 "league/flysystem": "required to use FlySystem data loader or cache resolver",
                 "monolog/monolog": "A psr/log compatible logger is required to enable logging",
+                "symfony/messenger": "If you like to process images in background",
                 "symfony/templating": "required to use deprecated Templating component instead of Twig"
             },
             "type": "symfony-bundle",
@@ -3889,9 +3895,9 @@
             ],
             "support": {
                 "issues": "https://github.com/liip/LiipImagineBundle/issues",
-                "source": "https://github.com/liip/LiipImagineBundle/tree/2.6.1"
+                "source": "https://github.com/liip/LiipImagineBundle/tree/2.7.0"
             },
-            "time": "2021-05-22T08:55:29+00:00"
+            "time": "2021-10-28T10:11:26+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -17923,5 +17929,5 @@
         "ext-openssl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/config/packages/liip_imagine.yml
+++ b/config/packages/liip_imagine.yml
@@ -1,6 +1,8 @@
 liip_imagine:
     driver: imagick
     data_loader: flysystem_data_loader
+    webp:
+        generate: true
     filter_sets:
         cache: ~
         avatar_med:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This is an alternative PR to #15596 which allows using the 2.7.0 version of `liip/imagine-bundle`, and making use of the [WebP](https://github.com/liip/LiipImagineBundle/blob/2.x/Resources/doc/basic-usage.rst#webp-image-format) image format for thumbnails

Edit: tested on a deployed Serenity env, thumbnails are correctly rendered (grid/PEF/assets/ref entities), on Chrome, Firefox and Safari

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
