### PR TITLE
PIM-10208: Fix currency settings page crashing when label is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@
 - PIM-10194: Fix pagination for list products/product models endpoints with search_after pagination type
 - PIM-10199: Fix occasional segmentation fault when generating thumbnails
 - PIM-10206: Fix product and product model save when they had values for a deleted channel or locale
+- PIM-10208: Fix currency settings page crashing when label is not found
 
 ## New features
 

--- a/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
+++ b/src/Akeneo/Channel/Bundle/Twig/LocaleExtension.php
@@ -4,6 +4,7 @@ namespace Akeneo\Channel\Bundle\Twig;
 
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Symfony\Component\Intl;
+use Symfony\Component\Intl\Exception\MissingResourceException;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
@@ -96,12 +97,16 @@ class LocaleExtension extends AbstractExtension
         return Intl\Currencies::getSymbol($code, $language);
     }
 
-    public function currencyLabel(string $code, ?string $translateIn = null): string
+    public function currencyLabel(string $code, ?string $translateIn = null): ?string
     {
         $translateIn = $translateIn ?: $this->getCurrentLocaleCode();
         $language = \Locale::getPrimaryLanguage($translateIn);
 
-        return Intl\Currencies::getName($code, $language);
+        try {
+            return Intl\Currencies::getName($code, $language);
+        } catch (MissingResourceException) {
+            return null;
+        }
     }
 
     /**

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/views/Property/currency_label.html.twig
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/views/Property/currency_label.html.twig
@@ -1,1 +1,5 @@
-{{ value }} ({{ currency_label(value) }})
+{% if currency_label(value) %}
+  {{ value }} ({{ currency_label(value) }})
+{% else %}
+  {{ value }}
+{% endif %}

--- a/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
+++ b/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
@@ -66,6 +66,14 @@ class LocaleExtensionSpec extends ObjectBehavior
 
     }
 
+    function it_returns_null_when_the_currency_label_is_not_found($userContext, LocaleInterface $en)
+    {
+        $userContext->getCurrentLocale()->willReturn($en);
+        $this->currencyLabel('XSU')->shouldReturn(null);
+        $this->currencyLabel('XSU', 'fr_FR')->shouldReturn(null);
+
+    }
+
     function getMatchers(): array
     {
         $filterArgs = new Node();

--- a/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
+++ b/tests/back/Channel/Specification/Bundle/Twig/LocaleExtensionSpec.php
@@ -71,7 +71,6 @@ class LocaleExtensionSpec extends ObjectBehavior
         $userContext->getCurrentLocale()->willReturn($en);
         $this->currencyLabel('XSU')->shouldReturn(null);
         $this->currencyLabel('XSU', 'fr_FR')->shouldReturn(null);
-
     }
 
     function getMatchers(): array


### PR DESCRIPTION
Fixing the currency settings crashing when the currency label for an unknown currency code was not found (because we are using Symfony\Component\Intl to retrieve currency labels)