### PR TITLE
PIM-10198 customised error notifications on family variant save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,7 @@
 - PIM-10193: fix TypeError(implode(): Argument #2 () must be of type ?array, string given)
 - PIM-10194: Fix pagination for list products/product models endpoints with search_after pagination type
 - PIM-10199: Fix occasional segmentation fault when generating thumbnails
+- PIM-10198: Fixed error message display when saving family variant
 
 ## New features
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/save.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/save.js
@@ -65,24 +65,23 @@ define([
         .fail(this.fail.bind(this))
         .always(this.hideLoadingMask.bind(this));
     },
-
     fail: function (response) {
       switch (response.status) {
-      case 422:
-      case 400:
-        this.getRoot().trigger('pim_enrich:form:entity:bad_request', {
-          sentData: this.getFormData(),
-          response: response.responseJSON,
-        });
-        break;
-      case 500:
-        /* global console */
-        const message = response.responseJSON ? response.responseJSON : response;
+        case 422:
+        case 400:
+          this.getRoot().trigger('pim_enrich:form:entity:bad_request', {
+            sentData: this.getFormData(),
+            response: response.responseJSON,
+          });
+          break;
+        case 500:
+          /* global console */
+          const message = response.responseJSON ? response.responseJSON : response;
 
-        console.error('Errors:', message);
-        this.getRoot().trigger('pim_enrich:form:entity:error:save', message);
-        break;
-      default:
+          console.error('Errors:', message);
+          this.getRoot().trigger('pim_enrich:form:entity:error:save', message);
+          break;
+        default:
       }
 
       const responseJSON = response.responseJSON;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/save.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/save.js
@@ -65,5 +65,35 @@ define([
         .fail(this.fail.bind(this))
         .always(this.hideLoadingMask.bind(this));
     },
+
+    fail: function (response) {
+      switch (response.status) {
+      case 422:
+      case 400:
+        this.getRoot().trigger('pim_enrich:form:entity:bad_request', {
+          sentData: this.getFormData(),
+          response: response.responseJSON,
+        });
+        break;
+      case 500:
+        /* global console */
+        const message = response.responseJSON ? response.responseJSON : response;
+
+        console.error('Errors:', message);
+        this.getRoot().trigger('pim_enrich:form:entity:error:save', message);
+        break;
+      default:
+      }
+
+      const responseJSON = response.responseJSON;
+
+      if (Array.isArray(responseJSON)) {
+        for (const errorPayload of responseJSON) {
+          messenger.notify('error', errorPayload.message);
+        }
+      } else {
+        messenger.notify('error', this.updateFailureMessage);
+      }
+    },
   });
 });


### PR DESCRIPTION
Fixes : [PIM-10198](https://akeneo.atlassian.net/browse/PIM-10198)

Initially the task was to update error message to display a user-friendlier message when saving family variant with wrong attributes.
However it appears that such [messages are already in place](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Structure/Component/Validator/Constraints/FamilyVariant.php) and returned to the front end .
On the front side, [Family variant saver  handles saving](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family-variant/form/save.js)
Family variant saver does not personally handles errors but delegates it to [parent saver ](https://github.com/akeneo/pim-community-dev/blob/58a1d2b503d473426f95d5e213a10f5ff3dddd13/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/save.js#L94-L115)which in turn displays a generic message

This fix copies the parent saver failing method and personalizes error notifications.