### PR TITLE
PIM-10187: Fix impossible to configure the columns of the product grid if attribute labels are too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,7 @@
 - PIM-10167: Fix import file - datetime in price attribute break the import
 - PIM-10177: Fix warning level for status badge on last operations
 - PIM-10158: Fix failed migration longtext to json for akeneo_batch_job_execution.raw_parameters du to empty values
+- PIM-10187: Fix impossible to configure the columns of the product grid if attribute labels are too long
 - PIM-10155: Decrease batch size during indexation of products and product models
 - PIM-10182: Search_after uses identifiers/codes instead of encrypted Mysql ids in external API
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/ColumnConfigurator.less
@@ -8,13 +8,13 @@
   font-size: @AknFontSizeBig;
 
   &-column {
-    flex-basis: 30%;
+    width: 30%;
     flex-grow: 1;
     border: 1px solid @AknBorderColor;
     margin-right: @AknFullPagePadding;
 
     &--large {
-      flex-basis: 80%;
+      width: 80%;
     }
 
     &--gray {
@@ -22,7 +22,7 @@
     }
 
     &--fixed {
-      flex-basis: 300px;
+      width: 300px;
     }
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/VerticalList.less
@@ -23,6 +23,12 @@
     white-space: nowrap;
     overflow: hidden;
 
+    &-itemLabel {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
     &--selectable {
       cursor: pointer;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
@@ -1,6 +1,6 @@
 <% _.each(attributes, function (attribute) { %>
 <li class="AknVerticalList-item AknVerticalList-item--movable" data-attribute-code="<%- attribute.code %>">
-    <div class="AknVerticalList-item-itemLabel">
+    <div class="AknVerticalList-item-itemLabel" title="<%- i18n.getLabel(attribute.labels, userContext.get('catalogLocale'), attribute.code) %>">
         <span class="attribute-label"><%- i18n.getLabel(attribute.labels, userContext.get('catalogLocale'), attribute.code) %></span>
     </div>
     <span class="AknIconButton AknIconButton--grey AknIconButton--small remove"><i class="icon-trash"></i></span>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/export/product/edit/content/structure/attribute-list.html
@@ -1,6 +1,6 @@
 <% _.each(attributes, function (attribute) { %>
 <li class="AknVerticalList-item AknVerticalList-item--movable" data-attribute-code="<%- attribute.code %>">
-    <div>
+    <div class="AknVerticalList-item-itemLabel">
         <span class="attribute-label"><%- i18n.getLabel(attribute.labels, userContext.get('catalogLocale'), attribute.code) %></span>
     </div>
     <span class="AknIconButton AknIconButton--grey AknIconButton--small remove"><i class="icon-trash"></i></span>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/columns.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/columns.html
@@ -1,7 +1,7 @@
 <ul id="column-list" class="AknVerticalList connected-sortable">
     <% _.each(columns, function(column) { %>
     <li class="AknVerticalList-item AknVerticalList-item--movable" data-value="<%- column.code %>" data-group="<%- column.group %>">
-        <div><%- column.label %></div>
+        <div class="AknVerticalList-item-itemLabel" title="<%- column.label %>"><%- column.label %></div>
     </li>
     <% }); %>
 </ul>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/modal.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/modal.html
@@ -8,7 +8,7 @@
                 </li>
                 <% _.each(groups, (group) => { %>
                 <li class="AknVerticalList-item AknVerticalList-item--selectable tab" data-group data-value="<%- group.code %>">
-                    <div class="AknVerticalList-item-itemLabel"><%- group.label %></div>
+                    <div class="AknVerticalList-item-itemLabel" title="<%- group.label %>"><%- group.label %></div>
                     <span class="AknBadge"><%- group.count %></span>
                 </li>
                 <% }) %>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/modal.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/modal.html
@@ -8,7 +8,8 @@
                 </li>
                 <% _.each(groups, (group) => { %>
                 <li class="AknVerticalList-item AknVerticalList-item--selectable tab" data-group data-value="<%- group.code %>">
-                    <%- group.label %><span class="AknBadge"><%- group.count %></span>
+                    <div class="AknVerticalList-item-itemLabel"><%- group.label %></div>
+                    <span class="AknBadge"><%- group.count %></span>
                 </li>
                 <% }) %>
             </ul>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/selected.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/selected.html
@@ -1,7 +1,7 @@
 <ul id="column-selection" class="AknVerticalList connected-sortable ui-sortable">
     <% _.each(columns, (column) => { %>
     <li class="AknVerticalList-item AknVerticalList-item--movable" data-value="<%- column.code %>" data-group="<%- column.group %>">
-        <div><%- column.label %></div>
+        <div class="AknVerticalList-item-itemLabel"><%- column.label %></div>
         <% if (column.removable) { %>
         <div class="AknVerticalList-delete action" title="<%- _.__('pim_datagrid.column_configurator.remove_column') %>"></div>
         <% } %>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/selected.html
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/templates/datagrid/column-selector/selected.html
@@ -1,7 +1,7 @@
 <ul id="column-selection" class="AknVerticalList connected-sortable ui-sortable">
     <% _.each(columns, (column) => { %>
     <li class="AknVerticalList-item AknVerticalList-item--movable" data-value="<%- column.code %>" data-group="<%- column.group %>">
-        <div class="AknVerticalList-item-itemLabel"><%- column.label %></div>
+        <div class="AknVerticalList-item-itemLabel" title="<%- column.label %>"><%- column.label %></div>
         <% if (column.removable) { %>
         <div class="AknVerticalList-delete action" title="<%- _.__('pim_datagrid.column_configurator.remove_column') %>"></div>
         <% } %>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR I fixed the drag and drop in the column datagrid selector. 

Why we have the problem ?
Because the column does not have the same width depending on the length of label. When the attribute group label is too long the column does not take 30% the other take less. When we try to drag and drop we cannot drop in the right column because the width of the column is more than the column so the pointer is blocked.

Now the column are not anymore a flex-basic => it's a width so we need to handle the overflow

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
