### PR TITLE
CXP-1035: hide connected apps menu

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/form_extensions.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/form_extensions.yml
@@ -138,6 +138,7 @@ extensions:
     pim-menu-connect-connected-apps:
         module: pim/menu/item
         parent: pim-menu-connect-navigation-block
+        feature: marketplace_activate
         position: 40
         config:
             title: pim_menu.item.connected_apps


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

![Screenshot_2021-12-20_11-39-24](https://user-images.githubusercontent.com/1421130/146754453-ddd1d33d-edb5-4849-8373-2c855adf4220.png)

The `feature` option hides form_extensions, see https://github.com/akeneo/pim-community-dev/blob/417d8b3a0d2d29425a9b8422be1281476fc5cc9a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/config-provider.js#L22-L23

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
