### PR TITLE
RAC-1079: Increment warning_count when adding warning

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Job/DoctrineJobRepository.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Job/DoctrineJobRepository.php
@@ -199,8 +199,20 @@ SQL;
         $statement->bindValue('item', $warning->getItem(), 'array');
         $statement->execute();
 
+        $this->incrementWarningCount($stepExecution->getId());
+
         if ($stepExecution->getWarnings() instanceof PersistentCollection) {
             $stepExecution->getWarnings()->setInitialized(false);
         }
+    }
+
+    private function incrementWarningCount(int $stepExecutionId): void
+    {
+        $sqlQuery = <<<SQL
+    UPDATE akeneo_batch_step_execution
+    SET warning_count = warning_count + 1
+    WHERE id = :step_execution_id
+SQL;
+        $this->jobManager->getConnection()->executeQuery($sqlQuery, ['step_execution_id' => $stepExecutionId]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

On the revamped process tracker, we're reading the warning_count column in job_execution but it is never incremented.

![Screenshot from 2021-11-29 15-31-53](https://user-images.githubusercontent.com/35272857/143886325-75863d80-45e3-413f-9368-ae3e55f3aa38.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
