### PR TITLE
PIM-10162: Fix dropdown vertical position

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10162: Not all locales are displayed when using compare/translate feature on product
+
 # 5.0.57 (2021-11-08)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/lib/bootstrap/js/bootstrap.js
@@ -456,9 +456,11 @@
         const boundedHeight = Math.min(outerHeight, maxHeight);
         const isScrollable = outerHeight > maxHeight;
         const listIsLongerThanPage = boundedHeight + parentOffset + gap > bodyHeight;
+        const parentOffsetBottom = $parent.offset().top + $parent.height();
+        const listIsOverlappingTop = parentOffsetBottom - outerHeight < 0;
 
-        if (false === isScrollable && listIsLongerThanPage) {
-          $parent.toggleClass('top', listIsLongerThanPage);
+        if (false === isScrollable && listIsLongerThanPage && false === listIsOverlappingTop) {
+          $parent.toggleClass('top', true);
         }
 
         if (outerWidth + $parent.offset().left + gap > $('body').width()) {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-10162

When dropdown will overlap the bottom page, we added the top position so the list was displayed to the top. But we didn't test if the list will overlap the top. Now if the list overlaps the bottom and the top, we let the bottom position.  


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
