### PR TITLE
15685: Fixed duplicate fetch of sessions flash

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/views/CategoryTree/edit.html.twig
@@ -6,10 +6,6 @@
     {% include "AkeneoPimEnrichmentBundle:CategoryTree:_scripts.html.twig" %}
 {% endblock %}
 
-<script type="text/javascript" nonce="{{ js_nonce() }}">
-    window.flashMessages = JSON.parse('{{ app.session.flashbag.all|json_encode()|raw }}');
-</script>
-
 <script nonce="{{ js_nonce() }}">
     require(
         [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The sessions flash messages are already fetched in form.html.twig. The second fetch renders issue 15685 where the flash messages are not displayed on category save action.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc

Resolves #15685 