### PR TITLE
CPM-331: Default behavior for completeness calculation of table attribute values

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -68,6 +68,7 @@ services:
                 - 'akeneo_reference_entity_collection'
                 - 'pim_catalog_asset_collection'
                 - 'pim_assets_collection'
+                - 'pim_catalog_table'
         tags:
             - { name: akeneo.pim.structure.query.get_required_attributes_masks_per_attribute_type }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Since #15776 was merged, the completeness calculation does not take table attributes into account. This is a temporary fix to reinstate the former behavior, this change will be reverted when https://github.com/akeneo/pim-enterprise-dev/pull/12290 is merged

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
