### PR TITLE
PIM-10193: fix TypeError(implode(): Argument #2 () must be of type ?array, string given)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@
 - PIM-10155: Decrease batch size during indexation of products and product models
 - PIM-10182: Search_after uses identifiers/codes instead of encrypted Mysql ids in external API
 - PIM-10149: Fix group product page OOM (remove group to products association)
+- PIM-10193: fix TypeError(implode(): Argument #2 () must be of type ?array, string given)
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/AttributeValidatorHelper.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/AttributeValidatorHelper.php
@@ -95,7 +95,7 @@ class AttributeValidatorHelper
                 sprintf(
                     'Attribute "%s" is locale specific and expects one of these locales: %s, "%s" given.',
                     $attribute->getCode(),
-                    implode($attribute->getAvailableLocaleCodes(), ', '),
+                    implode(', ', $attribute->getAvailableLocaleCodes()),
                     $locale
                 )
             );

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/AttributeValidatorHelperSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/AttributeValidatorHelperSpec.php
@@ -82,6 +82,21 @@ class AttributeValidatorHelperSpec extends ObjectBehavior
         $this->validateScope($name, null);
     }
 
+    function it_throws_an_exception_when_attribute_localizable_is_not_in_locale_specific(
+        AttributeInterface $description,
+        AttributeInterface $name
+    ) {
+        $description->getCode()->willReturn('description');
+        $description->isLocalizable()->willReturn(true);
+        $description->isLocaleSpecific()->willReturn(true);
+        $description->getAvailableLocaleCodes()->willReturn(['en_US', 'de_DE']);
+        $name->isLocalizable()->willReturn(false);
+        $name->getCode()->willReturn('name');
+
+        $this->shouldThrow(new \LogicException('Attribute "description" is locale specific and expects one of these locales: en_US, de_DE, "fr_FR" given.'))
+            ->during('validateLocale', [$description, 'fr_FR']);
+    }
+
     function it_throws_an_exception_when_attribute_scopable_requirement_is_not_respected(
         AttributeInterface $description,
         AttributeInterface $name

--- a/tests/legacy/features/Context/WebUser.php
+++ b/tests/legacy/features/Context/WebUser.php
@@ -1143,28 +1143,6 @@ class WebUser extends PimContext
     }
 
     /**
-     * @param string $groups
-     *
-     * @Then /^the order of groups should be "([^"]*)"$/
-     */
-    public function orderOfGroupsShouldBe($groups)
-    {
-        $actualGroups = $this->getCurrentPage()->getGroups();
-        Assert::assertEquals($groups, implode($actualGroups, ', '));
-    }
-
-    /**
-     * @param string $attributeGroups
-     *
-     * @Then /^the order of attribute groups should be "([^"]*)"$/
-     */
-    public function orderOfAttributeGroupsShouldBe($attributeGroups)
-    {
-        $actualAttributeGroups = $this->getCurrentPage()->getAttributeGroups();
-        Assert::assertEquals($attributeGroups, implode($actualAttributeGroups, ', '));
-    }
-
-    /**
      * @param string $group
      *
      * @Then /^I should see available group "([^"]*)"$/


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since PHP 8.0 implode throw an TypeError when separator is in the second parameter

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
