### PR TITLE
RAC-966: Get field before clicking it

### DIFF
--- a/tests/legacy/features/Context/Page/Base/Base.php
+++ b/tests/legacy/features/Context/Page/Base/Base.php
@@ -3,6 +3,7 @@
 namespace Context\Page\Base;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Context\FeatureContext;
@@ -137,22 +138,22 @@ class Base extends Page
      */
     public function toggleSwitch($locator, $on = true)
     {
-        $field = $this->findField($locator);
+        $this->spin(function () use ($locator, $on) {
+            $field = $this->findField($locator);
+            if ($field->getAttribute('role') === 'switch') {
+                // BooleanInput.tsx from DSM
+                $field->find('css', sprintf('*[title=%s]', $on ? 'Yes' : 'No'))->click();
 
-        if ($field->getAttribute('role') === 'switch') {
-            // BooleanInput.tsx from DSM
-            $field->find('css', sprintf('*[title=%s]', $on ? 'Yes' : 'No'))->click();
+                return true;
+            }
 
-            return;
-        }
-
-        $this->spin(function () use ($field, $on) {
             // Legacy boolean
             if ($on !== $field->isChecked()) {
                 $switch = $this->getClosest($field, 'switch');
                 if (null === $switch) {
                     return false;
                 }
+
                 $switch->click();
             }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR should fix the following flaky tests : 
- tests/legacy/features/pim/structure/read-only-attribute/attribute.feature:32
- tests/legacy/features/pim/permission/product-model/edit_product_model.feature:15

Now we spin while the field is found. Tested locally 200x without error

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
