### PR TITLE
PIM-10203: add getCategoriesForThisLevel on product model interface

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Reader/Database/MassEdit/ProductAndProductModelReader.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Reader/Database/MassEdit/ProductAndProductModelReader.php
@@ -94,7 +94,6 @@ class ProductAndProductModelReader implements
             }
             $this->stepExecution->incrementSummaryInfo('read');
         }
-        $this->firstRead = false;
 
         $this->firstRead = false;
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -850,7 +850,7 @@ class ProductModel implements ProductModelInterface
     /**
      * {@inheritDoc}
      */
-    public function getCategoriesForThisLevel(): Collection
+    public function getCategoriesForCurrentLevel(): Collection
     {
         return new ArrayCollection($this->categories->toArray());
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -848,6 +848,14 @@ class ProductModel implements ProductModelInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getCategoriesForThisLevel(): Collection
+    {
+        return new ArrayCollection($this->categories->toArray());
+    }
+
+    /**
      * @param EntityWithFamilyVariantInterface $entity
      * @param WriteValueCollection  $valueCollection
      *

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
@@ -135,4 +135,9 @@ interface ProductModelInterface extends
      * @return ValueInterface|null
      */
     public function getImage(): ?ValueInterface;
+
+    /**
+     * Return the categories for the current level
+     */
+    public function getCategoriesForThisLevel(): Collection;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModelInterface.php
@@ -139,5 +139,5 @@ interface ProductModelInterface extends
     /**
      * Return the categories for the current level
      */
-    public function getCategoriesForThisLevel(): Collection;
+    public function getCategoriesForCurrentLevel(): Collection;
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Model;
 
+use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\AssociationInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
@@ -18,7 +19,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Pim\Structure\Component\Model\AssociationType;
-use Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
@@ -1313,6 +1313,26 @@ class ProductModelSpec extends ObjectBehavior
 
         $this->getAssociatedGroups('x_sell')->shouldBeLike(new ArrayCollection([$plate, $spoon]));
         $this->getAssociatedGroups('another_association_type')->shouldReturn(null);
+    }
+
+    function it_returns_categories_for_the_current_level()
+    {
+        $categoryA = new Category();
+        $categoryA->setCode('A');
+        $categoryB = new Category();
+        $categoryB->setCode('B');
+        $categoryC = new Category();
+        $categoryC->setCode('C');
+        $rootProductModel = new ProductModel();
+        $rootProductModel->addCategory($categoryA);
+
+        $this->setParent($rootProductModel);
+        $this->addCategory($categoryB);
+        $this->addCategory($categoryC);
+
+        $categories = $this->getCategoriesForThisLevel();
+        $categories->shouldBeAnInstanceOf(ArrayCollection::class);
+        $categories->toArray()->shouldBe([$categoryB, $categoryC]);
     }
 
     private function someRawQuantifiedAssociations(): array

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/ProductModelSpec.php
@@ -1330,7 +1330,7 @@ class ProductModelSpec extends ObjectBehavior
         $this->addCategory($categoryB);
         $this->addCategory($categoryC);
 
-        $categories = $this->getCategoriesForThisLevel();
+        $categories = $this->getCategoriesForCurrentLevel();
         $categories->shouldBeAnInstanceOf(ArrayCollection::class);
         $categories->toArray()->shouldBe([$categoryB, $categoryC]);
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

See https://github.com/akeneo/pim-enterprise-dev/pull/12541  
To fix the issue, we want to know which are the categories for the current level, and not have the categories of the parent.


**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
