### PR TITLE
PIM-10145: Fix duplicate form token

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/reset.html.twig
+++ b/src/Akeneo/UserManagement/Bundle/Resources/views/Reset/reset.html.twig
@@ -16,7 +16,6 @@
     }) }}
     <div class="InputGroup">
         {{ form_widget(form.plainPassword, {'required': true}) }}
-        {{ form_widget(form._token) }}
         <div class="CancelPasswordReset">
             <a href="{{ path('pim_user_security_login') }}">{{ 'pim_common.cancel'|trans }}</a>
         </div>


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The reset form page was in 500 again because of the duplicate renderer of the `_token` field:

```log
An exception has been thrown during the rendering of a template ("Field "_token" has already been rendered, save the result of previous render call to a variable and output that instead.") in "@PimUI/Form/pim-fields.html.twig".
```

The changelog was already updated in this [PR](https://github.com/akeneo/pim-community-dev/pull/15642)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
