### PR TITLE
RAC-1078: Add indexes on job execution to fix search performances

### DIFF
--- a/src/Akeneo/Platform/Job/back/Infrastructure/Installer/JobInstaller.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Installer/JobInstaller.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Platform\Job\Infrastructure\Installer;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
+use Doctrine\DBAL\Driver\Connection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class JobInstaller implements EventSubscriberInterface
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            InstallerEvents::POST_DB_CREATE => ['createJobExecutionIndexes'],
+        ];
+    }
+
+    public function createJobExecutionIndexes(): void
+    {
+        $sql = <<<SQL
+        CREATE INDEX started_time_idx ON akeneo_batch_job_execution ((start_time IS NULL), start_time);
+        CREATE INDEX user_idx ON akeneo_batch_job_execution (user);
+        CREATE INDEX status_idx ON akeneo_batch_job_execution (status);
+SQL;
+
+        $this->connection->exec($sql);
+    }
+}

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -2,3 +2,10 @@ services:
     Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionHandler:
         arguments:
             - '@Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface'
+
+    akeneo.job.installer:
+        class: Akeneo\Platform\Job\Infrastructure\Installer\JobInstaller
+        arguments:
+            - '@doctrine.dbal.default_connection'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/components/JobExecutionList/JobExecutionTable.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/components/JobExecutionList/JobExecutionTable.tsx
@@ -86,7 +86,7 @@ const JobExecutionTable = ({
           >
             <Table.Cell rowTitle={true}>{jobExecutionRow.job_name}</Table.Cell>
             <Table.Cell>
-              {translate(`pim_import_export.widget.last_operations.job_type.${jobExecutionRow.type}`)}
+              {translate(`akeneo_job_process_tracker.type.${jobExecutionRow.type}`)}
             </Table.Cell>
             <Table.Cell>
               {jobExecutionRow.started_at

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionList.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionList.tsx
@@ -37,7 +37,7 @@ const JobExecutionList = () => {
   };
 
   const handleSortChange = (sort: JobExecutionFilterSort) => {
-    setJobExecutionFilter(jobExecutionFilter => ({...jobExecutionFilter, sort}));
+    setJobExecutionFilter(jobExecutionFilter => ({...jobExecutionFilter, page: 1, sort}));
   };
 
   const handleStatusFilterChange = (status: JobStatus[]) => {

--- a/upgrades/schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution.php
+++ b/upgrades/schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $this->skipIf($this->indexesExist(), 'Indexed IDX_STARTED_TIME, IDX_USER and IDX_STATUS already exists in akeneo_batch_job_execution');
+
+        $this->addSql('CREATE INDEX started_time_idx ON akeneo_batch_job_execution ((start_time IS NULL), start_time)');
+        $this->addSql('CREATE INDEX user_idx ON akeneo_batch_job_execution (user)');
+        $this->addSql('CREATE INDEX status_idx ON akeneo_batch_job_execution (status)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function indexesExist(): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset(
+            $indexIndexedByName['started_time_idx'],
+            $indexIndexedByName['user_idx'],
+            $indexIndexedByName['status_idx']
+        );
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_Integration.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_6_0_20211124163100_add_index_to_improve_search_on_job_execution_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_6_0_20211124163100_add_index_to_improve_search_on_job_execution';
+
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_a_new_type_column_to_the_connection_table(): void
+    {
+        $this->dropIndexesIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertTrue($this->indexesExist());
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->dropIndexesIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->indexesExist());
+    }
+
+    private function dropIndexesIfExists(): void
+    {
+        if ($this->indexExist('started_time_idx')) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX started_time_idx;');
+        }
+
+        if ($this->indexExist('user_idx')) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX user_idx;');
+        }
+
+        if ($this->indexExist('status_idx')) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX status_idx;');
+        }
+
+        Assert::assertEquals(false, $this->indexesExist());
+    }
+
+    private function indexesExist(): bool
+    {
+        return $this->indexExist('started_time_idx') && $this->indexExist('IDX_USER') && $this->indexExist('IDX_STATUS');
+    }
+
+    private function indexExist(string $indexName): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset($indexIndexedByName[$indexName]);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR : 
- I added indexes on job execution in order to improve performance of the new process tracker.  
- I used the same translation key that the filter (Some job type are not translated with the previous translation key)
- I reset now the page when sorting another column (there is no sense to keep the actual page) 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
