### PR TITLE
RAC-973: Process tracker filters should be persisted in the local storage

### DIFF
--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionList.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionList.tsx
@@ -1,6 +1,7 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback} from 'react';
 import {AttributesIllustration, Breadcrumb, Pagination} from 'akeneo-design-system';
 import {
+  useStorageState,
   useTranslate,
   useRoute,
   PimView,
@@ -19,10 +20,15 @@ import {
   JobStatus,
 } from '../models';
 
+const FILTER_LOCAL_STORAGE_KEY = 'process-tracker.filters';
+
 const JobExecutionList = () => {
   const activityHref = useRoute('pim_dashboard_index');
   const translate = useTranslate();
-  const [jobExecutionFilter, setJobExecutionFilter] = useState<JobExecutionFilter>(getDefaultJobExecutionFilter());
+  const [jobExecutionFilter, setJobExecutionFilter] = useStorageState<JobExecutionFilter>(
+    getDefaultJobExecutionFilter(),
+    FILTER_LOCAL_STORAGE_KEY
+  );
   const jobExecutionTable = useJobExecutionTable(jobExecutionFilter);
   const matchesCount = jobExecutionTable === null ? 0 : jobExecutionTable.matches_count;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Filter state are now persisted in browser local storage.
The page is not keep cause search bar debounce useEffect but it better because it will avoid failure when job are purged between filter appliance and page reload.
