### PR TITLE
PIM-10210: Fix notifications can't be displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,7 @@
 - PIM-10197: Added safeguards against attribute change to locale specific when the same attribute is a variant axis for a family
 - PIM-10208: Fix currency settings page crashing when label is not found
 - PIM-10192: Retry mechanism in delete action of ES documents
+- PIM-10210: Fix notifications can't be displayed
 
 ## New features
 

--- a/upgrades/schema/Version_6_0_20211217145100_use_the_new_process_tracker_route.php
+++ b/upgrades/schema/Version_6_0_20211217145100_use_the_new_process_tracker_route.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20211217145100_use_the_new_process_tracker_route extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE pim_notification_notification SET route = "akeneo_job_process_tracker_details" WHERE route = "pim_enrich_job_tracker_show"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20211217145100_use_the_new_process_tracker_route_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20211217145100_use_the_new_process_tracker_route_Integration.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+class Version_6_0_20211217145100_use_the_new_process_tracker_route_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_6_0_20211217145100_use_the_new_process_tracker_route';
+
+    public function test_it_adds_a_default_role_type_to_oro_access_role(): void
+    {
+        $this->addNotification();
+
+        $this->assertTrue($this->notificationTableContainOldProcessTrackerRoute());
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->assertFalse($this->notificationTableContainOldProcessTrackerRoute());
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function addNotification(): void
+    {
+        $this->getConnection()->executeStatement(<<<SQL
+            INSERT INTO pim_notification_notification (route, routeParams, message, messageParams, comment, created, type, context)
+            VALUES ('pim_enrich_job_tracker_show', 'a:1:{s:2:"id";i:21;}', 'pim_mass_edit.notification.mass_edit.error', 'a:1:{s:7:"%label%";s:28:"Mass edit product attributes";}', NULL, '2021-12-15 14:59:31', 'error', 'a:1:{s:10:"actionType";s:9:"mass_edit";}');
+        SQL);
+    }
+
+    private function notificationTableContainOldProcessTrackerRoute(): bool
+    {
+        $query = <<<SQL
+SELECT *
+FROM pim_notification_notification
+WHERE route = 'pim_enrich_job_tracker_show'
+SQL;
+
+        return !empty($this->getConnection()->fetchAllAssociative($query));
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, i fixed the following error : 
`Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route "pim_enrich_job_tracker_show" as such route does not exist.")." at /srv/pim/vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig line 6`

Why we have this error ? 
Because when we deployed the process tracker revamp we have renamed the route name. 
Because notification redirect url is stored in database we forget it

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
