### PR TITLE
Fix Version_6_0_20210331105730

### DIFF
--- a/upgrades/schema/Version_6_0_20210331105730_remove_datagrid_view_unique_label_constraint.php
+++ b/upgrades/schema/Version_6_0_20210331105730_remove_datagrid_view_unique_label_constraint.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pim\Upgrade\Schema;
 
 use Doctrine\DBAL\Connection as DbalConnection;
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
@@ -29,16 +28,14 @@ final class Version_6_0_20210331105730_remove_datagrid_view_unique_label_constra
     public function up(Schema $schema): void
     {
         $selectUniqueConstraint = <<< SQL
-SELECT DISTINCT CONSTRAINT_NAME
-FROM information_schema.TABLE_CONSTRAINTS
-WHERE table_name = 'pim_datagrid_view' AND constraint_type = 'UNIQUE' AND TABLE_SCHEMA = 'akeneo_pim';
-SQL;
+            SELECT DISTINCT CONSTRAINT_NAME
+            FROM information_schema.TABLE_CONSTRAINTS
+            WHERE table_name = 'pim_datagrid_view' AND constraint_type = 'UNIQUE' AND TABLE_SCHEMA = 'akeneo_pim';
+        SQL;
         $uniqueConstraintKeyName = $this->dbalConnection()->executeQuery($selectUniqueConstraint)->fetchOne();
 
-        $this->addSql(<<<SQL
-ALTER TABLE pim_datagrid_view
-DROP index $uniqueConstraintKeyName
-SQL);
+        $this->skipIf(!$uniqueConstraintKeyName, 'pim_datagrid_view unique constraint is already up to date');
+        $this->addSql("ALTER TABLE pim_datagrid_view DROP index $uniqueConstraintKeyName");
     }
 
     public function down(Schema $schema): void


### PR DESCRIPTION
The constraint is already remove by a backport in https://github.com/akeneo/pim-community-dev/pull/15580 and can therefore not exists in 5.0. We must add a condition to remove it only if exists.