### PR TITLE
CXP-1026: Fix connectivity php_cd

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Event/EventsApiRequestSucceededEvent.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Domain\Webhook\Event;
 
 use Akeneo\Platform\Component\EventQueue\EventInterface;
-use Webmozart\Assert\Assert;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -23,7 +22,15 @@ class EventsApiRequestSucceededEvent
      */
     public function __construct(string $connectionCode, array $events)
     {
-        Assert::allIsInstanceOf($events, EventInterface::class);
+        foreach ($events as $event) {
+            if (!$event instanceof EventInterface) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Expected event of type "%s", got "%s".',
+                    EventInterface::class,
+                    get_debug_type($event),
+                ));
+            }
+        }
 
         $this->connectionCode = $connectionCode;
         $this->events = $events;

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -11,246 +11,28 @@ $finder->notPath('tests');
 $builder = new RuleBuilder();
 
 $rules = [
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Domain\Audit',
-
-            // Could be in \Audit
-            'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
-            'Akeneo\Connectivity\Connection\Domain\ValueObject\DateTimePeriod',
-
-            // Not ok
-            'Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\ErrorType',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Application\Audit'),
-
-    $builder->only(
-        [
-            // Ok
-            'Akeneo\Connectivity\Connection\Domain\ErrorManagement',
-            'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
-
-            // Ambigue
-            'FOS\RestBundle\Context\Context',
-            'FOS\RestBundle\Serializer\Serializer',
-            'Symfony\Component\Validator\ConstraintViolationInterface',
-            'Symfony\Component\Validator\ConstraintViolationListInterface',
-
-            // ???
-            'Akeneo\Connectivity\Connection\Application\ConnectionContextInterface',
-            'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Application\ErrorManagement'),
-
-    $builder->only(
-        [
-            // Ok
-            'Akeneo\Connectivity\Connection\Domain\Settings',
-
-            // Ambigue
-            'Symfony\Component\Validator\Constraint',
-            'Symfony\Component\Validator\ConstraintValidator',
-            'Symfony\Component\Validator\Validator\ValidatorInterface',
-            'Symfony\Component\Validator\Exception\UnexpectedTypeException',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Application\Settings'),
-
-    $builder->only(
-        [
-            // Ok
-            'Symfony\Component\OptionsResolver\OptionsResolver',
-
-            // Ambigue
-            'Symfony\Component\Validator\Constraint',
-            'Symfony\Component\Validator\ConstraintValidator',
-            'Symfony\Component\Validator\Exception\UnexpectedTypeException',
-            'Symfony\Component\Validator\Exception\UnexpectedValueException',
-            'Symfony\Component\Validator\Validator\ValidatorInterface',
-            'Psr\Http\Message\ResponseInterface',
-            'Psr\Log\LoggerInterface',
-
-            // Ok
-            'Akeneo\Connectivity\Connection\Domain\Clock',
-            'Akeneo\Connectivity\Connection\Domain\Webhook',
-            'Akeneo\Platform\Component\EventQueue',
-            'Akeneo\Platform\Component\Webhook',
-
-            // Not ok
-            'Akeneo\UserManagement\Component\Model\UserInterface',
-            'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
-            'Doctrine\Persistence',
-            'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface',
-            'Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken',
-            'Symfony\Component\Security\Core\User\UserInterface',
-
-            // ???
-            'Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException',
-            'Akeneo\Connectivity\Connection\Domain\Settings\Persistence\Repository\ConnectionRepository',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Application\Webhook'),
-
+    $builder->only([
+        'Akeneo\Connectivity\Connection\Domain',
+    ])->in('Akeneo\Connectivity\Connection\Domain'),
 
     $builder->only([
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\DateTimePeriod',
-
-        // Not ok
-        'Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\ErrorType',
-    ])->in('Akeneo\Connectivity\Connection\Domain\Audit'),
+        'Akeneo\Connectivity\Connection\Domain',
+        'Akeneo\Connectivity\Connection\Application',
+    ])->in('Akeneo\Connectivity\Connection\Application'),
 
     $builder->only([
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
+        'Akeneo\Connectivity\Connection\Domain',
+        'Akeneo\Connectivity\Connection\Application',
+        'Akeneo\Connectivity\Connection\Infrastructure',
 
-        // Not ok
-        'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionCode',
-    ])->in('Akeneo\Connectivity\Connection\Domain\ErrorManagement'),
-
-    $builder->only([
-        'Symfony\Component\Validator\Context\ExecutionContextInterface',
-        'Symfony\Component\Validator\ConstraintViolationInterface',
-        'Symfony\Component\Validator\ConstraintViolationListInterface',
-    ])->in('Akeneo\Connectivity\Connection\Domain\Settings'),
-
-    $builder->only([
-        'Akeneo\Platform\Component\EventQueue\EventInterface',
-        'Akeneo\Platform\Component\EventQueue\Author',
-        'Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface',
-
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\Url',
-
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated',
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved',
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated',
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated',
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved',
-        'Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated',
-
-        'Webmozart\Assert\Assert',
-    ])->in('Akeneo\Connectivity\Connection\Domain\Webhook'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Application',
-            'Akeneo\Connectivity\Connection\Domain',
-
-            'Akeneo\Tool\Bundle\ApiBundle\Entity\Client',
-
-            'Doctrine\DBAL\Driver\Connection',
-
-            // OAuth server authentication
-            'FOS\OAuthServerBundle\Model\ClientManagerInterface',
-            'FOS\OAuthServerBundle\Util\Random',
-            'OAuth2\OAuth2',
-
-            // For acceptance tests purpose
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryConnectionRepository',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\Client'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Application',
-            'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\Tool\Component\StorageUtils',
-
-            'Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\GroupRepository',
-            'Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository',
-            'Akeneo\UserManagement\Bundle\Manager\UserManager',
-            'Akeneo\UserManagement\Component\Model\GroupInterface',
-            'Akeneo\UserManagement\Component\Model\RoleInterface',
-            'Akeneo\UserManagement\Component\Model\User',
-            'Akeneo\UserManagement\Component\Model\UserInterface',
-            'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
-
-            // For acceptance tests purpose
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryConnectionRepository',
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryUserPermissionsRepository',
-
-            'Doctrine\DBAL\Driver\Connection',
-
-            'Symfony\Component\Validator\Validator\ValidatorInterface',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\User'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Application',
-            'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\Pim\Enrichment\Component\FileStorage',
-            'Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent',
-            'Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents',
-            'Akeneo\Tool\Component\FileStorage\File\FileStorerInterface',
-            'Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface',
-            'Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface',
-            'Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface',
-            'Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface',
-            'Akeneo\UserManagement\Component\Model\GroupInterface',
-            'Akeneo\UserManagement\Component\Model\RoleInterface',
-            'Akeneo\UserManagement\Component\Model\UserInterface',
-            'Doctrine\DBAL\Connection',
-            'Doctrine\DBAL\Types\Types',
-            'OAuth2\OAuth2',
-            'Symfony\Component',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\Install'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Application',
-            'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\Connectivity\Connection\Infrastructure',
-
-            // Dependency on HTTP foundation for Request/Response
-            'Symfony\Component\HttpFoundation',
-            'Symfony\Component\HttpKernel\Exception',
-            // Dependency on constraint violations to correctly display errors on frontend
-            'Symfony\Component\Validator\ConstraintViolationListInterface',
-            // ACL dependency
-            'Symfony\Component\Security\Core\Exception\AccessDeniedException',
-            'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
-            'Oro\Bundle\SecurityBundle\SecurityFacade',
-            // Dependency to retrieve the current User (and his timezone).
-            'Akeneo\UserManagement\Bundle\Context\UserContext',
-            // Feature flag dependency
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
-
-            'Psr\Log\LoggerInterface',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\InternalApi'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\UserManagement\Component\Model\User',
-
-            // Dependency for uuid generation
-            'Ramsey\Uuid\Uuid',
-
-            // Dependency on Doctrine DBAL for persistence layer
-            'Doctrine\DBAL',
-
-            // Dependency on Elasticsearch
-            'Akeneo\Tool\Bundle\ElasticsearchBundle\Client',
-
-            // Dependency on Encrypter
-            'Akeneo\Connectivity\Connection\Infrastructure\Service\Encrypter',
-
-            'Symfony\Component\OptionsResolver\OptionsResolver',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\Persistence'),
-
-    $builder->only(
-        [
-            'Symfony\Component',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Infrastructure\Symfony'),
-
-    $builder->only(
-        [
-            'Akeneo\Connectivity\Connection\Domain\Marketplace',
-        ]
-    )->in('Akeneo\Connectivity\Connection\Domain\Marketplace'),
+        'Doctrine\DBAL',
+        'Symfony\Component\Console',
+        'Symfony\Component\EventDispatcher',
+        'Symfony\Component\HttpFoundation',
+        'Symfony\Component\HttpKernel',
+        'Symfony\Component\Routing',
+        'Symfony\Component\Validator',
+    ])->in('Akeneo\Connectivity\Connection\Infrastructure'),
 ];
 
 $config = new Configuration($rules, $finder);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
```
Parsing 351 nodes...
Checking 3 rules...

Node Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\ConstraintViolationInterface
    * Symfony\Component\Validator\ConstraintViolationListInterface

Node Akeneo\Connectivity\Connection\Domain\Settings\Validation\Connection\ConnectionLabelMustBeValid does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\Context\ExecutionContextInterface

Node Akeneo\Connectivity\Connection\Domain\Settings\Validation\Connection\ConnectionImageMustBeValid does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\Context\ExecutionContextInterface

Node Akeneo\Connectivity\Connection\Domain\Settings\Validation\Connection\FlowTypeMustBeValid does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\Context\ExecutionContextInterface

Node Akeneo\Connectivity\Connection\Domain\Settings\Validation\Connection\ConnectionCodeMustBeValid does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\Context\ExecutionContextInterface

Node Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequest does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Symfony\Component\Validator\ConstraintViolationInterface
    * Symfony\Component\Validator\ConstraintViolationListInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Platform\Component\EventQueue\Author
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\Exception\WebhookEventDataBuilderNotFoundException does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\Event\EventsApiRequestSucceededEvent does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\EventNormalizer\ProductModelEventNormalizer does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelRemoved
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\EventNormalizer\EventNormalizerInterface does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\EventNormalizer\EventNormalizer does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Domain\Webhook\EventNormalizer\ProductEventNormalizer does not respect the rule Akeneo\Connectivity\Connection\Domain because of the tokens:
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved
    * Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Validator\ValidatorInterface

Node Akeneo\Connectivity\Connection\Application\Settings\Command\UpdateConnectionHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Validator\ValidatorInterface

Node Akeneo\Connectivity\Connection\Application\Settings\Validation\Connection\CodeMustBeUnique does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Settings\Validation\Connection\CodeMustBeUniqueValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException

Node Akeneo\Connectivity\Connection\Application\Settings\Validation\Connection\ImageMustExist does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Settings\Validation\Connection\ImageMustExistValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException

Node Akeneo\Connectivity\Connection\Application\ErrorManagement\Service\CollectApiError does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * FOS\RestBundle\Context\Context
    * FOS\RestBundle\Serializer\Serializer
    * Symfony\Component\Validator\ConstraintViolationInterface
    * Symfony\Component\Validator\ConstraintViolationListInterface

Node Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthorizationHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry
    * Symfony\Component\Validator\Validator\ValidatorInterface

Node Akeneo\Connectivity\Connection\Application\Apps\Command\CreateAppWithAuthorizationHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProviderInterface
    * Symfony\Component\Validator\Validator\ValidatorInterface

Node Akeneo\Connectivity\Connection\Application\Apps\AppRoleWithScopesFactoryInterface does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\UserManagement\Component\Model\RoleInterface

Node Akeneo\Connectivity\Connection\Application\Marketplace\MarketplaceAnalyticsGenerator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceAliasesInterface
    * Akeneo\Platform\Bundle\FrameworkBundle\Service\PimUrl
    * Akeneo\Platform\VersionProviderInterface

Node Akeneo\Connectivity\Connection\Application\Marketplace\MarketplaceUrlGenerator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\VersionProviderInterface

Node Akeneo\Connectivity\Connection\Application\Marketplace\AppUrlGenerator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Bundle\FrameworkBundle\Service\PimUrl

Node Akeneo\Connectivity\Connection\Application\Webhook\Log\EventSubscriptionSendApiEventRequestLog does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Psr\Http\Message\ResponseInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Service\ApiEventBuildErrorLogger does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Service\EventsApiDebugLogger does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\SendApiEventRequestLogger does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Psr\Http\Message\ResponseInterface
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Service\Logger\ReachRequestLimitLogger does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Service\EventSubscriptionSkippedOwnEventLogger does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\EventInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Command\UpdateWebhookHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Validator\ValidatorInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\BulkEvent
    * Akeneo\Platform\Component\EventQueue\BulkEventInterface
    * Akeneo\Platform\Component\EventQueue\EventInterface
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\BulkEventInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\WebhookUserAuthenticator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\UserManagement\Component\Repository\UserRepositoryInterface
    * Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
    * Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken
    * Symfony\Component\Security\Core\User\UserInterface

Node Akeneo\Connectivity\Connection\Application\Webhook\WebhookEventBuilder does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\Platform\Component\EventQueue\BulkEventInterface
    * Akeneo\Platform\Component\EventQueue\EventInterface
    * Akeneo\Platform\Component\Webhook\Context
    * Akeneo\Platform\Component\Webhook\EventDataBuilderInterface
    * Akeneo\Platform\Component\Webhook\EventDataCollection
    * Akeneo\UserManagement\Component\Model\UserInterface
    * Symfony\Component\OptionsResolver\OptionsResolver

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\ConnectionMustExist does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\EventSubscriptionsLimitValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException
    * Symfony\Component\Validator\Exception\UnexpectedValueException

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\EnabledWebhookRequiresAnUrlValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\EnabledWebhookRequiresAnUrl does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\ConnectionMustExistValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\EventSubscriptionsLimit does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrl does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint

Node Akeneo\Connectivity\Connection\Application\Webhook\Validation\ExternalUrlValidator does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Symfony\Component\Validator\Constraint
    * Symfony\Component\Validator\ConstraintValidator
    * Symfony\Component\Validator\Exception\UnexpectedTypeException

Node Akeneo\Connectivity\Connection\Application\User\CreateUserGroupInterface does not respect the rule Akeneo\Connectivity\Connection\Application because of the tokens:
    * Akeneo\UserManagement\Component\Model\GroupInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\PurgeEventsApiSuccessLogsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\SearchEventSubscriptionDebugLogsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client
    * Symfony\Component\OptionsResolver\OptionsResolver

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\GetAllEventSubscriptionDebugLogsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\ElasticsearchSelectLastConnectionBusinessErrorsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\PurgeConnectionErrorsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Query\PurgeEventsApiErrorLogsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Repository\ElasticsearchBusinessErrorRepository does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Elasticsearch\Repository\ElasticsearchEventsApiDebugRepository does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ElasticsearchBundle\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query\DbalSelectActiveWebhooksQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Component\Model\User

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query\DbalSelectConnectionWithCredentialsByCodeQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Component\Model\User

Node Akeneo\Connectivity\Connection\Infrastructure\Persistence\Dbal\Query\DbalExtractConnectionsProductEventCountQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Component\Model\User

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\WebhookController does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Oro\Bundle\SecurityBundle\SecurityFacade
    * Symfony\Component\Security\Core\Exception\AccessDeniedException

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\AuditController does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Bundle\Context\UserContext

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\EventsApiDebugController does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Oro\Bundle\SecurityBundle\SecurityFacade
    * Symfony\Component\Security\Core\Exception\AccessDeniedException

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\ConnectionController does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Oro\Bundle\SecurityBundle\SecurityFacade
    * Symfony\Component\Security\Core\Exception\AccessDeniedException

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Apps\GetAppActivateUrlController does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Marketplace\GetAllApps does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Akeneo\UserManagement\Bundle\Context\UserContext
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Marketplace\GetWebMarketplaceUrl does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Bundle\Context\UserContext

Node Akeneo\Connectivity\Connection\Infrastructure\InternalApi\Controller\Marketplace\GetAllExtensions does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Bundle\Context\UserContext
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\ApiAuthenticationEventSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\EventSubscriber\ApiAuthenticationEvent

Node Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\ConnectionContextEventSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\EventSubscriber\ApiAuthenticationEvent

Node Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\AclPrivilegesEventSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\Acl\Event\PrivilegesPostLoadEvent
    * Oro\Bundle\SecurityBundle\Model\AclPrivilege

Node Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\ReadProductsEventSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Pim\Enrichment\Component\Product\Event\Connector\ReadProductsEvent

Node Akeneo\Connectivity\Connection\Infrastructure\EventSubscriber\ApiErrorEventSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Pim\Enrichment\Bundle\Event\ProductValidationErrorEvent
    * Akeneo\Pim\Enrichment\Bundle\Event\TechnicalErrorEvent
    * Akeneo\Pim\Enrichment\Component\Product\Event\ProductDomainErrorEvent
    * Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface
    * FOS\RestBundle\Context\Context

Node Akeneo\Connectivity\Connection\Infrastructure\Install\FixturesLoader does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Pim\Enrichment\Component\FileStorage
    * Akeneo\Tool\Component\FileStorage\File\FileStorerInterface
    * Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface
    * Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface
    * Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface
    * Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface
    * Akeneo\UserManagement\Component\Model\GroupInterface
    * Akeneo\UserManagement\Component\Model\RoleInterface
    * Akeneo\UserManagement\Component\Model\UserInterface
    * OAuth2\OAuth2

Node Akeneo\Connectivity\Connection\Infrastructure\Install\InstallSubscriber does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent
    * Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents

Node Akeneo\Connectivity\Connection\Infrastructure\MessageHandler\BusinessEventHandler does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Component\EventQueue\BulkEventInterface
    * Symfony\Component\Messenger\Handler\MessageSubscriberInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Client\Fake\FakeRegenerateClientSecret does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * FOS\OAuthServerBundle\Util\Random

Node Akeneo\Connectivity\Connection\Infrastructure\Client\Fos\DeleteClient does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\Entity\Client
    * FOS\OAuthServerBundle\Model\ClientManagerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Client\Fos\CreateClient does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\Entity\Client
    * FOS\OAuthServerBundle\Model\ClientManagerInterface
    * OAuth2\OAuth2

Node Akeneo\Connectivity\Connection\Infrastructure\Client\Fos\FosRegenerateClientSecret does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\Entity\Client
    * FOS\OAuthServerBundle\Model\ClientManagerInterface
    * FOS\OAuthServerBundle\Util\Random

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\AppRoleWithScopesFactory does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface
    * Akeneo\UserManagement\Component\Connector\RoleWithPermissions
    * Akeneo\UserManagement\Component\Model\RoleInterface
    * Akeneo\UserManagement\Component\Storage\Saver\RoleWithPermissionsSaver

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Normalizer\ViolationListNormalizer does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Symfony\Component\Serializer\Normalizer\NormalizerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\AuthorizationCodeGenerator does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Component\Model\UserInterface
    * Akeneo\UserManagement\Component\Repository\UserRepositoryInterface
    * FOS\OAuthServerBundle\Model\ClientManagerInterface
    * OAuth2\IOAuth2GrantCode
    * OAuth2\Model\IOAuth2Client

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProviderInterface does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\Entity\Client

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\CreateAccessToken does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * OAuth2\IOAuth2GrantCode
    * OAuth2\Model\IOAuth2AuthCode

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Bundle\ApiBundle\Entity\Client
    * FOS\OAuthServerBundle\Model\ClientManagerInterface
    * OAuth2\OAuth2

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetAllConnectedAppScopeMessagesAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\DeleteAppAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetConnectedAppAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetAllConnectedAppsAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\AuthorizeAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\ConfirmAuthorizationAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * Oro\Bundle\SecurityBundle\SecurityFacade
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\RequestAccessTokenAction does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation\ClientIdMustBeValidValidator does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * FOS\OAuthServerBundle\Model\ClientInterface
    * FOS\OAuthServerBundle\Model\ClientManagerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation\CodeChallengeMustBeValidValidator does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\Validation\AuthorizationCodeMustBeValidValidator does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * OAuth2\IOAuth2GrantCode
    * OAuth2\Model\IOAuth2AuthCode

Node Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface
    * Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface
    * Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface
    * Akeneo\UserManagement\Component\Model\GroupInterface

Node Akeneo\Connectivity\Connection\Infrastructure\ContentSecurityPolicy\MarketplaceContentSecurityPolicy does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\UIBundle\Provider\ContentSecurityPolicy\ContentSecurityPolicyProviderInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceAliases does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\VersionProviderInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAllExtensionsQuery does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\VersionProviderInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApi does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag
    * GuzzleHttp\ClientInterface
    * Psr\Log\LoggerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Symfony\DependencyInjection\AkeneoConnectivityConnectionExtension does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Symfony\Component\Config\FileLocator
    * Symfony\Component\DependencyInjection\ContainerBuilder
    * Symfony\Component\DependencyInjection\Loader\YamlFileLoader

Node Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\WebhookReachabilityChecker does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * GuzzleHttp\ClientInterface
    * GuzzleHttp\Exception\GuzzleException
    * GuzzleHttp\Exception\RequestException
    * GuzzleHttp\Psr7\Request
    * Psr\Http\Message\ResponseInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Webhook\Service\CacheClearer does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Cache\LRUCachedGetAttributes
    * Akeneo\Tool\Bundle\ConnectorBundle\Doctrine\UnitOfWorkAndRepositoriesClearer
    * Akeneo\Tool\Component\StorageUtils\Cache\CachedQueriesClearerInterface

Node Akeneo\Connectivity\Connection\Infrastructure\Webhook\Client\GuzzleWebhookClient does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * GuzzleHttp\ClientInterface
    * GuzzleHttp\Exception\RequestException
    * GuzzleHttp\Pool
    * GuzzleHttp\Psr7\Request
    * GuzzleHttp\Psr7\Response
    * Symfony\Component\Serializer\Encoder\EncoderInterface

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\CreateUser does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface
    * Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface
    * Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\DeleteUser does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface
    * Akeneo\UserManagement\Component\Repository\UserRepositoryInterface

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\DeleteUserRole does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface
    * Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\RegenerateUserPassword does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\UserManagement\Bundle\Manager\UserManager
    * Akeneo\UserManagement\Component\Model\UserInterface

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\DeleteUserGroup does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface
    * Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\GroupRepository

Node Akeneo\Connectivity\Connection\Infrastructure\User\Internal\UpdateUserPermissions does not respect the rule Akeneo\Connectivity\Connection\Infrastructure because of the tokens:
    * Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface
    * Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\GroupRepository
    * Akeneo\UserManagement\Bundle\Doctrine\ORM\Repository\RoleRepository
    * Akeneo\UserManagement\Bundle\Manager\UserManager
    * Akeneo\UserManagement\Component\Model\GroupInterface
    * Akeneo\UserManagement\Component\Model\RoleInterface
    * Akeneo\UserManagement\Component\Model\UserInterface


108 coupling issues found ✖😥🍆
```

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc


[CXP-1026]: https://akeneo.atlassian.net/browse/CXP-1026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ