### PR TITLE
CPM-318: Refactor tabs errors

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/fields/field.js
@@ -63,7 +63,10 @@ define([
       this.render();
 
       if (this.errors.length) {
-        this.getRoot().trigger('pim_enrich:form:form-tabs:add-error', this.getTabCode());
+        this.getRoot().trigger('pim_enrich:form:form-tabs:add-errors', {
+          tabCode: this.getTabCode(),
+          errors: this.errors,
+        });
         this.getRoot().trigger('pim_enrich:form:form-tabs:change', this.getTabCode());
       }
     },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/form-tabs.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/form-tabs.js
@@ -175,7 +175,7 @@ define(['jquery', 'underscore', 'backbone', 'pim/form', 'pim/template/form/form-
 
     removeError: function () {
       let dirty = false;
-      this.tabs.forEach((tab) => {
+      this.tabs.forEach(tab => {
         if (tab.fieldErrors.length) {
           tab.fieldErrors = [];
           dirty = true;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/form-tabs.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/form-tabs.js
@@ -54,8 +54,8 @@ define(['jquery', 'underscore', 'backbone', 'pim/form', 'pim/template/form/form-
       this.onExtensions('tab:register', this.registerTab.bind(this));
       this.onExtensions('tab:refresh', this.refreshTab.bind(this));
       this.listenTo(this.getRoot(), 'pim_enrich:form:form-tabs:change', this.setCurrentTab);
-      this.listenTo(this.getRoot(), 'pim_enrich:form:form-tabs:add-error', this.addError);
-      this.listenTo(this.getRoot(), 'pim_enrich:form:form-tabs:remove-error', this.removeError);
+      this.listenTo(this.getRoot(), 'pim_enrich:form:form-tabs:add-errors', this.addError);
+      this.listenTo(this.getRoot(), 'pim_enrich:form:form-tabs:remove-errors', this.removeError);
 
       return BaseForm.prototype.configure.apply(this, arguments);
     },
@@ -73,7 +73,7 @@ define(['jquery', 'underscore', 'backbone', 'pim/form', 'pim/template/form/form-
           code: event.code,
           isVisible: event.isVisible,
           label: event.label,
-          fieldErrorCount: 0,
+          fieldErrors: [],
         });
         this.render();
       } else {
@@ -165,18 +165,23 @@ define(['jquery', 'underscore', 'backbone', 'pim/form', 'pim/template/form/form-
       return this;
     },
 
-    addError: function (tabCode) {
+    addError: function ({tabCode, errors}) {
       const tab = this.tabs.find(currentTab => currentTab.code === tabCode);
       if (tab) {
-        tab.fieldErrorCount++;
+        tab.fieldErrors.push(errors);
         this.render();
       }
     },
 
-    removeError: function (tabCode) {
-      const tab = this.tabs.find(currentTab => currentTab.code === tabCode);
-      if (tab) {
-        tab.fieldErrorCount = Math.max(0, tab.fieldErrorCount - 1);
+    removeError: function () {
+      let dirty = false;
+      this.tabs.forEach((tab) => {
+        if (tab.fieldErrors.length) {
+          tab.fieldErrors = [];
+          dirty = true;
+        }
+      });
+      if (dirty) {
         this.render();
       }
     },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
@@ -56,8 +56,7 @@ define([
     resetValidationErrors: function () {
       if (Object.entries(this.errors).length >= 0) {
         this.getRoot().trigger(
-          'pim_enrich:form:form-tabs:remove-error',
-          this.config.tabCode ? this.config.tabCode : this.code
+          'pim_enrich:form:form-tabs:remove-errors',
         );
         this.errors = {};
       }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/common/edit/properties.js
@@ -55,9 +55,7 @@ define([
      */
     resetValidationErrors: function () {
       if (Object.entries(this.errors).length >= 0) {
-        this.getRoot().trigger(
-          'pim_enrich:form:form-tabs:remove-errors',
-        );
+        this.getRoot().trigger('pim_enrich:form:form-tabs:remove-errors');
         this.errors = {};
       }
     },

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/job/product/edit/content.js
@@ -38,13 +38,17 @@ define([
       });
       this.listenTo(this.getRoot(), 'pim_enrich:form:entity:validation_error', this.render.bind(this));
       this.listenTo(this.getRoot(), 'pim_enrich:form:entity:pre_save', () => {
-        this.getRoot().trigger('pim_enrich:form:form-tabs:remove-error', this.getTabCode());
+        this.getRoot().trigger('pim_enrich:form:form-tabs:remove-errors');
       });
 
       this.listenTo(this.getRoot(), 'pim_enrich:form:entity:bad_request', event => {
         const validationErrors = event.response.normalized_errors;
-        if (filterErrors(validationErrors, '[filters]').length > 0) {
-          this.getRoot().trigger('pim_enrich:form:form-tabs:add-error', this.getTabCode());
+        const errors = filterErrors(validationErrors, '[filters]');
+        if (errors.length > 0) {
+          this.getRoot().trigger('pim_enrich:form:form-tabs:add-errors', {
+            tabCode: this.getTabCode(),
+            errors,
+          });
         }
       });
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/form-tabs.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/form/form-tabs.html
@@ -4,7 +4,7 @@
             <li class="AknHorizontalNavtab-item<% if (currentTab === tab.code) { %> active<% } %>" data-tab="<%- tab.code %>">
                 <a class="AknHorizontalNavtab-link <% if (currentTab === tab.code) { %> AknHorizontalNavtab-link--active<% } %>" href="javascript:void(0);">
                     <%= tab.label %>
-                    <% if (tab.fieldErrorCount > 0) { %>
+                    <% if (tab.fieldErrors.length) { %>
                         <div class="AknBadge AknBadge--small  AknBadge--highlight AknBadge--highlight--below-average"></div>
                     <% } %>
                 </a>


### PR DESCRIPTION
There was some glitches with the previous way of computing errors on form tabs
Sometimes, a red badge stays in the tab, even if the error was fixed.
The previous way was too "random", so we refactor it to register errors and not doing some increment/decrement weird counting.