### PR TITLE
reset user consent scope

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
@@ -34,10 +34,7 @@ final class RequestAppAuthenticationHandler
     {
         // @TODO validate Command & throw InvalidAppAuthenticationRequest()
 
-        if (
-            count($command->getRequestedAuthenticationScopes()->getScopes()) > 0
-            && false === $command->getRequestedAuthenticationScopes()->hasScope(AuthenticationScope::SCOPE_OPENID)
-        ) {
+        if (false === $command->getRequestedAuthenticationScopes()->hasScope(AuthenticationScope::SCOPE_OPENID)) {
             $this->createUserConsentQuery->execute(
                 $command->getPimUserId(),
                 $command->getAppId(),


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

If the openid scope is not in the scope requested, empty the user consent scope column.

Catch those cases:
- from a connected app and a user who consented "openid profile email" to "profile email" -> remove consented scopes (was already catched by the condition)
- from a disconnected app (removed) and a user who consented "openid profile email" to "no openid requested anymore" -> remove consented scopes (this PR catch this case)

implies that all app users even from apps without openid requested, we create a consent line with empty scopes

other solution:
keep the if requested scope > 0 as is, but add another if which try to find the user in the user consent table to empty its scope column if needed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
