### PR TITLE
RAC-1101: Move query validation into handler

### DIFF
--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionHandler.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionHandler.php
@@ -21,9 +21,26 @@ final class SearchJobExecutionHandler
 
     public function search(SearchJobExecutionQuery $query): JobExecutionTable
     {
+        $this->validateQuery($query);
+
         $jobExecutionRows = $this->findJobExecutionRowsForQuery->search($query);
         $matchesCount = $this->findJobExecutionRowsForQuery->count($query);
 
         return new JobExecutionTable($jobExecutionRows, $matchesCount);
+    }
+
+    private function validateQuery(SearchJobExecutionQuery $query): void
+    {
+        if (!in_array($query->sortColumn, SearchJobExecutionQuery::$supportedSortColumns)) {
+            throw new \InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn));
+        }
+
+        if (!in_array($query->sortDirection, SearchJobExecutionQuery::$supportedSortDirections)) {
+            throw new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection));
+        }
+
+        if (!$query->hasOneFilterSet() && SearchJobExecutionQuery::MAX_PAGE_WITHOUT_FILTER < $query->page) {
+            throw new \InvalidArgumentException('Page can not be greater than 50 when no filter are set');
+        }
     }
 }

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionHandler.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionHandler.php
@@ -39,7 +39,7 @@ final class SearchJobExecutionHandler
             throw new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection));
         }
 
-        if (!$query->hasOneFilterSet() && SearchJobExecutionQuery::MAX_PAGE_WITHOUT_FILTER < $query->page) {
+        if (SearchJobExecutionQuery::MAX_PAGE_WITHOUT_FILTER < $query->page) {
             throw new \InvalidArgumentException('Page can not be greater than 50 when no filter are set');
         }
     }

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
@@ -11,6 +11,21 @@ namespace Akeneo\Platform\Job\Application\SearchJobExecution;
  */
 class SearchJobExecutionQuery
 {
+    public const MAX_PAGE_WITHOUT_FILTER = 50;
+
+    public static array $supportedSortColumns = [
+        'job_name',
+        'type',
+        'started_at',
+        'username',
+        'status',
+    ];
+
+    public static array $supportedSortDirections = [
+        'ASC',
+        'DESC',
+    ];
+
     public int $page = 1;
     public int $size = 25;
     public string $sortColumn = 'started_at';

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
@@ -20,4 +20,13 @@ class SearchJobExecutionQuery
     public array $status = [];
     public array $code = [];
     public string $search = '';
+
+    public function hasOneFilterSet(): bool
+    {
+        return !empty($this->user) ||
+            !empty($this->type) ||
+            !empty($this->status) ||
+            !empty($this->code) ||
+            !empty($this->search);
+    }
 }

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/SearchJobExecutionQuery.php
@@ -35,13 +35,4 @@ class SearchJobExecutionQuery
     public array $status = [];
     public array $code = [];
     public string $search = '';
-
-    public function hasOneFilterSet(): bool
-    {
-        return !empty($this->user) ||
-            !empty($this->type) ||
-            !empty($this->status) ||
-            !empty($this->code) ||
-            !empty($this->search);
-    }
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
@@ -68,17 +68,21 @@ final class IndexAction
         $searchJobExecutionQuery->sortColumn = $sort['column'] ?? 'started_at';
         $searchJobExecutionQuery->sortDirection = $sort['direction'] ?? 'DESC';
 
-        $user = $request->get('user', []);
-        if (!$this->securityFacade->isGranted('pim_enrich_job_tracker_view_all_jobs')) {
-            $user = [$this->security->getUser()->getUserIdentifier()];
-        }
-        $searchJobExecutionQuery->user = $user;
-
+        $searchJobExecutionQuery->user = $this->getUserFilter($request);
         $searchJobExecutionQuery->type = $request->get('type', []);
         $searchJobExecutionQuery->status = $request->get('status', []);
         $searchJobExecutionQuery->search = $request->get('search', '');
         $searchJobExecutionQuery->code = $request->get('code', []);
 
         return $searchJobExecutionQuery;
+    }
+
+    private function getUserFilter(Request $request): array
+    {
+        $user = $request->get('user', []);
+        if (!$this->securityFacade->isGranted('pim_enrich_job_tracker_view_all_jobs')) {
+            $user = [$this->security->getUser()->getUserIdentifier()];
+        }
+        return $user;
     }
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Controller/IndexAction.php
@@ -42,32 +42,43 @@ final class IndexAction
         }
 
         $this->denyAccessUnlessAclIsGranted();
-        $user = $request->get('user', []);
-        if (!$this->securityFacade->isGranted('pim_enrich_job_tracker_view_all_jobs')) {
-            $user = [$this->security->getUser()->getUserIdentifier()];
-        }
 
-        $searchJobExecutionQuery = new SearchJobExecutionQuery();
-        $searchJobExecutionQuery->page = (int) $request->get('page', 1);
-        $searchJobExecutionQuery->size = (int) $request->get('size', 25);
-        $sort = $request->get('sort');
-        $searchJobExecutionQuery->sortColumn = $sort['column'] ?? 'started_at';
-        $searchJobExecutionQuery->sortDirection = $sort['direction'] ?? 'DESC';
-        $searchJobExecutionQuery->type = $request->get('type', []);
-        $searchJobExecutionQuery->user = $user;
-        $searchJobExecutionQuery->status = $request->get('status', []);
-        $searchJobExecutionQuery->search = $request->get('search', '');
-        $searchJobExecutionQuery->code = $request->get('code', []);
+        $searchJobExecutionQuery = $this->createSearchQuery($request);
 
         $jobExecutionTable = $this->searchJobExecutionHandler->search($searchJobExecutionQuery);
 
         return new JsonResponse($jobExecutionTable->normalize());
     }
 
-    private function denyAccessUnlessAclIsGranted()
+    private function denyAccessUnlessAclIsGranted(): void
     {
         if (!$this->securityFacade->isGranted('pim_enrich_job_tracker_index')) {
             throw new AccessDeniedHttpException('Access forbidden. You are not allowed to list jobs.');
         }
+    }
+
+    private function createSearchQuery(Request $request): SearchJobExecutionQuery
+    {
+        $searchJobExecutionQuery = new SearchJobExecutionQuery();
+
+        $searchJobExecutionQuery->page = (int) $request->get('page', 1);
+        $searchJobExecutionQuery->size = (int) $request->get('size', 25);
+
+        $sort = $request->get('sort');
+        $searchJobExecutionQuery->sortColumn = $sort['column'] ?? 'started_at';
+        $searchJobExecutionQuery->sortDirection = $sort['direction'] ?? 'DESC';
+
+        $user = $request->get('user', []);
+        if (!$this->securityFacade->isGranted('pim_enrich_job_tracker_view_all_jobs')) {
+            $user = [$this->security->getUser()->getUserIdentifier()];
+        }
+        $searchJobExecutionQuery->user = $user;
+
+        $searchJobExecutionQuery->type = $request->get('type', []);
+        $searchJobExecutionQuery->status = $request->get('status', []);
+        $searchJobExecutionQuery->search = $request->get('search', '');
+        $searchJobExecutionQuery->code = $request->get('code', []);
+
+        return $searchJobExecutionQuery;
     }
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
@@ -72,9 +72,6 @@ SQL;
         $queryParamsTypes = $this->buildQueryParamsTypes();
 
         $page = $query->page;
-        if ($page > 50) {
-            throw new \InvalidArgumentException('The page number can not be greater than 50');
-        }
         $size = $query->size;
 
         $rawJobExecutions = $this->connection->executeQuery(
@@ -181,17 +178,13 @@ SQL;
     {
         $sortDirection = $query->sortDirection;
 
-        if (!in_array($sortDirection, ['ASC', 'DESC'])) {
-            throw new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection));
-        }
-
         $orderByColumn = match ($query->sortColumn) {
             'job_name' => sprintf("ji.label %s", $sortDirection),
             'type' => sprintf("ji.type %s", $sortDirection),
             'started_at' => sprintf("je.start_time %s", $sortDirection),
             'username' => sprintf("je.user %s", $sortDirection),
             'status' => sprintf("je.status %s", $sortDirection),
-            default => throw new \InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn)),
+            default => throw new \InvalidArgumentException(sprintf('Unknown sort column "%s"', $query->sortColumn)),
         };
 
         return sprintf('ORDER BY %s', $orderByColumn);

--- a/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
@@ -109,7 +109,7 @@ class SearchJobExecutionHandlerTest extends AcceptanceTestCase
         $query = new SearchJobExecutionQuery();
         $query->page = 51;
 
-        $this->expectExceptionObject(new \InvalidArgumentException('Page can not be greater than 50 when no filter are set'));
+        $this->expectExceptionObject(new \InvalidArgumentException('Page can not be greater than 50'));
 
         $this->getHandler()->search($query);
     }
@@ -117,17 +117,15 @@ class SearchJobExecutionHandlerTest extends AcceptanceTestCase
     /**
      * @test
      */
-    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
+    public function it_throws_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
     {
         $query = new SearchJobExecutionQuery();
         $query->type = ['export'];
         $query->page = 51;
 
-        $result = $this->getHandler()->search($query);
+        $this->expectExceptionObject(new \InvalidArgumentException('Page can not be greater than 50'));
 
-        $expectedResult = new JobExecutionTable([], 0);
-
-        $this->assertEquals($expectedResult, $result);
+        $this->getHandler()->search($query);
     }
 
     private function getSearchJobExecution(): InMemorySearchJobExecution

--- a/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
@@ -75,6 +75,61 @@ class SearchJobExecutionHandlerTest extends AcceptanceTestCase
         $this->assertEquals($expectedResult, $result);
     }
 
+    /**
+     * @test
+     */
+    public function it_throws_invalid_argument_exception_when_sort_column_is_not_supported()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->sortColumn = 'invalid_column';
+
+        $this->expectExceptionObject(new \InvalidArgumentException('Sort column "invalid_column" is not supported'));
+
+        $this->getHandler()->search($query);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_invalid_argument_exception_when_sort_direction_is_not_supported()
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->sortDirection = 'DASC';
+
+        $this->expectExceptionObject(new \InvalidArgumentException('Sort direction "DASC" is not supported'));
+
+        $this->getHandler()->search($query);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_page_is_greater_than_50_and_no_filter(): void
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->page = 51;
+
+        $this->expectExceptionObject(new \InvalidArgumentException('Page can not be greater than 50 when no filter are set'));
+
+        $this->getHandler()->search($query);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
+    {
+        $query = new SearchJobExecutionQuery();
+        $query->type = ['export'];
+        $query->page = 51;
+
+        $result = $this->getHandler()->search($query);
+
+        $expectedResult = new JobExecutionTable([], 0);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
     private function getSearchJobExecution(): InMemorySearchJobExecution
     {
         return $this->get('Akeneo\Platform\Job\Application\SearchJobExecution\SearchJobExecutionInterface');

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -607,30 +607,6 @@ class SearchJobExecutionTest extends IntegrationTestCase
     /**
      * @test
      */
-    public function it_throws_invalid_argument_exception_when_sort_column_is_not_supported()
-    {
-        $query = new SearchJobExecutionQuery();
-        $query->sortColumn = 'invalid_column';
-
-        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Sort column "%s" is not supported', $query->sortColumn)));
-        $this->getQuery()->search($query);
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_invalid_argument_exception_when_sort_direction_is_not_supported()
-    {
-        $query = new SearchJobExecutionQuery();
-        $query->sortDirection = 'DASC';
-
-        $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Sort direction "%s" is not supported', $query->sortDirection)));
-        $this->getQuery()->search($query);
-    }
-
-    /**
-     * @test
-     */
     public function it_returns_job_execution_count_filtered_by_search()
     {
         $this->loadFixtures();
@@ -652,37 +628,6 @@ class SearchJobExecutionTest extends IntegrationTestCase
         $query->code = ['a_product_export'];
 
         $this->assertEquals(1, $this->getQuery()->count($query));
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_exception_when_page_is_greater_than_50_and_no_filter(): void
-    {
-        $this->loadFixtures();
-
-        $query = new SearchJobExecutionQuery();
-        $query->page = 51;
-
-        $this->expectExceptionMessage('The page number can not be greater than 50 when no filter are set');
-        $this->getQuery()->search($query);
-    }
-
-    /**
-     * @test
-     */
-    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
-    {
-        $this->loadFixtures();
-
-        $query = new SearchJobExecutionQuery();
-        $query->type = ['export'];
-        $query->size = 1;
-        $query->page = 51;
-
-        $expectedJobExecutions = [];
-
-        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
     }
 
     private function loadFixtures()

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -671,7 +671,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
     /**
      * @test
      */
-    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_filters_are_set(): void
+    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
     {
         $this->loadFixtures();
 

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -654,6 +654,37 @@ class SearchJobExecutionTest extends IntegrationTestCase
         $this->assertEquals(1, $this->getQuery()->count($query));
     }
 
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_page_is_greater_than_50_and_no_filter(): void
+    {
+        $this->loadFixtures();
+
+        $query = new SearchJobExecutionQuery();
+        $query->page = 51;
+
+        $this->expectExceptionMessage('The page number can not be greater than 50 when no filter are set');
+        $this->getQuery()->search($query);
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_throw_exception_when_page_is_greater_than_50_and_filters_are_set(): void
+    {
+        $this->loadFixtures();
+
+        $query = new SearchJobExecutionQuery();
+        $query->type = ['export'];
+        $query->size = 1;
+        $query->page = 51;
+
+        $expectedJobExecutions = [];
+
+        $this->assertEquals($expectedJobExecutions, $this->getQuery()->search($query));
+    }
+
     private function loadFixtures()
     {
         $aProductImportJobInstanceId = $this->fixturesJobHelper->createJobInstance([

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -654,36 +654,6 @@ class SearchJobExecutionTest extends IntegrationTestCase
         $this->assertEquals(1, $this->getQuery()->count($query));
     }
 
-    /**
-     * @test
-     */
-    public function it_throws_exception_when_page_is_greater_than_50(): void
-    {
-        $this->loadFixtures();
-
-        $query = new SearchJobExecutionQuery();
-        $query->page = 51;
-
-        $this->expectExceptionMessage('The page number can not be greater than 50');
-        $this->getQuery()->search($query);
-    }
-
-    /**
-     * @test
-     */
-    public function it_throws_exception_when_page_is_greater_than_50_and_at_least_one_filter_is_set(): void
-    {
-        $this->loadFixtures();
-
-        $query = new SearchJobExecutionQuery();
-        $query->type = ['export'];
-        $query->size = 1;
-        $query->page = 51;
-
-        $this->expectExceptionMessage('The page number can not be greater than 50');
-        $this->getQuery()->search($query);
-    }
-
     private function loadFixtures()
     {
         $aProductImportJobInstanceId = $this->fixturesJobHelper->createJobInstance([

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionFilter.test.ts
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionFilter.test.ts
@@ -72,3 +72,8 @@ test('it can tell if the given filter has at least one filter set', () => {
   expect(hasOneFilterSet(getDefaultJobExecutionFilter())).toEqual(false);
   expect(hasOneFilterSet({...getDefaultJobExecutionFilter(), code: ['a_job']})).toEqual(true);
 });
+
+test('it can tell if the given filter has at least one filter set', () => {
+  expect(hasOneFilterSet(getDefaultJobExecutionFilter())).toEqual(false);
+  expect(hasOneFilterSet({...getDefaultJobExecutionFilter(), code: ['a_job']})).toEqual(true);
+});


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As we discuss [here](https://akeneo.slack.com/archives/C02CZHWASM6/p1638525168027500), it is better for code sense and readability to validate query at the beginning of handler instead of inside the search job execution.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
