### PR TITLE
RAC-1091: Fix user is redirected to the job execution when user stop a job

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Modal/Modal.tsx
+++ b/front-packages/akeneo-design-system/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, ReactNode, useEffect, useRef} from 'react';
+import React, {ReactElement, ReactNode, SyntheticEvent, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import styled from 'styled-components';
 import {AkeneoThemedProps, CommonStyle, getColor, getFontSize} from '../../theme';
@@ -139,9 +139,13 @@ const Modal: React.FC<ModalProps> & {
     };
   }, []);
 
+  const stopEventPropagation = (event: SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
   return createPortal(
     <ModalContext.Provider value={true}>
-      <ModalContainer role="dialog" {...rest}>
+      <ModalContainer onClick={stopEventPropagation} role="dialog" {...rest}>
         <ModalCloseButton
           title={closeTitle}
           level="tertiary"

--- a/front-packages/akeneo-design-system/src/components/Modal/Modal.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Modal/Modal.unit.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import {Modal, useInModal} from './Modal';
 import {fireEvent, render, screen} from '../../storybook/test-util';
+import {Table} from '../Table/Table';
+import userEvent from '@testing-library/user-event';
+import {Button} from '../Button/Button';
 
 test('it renders its children properly', () => {
   render(
@@ -53,6 +56,28 @@ test('it calls the onClose handler when hitting the Escape key', () => {
   fireEvent.keyDown(document, {key: 'Escape', code: 'Escape'});
 
   expect(onClose).toBeCalledTimes(1);
+});
+
+test('it does not forward click on parent node by default', () => {
+  const handleRowClick = jest.fn();
+  const handleButtonClick = jest.fn();
+  render(
+    <Table>
+      <Table.Row>
+        <Table.Cell onClick={handleRowClick}>
+          <Modal closeTitle="Close" onClose={jest.fn()}>
+            Modal content
+            <Button onClick={handleButtonClick}>Button</Button>
+          </Modal>
+        </Table.Cell>
+      </Table.Row>
+    </Table>
+  );
+
+  userEvent.click(screen.getByText('Button'));
+
+  expect(handleButtonClick).toBeCalledTimes(1);
+  expect(handleRowClick).toBeCalledTimes(0);
 });
 
 const Component = () => {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually in the new process tracker the user is redirected to the job execution detail when the user stop it.

Why: 
As describe here the portal redirect event to the parent : https://fr.reactjs.org/docs/portals.html#event-bubbling-through-portals.
The parent have a onClick so the onClick is called no matter where the user clicks in the modal

Why it doesn't appear in the current grid:
Because the page is reloaded to reload the datagrid
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
