### PR TITLE
CXP-758 monitoring settings query

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi;
+
+use Akeneo\Connectivity\Connection\Application\Settings\Query\FindAConnectionHandler;
+use Akeneo\Connectivity\Connection\Application\Settings\Query\FindAConnectionQuery;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetConnectedAppMonitoringSettingsAction
+{
+    public function __construct(
+        private FeatureFlag $featureFlag,
+        private SecurityFacade $security,
+        private FindAConnectionHandler $findAConnectionHandler,
+    ) {}
+
+    public function __invoke(Request $request, string $connectionCode): Response
+    {
+        if (!$this->featureFlag->isEnabled()) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        if (!$this->security->isGranted('akeneo_connectivity_connection_manage_apps')) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $connection = $this->findAConnectionHandler->handle(new FindAConnectionQuery($connectionCode));
+
+        if (null === $connection) {
+            throw new NotFoundHttpException("Connected app with connection code $connectionCode does not exist.");
+        }
+
+        return new JsonResponse([
+            'flow_type' => $connection->flowType(),
+            'auditable' => $connection->auditable(),
+        ]);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
@@ -25,7 +25,8 @@ class GetConnectedAppMonitoringSettingsAction
         private FeatureFlag $featureFlag,
         private SecurityFacade $security,
         private FindAConnectionHandler $findAConnectionHandler,
-    ) {}
+    ) {
+    }
 
     public function __invoke(Request $request, string $connectionCode): Response
     {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/InternalApi/GetConnectedAppMonitoringSettingsAction.php
@@ -45,7 +45,7 @@ class GetConnectedAppMonitoringSettingsAction
         $connection = $this->findAConnectionHandler->handle(new FindAConnectionQuery($connectionCode));
 
         if (null === $connection) {
-            throw new NotFoundHttpException("Connected app with connection code $connectionCode does not exist.");
+            throw new NotFoundHttpException("Connection with connection code $connectionCode does not exist.");
         }
 
         return new JsonResponse([

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -154,3 +154,10 @@ services:
             - '@oro_security.security_facade'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\DbalConnectedAppRepository'
             - '@Akeneo\Connectivity\Connection\Application\Apps\Command\DeleteAppHandler'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetConnectedAppMonitoringSettingsAction:
+        public: true
+        arguments:
+            - '@akeneo_connectivity.connection.marketplace_activate.feature'
+            - '@oro_security.security_facade'
+            - '@akeneo_connectivity.connection.application.handler.find_a_connection'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing/apps.yml
@@ -32,3 +32,8 @@ akeneo_connectivity_connection_apps_rest_delete:
     path: '/connected-apps/{connectionCode}'
     controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\DeleteAppAction
     methods: [DELETE]
+
+akeneo_connectivity_connection_apps_rest_get_connected_app_monitoring_settings:
+    path: '/connected-apps/{connectionCode}/monitoring-settings'
+    controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\InternalApi\GetConnectedAppMonitoringSettingsAction
+    methods: [GET]

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppMonitoringSettingsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppMonitoringSettingsActionEndToEnd.php
@@ -20,12 +20,14 @@ use Symfony\Component\HttpFoundation\Response;
 class GetConnectedAppMonitoringSettingsActionEndToEnd extends WebTestCase
 {
     private FakeFeatureFlag $featureFlagMarketplaceActivate;
+    private ConnectionLoader $connectionLoader;
 
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->featureFlagMarketplaceActivate = $this->get('akeneo_connectivity.connection.marketplace_activate.feature');
+        $this->connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
     }
 
     protected function getConfiguration(): Configuration
@@ -37,6 +39,8 @@ class GetConnectedAppMonitoringSettingsActionEndToEnd extends WebTestCase
     {
         $this->featureFlagMarketplaceActivate->disable();
         $this->authenticateAsAdmin();
+
+        $this->connectionLoader->createConnection('connectionCodeA', 'Connector A', FlowType::DATA_SOURCE, true);
 
         $this->client->request(
             'GET',
@@ -90,9 +94,11 @@ class GetConnectedAppMonitoringSettingsActionEndToEnd extends WebTestCase
         $this->authenticateAsAdmin();
         $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
 
+        $this->connectionLoader->createConnection('connectionCodeA', 'Connector A', FlowType::DATA_SOURCE, true);
+
         $this->client->request(
             'GET',
-            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings',
+            '/rest/apps/connected-apps/unknownCode/monitoring-settings',
             [],
             [],
             [

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppMonitoringSettingsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppMonitoringSettingsActionEndToEnd.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\EndToEnd\Apps\InternalApi;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectionLoader;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetConnectedAppMonitoringSettingsActionEndToEnd extends WebTestCase
+{
+    private FakeFeatureFlag $featureFlagMarketplaceActivate;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->featureFlagMarketplaceActivate = $this->get('akeneo_connectivity.connection.marketplace_activate.feature');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_throws_not_found_exception_with_feature_flag_disabled(): void
+    {
+        $this->featureFlagMarketplaceActivate->disable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings'
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_redirects_on_missing_xmlhttprequest_header(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings'
+        );
+
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        assert($response instanceof RedirectResponse);
+        Assert::assertEquals('/', $response->getTargetUrl());
+    }
+
+    public function test_it_throws_access_denied_exception_with_missing_acl(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->removeAclFromRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    public function test_it_throws_not_found_exception_with_wrong_connection_code(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function test_it_gets_connected_app_monitoring_settings(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+
+        /** @var ConnectionLoader $connectionLoader */
+        $connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+
+        $connectionLoader->createConnection('connectionCodeA', 'Connector A', FlowType::DATA_SOURCE, true);
+        $connectionLoader->createConnection('connectionCodeB', 'Connector B', FlowType::DATA_DESTINATION, false);
+        $connectionLoader->createConnection('connectionCodeC', 'Connector C', FlowType::OTHER, true);
+
+        $expectedResult = [
+            'flow_type' => FlowType::DATA_SOURCE,
+            'auditable' => true,
+        ];
+
+        $this->client->request(
+            'GET',
+            '/rest/apps/connected-apps/connectionCodeA/monitoring-settings',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ]
+        );
+        $response = $this->client->getResponse();
+        $result = \json_decode($response->getContent(), true);
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        Assert::assertEquals($expectedResult, $result);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-monitoring-settings.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-monitoring-settings.ts
@@ -1,8 +1,8 @@
 import {useRoute} from '../../shared/router';
 import {useCallback} from 'react';
-import {MonitorSettings} from '../../model/Apps/monitor-settings';
+import {MonitoringSettings} from '../../model/Apps/monitoring-settings';
 
-export const useFetchConnectedAppMonitoringSettings = (connectionCode: string): (() => Promise<MonitorSettings>) => {
+export const useFetchConnectedAppMonitoringSettings = (connectionCode: string): (() => Promise<MonitoringSettings>) => {
     const url = useRoute('akeneo_connectivity_connection_apps_rest_get_connected_app_monitoring_settings', {
         connectionCode: connectionCode,
     });

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-monitoring-settings.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-connected-app-monitoring-settings.ts
@@ -1,0 +1,21 @@
+import {useRoute} from '../../shared/router';
+import {useCallback} from 'react';
+import {MonitorSettings} from '../../model/Apps/monitor-settings';
+
+export const useFetchConnectedAppMonitoringSettings = (connectionCode: string): (() => Promise<MonitorSettings>) => {
+    const url = useRoute('akeneo_connectivity_connection_apps_rest_get_connected_app_monitoring_settings', {
+        connectionCode: connectionCode,
+    });
+
+    return useCallback(async () => {
+        const response = await fetch(url, {
+            method: 'GET',
+            headers: [['X-Requested-With', 'XMLHttpRequest']],
+        });
+        if (false === response.ok) {
+            return Promise.reject(`${response.status} ${response.statusText}`);
+        }
+
+        return Promise.resolve(response.json());
+    }, [url]);
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/monitor-settings.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/monitor-settings.ts
@@ -1,0 +1,6 @@
+import {FlowType} from '../flow-type.enum';
+
+export type MonitorSettings = {
+    flowType: FlowType;
+    auditable: boolean;
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/monitoring-settings.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/monitoring-settings.ts
@@ -1,6 +1,6 @@
 import {FlowType} from '../flow-type.enum';
 
-export type MonitorSettings = {
+export type MonitoringSettings = {
     flowType: FlowType;
     auditable: boolean;
 };

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-monitoring-settings.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-connected-app-monitoring-settings.test.ts
@@ -1,0 +1,22 @@
+import {renderHook} from '@testing-library/react-hooks';
+import {mockFetchResponses} from '../../../test-utils';
+
+import {useFetchConnectedAppMonitoringSettings} from '@src/connect/hooks/use-fetch-connected-app-monitoring-settings';
+
+test('it fetches the connected app monitor settings', async () => {
+    const expectedMonitorSettings = {
+        flow_type: 'data_source',
+        auditable: true,
+    };
+
+    mockFetchResponses({
+        'akeneo_connectivity_connection_apps_rest_get_connected_app_monitoring_settings?connectionCode=connectionCodeA':
+            {
+                json: expectedMonitorSettings,
+            },
+    });
+    const {result} = renderHook(() => useFetchConnectedAppMonitoringSettings('connectionCodeA'));
+    const monitorSettings = await result.current();
+
+    expect(monitorSettings).toStrictEqual(expectedMonitorSettings);
+});


### PR DESCRIPTION
Prerequisite query for App monitoring feature:

- new endpoint to fetch Monitor settings for a connected app (flow type and auditable flag)
- associated hook
