### PR TITLE
RAC-1010: Use common label on LocaleSelector

### DIFF
--- a/front-packages/shared/src/components/LocaleSelector.tsx
+++ b/front-packages/shared/src/components/LocaleSelector.tsx
@@ -49,13 +49,13 @@ const LocaleSelector = ({value, values, completeValues, onChange}: LocaleSelecto
 
   return (
     <DropdownContainer>
-      <SwitcherButton label={translate('pim_enrich.entity.locale.plural_label')} onClick={open}>
+      <SwitcherButton label={translate('pim_common.locale')} onClick={open}>
         <HighlightLocaleWithFlag code={selectedLocale.code} languageLabel={selectedLocale.label} />
       </SwitcherButton>
       {isOpen && (
         <Dropdown.Overlay verticalPosition="down" onClose={close}>
           <Dropdown.Header>
-            <Dropdown.Title>{translate('pim_enrich.entity.attribute.module.edit.select_locale')}</Dropdown.Title>
+            <Dropdown.Title>{translate('pim_common.locale')}</Dropdown.Title>
           </Dropdown.Header>
           <Dropdown.ItemCollection>
             {values.map(locale => (

--- a/front-packages/shared/src/components/LocaleSelector.unit.tsx
+++ b/front-packages/shared/src/components/LocaleSelector.unit.tsx
@@ -22,7 +22,7 @@ const locales = [
 test('It renders the current locale', () => {
   renderWithProviders(<LocaleSelector values={locales} value={'fr_FR'} />);
 
-  expect(screen.getByText('pim_enrich.entity.locale.plural_label:')).toBeInTheDocument();
+  expect(screen.getByText('pim_common.locale:')).toBeInTheDocument();
   expect(screen.getByText('French (France)')).toBeInTheDocument();
 });
 

--- a/front-packages/shared/src/models/locale.ts
+++ b/front-packages/shared/src/models/locale.ts
@@ -50,9 +50,8 @@ const createLocaleFromCode = (code: LocaleCode): Locale => {
   };
 };
 
-const localeExists = (locales: Locale[], currentLocale: LocaleCode) => {
-  return locales.some(({code}: Locale) => code === currentLocale);
-};
+const localeExists = (locales: Locale[], currentLocale: LocaleCode) =>
+  locales.some(({code}: Locale) => code === currentLocale);
 
 export {createLocaleFromCode, denormalizeLocale, localeExists, isLocales, isLocale};
 export type {Locale, LocaleCode, LocaleLabel, LocaleRegion, LocaleLanguage, LocaleReference};


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

Using the singular label on the Locale Selector to be more consistent
