### PR TITLE
RAC: Fix compatibility with onboarder

### DIFF
--- a/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -6,6 +6,10 @@ akeneo_job_process_tracker_details:
   requirements:
     id: \d+
 
+# Used for onboarder compatibility
+pim_enrich_job_tracker_index:
+  path: /job
+
 akeneo_job_index_action:
   path: /rest/process-tracker
   defaults: { _controller: akeneo.job.controller.get_job_execution_action }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As we cannot modify the onboarder (https://github.com/akeneo/pim-onboarder/pull/879) for compatibility reason, i added the url used by onboarder

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
