### PR TITLE
Assert that the value is correctly set in the field

### DIFF
--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -1005,6 +1005,16 @@ class WebUser extends PimContext
 
             $this->getCurrentPage()->fillField($field, $value);
 
+            $this->spin(function () use ($field, $value) {
+                try {
+                    $this->getCurrentPage()->assertFieldIsFilled($field, $value);
+                } catch (\BadMethodCallException $e) {
+                    return true;
+                }
+
+                return true;
+            }, sprintf('Cannot assert that the field "%s" was correctly filled', $field));
+
             return true;
         }, sprintf('Cannot fill the field "%s"', $field));
     }

--- a/tests/legacy/features/pim/enrichment/reference-data/product/display_history.feature
+++ b/tests/legacy/features/pim/enrichment/reference-data/product/display_history.feature
@@ -24,7 +24,7 @@ Feature: Display the product history
       | version | property   | value  | date |
       | 2       | Heel color | ua-red | now  |
     When I visit the "Attributes" column tab
-    And I change the "Heel color" to "Green"
+    And I change the "Heel color" to "Green (HTML/CSS Color)"
     And I save the product
     And I visit the "History" column tab
     Then I should see history:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

With a test like this:
```
Given I change the "Weather conditions" to "Hot, Cold, Dry, Wet"
And I save the product
```
The select2 component is updated by triggering js events.
Sadly, the save button is then clicked before all the changes are propagated to the form state stored in backbone.
That's why only a part of the selected values are saved and we randomly have the following error: `Expected product field "Weather conditions" to contain "cold, dry, hot, wet", but got "dry, hot, wet".`

I'm proposing that each time we fill a field in the PEF, we spin until the value is as expected.
It should prevent this race condition.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
