### PR TITLE
BH-859: Use lazy commands

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/ConsolidateDashboardRatesCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/ConsolidateDashboardRatesCommand.php
@@ -17,8 +17,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class ConsolidateDashboardRatesCommand extends Command
 {
-    /** @var ConsolidateDashboardRates */
-    private $consolidateDashboardRates;
+    protected static $defaultName = 'pim:data-quality-insights:consolidate-dashboard-rates';
+    protected static $defaultDescription = 'Consolidate the Data-Quality-Insights dashboard rates.';
+
+    private ConsolidateDashboardRates $consolidateDashboardRates;
 
     public function __construct(ConsolidateDashboardRates $consolidateDashboardRates)
     {
@@ -29,10 +31,7 @@ final class ConsolidateDashboardRatesCommand extends Command
 
     protected function configure()
     {
-        $this
-            ->setName('pim:data-quality-insights:consolidate-dashboard-rates')
-            ->setDescription('Consolidate the Data-Quality-Insights dashboard rates.')
-            ->addArgument('day', InputArgument::OPTIONAL, 'Day of the consolidation "Y-m-d".', date('Y-m-d'));
+        $this->addArgument('day', InputArgument::OPTIONAL, 'Day of the consolidation "Y-m-d".', date('Y-m-d'));
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -49,6 +48,6 @@ final class ConsolidateDashboardRatesCommand extends Command
         $this->consolidateDashboardRates->consolidate($consolidationDate);
         $output->writeln('Consolidation done.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/InitializeProductsEvaluationsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/InitializeProductsEvaluationsCommand.php
@@ -19,12 +19,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 final class InitializeProductsEvaluationsCommand extends Command
 {
+    protected static $defaultName = 'pim:data-quality-insights:initialize-products-evaluations';
+    protected static $defaultDescription = 'Initialize the evaluations of all the products and product models.';
+
     private const BATCH_SIZE = 100;
 
     private Connection $dbConnection;
-
     private CriteriaEvaluationRegistry $productCriteriaRegistry;
-
     private CriteriaEvaluationRegistry $productModelCriteriaRegistry;
 
     public function __construct(
@@ -41,10 +42,7 @@ final class InitializeProductsEvaluationsCommand extends Command
 
     protected function configure()
     {
-        $this
-            ->setName('pim:data-quality-insights:initialize-products-evaluations')
-            ->setDescription('Initialize the evaluations of all the products and product models.')
-            ->setHidden(true);
+        $this->setHidden(true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -61,14 +59,14 @@ final class InitializeProductsEvaluationsCommand extends Command
 
             if ($confirm !== true) {
                 $io->text('Operation aborted. Nothing has been done.');
-                return 0;
+                return Command::SUCCESS;
             }
         }
 
         $this->initializeProducts($io);
         $this->initializeProductModels($io);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function initializeProducts(SymfonyStyle $io): void

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/LaunchEvaluationsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/LaunchEvaluationsCommand.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Comma
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Exception\AnotherJobStillRunningException;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\JobLauncher\RunUniqueProcessJob;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Connector\JobParameters\EvaluationsParameters;
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Symfony\Component\Console\Command\Command;
@@ -19,11 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class LaunchEvaluationsCommand extends Command
 {
-    /** @var FeatureFlag */
-    private $featureFlag;
+    protected static $defaultName = 'pim:data-quality-insights:evaluations';
+    protected static $defaultDescription = 'Launch the evaluations of products and structure';
 
-    /** @var RunUniqueProcessJob */
-    private $runUniqueProcessJob;
+    private FeatureFlag $featureFlag;
+    private RunUniqueProcessJob $runUniqueProcessJob;
 
     public function __construct(
         RunUniqueProcessJob $runUniqueProcessJob,
@@ -35,18 +34,11 @@ class LaunchEvaluationsCommand extends Command
         $this->runUniqueProcessJob = $runUniqueProcessJob;
     }
 
-    protected function configure()
-    {
-        $this
-            ->setName('pim:data-quality-insights:evaluations')
-            ->setDescription('Launch the evaluations of products and structure');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (! $this->featureFlag->isEnabled()) {
             $output->writeln('<info>Data Quality Insights feature is disabled</info>');
-            return 0;
+            return Command::SUCCESS;
         }
 
         try {
@@ -57,6 +49,6 @@ class LaunchEvaluationsCommand extends Command
             exit(0);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/MigrateProductCriterionEvaluationCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/MigrateProductCriterionEvaluationCommand.php
@@ -15,6 +15,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class MigrateProductCriterionEvaluationCommand extends Command
 {
+    protected static $defaultName = 'pimee:data-quality-insights:migrate-product-criterion-evaluation';
+    protected static $defaultDescription = 'Migrate the products criteria evaluations with empty results and pending status.';
+
     private Connection $dbConnection;
 
     public function __construct(Connection $dbConnection)
@@ -26,10 +29,7 @@ final class MigrateProductCriterionEvaluationCommand extends Command
 
     protected function configure()
     {
-        $this
-            ->setName('pimee:data-quality-insights:migrate-product-criterion-evaluation')
-            ->setDescription('Migrate the products criteria evaluations with empty results and pending status.')
-            ->setHidden(true);
+        $this->setHidden(true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -37,7 +37,7 @@ final class MigrateProductCriterionEvaluationCommand extends Command
         if ($this->isMigrationDone()) {
             $output->writeln('The migration has already been performed.');
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $output->writeln('Start migration of products...');
@@ -70,7 +70,7 @@ SQL
 
         $output->writeln('Migration done.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function isMigrationDone(): bool

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/PrepareEvaluationsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/PrepareEvaluationsCommand.php
@@ -19,11 +19,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class PrepareEvaluationsCommand extends Command
 {
-    /** @var FeatureFlag */
-    private $featureFlag;
+    protected static $defaultName = 'pim:data-quality-insights:prepare-evaluations';
+    protected static $defaultDescription = 'Prepare the evaluations of products and structure';
 
-    /** @var RunUniqueProcessJob */
-    private $runUniqueProcessJob;
+    private FeatureFlag $featureFlag;
+    private RunUniqueProcessJob $runUniqueProcessJob;
 
     public function __construct(
         RunUniqueProcessJob $runUniqueProcessJob,
@@ -35,18 +35,11 @@ class PrepareEvaluationsCommand extends Command
         $this->featureFlag = $featureFlag;
     }
 
-    protected function configure()
-    {
-        $this
-            ->setName('pim:data-quality-insights:prepare-evaluations')
-            ->setDescription('Prepare the evaluations of products and structure');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (! $this->featureFlag->isEnabled()) {
             $output->writeln('Data Quality Insights feature is disabled');
-            return 0;
+            return Command::SUCCESS;
         }
 
         try {
@@ -64,6 +57,6 @@ class PrepareEvaluationsCommand extends Command
             exit(0);
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/PurgeOutdatedDataCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/PurgeOutdatedDataCommand.php
@@ -17,6 +17,9 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 final class PurgeOutdatedDataCommand extends Command
 {
+    protected static $defaultName = 'pim:data-quality-insights:purge-outdated-data';
+    protected static $defaultDescription = 'Purge the outdated data persisted for Data-Quality-Insights.';
+
     private PurgeOutdatedData $purgeOutdatedData;
 
     public function __construct(PurgeOutdatedData $purgeOutdatedData)
@@ -28,10 +31,13 @@ final class PurgeOutdatedDataCommand extends Command
 
     protected function configure()
     {
-        $this
-            ->setName('pim:data-quality-insights:purge-outdated-data')
-            ->setDescription('Purge the outdated data persisted for Data-Quality-Insights.')
-            ->addOption('date', 'd', InputOption::VALUE_REQUIRED, 'Date from which the purge will be launched (Y-m-d)', date('Y-m-d'));
+        $this->addOption(
+            'date',
+            'd',
+            InputOption::VALUE_REQUIRED,
+            'Date from which the purge will be launched (Y-m-d)',
+            date('Y-m-d')
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -47,12 +53,12 @@ final class PurgeOutdatedDataCommand extends Command
         }
 
         if (!$this->confirmPurge($input, $output)) {
-            return 0;
+            return Command::SUCCESS;
         }
 
         $this->purgeOutdatedData($purgeDate, $output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function purgeOutdatedData(\DateTimeImmutable $purgeDate, OutputInterface $output)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/RecomputeProductsScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/RecomputeProductsScores.php
@@ -20,10 +20,11 @@ use Symfony\Component\Security\Core\User\User;
  */
 final class RecomputeProductsScores extends Command
 {
+    protected static $defaultName = 'pim:data-quality-insights:recompute-product-scores';
+    protected static $defaultDescription = 'Launch the job that will re-compute all the products scores';
+
     private FeatureFlag $featureFlag;
-
     private JobLauncherInterface $queueJobLauncher;
-
     private JobInstanceRepository $jobInstanceRepository;
 
     public function __construct(
@@ -40,17 +41,14 @@ final class RecomputeProductsScores extends Command
 
     protected function configure()
     {
-        $this
-            ->setName('pim:data-quality-insights:recompute-product-scores')
-            ->setDescription('Launch the job that will re-compute all the products scores')
-            ->setHidden(true);
+        $this->setHidden(true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (! $this->featureFlag->isEnabled()) {
             $output->writeln('Data Quality Insights feature is disabled');
-            return 0;
+            return Command::SUCCESS;
         }
 
         $jobInstance = $this->getJobInstance();
@@ -59,7 +57,7 @@ final class RecomputeProductsScores extends Command
 
         $output->writeln('The job that re-compute products scores has been launched.');
 
-        return 0;
+        return Command::SUCCESS;
     }
 
     private function getJobInstance(): JobInstance

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/SchedulePeriodicTasksCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/SchedulePeriodicTasksCommand.php
@@ -16,11 +16,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class SchedulePeriodicTasksCommand extends Command
 {
-    /** @var SchedulePeriodicTasks */
-    private $schedulePeriodicTasks;
+    protected static $defaultName = 'pim:data-quality-insights:schedule-periodic-tasks';
+    protected static $defaultDescription = 'Schedule the periodic tasks of Data-Quality-Insights.';
 
-    /** @var FeatureFlag */
-    private $featureFlag;
+    private SchedulePeriodicTasks $schedulePeriodicTasks;
+    private FeatureFlag $featureFlag;
 
     public function __construct(SchedulePeriodicTasks $schedulePeriodicTasks, FeatureFlag $featureFlag)
     {
@@ -30,23 +30,16 @@ final class SchedulePeriodicTasksCommand extends Command
         $this->featureFlag = $featureFlag;
     }
 
-    protected function configure()
-    {
-        $this
-            ->setName('pim:data-quality-insights:schedule-periodic-tasks')
-            ->setDescription('Schedule the periodic tasks of Data-Quality-Insights.');
-    }
-
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (! $this->featureFlag->isEnabled()) {
             $output->writeln('Data Quality Insights feature is disabled');
-            return 0;
+            return Command::SUCCESS;
         }
         $this->schedulePeriodicTasks->schedule(new \DateTimeImmutable('-1 DAY'));
 
         $output->writeln('Data-Quality-Insights periodic tasks have been scheduled');
 
-        return 0;
+        return Command::SUCCESS;
     }
 }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -7,7 +7,7 @@ use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
 use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
 use Akeneo\Platform\Bundle\InstallerBundle\FixtureLoader\FixtureJobLoader;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\ClientRegistry;
-use Doctrine\DBAL\Driver\Connection;
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -31,6 +31,7 @@ use Symfony\Component\Process\Process;
 class DatabaseCommand extends Command
 {
     protected static $defaultName = 'pim:installer:db';
+    protected static $defaultDescription = 'Prepare database and load fixtures';
 
     const LOAD_ALL = 'all';
     const LOAD_BASE = 'base';
@@ -65,8 +66,6 @@ class DatabaseCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('pim:installer:db')
-            ->setDescription('Prepare database and load fixtures')
             ->addOption(
                 'fixtures',
                 null,

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Command/ListClientsCommand.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Command/ListClientsCommand.php
@@ -18,26 +18,15 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ListClientsCommand extends Command
 {
     protected static $defaultName = 'pim:oauth-server:list-clients';
+    protected static $defaultDescription = 'Lists all existing pairs of client id / secret for the web API';
 
-    /** @var EntityRepository */
-    private $clientRepository;
+    private EntityRepository $clientRepository;
 
     public function __construct(EntityRepository $clientRepository)
     {
         parent::__construct();
 
         $this->clientRepository = $clientRepository;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
-    {
-        $this
-            ->setName('pim:oauth-server:list-clients')
-            ->setDescription('Lists all existing pairs of client id / secret for the web API')
-        ;
     }
 
     /**
@@ -50,7 +39,7 @@ class ListClientsCommand extends Command
         if (empty($clients)) {
             $output->writeln('No client is currently registered.');
 
-            return 0;
+            return Command::SUCCESS;
         }
 
         $table = new Table($output);
@@ -66,6 +55,6 @@ class ListClientsCommand extends Command
 
         $table->render($output);
 
-        return 0;
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
There are several avantages to use lazy commands. From a performance point of vue, I've traced **a lot** of services instanciated just to regsiter commands.

I create this PR because I've run into an issue when warming up the application without a database container up. One of the instantiated commands triggered a listener trying to make a database call and then resulting in an error when I had no use of this call (only seen in APP_DEBUG=1 mode).

From https://symfony.com/blog/new-in-symfony-3-4-lazy-commands:

> the Symfony Console suffered a shortcoming since day one: you must instantiate all commands to register them in the console application. The reason is that even the command name itself is defined inside a method called configure(), so you must instantiate the command class to configure it and get the command name.
>
> In practice, this shortcoming is not a real problem for lots of applications. However, if you have lots of commands or they are very complex (because they make use of a lot of services) this can hurt performance. Moreover, if there is a single error when instantiating any of the commands, you can't run the application console, even if you are not executing the failing command.
>
> In Symfony 3.4, we were finally able to fix this issue and console commands can now be lazy. This means that commands no longer need to be instantiated when running the console application, so executing any command will be a bit faster in Symfony 3.4.

Then in https://symfony.com/blog/new-in-symfony-5-3-lazy-command-description:

> Symfony commands aren’t fully lazy. If you run bin/console without arguments (or the equivalent bin/console list command) you see the entire list of commands registered in the application and their descriptions. This requires instantiating all commands, because their description is not lazy.
>
> You might think that this is not important, because you rarely list commands and it’s OK if it takes a few milliseconds to run. That’s true, but this makes it harder/impossible to implement another feature that we want to include in future Symfony versions: console autocompletion.

https://symfony.com/doc/current/service_container.html#service-container-services-load-example