### PR TITLE
PIM-10204: Use catalog locale for option labels in simple/multi select attributes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10204: Use catalog locale for option labels in simple/multi select attributes
+
 # 5.0.62 (2021-12-10)
 
 # 5.0.61 (2021-12-02)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/components/ListItem.tsx
@@ -36,7 +36,7 @@ const ListItem: FC<AttributeOptionItemProps> = ({children, ...props}) => {
   const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState<boolean>(false);
   const attributeContext = useAttributeContext();
   const rowRef = useRef(null);
-  const locale = useUserContext().get('uiLocale');
+  const locale = useUserContext().get('catalogLocale');
 
   const deleteOption = () => {
     setShowDeleteConfirmationModal(false);


### PR DESCRIPTION
Instead of UI locale