### PR TITLE
CXP-984: Quick fixes on App display

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -127,7 +127,7 @@ akeneo_connectivity.connection:
                     permissions: Permissions
                     summary: Well done!
                 authorize:
-                    title: 'App {{ app_name }} needs to'
+                    title: '{{ app_name }} needs to'
                     no_scope_title: 'The {{ app_name }} App would like to access your PIM.'
                     no_scope: No specific authorizations have been requested.
                     helper: To know more about app authorization,

--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
@@ -59,4 +59,8 @@ const Header = styled.header`
     padding: 40px 40px 20px;
     background: white;
     z-index: 10;
+
+    .AknImage-display {
+        max-width: 100%;
+    }
 `;

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -3,7 +3,6 @@ import {Breadcrumb, TabBar, useTabBar} from 'akeneo-design-system';
 import {Translate, useTranslate} from '../../../shared/translate';
 import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
-import {useMediaUrlGenerator} from '../../../settings/use-media-url-generator';
 import {ApplyButton, DropdownLink, PageContent, PageHeader, SecondaryActionsDropdownButton} from '../../../common';
 import {UserButtons} from '../../../shared/user';
 import {ConnectedAppSettings} from './ConnectedAppSettings';
@@ -27,7 +26,6 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
     const notify = useNotify();
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
     const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
-    const generateMediaUrl = useMediaUrlGenerator();
     const [providers, permissions, setPermissions] = usePermissionsFormProviders(connectedApp.user_group_name);
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState<boolean>(false);
     const [activeTab, setActiveTab] = useSessionStorageState(settingsTabName, 'pim_connectedApp_activeTab');
@@ -138,7 +136,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                 ]}
                 userButtons={<UserButtons />}
                 state={<FormState />}
-                imageSrc={generateMediaUrl(connectedApp.logo, 'thumbnail')}
+                imageSrc={connectedApp.logo}
             >
                 {connectedApp.name}
             </PageHeader>


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We prefixed the introduction sentence by "App".
With an App called `App prototype`, it does `App App prototype needs to`.
I'm proposing to remove the word `App` from the sentence.
**Before**
![Screenshot_2021-11-19_13-40-42](https://user-images.githubusercontent.com/1421130/142625748-f849a7ab-e8c8-4baa-be0d-5d1ea0d5a517.png)
**After**
![Screenshot_2021-11-19_13-40-51](https://user-images.githubusercontent.com/1421130/142625765-facb680a-5ff8-4852-a7c8-15d2ec541c39.png)

----

The image in App Settings was not displayed, now it's working:

![Screenshot_2021-11-19_13-46-57](https://user-images.githubusercontent.com/1421130/142625810-ac697681-8635-47ff-9e08-b57dab93865d.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
