### PR TITLE
CXP-1010: update behat scenario

### DIFF
--- a/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
+++ b/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
@@ -182,7 +182,11 @@ SQL;
         Assert::assertEquals([
             'access_token',
             'token_type',
+            'scope',
         ], array_keys($payload));
+
+        Assert::assertEquals('bearer', $payload['token_type']);
+        Assert::assertEquals('read_catalog_structure read_products', $payload['scope']);
     }
 
     private function getCreatedAuthorizationCode(): ?string

--- a/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
+++ b/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
@@ -10,6 +10,7 @@ use Context\Spin\SpinCapableTrait;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
 use PHPUnit\Framework\Assert;
 use Pim\Behat\Context\PimContext;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
@@ -148,18 +149,43 @@ SQL;
     }
 
     /**
-     * @Then it has an authorization code
+     * @Then it can exchange the authorization code for a token
      */
-    public function itHasAnAuthorizationCode()
+    public function itCanExchangeTheAuthorizationCodeForAToken()
     {
+        if ($this->connectedApp === null) {
+            throw new \LogicException('There is no connected app in the Context');
+        }
+
         $code = $this->getCreatedAuthorizationCode();
 
-        if (empty($code)) {
-            throw new \LogicException('Unable to find an authorization code');
-        }
+        $client = new KernelBrowser($this->getKernel());
+        $client->request(
+            'POST',
+            '/connect/apps/v1/oauth2/token',
+            [
+                'client_id' => $this->connectedApp['id'],
+                'code' => $code,
+                'code_identifier' => 'foo',
+                'code_challenge' => 'bar',
+                'grant_type' => 'authorization_code',
+            ],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/x-www-form-urlencoded',
+            ],
+        );
+
+        $response = $client->getResponse();
+        $payload = json_decode($response->getContent(), true);
+
+        Assert::assertEquals([
+            'access_token',
+            'token_type',
+        ], array_keys($payload));
     }
 
-    private function getCreatedAuthorizationCode(): array
+    private function getCreatedAuthorizationCode(): ?string
     {
         if ($this->connectedApp === null) {
             throw new \LogicException('There is no connected app in the Context');
@@ -177,9 +203,9 @@ JOIN akeneo_connectivity_connected_app ON akeneo_connectivity_connected_app.conn
 WHERE akeneo_connectivity_connected_app.id = :id
 SQL;
 
-        return $connection->fetchAssoc($query, [
+        return $connection->fetchOne($query, [
             'id' => $this->connectedApp['id'],
-        ]) ?: [];
+        ]) ?: null;
     }
 
     private function assertRoleAclsAreGranted(array $roles, array $acls): void

--- a/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
+++ b/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
@@ -32,4 +32,4 @@ Feature: Activate an OAuth2 client application in the PIM
       | pim_api_attribute_group_edit | false   |
       | pim_api_family_edit          | false   |
       | pim_api_family_variant_edit  | false   |
-    And it has an authorization code
+    And it can exchange the authorization code for a token


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

With this PR, in the behat scenario for activating an App, we are replacing:
`And it has an authorization code` which was only checking if there was an authorization code in the database
to 
`And it can exchange the authorization code for a token` which calls the Create Access Token endpoint, exchanging the Authorization code for a token.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
