### PR TITLE
RAC-975: Backend service to query job executions should support sorting on each columns

### DIFF
--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
@@ -11,6 +11,8 @@ class SearchJobExecutionQuery
 {
     public int $page = 1;
     public int $size = 25;
+    public string $sortColumn = 'started_at';
+    public string $sortDirection = 'DESC';
     public array $type = [];
     public array $status = [];
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
@@ -34,6 +34,8 @@ final class IndexAction
         $searchJobExecutionQuery = new SearchJobExecutionQuery();
         $searchJobExecutionQuery->page = (int) $request->get('page', 1);
         $searchJobExecutionQuery->size = (int) $request->get('size', 25);
+        $searchJobExecutionQuery->sortColumn = $request->get('sort_column', 'started_at');
+        $searchJobExecutionQuery->sortDirection = $request->get('sort_direction', 'DESC');
         $searchJobExecutionQuery->type = $request->get('type', []);
         $searchJobExecutionQuery->status = $request->get('status', []);
 

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
@@ -11,7 +11,6 @@ use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
-use InvalidArgumentException;
 
 /**
  * @author Grégoire Houssard <gregoire.houssard@akeneo.com>
@@ -136,7 +135,7 @@ SQL;
         $sortDirection = $query->sortDirection;
 
         if (!in_array($sortDirection, ['ASC', 'DESC'])) {
-            throw new InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection));
+            throw new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection));
         }
 
         switch ($query->sortColumn) {
@@ -159,7 +158,7 @@ SQL;
                 $orderByColumn = "warning_count $sortDirection";
                 break;
             default:
-                throw new InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn));
+                throw new \InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn));
         }
 
         return sprintf('ORDER BY %s', $orderByColumn);

--- a/src/Akeneo/Platform/Job/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Job/back/tests/.php_cd.php
@@ -29,7 +29,6 @@ $rules = [
             'Akeneo\Tool',
             'Doctrine\DBAL\Connection',
             'Doctrine\DBAL\Types',
-            'InvalidArgumentException',
             'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
             'Oro\Bundle\SecurityBundle\SecurityFacade',
             'Symfony\Component',

--- a/src/Akeneo/Platform/Job/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Job/back/tests/.php_cd.php
@@ -29,6 +29,7 @@ $rules = [
             'Akeneo\Tool',
             'Doctrine\DBAL\Connection',
             'Doctrine\DBAL\Types',
+            'InvalidArgumentException',
             'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
             'Oro\Bundle\SecurityBundle\SecurityFacade',
             'Symfony\Component',

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -179,6 +179,69 @@ class SearchJobExecutionTest extends IntegrationTestCase
         $this->assertEquals(1, $this->getQuery()->count($query));
     }
 
+    /**
+     * @test
+     */
+    public function it_returns_ordered_by_warning_count_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'warning_count';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                null,
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[1],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
+                null,
+                'STARTED',
+                0,
+                2,
+                1,
+                3
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_invalid_argument_exception_when_sort_column_is_not_supported()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->sortColumn = 'invalid_column';
+
+        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn)));
+        $this->getQuery()->search($query);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_invalid_argument_exception_when_sort_direction_is_not_supported()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->sortDirection = 'DASC';
+
+        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection)));
+        $this->getQuery()->search($query);
+    }
+
     private function loadFixtures()
     {
         $aProductImportJobInstanceId = $this->fixturesLoader->createJobInstance([

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -68,7 +68,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                 'a_product_import',
                 'import',
                 new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
-                null,
+                'peter',
                 'STARTED',
                 0,
                 2,
@@ -80,7 +80,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                 'a_product_import',
                 'import',
                 new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
-                null,
+                'julia',
                 'COMPLETED',
                 4,
                 0,
@@ -182,6 +182,205 @@ class SearchJobExecutionTest extends IntegrationTestCase
     /**
      * @test
      */
+    public function it_returns_ordered_by_job_name_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'job_name';
+        $query->sortDirection = 'ASC';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[3],
+                'a_product_export',
+                'export',
+                null,
+                null,
+                'STARTING',
+                0,
+                0,
+                0,
+                3,
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                'julia',
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ordered_by_type_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'type';
+        $query->sortDirection = 'ASC';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[3],
+                'a_product_export',
+                'export',
+                null,
+                null,
+                'STARTING',
+                0,
+                0,
+                0,
+                3,
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                'julia',
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ordered_by_started_at_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'started_at';
+        $query->sortDirection = 'ASC';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                'julia',
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[1],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
+                'peter',
+                'STARTED',
+                0,
+                2,
+                1,
+                3
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ordered_by_username_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'username';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[1],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
+                'peter',
+                'STARTED',
+                0,
+                2,
+                1,
+                3
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                'julia',
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_ordered_by_status_job_executions()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->size = 2;
+        $query->sortColumn = 'status';
+        $query->sortDirection = 'ASC';
+
+        $expectedJobExecutions = [
+            new JobExecutionRow(
+                $this->jobExecutionIds[0],
+                'a_product_import',
+                'import',
+                new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
+                'julia',
+                'COMPLETED',
+                4,
+                0,
+                3,
+                3
+            ),
+            new JobExecutionRow(
+                $this->jobExecutionIds[2],
+                'a_product_import',
+                'import',
+                null,
+                null,
+                'STARTING',
+                0,
+                0,
+                0,
+                3,
+            ),
+        ];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_ordered_by_warning_count_job_executions()
     {
         $query = new SearchJobExecutionQuery();
@@ -194,7 +393,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                 'a_product_import',
                 'import',
                 new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
-                null,
+                'julia',
                 'COMPLETED',
                 4,
                 0,
@@ -206,7 +405,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                 'a_product_import',
                 'import',
                 new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
-                null,
+                'peter',
                 'STARTED',
                 0,
                 2,
@@ -268,12 +467,14 @@ class SearchJobExecutionTest extends IntegrationTestCase
         $this->jobExecutionIds[] = $this->fixturesLoader->createJobExecution([
             'job_instance_id' => $aProductImportJobInstanceId,
             'start_time' => '2020-01-01T01:00:00+01:00',
+            'user' => 'julia',
             'status' => BatchStatus::COMPLETED,
         ]);
 
         $this->jobExecutionIds[] = $this->fixturesLoader->createJobExecution([
             'job_instance_id' => $aProductImportJobInstanceId,
             'start_time' => '2020-01-02T01:00:00+01:00',
+            'user' => 'peter',
             'status' => BatchStatus::STARTED,
         ]);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Handle sort column and directions in query to be able to sort all columns of job execution table.

**Definition Of Done (for Core Developer only)**

- [x] Tests
