### PR TITLE
Make sure 'last_update' exists in fetch result

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/StructureVersion/Provider/StructureVersion.php
@@ -43,7 +43,7 @@ SQL;
             ['resource_names' => \Doctrine\DBAL\Connection::PARAM_STR_ARRAY]
         );
 
-        $loggedAt = $stmt->fetch(\PDO::FETCH_ASSOC)['last_update'];
+        $loggedAt = $stmt->fetch(\PDO::FETCH_ASSOC)['last_update'] ?? null;
 
         if (null === $loggedAt) {
             return 0;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This PR solves the problem described in issue 15073 by adding a check if 'last_updated' exists in the resulting array of the fetch statement.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
