### PR TITLE
CXP-1033: remove database migrations tests from octopus workflow

### DIFF
--- a/.circleci/workflows/squads/octopus.yml
+++ b/.circleci/workflows/squads/octopus.yml
@@ -2,7 +2,7 @@ version: 2.1
 workflows:
     version: 2
 
-    octopus_workflow:
+    octopus_pull_request:
         when:
             not:
                 equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
@@ -26,16 +26,12 @@ workflows:
             - test_marketplace_activate_e2e:
                   requires:
                       - build_dev_ce
-            - test_back_data_migrations:
-                  requires:
-                      - build_dev_ce
             - pull_request_success:
                   requires:
                       - test_front_connectivity
                       - test_back_connectivity
-                      - test_back_data_migrations
 
-    weekly_octopus_code_quality:
+    octopus_weekly_code_quality:
         when:
             and:
                 - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When introducing a new database migration, `test_back_data_migrations` is not enough to check that everything is good.
When we do, we need to launch the full CI.
So, this is useless to launch it everytime we change Connectivity code.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
