### PR TITLE
RAC-1106: add index to optimize count query

### DIFF
--- a/upgrades/schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query.php
+++ b/upgrades/schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf($this->indexExists(), 'Index job_instance_id_user_status_is_visible_idx already exists in akeneo_batch_job_instance');
+
+        $this->addSql('CREATE INDEX job_instance_id_user_status_is_visible_idx ON akeneo_batch_job_execution (job_instance_id, user, status, is_visible)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function indexExists(): bool
+    {
+        $indices = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indicesIndexedByName = array_column($indices, null, 'Key_name');
+
+        return array_key_exists('job_instance_id_user_status_is_visible_idx', $indicesIndexedByName);
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration';
+
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_a_new_index_on_is_visible_column_to_the_job_execution_table(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertTrue($this->indexExists());
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->indexExists());
+    }
+
+    private function dropIndexIfExists(): void
+    {
+        if ($this->indexExists()) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX job_instance_id_user_status_is_visible_idx;');
+        }
+
+        Assert::assertEquals(false, $this->indexExists());
+    }
+
+    private function indexExists(): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexesIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return array_key_exists('job_instance_id_user_status_is_visible_idx', $indexesIndexedByName);
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration.php
@@ -17,7 +17,7 @@ class Version_6_0_20211213191300_add_index_to_improve_process_tracker_count_quer
 {
     use ExecuteMigrationTrait;
 
-    private const MIGRATION_LABEL = '_6_0_20211213191300_add_index_to_improve_process_tracker_count_query_Integration';
+    private const MIGRATION_LABEL = '_6_0_20211213191300_add_index_to_improve_process_tracker_count_query';
 
     private Connection $connection;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Depending on filters applied, the count query used to print the total result on top of process tracker page can take 2s. This index optimizes that query by putting the join column and filters column in the index.

Before : 

![Screenshot from 2021-12-14 09-44-21](https://user-images.githubusercontent.com/35272857/145963961-7bd505ad-ae92-4f71-9852-b64100f50a55.png)

After :

![Screenshot from 2021-12-14 09-47-09](https://user-images.githubusercontent.com/35272857/145964341-2b591442-b1ac-4735-ad4a-6d99c46c534c.png)

These tests was done on the madeira cloned env.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
