### PR TITLE
PIM-10128 Fixed disabled user activation after password reset

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,8 @@
 # 5.0.x
 
+## Bug fixes
+- PIM-10128: Fixed disabled user activation after password reset
+
 # 5.0.55 (2021-11-03)
 
 ## Bug fixes

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -75,7 +75,7 @@ class ResetController extends Controller
         $username = $request->request->get('username');
         $user = $this->userManager->findUserByUsernameOrEmail($username);
 
-        if (null === $user) {
+        if (null === $user || false === $user->isEnabled()) {
             return [];
         }
 
@@ -143,7 +143,7 @@ class ResetController extends Controller
     {
         $user = $this->userManager->findUserByConfirmationToken($token);
 
-        if (null === $user) {
+        if (null === $user || false === $user->isEnabled()) {
             throw $this->createNotFoundException(
                 sprintf('The user with "confirmation token" does not exist for value "%s"', $token)
             );

--- a/src/Akeneo/UserManagement/Bundle/Form/Handler/ResetHandler.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Handler/ResetHandler.php
@@ -51,8 +51,7 @@ class ResetHandler
         $user
             ->setPlainPassword($this->form->getData()->getPlainPassword())
             ->setConfirmationToken(null)
-            ->setPasswordRequestedAt(null)
-            ->setEnabled(true);
+            ->setPasswordRequestedAt(null);
 
         $this->manager->updateUser($user);
     }


### PR DESCRIPTION
Fixes: [PIM-10128](https://akeneo.atlassian.net/browse/PIM-10128)

Fixes security a breach where password reset enables user even if  the said user were previously disabled. 
Withdraws ability to reset the password as a inactive account:
- no reset password email send
- for existing emails : link will redirect to an error (just like when email expires)