### PR TITLE
Cxp 989 fix openid consent

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/ConsentAppAuthenticationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/ConsentAppAuthenticationHandler.php
@@ -40,8 +40,8 @@ final class ConsentAppAuthenticationHandler
     public function handle(ConsentAppAuthenticationCommand $command): void
     {
         $violations = $this->validator->validate($command);
-        if (count($violations) > 0) {
-            throw new \InvalidArgumentException();
+        if ($violations->count() > 0) {
+            throw new \InvalidArgumentException($violations->get(0)->getMessage());
         }
 
         $appId = $command->getClientId();

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/ConsentAppAuthenticationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/ConsentAppAuthenticationHandler.php
@@ -41,7 +41,7 @@ final class ConsentAppAuthenticationHandler
     {
         $violations = $this->validator->validate($command);
         if ($violations->count() > 0) {
-            throw new \InvalidArgumentException($violations->get(0)->getMessage());
+            throw new \InvalidArgumentException((string)$violations->get(0)->getMessage());
         }
 
         $appId = $command->getClientId();

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
@@ -38,7 +38,7 @@ final class RequestAppAuthenticationHandler
     {
         $violations = $this->validator->validate($command);
         if ($violations->count() > 0) {
-            throw new \InvalidArgumentException($violations->get(0)->getMessage());
+            throw new \InvalidArgumentException((string)$violations->get(0)->getMessage());
         }
 
         $userId = $command->getPimUserId();

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RequestAppAuthenticationHandler.php
@@ -37,14 +37,18 @@ final class RequestAppAuthenticationHandler
     public function handle(RequestAppAuthenticationCommand $command): void
     {
         $violations = $this->validator->validate($command);
-        if (count($violations) > 0) {
-            throw new \InvalidArgumentException();
+        if ($violations->count() > 0) {
+            throw new \InvalidArgumentException($violations->get(0)->getMessage());
         }
 
+        $userId = $command->getPimUserId();
+        $appId = $command->getAppId();
+
+        // If openid scope isn't requested, clear all the user consentend scopes & skip the authentication.
         if (false === $command->getRequestedAuthenticationScopes()->hasScope(AuthenticationScope::SCOPE_OPENID)) {
             $this->createUserConsentQuery->execute(
-                $command->getPimUserId(),
-                $command->getAppId(),
+                $userId,
+                $appId,
                 [],
                 $this->clock->now()
             );
@@ -52,26 +56,40 @@ final class RequestAppAuthenticationHandler
             return;
         }
 
+        $consentedScopes = $this->getUserConsentedAuthenticationScopesQuery->execute($userId, $appId);
         $requestedScopes = $command->getRequestedAuthenticationScopes()->getScopes();
-        $alreadyConsentedScopes = $this->getUserConsentedAuthenticationScopesQuery->execute(
-            $command->getPimUserId(),
-            $command->getAppId()
-        );
 
-        $removedScopes = array_diff($alreadyConsentedScopes, $requestedScopes);
-        if (count($removedScopes) > 0) {
-            $remainingScopes = array_diff($alreadyConsentedScopes, $removedScopes);
+        $requestedScopesAlreadyConsented = array_intersect($consentedScopes, $requestedScopes);
+        $newScopesRequiringConsent = array_diff($requestedScopes, $requestedScopesAlreadyConsented);
+
+        // Check & remove previously consented scopes that are not requested anymore.
+        if (count($requestedScopesAlreadyConsented) < count($consentedScopes)) {
             $this->createUserConsentQuery->execute(
-                $command->getPimUserId(),
-                $command->getAppId(),
-                $remainingScopes,
+                $userId,
+                $appId,
+                $requestedScopesAlreadyConsented,
                 $this->clock->now()
             );
         }
 
-        $newScopes = array_diff($requestedScopes, $alreadyConsentedScopes);
-        if (count($newScopes) > 0) {
-            throw new UserConsentRequiredException($command->getAppId(), $command->getPimUserId(), $newScopes);
+        // Nothing to do if there is no new scopes to consent.
+        if (count($newScopesRequiringConsent) === 0) {
+            return;
         }
+
+        // If there is only one new scope and it's openid, then we automatically give consent.
+        if (count($newScopesRequiringConsent) === 1 && reset($newScopesRequiringConsent) === AuthenticationScope::SCOPE_OPENID) {
+            $this->createUserConsentQuery->execute(
+                $userId,
+                $appId,
+                [AuthenticationScope::SCOPE_OPENID],
+                $this->clock->now()
+            );
+
+            return;
+        }
+
+        // Throws if there is one or more new scopes that need consent.
+        throw new UserConsentRequiredException($command->getAppId(), $command->getPimUserId(), $newScopesRequiringConsent);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RequestAppAuthenticationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RequestAppAuthenticationHandlerIntegration.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Command;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthenticationCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthenticationHandler;
+use Akeneo\Connectivity\Connection\Domain\Apps\Exception\UserConsentRequiredException;
+use Akeneo\Connectivity\Connection\Domain\Apps\ValueObject\ScopeList;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use FOS\OAuthServerBundle\Model\ClientInterface;
+use FOS\OAuthServerBundle\Model\ClientManagerInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RequestAppAuthenticationHandlerIntegration extends TestCase
+{
+    private RequestAppAuthenticationHandler $requestAppAuthenticationHandler;
+    private ClientManagerInterface $clientManager;
+    private PropertyAccessor $propertyAccessor;
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestAppAuthenticationHandler = $this->get(RequestAppAuthenticationHandler::class);
+        $this->clientManager = $this->get('fos_oauth_server.client_manager.default');
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_consents_automatically_when_openid_is_the_only_scope_requested(): void
+    {
+        $this->createOAuth2Client([
+            'marketplacePublicAppId' => 'e4d35502-08c9-40b4-a378-05d4cb255862',
+        ]);
+        $user = $this->createAdminUser();
+
+        $command = new RequestAppAuthenticationCommand(
+            'e4d35502-08c9-40b4-a378-05d4cb255862',
+            $user->getId(),
+            ScopeList::fromScopeString('openid')
+        );
+        $this->requestAppAuthenticationHandler->handle($command);
+
+        $result = $this->connection->fetchAssociative(
+            'SELECT * FROM akeneo_connectivity_user_consent WHERE app_id = :appId AND user_id = :userId',
+            [
+                'appId' => 'e4d35502-08c9-40b4-a378-05d4cb255862',
+                'userId' => $user->getId()
+            ]
+        );
+
+        $this->assertEquals(['openid'], json_decode($result['scopes'], true));
+    }
+
+    public function test_it_throws_when_new_scopes_are_requiring_consent(): void
+    {
+        $this->createOAuth2Client([
+            'marketplacePublicAppId' => 'e4d35502-08c9-40b4-a378-05d4cb255862',
+        ]);
+        $user = $this->createAdminUser();
+
+        $this->expectExceptionObject(
+            new UserConsentRequiredException('e4d35502-08c9-40b4-a378-05d4cb255862', $user->getId(), ['profile', 'email'])
+        );
+
+        $command = new RequestAppAuthenticationCommand(
+            'e4d35502-08c9-40b4-a378-05d4cb255862',
+            $user->getId(),
+            ScopeList::fromScopeString('openid profile email')
+        );
+        $this->requestAppAuthenticationHandler->handle($command);
+    }
+
+    private function createOAuth2Client(array $data): ClientInterface
+    {
+        $client = $this->clientManager->createClient();
+        foreach ($data as $key => $value) {
+            $this->propertyAccessor->setValue($client, $key, $value);
+        }
+        $this->clientManager->updateClient($client);
+
+        return $client;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/RequestAppAuthenticationHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/RequestAppAuthenticationHandlerSpec.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Application\Apps\Command;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthenticationCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RequestAppAuthenticationHandler;
+use Akeneo\Connectivity\Connection\Domain\Apps\Exception\UserConsentRequiredException;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query\CreateUserConsentQueryInterface;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\Query\GetUserConsentedAuthenticationScopesQueryInterface;
+use Akeneo\Connectivity\Connection\Domain\Apps\ValueObject\ScopeList;
+use Akeneo\Connectivity\Connection\Domain\Clock;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RequestAppAuthenticationHandlerSpec extends ObjectBehavior
+{
+    public function let(
+        GetUserConsentedAuthenticationScopesQueryInterface $getUserConsentedAuthenticationScopesQuery,
+        CreateUserConsentQueryInterface $createUserConsentQuery,
+        Clock $clock,
+        ValidatorInterface $validator
+    ): void {
+        $this->beConstructedWith(
+            $getUserConsentedAuthenticationScopesQuery,
+            $createUserConsentQuery,
+            $clock,
+            $validator
+        );
+    }
+
+    public function it_is_instantiable()
+    {
+        $this->shouldHaveType(RequestAppAuthenticationHandler::class);
+    }
+
+    public function it_throws_when_the_command_is_invalid(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $constraintViolationList,
+        ConstraintViolationInterface $constraintViolation
+    ): void {
+        $command = new RequestAppAuthenticationCommand('a_app_id', 1, ScopeList::fromScopeString(''));
+
+        $validator->validate($command)
+            ->willReturn($constraintViolationList);
+        $constraintViolationList->count()
+            ->willReturn(1);
+        $constraintViolationList->get(0)
+            ->willReturn($constraintViolation);
+        $constraintViolation->getMessage()
+            ->willReturn('a_validation_error');
+
+        $this->shouldThrow(new \InvalidArgumentException('a_validation_error'))->during('handle', [$command]);
+    }
+
+    public function it_clears_consented_scopes_when_openid_is_not_requested(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $constraintViolationList,
+        Clock $clock,
+        CreateUserConsentQueryInterface $createUserConsentQuery
+    ): void {
+        $command = new RequestAppAuthenticationCommand('a_app_id', 1, ScopeList::fromScopeString('a_scope'));
+
+        $validator->validate($command)
+            ->willReturn($constraintViolationList);
+        $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2020-01-01T00:00:00Z');
+        $clock->now()
+            ->willReturn($dateTime);
+
+        $createUserConsentQuery->execute(1, 'a_app_id', [], $dateTime)
+            ->shouldBeCalledOnce();
+
+        $this->handle($command);
+    }
+
+    public function it_removes_previously_consented_scopes_that_are_not_requested_anymore(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $constraintViolationList,
+        GetUserConsentedAuthenticationScopesQueryInterface $getUserConsentedAuthenticationScopesQuery,
+        Clock $clock,
+        CreateUserConsentQueryInterface $createUserConsentQuery
+    ): void {
+        $command = new RequestAppAuthenticationCommand('a_app_id', 1, ScopeList::fromScopeString('openid a_scope'));
+
+        $validator->validate($command)
+            ->willReturn($constraintViolationList);
+        $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2020-01-01T00:00:00Z');
+        $clock->now()
+            ->willReturn($dateTime);
+
+        $getUserConsentedAuthenticationScopesQuery->execute(1, 'a_app_id')
+            ->willReturn(['openid', 'a_scope', 'a_scope_not_requested']);
+
+        $createUserConsentQuery->execute(1, 'a_app_id', ['openid', 'a_scope'], $dateTime)
+            ->shouldBeCalledOnce();
+
+        $this->handle($command);
+    }
+
+    public function it_consents_automatically_when_openid_is_the_only_scope_requested(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $constraintViolationList,
+        GetUserConsentedAuthenticationScopesQueryInterface $getUserConsentedAuthenticationScopesQuery,
+        Clock $clock,
+        CreateUserConsentQueryInterface $createUserConsentQuery
+    ): void {
+        $command = new RequestAppAuthenticationCommand('a_app_id', 1, ScopeList::fromScopeString('openid'));
+
+        $validator->validate($command)
+            ->willReturn($constraintViolationList);
+        $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2020-01-01T00:00:00Z');
+        $clock->now()
+            ->willReturn($dateTime);
+
+        $getUserConsentedAuthenticationScopesQuery->execute(1, 'a_app_id')
+            ->willReturn([]);
+
+        $createUserConsentQuery->execute(1, 'a_app_id', ['openid'], $dateTime)
+            ->shouldBeCalledOnce();
+
+        $this->handle($command);
+    }
+
+    public function it_throws_when_new_scopes_are_requiring_consent(
+        ValidatorInterface $validator,
+        ConstraintViolationListInterface $constraintViolationList,
+        GetUserConsentedAuthenticationScopesQueryInterface $getUserConsentedAuthenticationScopesQuery,
+        Clock $clock
+    ): void {
+        $command = new RequestAppAuthenticationCommand('a_app_id', 1, ScopeList::fromScopeString('openid a_new_scope'));
+
+        $validator->validate($command)
+            ->willReturn($constraintViolationList);
+        $dateTime = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ATOM, '2020-01-01T00:00:00Z');
+        $clock->now()
+            ->willReturn($dateTime);
+
+        $getUserConsentedAuthenticationScopesQuery->execute(1, 'a_app_id')
+            ->willReturn(['openid']);
+
+        $exception = new UserConsentRequiredException('a_app_id', 1, ['a_new_scope']);
+        $this->shouldThrow($exception)->during('handle', [$command]);
+    }
+}


### PR DESCRIPTION
Fix a regression where the consent modal was displayed to the user when only the openid scope was requested, instead of automatically consenting to it.