### PR TITLE
CXP-1013: Add an Open App button to Connected Apps

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -83,6 +83,7 @@ akeneo_connectivity.connection:
                 card:
                     developed_by: Developed by
                     manage_app: Manage app
+                    open_app: Open App
                 flash:
                     error: Sorry, an error occured while fetching the connected apps list.
             edit:

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -124,6 +124,9 @@ const ConnectedAppCard: FC<Props> = ({item}) => {
                 <Button ghost level='tertiary' href={connectedAppUrl}>
                     {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.manage_app')}
                 </Button>
+                <Button level='secondary' href={item.activate_url} disabled={!item.activate_url} target='_blank'>
+                    {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.open_app')}
+                </Button>
             </Actions>
         </CardContainer>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
@@ -1,0 +1,62 @@
+import {useEffect, useState} from 'react';
+import {NotificationLevel, useNotify} from '../../shared/notify';
+import {ConnectedApp} from '../../model/Apps/connected-app';
+import {useFeatureFlags} from '../../shared/feature-flags';
+import {useFetchConnectedApps} from './use-fetch-connected-apps';
+import {useFetchApps} from './use-fetch-apps';
+import {useTranslate} from '../../shared/translate';
+
+export const useConnectedApps = (): ConnectedApp[] | null | false => {
+    const featureFlag = useFeatureFlags();
+    const notify = useNotify();
+    const translate = useTranslate();
+    const fetchConnectedApps = useFetchConnectedApps();
+    const fetchApps = useFetchApps();
+    const [connectedApps, setConnectedApps] = useState<ConnectedApp[] | null | false>(null);
+
+    useEffect(() => {
+        if (!featureFlag.isEnabled('marketplace_activate')) {
+            setConnectedApps([]);
+            return;
+        }
+
+        (async () => {
+            let connectedApps: ConnectedApp[] | null | false;
+
+            try {
+                connectedApps = await fetchConnectedApps();
+                setConnectedApps(connectedApps);
+            } catch (e) {
+                setConnectedApps(false);
+                notify(
+                    NotificationLevel.ERROR,
+                    translate('akeneo_connectivity.connection.connect.connected_apps.list.flash.error')
+                );
+                return;
+            }
+
+            if (!connectedApps || connectedApps.length === 0) {
+                return;
+            }
+
+            try {
+                const apps = await fetchApps();
+                setConnectedApps(connectedApps =>
+                    !connectedApps
+                        ? connectedApps
+                        : connectedApps.map(connectedApp => {
+                              const app = apps.apps.find(app => app.id === connectedApp.id);
+                              return {
+                                  ...connectedApp,
+                                  activate_url: app?.activate_url || undefined,
+                              };
+                          })
+                );
+            } catch (e) {
+                return;
+            }
+        })();
+    }, [fetchConnectedApps]);
+
+    return connectedApps;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
@@ -41,17 +41,19 @@ export const useConnectedApps = (): ConnectedApp[] | null | false => {
 
             try {
                 const apps = await fetchApps();
-                setConnectedApps(connectedApps =>
-                    !connectedApps
-                        ? connectedApps
-                        : connectedApps.map(connectedApp => {
-                              const app = apps.apps.find(app => app.id === connectedApp.id);
-                              return {
-                                  ...connectedApp,
-                                  activate_url: app?.activate_url || undefined,
-                              };
-                          })
-                );
+                setConnectedApps(state => {
+                    if (state === null || state === false) {
+                        return state;
+                    }
+
+                    return state.map(connectedApp => {
+                        const app = apps.apps.find(app => app.id === connectedApp.id);
+                        return {
+                            ...connectedApp,
+                            activate_url: app?.activate_url || undefined,
+                        };
+                    });
+                });
             } catch (e) {
                 return;
             }

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-apps.ts
@@ -1,7 +1,8 @@
 import {useRoute} from '../../shared/router';
 import {useCallback} from 'react';
+import {Apps} from '../../model/app';
 
-export const useFetchApps = () => {
+export const useFetchApps = (): (() => Promise<Apps>) => {
     const url = useRoute('akeneo_connectivity_connection_marketplace_rest_get_all_apps');
 
     return useCallback(async () => {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useEffect, useState} from 'react';
+import React, {FC} from 'react';
 import {Breadcrumb} from 'akeneo-design-system';
 import {useTranslate} from '../../shared/translate';
 import {PageContent, PageHeader} from '../../common';
@@ -6,36 +6,13 @@ import {UserButtons} from '../../shared/user';
 import {useRouter} from '../../shared/router/use-router';
 import {ConnectedAppsContainerIsLoading} from '../components/ConnectedApps/ConnectedAppsContainerIsLoading';
 import {ConnectedAppsContainer} from '../components/ConnectedApps/ConnectedAppsContainer';
-import {ConnectedApp} from '../../model/Apps/connected-app';
-import {useFetchConnectedApps} from '../hooks/use-fetch-connected-apps';
-import {useFeatureFlags} from '../../shared/feature-flags';
-import {NotificationLevel, useNotify} from '../../shared/notify';
+import {useConnectedApps} from '../hooks/use-connected-apps';
 
 export const ConnectedAppsListPage: FC = () => {
     const translate = useTranslate();
     const generateUrl = useRouter();
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
-    const featureFlag = useFeatureFlags();
-    const fetchConnectedApps = useFetchConnectedApps();
-    const notify = useNotify();
-    const [connectedApps, setConnectedApps] = useState<ConnectedApp[] | null | false>(null);
-
-    useEffect(() => {
-        if (!featureFlag.isEnabled('marketplace_activate')) {
-            setConnectedApps([]);
-            return;
-        }
-
-        fetchConnectedApps()
-            .then(setConnectedApps)
-            .catch(() => {
-                setConnectedApps(false);
-                notify(
-                    NotificationLevel.ERROR,
-                    translate('akeneo_connectivity.connection.connect.connected_apps.list.flash.error')
-                );
-            });
-    }, [fetchConnectedApps]);
+    const connectedApps = useConnectedApps();
 
     const breadcrumb = (
         <Breadcrumb>

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
@@ -9,4 +9,5 @@ export type ConnectedApp = {
     categories: string[];
     certified: boolean;
     partner: string | null;
+    activate_url?: string;
 };

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
@@ -22,6 +22,7 @@ test('The connected app card renders', async () => {
         categories: ['category A1', 'category A2'],
         certified: false,
         partner: 'partner A',
+        activate_url: 'http://www.example.com/activate',
     };
 
     renderWithProviders(<ConnectedAppCard item={item} />);
@@ -35,5 +36,8 @@ test('The connected app card renders', async () => {
     expect(screen.queryByText('category A2')).toBeNull();
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.manage_app')
+    ).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.open_app')
     ).toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
@@ -1,0 +1,135 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {mockFetchResponses} from '../../../test-utils';
+import {useConnectedApps} from '@src/connect/hooks/use-connected-apps';
+import {useFeatureFlags} from '@src/shared/feature-flags/use-feature-flags';
+import {useNotify} from '@src/shared/notify';
+import {NotificationLevel} from '@src/shared/notify';
+
+jest.mock('@src/shared/feature-flags/use-feature-flags');
+jest.mock('@src/shared/notify');
+
+const notify = jest.fn();
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+test('it returns an empty list if the feature flag is disabled', () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => false}));
+
+    const {result} = renderHook(() => useConnectedApps());
+    expect(result.current).toEqual([]);
+});
+
+test('it notify if there it cannot retrieve connected apps', async () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
+    (useNotify as jest.Mock).mockImplementation(() => notify);
+
+    const {result, waitForNextUpdate} = renderHook(() => useConnectedApps());
+    await waitForNextUpdate();
+    expect(result.current).toEqual(false);
+    expect(notify).toBeCalledWith(
+        NotificationLevel.ERROR,
+        'akeneo_connectivity.connection.connect.connected_apps.list.flash.error'
+    );
+});
+
+test('it does not fetch the marketplace apps if there is no connected apps', async () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
+
+    mockFetchResponses({
+        akeneo_connectivity_connection_apps_rest_get_all_connected_apps: {
+            json: [],
+        },
+    });
+
+    const {result, waitForNextUpdate} = renderHook(() => useConnectedApps());
+    expect(result.current).toEqual(null);
+    await waitForNextUpdate();
+    expect(result.current).toEqual([]);
+});
+
+test('it does not fails if it cannot retrieve marketplace apps', async () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
+
+    const connectedApp = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'App A',
+        scopes: ['scope A1'],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.com/path/to/logo/a',
+        author: 'author A',
+        user_group_name: 'app_123456abcde',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+    };
+
+    mockFetchResponses({
+        akeneo_connectivity_connection_apps_rest_get_all_connected_apps: {
+            json: [connectedApp],
+        },
+        akeneo_connectivity_connection_marketplace_rest_get_all_apps: {
+            reject: true,
+            json: {},
+        },
+    });
+
+    const {result, waitForNextUpdate} = renderHook(() => useConnectedApps());
+    expect(result.current).toEqual(null);
+    await waitForNextUpdate();
+    expect(result.current).toEqual([connectedApp]);
+});
+
+test('it fetch connected apps', async () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
+
+    const connectedApp = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'App A',
+        scopes: ['scope A1'],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.com/path/to/logo/a',
+        author: 'author A',
+        user_group_name: 'app_123456abcde',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+    };
+
+    const marketplaceApp = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'Extension 1',
+        logo: 'http://www.example.com/path/to/logo/a',
+        author: 'Partner 1',
+        partner: 'Akeneo Partner',
+        description: 'Our Akeneo Connector',
+        url: 'https://marketplace.akeneo.com/extension/extension_1',
+        categories: ['E-commerce'],
+        certified: false,
+        activate_url: 'https://example.com/activate',
+        callback_url: 'https://example.com/oauth2',
+    };
+
+    const expectedApp = {
+        ...connectedApp,
+        activate_url: marketplaceApp.activate_url,
+    };
+
+    mockFetchResponses({
+        akeneo_connectivity_connection_apps_rest_get_all_connected_apps: {
+            json: [connectedApp],
+        },
+        akeneo_connectivity_connection_marketplace_rest_get_all_apps: {
+            json: {
+                total: 1,
+                apps: [marketplaceApp],
+            },
+        },
+    });
+
+    const {result, waitForNextUpdate} = renderHook(() => useConnectedApps());
+    expect(result.current).toEqual(null);
+    await waitForNextUpdate();
+    expect(result.current).toEqual([expectedApp]);
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
@@ -21,7 +21,7 @@ test('it returns an empty list if the feature flag is disabled', () => {
     expect(result.current).toEqual([]);
 });
 
-test('it notify if there it cannot retrieve connected apps', async () => {
+test('it notifies if it cannot retrieve connected apps', async () => {
     (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
     (useNotify as jest.Mock).mockImplementation(() => notify);
 
@@ -49,7 +49,7 @@ test('it does not fetch the marketplace apps if there is no connected apps', asy
     expect(result.current).toEqual([]);
 });
 
-test('it does not fails if it cannot retrieve marketplace apps', async () => {
+test('it does not fail if it cannot retrieve marketplace apps', async () => {
     (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
 
     const connectedApp = {
@@ -81,7 +81,7 @@ test('it does not fails if it cannot retrieve marketplace apps', async () => {
     expect(result.current).toEqual([connectedApp]);
 });
 
-test('it fetch connected apps', async () => {
+test('it fetches connected apps', async () => {
     (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => true}));
 
     const connectedApp = {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

![Screenshot_2021-12-01_13-47-20](https://user-images.githubusercontent.com/1421130/144242259-eb14cc9d-a513-47f3-8c28-952e52051710.png)

Here is the strategy.

- First, we fetch connected apps from the internal API.
- we render the view (the open app button is disabled)
- Then, we immediatly fetch all marketplace Apps from the marketplace API.
- If the marketplace API fails, nothing happens, the Open App stays disabled.
- If we successfully retrieved the marketplace Apps, we merge both responses and re-render.

Benefits:
- The Connected Apps UI is never slowed down by the marketplace
- The Connected Apps UI still works if the marketplace is down.
- Only 2 API calls are done, even with a lot of Connected Apps.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
