### PR TITLE
PIM-10160: Fix AM thumbnail generation when filename is longer than 100 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@
 - PIM-10129: Fix error 414 with a long filter list when launching a bulk action and quick export
 - PIM-10139: Fix missing translation key in Italian locale with "change family" mass action
 - PIM-10145: Fix reset password page
+- PIM-10160: Fix AM thumbnail generation when filename is longer than 100 characters
 
 ## New features
 

--- a/src/Akeneo/Tool/Component/FileStorage/PathGenerator.php
+++ b/src/Akeneo/Tool/Component/FileStorage/PathGenerator.php
@@ -32,16 +32,17 @@ class PathGenerator implements PathGeneratorInterface
     public function generate(\SplFileInfo $file)
     {
         $originalFileName = ($file instanceof UploadedFile) ? $file->getClientOriginalName() : $file->getFilename();
+        $originalExtension = ($file instanceof UploadedFile) ? $file->getClientOriginalExtension() : $file->getExtension();
         $uuid = $this->generateUuid($originalFileName);
         $sanitized = preg_replace('#[^A-Za-z0-9\.]#', '_', $originalFileName);
 
         if (strlen($sanitized) > 100) {
-            $sanitized = sprintf('%s.%s', substr($sanitized, 0, 95), $file->getExtension());
+            $sanitized = sprintf('%s.%s', substr($sanitized, 0, 95), $originalExtension);
         }
 
         $fileName = $uuid . '_' . $sanitized;
         $path = sprintf('%s/%s/%s/%s/', $uuid[0], $uuid[1], $uuid[2], $uuid[3]);
-        $pathName = $path.$fileName;
+        $pathName = $path . $fileName;
 
         return [
             'uuid'      => $uuid,

--- a/src/Akeneo/Tool/Component/FileStorage/spec/PathGeneratorSpec.php
+++ b/src/Akeneo/Tool/Component/FileStorage/spec/PathGeneratorSpec.php
@@ -3,11 +3,13 @@
 namespace spec\Akeneo\Tool\Component\FileStorage;
 
 use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class PathGeneratorSpec extends ObjectBehavior
 {
     public function it_generates_the_path_info_of_a_file(\SplFileInfo $file)
     {
+        $file->getExtension()->willReturn('txt');
         $file->getFilename()->willReturn('[test]un FICHIER plutôt sympa23.txt');
 
         $pathInfo = $this->generate($file);
@@ -18,6 +20,17 @@ class PathGeneratorSpec extends ObjectBehavior
     {
         $file->getFilename()->willReturn('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.pdf');
         $file->getExtension()->willReturn('pdf');
+
+        $pathInfo = $this->generate($file);
+        $pathInfo->shouldBeValidPathInfo('Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_la.pdf');
+    }
+
+    function it_cuts_the_filename_and_uses_the_original_extension_when_the_file_is_an_uploaded_file()
+    {
+        $file = new UploadedFile(
+            __FILE__,
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.pdf',
+        );
 
         $pathInfo = $this->generate($file);
         $pathInfo->shouldBeValidPathInfo('Lorem_ipsum_dolor_sit_amet__consectetur_adipiscing_elit__sed_do_eiusmod_tempor_incididunt_ut_la.pdf');


### PR DESCRIPTION

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

On the Asset manager, when uploading a file with a filename longer than 100 characters, the thumbnail generation would fail. This was because the path generator used to store the file would try to use the `$file->getExtension()` function but this would return an empty string on AM files as it using a different filename than the original filename of the actual file. Using the `UploadedFile::getClientOriginalExtension` method fixes this issue.