### PR TITLE
BH-953: Fix pim-enterprise-standard by adding the new workspace

### DIFF
--- a/std-build/package.json
+++ b/std-build/package.json
@@ -22,6 +22,7 @@
     "vendor/akeneo/pim-community-dev/front-packages/shared",
     "vendor/akeneo/pim-community-dev/front-packages/measurement",
     "vendor/akeneo/pim-community-dev/src/Akeneo/Connectivity/Connection/front",
+    "vendor/akeneo/pim-community-dev/src/Akeneo/Connectivity/Connection/workspaces/permission-form",
     "vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge",
     "vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front",
     "vendor/akeneo/pim-community-dev/src/Akeneo/Pim/Automation/DataQualityInsights/front",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

With this PR https://github.com/akeneo/pim-community-dev/pull/15258, a new workspace have been added but it not have been added in the standard


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
