### PR TITLE
RAC-1063: Fix instable test due to CssSelectorConverter cache

### DIFF
--- a/tests/legacy/features/pim/enrichment/product/export/export_products_by_text.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/export_products_by_text.feature
@@ -22,17 +22,16 @@ Feature: Export products according to text attribute filter
       | SNKRS-1Z | 1       | rangers | summer_collection | This is nice    | Ranger 1Z  |              |               | Nice title |
     And I am logged in as "Julia"
 
-  @skip
   Scenario: Export products by text values
     When I am on the "csv_footwear_product_export" export job edit page
     And I visit the "Content" tab
     And I filter by "completeness" with operator "No condition on completeness" and value ""
     And I visit the "Content" tab
     And I add available attributes Comment
-    And I add available attributes Name
     And I add available attributes Title
     And I add available attributes Title 2
     And I add available attributes Title 3
+    And I add available attributes Name
     And I switch the locale from "name" filter to "en_US"
     And I filter by "comment" with operator "Is equal to" and value "Awesome"
     And I filter by "name" with operator "Contains" and value "Ranger"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR i fixed the following behat: `tests/legacy/features/pim/enrichment/product/export/export_products_by_text.feature`

Why we have the error ?
Since https://github.com/akeneo/pim-community-dev/pull/15693 we passed from : symfony/css-selector: "v3.4.47" to "v5.3.4",
Now CssSelectorConverter (used to convert css path to xpath) use a cache. Problem is that the path have change between the time where user add the filter and user change the locale. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
