### PR TITLE
[CI] Fix multiselect fill value

### DIFF
--- a/tests/legacy/features/Behat/Decorator/Field/Select2Decorator.php
+++ b/tests/legacy/features/Behat/Decorator/Field/Select2Decorator.php
@@ -38,8 +38,9 @@ class Select2Decorator extends ElementDecorator
                 $result = $widget->find('css', sprintf('.select2-result-label:contains("%s")', $value));
 
                 if (null !== $result && $result->isVisible()) {
-                    $result->click();
-
+                    $this->getSession()->executeScript(
+                        sprintf('$(\'.select2-result-label:contains("%s")\').mouseup();', $value)
+                    );
                     return true;
                 }
 


### PR DESCRIPTION
Previously, we used PHP click method to click on a item in a Select2 box.
This "click", sometimes, was instable :shrug: 
I replaced it by a pure JS method to use "mouseup" method, because select2 lib only uses "onMouseUp" event to trigger selection.
After 2 hours in my computer, this raises no errors, let's try this method.