### PR TITLE
CXP-765: fix type of connection created for an app

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/CreateConnection.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/CreateConnection.php
@@ -15,6 +15,8 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\Connec
  */
 class CreateConnection implements CreateConnectionInterface
 {
+    private const CONNECTION_TYPE_APP = 'app';
+
     private ConnectionRepository $repository;
     private SelectConnectionWithCredentialsByCodeQuery $selectConnectionWithCredentialsByCodeQuery;
 
@@ -38,7 +40,10 @@ class CreateConnection implements CreateConnectionInterface
             $label,
             $flowType,
             $clientId,
-            $userId
+            $userId,
+            null,
+            false,
+            self::CONNECTION_TYPE_APP
         );
 
         $this->repository->create($connection);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Repository/DbalConnectionRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/Dbal/Repository/DbalConnectionRepository.php
@@ -39,7 +39,7 @@ SQL;
                 'label' => (string) $connection->label(),
                 'flow_type' => (string) $connection->flowType(),
                 'auditable' => $connection->auditable(),
-                'type' => $connection->type(),
+                'type' => (string) $connection->type(),
             ],
             [
                 'auditable' => Types::BOOLEAN,
@@ -50,7 +50,7 @@ SQL;
     public function findOneByCode(string $code): ?Connection
     {
         $selectQuery = <<<SQL
-SELECT code, label, flow_type, image, client_id, user_id, auditable
+SELECT code, label, flow_type, image, client_id, user_id, auditable, type
 FROM akeneo_connectivity_connection
 WHERE code = :code
 SQL;
@@ -65,7 +65,8 @@ SQL;
                 (int) $dataRow['client_id'],
                 (int) $dataRow['user_id'],
                 $dataRow['image'],
-                (bool) $dataRow['auditable']
+                (bool) $dataRow['auditable'],
+                $dataRow['type']
             ) : null;
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/InMemory/Repository/InMemoryConnectionRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Persistence/InMemory/Repository/InMemoryConnectionRepository.php
@@ -30,7 +30,7 @@ class InMemoryConnectionRepository implements ConnectionRepository
             'password' => uniqid(),
             'image' => null,
             'auditable' => $connection->auditable(),
-            'type' => 'default',
+            'type' => (string) $connection->type(),
         ];
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateAppWithAuthorizationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateAppWithAuthorizationHandlerIntegration.php
@@ -182,6 +182,7 @@ class CreateAppWithAuthorizationHandlerIntegration extends TestCase
         Assert::assertNotNull($foundConnection, 'No persisted connection found');
         Assert::assertEquals(FlowType::OTHER, $foundConnection->flowType());
         Assert::assertEquals($appName, $foundConnection->label());
+        Assert::assertEquals('app', $foundConnection->type());
 
         /** @var Client $foundClient */
         $foundClient = $this->clientManager->findClientBy(['id' => $foundConnection->clientId()->id()]);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

A Connection has a column `type`. Its `default` by default.
When creating an App, the underlying Connection should have the type `type` to be distinguishable from the others.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
