### PR TITLE
PIM-10206: Fix product and product model save when they had values for a deleted channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 - PIM-10193: fix TypeError(implode(): Argument #2 () must be of type ?array, string given)
 - PIM-10194: Fix pagination for list products/product models endpoints with search_after pagination type
 - PIM-10199: Fix occasional segmentation fault when generating thumbnails
+- PIM-10206: Fix product and product model save when they had values for a deleted channel or locale
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -66,6 +66,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\ChainedNonExistentValuesFilter'
         arguments:
             - !tagged akeneo.pim.enrichment.factory.non_existent_values_filter
+            - '@akeneo.pim.enrichment.factory.non_existent_values_filter.channel_locale'
             - '@akeneo.pim.enrichment.factory.empty_values_cleaner'
             - '@akeneo.pim.enrichment.factory.transform_raw_values_collections'
 
@@ -115,8 +116,6 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentChannelLocaleValuesFilter'
         arguments:
             - '@pim_channel.query.cache.channel_exists_with_locale'
-        tags:
-            - { name: akeneo.pim.enrichment.factory.non_existent_values_filter, priority: -1 }
 
     akeneo.pim.enrichment.factory.empty_values_cleaner:
         public: true

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilter.php
@@ -46,8 +46,6 @@ class ChainedNonExistentValuesFilter implements ChainedNonExistentValuesFilterIn
             $onGoingFilteredRawValues
         );
 
-        // PIM-10206: The NonExistentChannelLocaleValuesFilter is a different filter. It must check the values for
-        // all values, filtered or not.
         $onGoingFilteredRawValuesForChannelAndLocale = new OnGoingFilteredRawValues(
             [],
             $result->filteredRawValuesCollectionIndexedByType() + $result->nonFilteredRawValuesCollectionIndexedByType()

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -12,12 +12,8 @@ use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
  */
 class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
 {
-    /** @var ChannelExistsWithLocaleInterface */
-    private $channelsLocales;
-
-    public function __construct(ChannelExistsWithLocaleInterface $channelsLocales)
+    public function __construct(private ChannelExistsWithLocaleInterface $channelsLocales)
     {
-        $this->channelsLocales = $channelsLocales;
     }
 
     public function filter(OnGoingFilteredRawValues $onGoingFilteredRawValues): OnGoingFilteredRawValues

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/OnGoingFilteredRawValues.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/OnGoingFilteredRawValues.php
@@ -37,16 +37,10 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilte
  */
 final class OnGoingFilteredRawValues
 {
-    /** @var array */
-    private $filteredRawValuesCollectionIndexedByType;
-
-    /** @var array */
-    private $nonFilteredRawValuesCollectionIndexedByType;
-
-    public function __construct(array $filteredRawValuesCollectionIndexedByType, array $nonFilteredRawValuesCollectionByType)
-    {
-        $this->filteredRawValuesCollectionIndexedByType = $filteredRawValuesCollectionIndexedByType;
-        $this->nonFilteredRawValuesCollectionIndexedByType = $nonFilteredRawValuesCollectionByType;
+    public function __construct(
+        private array $filteredRawValuesCollectionIndexedByType,
+        private array $nonFilteredRawValuesCollectionIndexedByType
+    ) {
     }
 
     public static function fromNonFilteredValuesCollectionIndexedByType(array $nonFilteredValuesCollectionIndexedByType)
@@ -84,7 +78,7 @@ final class OnGoingFilteredRawValues
     {
         $products = [];
 
-        foreach ($this->filteredRawValuesCollectionIndexedByType as $type => $attributeCodes) {
+        foreach ($this->filteredRawValuesCollectionIndexedByType as $attributeCodes) {
             foreach ($attributeCodes as $attributeCode => $values) {
                 foreach ($values as $value) {
                     $products[$value['identifier']][$attributeCode] = $value['values'];

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/ChainedNonExistentValuesFilterSpec.php
@@ -3,18 +3,17 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
-use Akeneo\Channel\Component\Model\Channel;
-use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\ChainedNonExistentValuesFilterInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentChannelLocaleValuesFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentValuesFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\TransformRawValuesCollections;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -26,18 +25,22 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
     public function let(
         NonExistentValuesFilter $filter1,
         NonExistentValuesFilter $filter2,
+        NonExistentChannelLocaleValuesFilter $nonExistentChannelLocaleValuesFilter,
         GetAttributes $getAttributes
     ) {
         $description = new Attribute('description', AttributeTypes::TEXTAREA, [], true, true, null, null, false, 'textarea', []);
+        $name = new Attribute('name', AttributeTypes::TEXT, [], true, true, null, null, false, 'text', []);
         $color = new Attribute('color', AttributeTypes::OPTION_SIMPLE_SELECT, [], false, false, null, null, false, 'option', []);
 
         $getAttributes->forCodes(['attribute_that_does_not_exists'])->willReturn(['unknown_attribute' => null]);
         $getAttributes->forCodes(['color'])->willReturn(['color' => $color]);
 
         $getAttributes->forCodes(['description'])->willReturn(['description' => $description]);
+        $getAttributes->forCodes(['description', 'name'])->willReturn(['description' => $description, 'name' => $name]);
 
         $this->beConstructedWith(
             [$filter1, $filter2],
+            $nonExistentChannelLocaleValuesFilter,
             new EmptyValuesCleaner(),
             new TransformRawValuesCollections($getAttributes->getWrappedObject())
         );
@@ -50,44 +53,53 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
 
     public function it_filters_raw_value_collection(
         NonExistentValuesFilter $filter1,
-        NonExistentValuesFilter $filter2
+        NonExistentValuesFilter $filter2,
+        NonExistentChannelLocaleValuesFilter $nonExistentChannelLocaleValuesFilter
     ) {
         $rawValuesCollection = [
             'productA' => [
-                'description' => [
-                    '<all_channels>' => [
-                        '<all_locales>' => 'a description'
-                    ]
-                ]
-            ]
+                'description' => ['<all_channels>' => ['<all_locales>' => 'a description']],
+                'name' => ['<all_channels>' => ['<all_locales>' => 'a name']],
+            ],
         ];
 
-        $nonFilterRawValues = [
-            AttributeTypes::TEXTAREA => [
-                'description' => [
-                    [
-                        'identifier' => 'productA',
-                        'values' => [
-                            '<all_channels>' => [
-                                '<all_locales>' => 'a description'
-                            ]
-                        ],
-                        'properties' => []
-                    ]
-                ]
-            ]
-        ];
+        $textareaValues = [AttributeTypes::TEXTAREA => [
+            'description' => [
+                [
+                    'identifier' => 'productA',
+                    'values' => ['<all_channels>' => ['<all_locales>' => 'a description']],
+                    'properties' => [],
+                ],
+            ],
+        ]];
+        $textValues = [AttributeTypes::TEXT => [
+            'name' => [
+                [
+                    'identifier' => 'productA',
+                    'values' => ['<all_channels>' => ['<all_locales>' => 'a name']],
+                    'properties' => [],
+                ],
+            ],
+        ]];
+
+        $nonFilterRawValues = \array_merge($textareaValues, $textValues);
 
         $ongoingRawValues = new OnGoingFilteredRawValues([], $nonFilterRawValues);
-        $filter1->filter($ongoingRawValues)->willReturn($ongoingRawValues);
-        $filter2->filter($ongoingRawValues)->willReturn($ongoingRawValues);
+        $ongoingRawValuesAfterFilter1 = new OnGoingFilteredRawValues($textValues, $textareaValues);
+        $filter1->filter($ongoingRawValues)->shouldBeCalledOnce()->willReturn($ongoingRawValuesAfterFilter1);
+        $ongoingRawValuesAfterFilter2 = new OnGoingFilteredRawValues(\array_merge($textareaValues, $textValues), []);
+        $filter2->filter($ongoingRawValuesAfterFilter1)->shouldBeCalledOnce()->willReturn($ongoingRawValuesAfterFilter2);
+
+        $nonExistentChannelLocaleValuesFilter->filter($ongoingRawValues)
+            ->shouldBeCalledOnce()->willReturn($ongoingRawValues);
 
         $this->filterAll($rawValuesCollection)->shouldBeLike($rawValuesCollection);
     }
 
     public function it_filters_empty_values(
         NonExistentValuesFilter $filter1,
-        NonExistentValuesFilter $filter2
+        NonExistentValuesFilter $filter2,
+        NonExistentChannelLocaleValuesFilter $nonExistentChannelLocaleValuesFilter
     ) {
         $rawValuesCollection = [
             'productA' => [
@@ -134,6 +146,8 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
         $ongoingRawValues = new OnGoingFilteredRawValues([], $nonFilterRawValues);
         $filter1->filter($ongoingRawValues)->willReturn($ongoingRawValues);
         $filter2->filter($ongoingRawValues)->willReturn($ongoingRawValues);
+        $nonExistentChannelLocaleValuesFilter->filter($ongoingRawValues)
+            ->shouldBeCalledOnce()->willReturn($ongoingRawValues);
 
         $this->filterAll($rawValuesCollection)->shouldBeLike(['productA' => [], '123' => []]);
     }
@@ -141,7 +155,8 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
 
     function it_filters_unknown_attribute(
         NonExistentValuesFilter $filter1,
-        NonExistentValuesFilter $filter2
+        NonExistentValuesFilter $filter2,
+        NonExistentChannelLocaleValuesFilter $nonExistentChannelLocaleValuesFilter
     ) {
         $rawValuesCollection = [
             'productA' => [
@@ -156,6 +171,8 @@ final class ChainedNonExistentValuesFilterSpec extends ObjectBehavior
         $ongoingRawValues = new OnGoingFilteredRawValues([], []);
         $filter1->filter($ongoingRawValues)->willReturn($ongoingRawValues);
         $filter2->filter($ongoingRawValues)->willReturn($ongoingRawValues);
+        $nonExistentChannelLocaleValuesFilter->filter($ongoingRawValues)
+            ->shouldBeCalledOnce()->willReturn($ongoingRawValues);
 
         $this->filterAll($rawValuesCollection)->shouldBeLike(['productA' => []]);
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-10206

When a product is loaded, the non existent values are cleaned. The ChainedNonExistentValuesFilter cleans the values by running several filters. Each filter handles a particular attribute type, and once the filter is ran the values are put in a "filtered values" list. So we know these values are already filtered and we don't touch them anymore.
The problem is there was a NonExistentChannelLocaleValuesFilter that is ran at the end to remove the values that are not attached to an existent locale/scope, and this filter does not handle already filtered values. So some values are not cleaned. It should filter ALL the values.  

The fix is to remove the NonExistentChannelLocaleValuesFilter in the loop of filters (= remove the service tag), and run it at the end on all values.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
