### PR TITLE
PLG-468: DQI - Optimize product evaluations storage

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -6,7 +6,7 @@ find-legacy-translations:
 	.circleci/find_legacy_translations.sh
 
 .PHONY: coupling-back
-coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back connectivity-connection-coupling-back communication-channel-coupling-back job-coupling-back
+coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back connectivity-connection-coupling-back communication-channel-coupling-back job-coupling-back data-quality-insights-coupling-back
 
 ### Static tests
 static-back: check-pullup check-sf-services

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
@@ -38,25 +39,18 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
  */
 class GetProductEvaluation
 {
-    private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery;
-
-    private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
-
-    private CriteriaEvaluationRegistry $criteriaEvaluationRegistry;
-
     public function __construct(
-        GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
-        GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        CriteriaEvaluationRegistry $criteriaEvaluationRegistry
+        private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
+        private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
+        private CriteriaEvaluationRegistry $criteriaEvaluationRegistry,
+        private CompleteEvaluationWithImprovableAttributes $completeEvaluationWithImprovableAttributes
     ) {
-        $this->getCriteriaEvaluationsByProductIdQuery = $getCriteriaEvaluationsByProductIdQuery;
-        $this->getLocalesByChannelQuery = $getLocalesByChannelQuery;
-        $this->criteriaEvaluationRegistry = $criteriaEvaluationRegistry;
     }
 
     public function get(ProductId $productId): array
     {
         $criteriaEvaluations = $this->getCriteriaEvaluationsByProductIdQuery->execute($productId);
+        $criteriaEvaluations = ($this->completeEvaluationWithImprovableAttributes)($criteriaEvaluations);
         $channelsLocales = $this->getLocalesByChannelQuery->getChannelLocaleCollection();
 
         $formattedProductEvaluation = [];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
-use Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\CompletenessCalculationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * The aim of this service is to complete the evaluation of a product (or product model)
+ *  with the lists of improvable attributes that are not persisted in the database.
+ * For now, only the two completeness criteria are concerned.
+ * If there are more criteria to add, this service should be reworked with a registry.
+ */
+class CompleteEvaluationWithImprovableAttributes
+{
+    public function __construct(
+        private GetLocalesByChannelQueryInterface $localesByChannelQuery,
+        private CalculateProductCompletenessInterface $calculateRequiredAttributesCompleteness,
+        private CalculateProductCompletenessInterface $calculateNonRequiredAttributesCompleteness
+    ) {
+    }
+
+    public function __invoke(Read\CriterionEvaluationCollection $criterionEvaluationCollection): Read\CriterionEvaluationCollection
+    {
+        $criterionEvaluationCollection = $this->completeCompletenessEvaluation(
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE),
+            $criterionEvaluationCollection,
+            $this->calculateRequiredAttributesCompleteness
+        );
+
+        return $this->completeCompletenessEvaluation(
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE),
+            $criterionEvaluationCollection,
+            $this->calculateNonRequiredAttributesCompleteness
+        );
+    }
+
+    private function completeCompletenessEvaluation(
+        CriterionCode $criterionCode,
+        Read\CriterionEvaluationCollection $criterionEvaluationCollection,
+        CalculateProductCompletenessInterface $calculateCompleteness
+    ): Read\CriterionEvaluationCollection {
+        $criterionEvaluation = $criterionEvaluationCollection->get($criterionCode);
+
+        if (null === $criterionEvaluation) {
+            return $criterionEvaluationCollection;
+        }
+
+        $completenessResult = $calculateCompleteness->calculate($criterionEvaluation->getProductId());
+
+        $evaluationResultData = $criterionEvaluation->getResult()->getData();
+        $evaluationResultData['attributes_with_rates'] = $this->getAttributesWithRates($completenessResult);
+
+        $completedCriterionEvaluationResult = new Read\CriterionEvaluationResult(
+            $criterionEvaluation->getResult()->getRates(),
+            $criterionEvaluation->getResult()->getStatus(),
+            $evaluationResultData
+        );
+
+        $completedCriterionEvaluation = new Read\CriterionEvaluation(
+            $criterionEvaluation->getCriterionCode(),
+            $criterionEvaluation->getProductId(),
+            $criterionEvaluation->getEvaluatedAt(),
+            $criterionEvaluation->getStatus(),
+            $completedCriterionEvaluationResult
+        );
+
+        return $criterionEvaluationCollection->add($completedCriterionEvaluation);
+    }
+
+    private function getAttributesWithRates(CompletenessCalculationResult $completenessResult): array
+    {
+        $localesByChannel = $this->localesByChannelQuery->getChannelLocaleCollection();
+        $evaluationResultData = [];
+
+        foreach ($localesByChannel as $channelCode => $localeCodes) {
+            foreach ($localeCodes as $localeCode) {
+                $missingAttributes = $completenessResult->getMissingAttributes()->getByChannelAndLocale($channelCode, $localeCode);
+
+                $attributesRates = [];
+                if (null !== $missingAttributes) {
+                    foreach ($missingAttributes as $attributeCode) {
+                        $attributesRates[$attributeCode] = 0;
+                    }
+                }
+                $evaluationResultData[\strval($channelCode)][\strval($localeCode)] = $attributesRates;
+            }
+        }
+
+        return $evaluationResultData;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompleteness.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/Enrichment/EvaluateCompleteness.php
@@ -53,21 +53,14 @@ final class EvaluateCompleteness
         }
 
         $missingAttributes = $completenessResult->getMissingAttributes()->getByChannelAndLocale($channelCode, $localeCode);
-
-        $attributesRates = [];
-
-        if (null !== $missingAttributes) {
-            foreach ($missingAttributes as $attributeCode) {
-                $attributesRates[$attributeCode] = 0;
-            }
-        }
+        $missingAttributesCount = null === $missingAttributes ? 0 : count($missingAttributes);
 
         $totalNumberOfAttributes = $completenessResult->getTotalNumberOfAttributes()->getByChannelAndLocale($channelCode, $localeCode);
 
         $evaluationResult
             ->addRate($channelCode, $localeCode, $rate)
             ->addStatus($channelCode, $localeCode, CriterionEvaluationResultStatus::done())
-            ->addRateByAttributes($channelCode, $localeCode, $attributesRates)
+            ->addData('number_of_improvable_attributes', $channelCode, $localeCode, $missingAttributesCount)
             ->addData('total_number_of_attributes', $channelCode, $localeCode, $totalNumberOfAttributes)
         ;
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Write/CriterionEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Write/CriterionEvaluation.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
-use DateTimeImmutable;
 
 /**
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
@@ -18,7 +17,7 @@ final class CriterionEvaluation
     private CriterionCode $criterionCode;
     private ProductId $productId;
     private CriterionEvaluationStatus $status;
-    private ?DateTimeImmutable $evaluatedAt = null;
+    private ?\DateTimeImmutable $evaluatedAt = null;
     private ?CriterionEvaluationResult $result = null;
 
     public function __construct(
@@ -41,7 +40,7 @@ final class CriterionEvaluation
     public function end(CriterionEvaluationResult $result): self
     {
         $this->status = CriterionEvaluationStatus::done();
-        $this->evaluatedAt = new DateTimeImmutable();
+        $this->evaluatedAt = new \DateTimeImmutable();
         $this->result = $result;
 
         return $this;
@@ -53,7 +52,7 @@ final class CriterionEvaluation
         $this->status = CriterionEvaluationStatus::pending();
 
         if (false === $criterionApplicability->isApplicable()) {
-            $this->evaluatedAt = new DateTimeImmutable();
+            $this->evaluatedAt = new \DateTimeImmutable();
             $this->status = CriterionEvaluationStatus::done();
         }
 
@@ -84,7 +83,7 @@ final class CriterionEvaluation
         return $this->productId;
     }
 
-    public function getEvaluatedAt(): ?DateTimeImmutable
+    public function getEvaluatedAt(): ?\DateTimeImmutable
     {
         return $this->evaluatedAt;
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodes.php
@@ -21,6 +21,7 @@ final class TransformCriterionEvaluationResultCodes
     public const DATA_TYPES_ID = [
         'attributes_with_rates' => 1,
         'total_number_of_attributes' => 2,
+        'number_of_improvable_attributes' => 3,
     ];
 
     public const STATUS_ID = [
@@ -77,8 +78,9 @@ final class TransformCriterionEvaluationResultCodes
                     $resultDataByIds[self::DATA_TYPES_ID['attributes_with_rates']] =
                         $this->transformResultAttributeRatesCodesToIds($dataByCodes);
                     break;
+                case 'number_of_improvable_attributes':
                 case 'total_number_of_attributes':
-                    $resultDataByIds[self::DATA_TYPES_ID['total_number_of_attributes']] =
+                    $resultDataByIds[self::DATA_TYPES_ID[$dataType]] =
                         $this->transformChannelLocaleDataFromCodesToIds($dataByCodes, fn ($number) => $number);
                     break;
                 default:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIds.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIds.php
@@ -62,6 +62,10 @@ final class TransformCriterionEvaluationResultIds
                     $dataByCodes['total_number_of_attributes'] =
                         $this->transformChannelLocaleDataFromIdsToCodes($dataByIds, fn ($number) => $number);
                     break;
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes']:
+                    $dataByCodes['number_of_improvable_attributes'] =
+                        $this->transformChannelLocaleDataFromIdsToCodes($dataByIds, fn ($number) => $number);
+                    break;
                 default:
                     throw new CriterionEvaluationResultTransformationFailedException(sprintf('Unknown data type id "%s"', $dataType));
             }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -24,6 +24,7 @@ services:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_criteria_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product.complete_evaluation_with_improvable_attributes'
 
     akeneo.pim.automation.data_quality_insights.get_product_model_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
@@ -31,6 +32,7 @@ services:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_model_criteria_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_model.complete_evaluation_with_improvable_attributes'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateDashboardRates:
         arguments:
@@ -185,3 +187,17 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Query\GetProductKeyIndicatorsQuery'
             - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment::CODE
             - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage::CODE
+
+    akeneo.pim.automation.data_quality_insights.product.complete_evaluation_with_improvable_attributes:
+        class: Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.calculate_product_completeness_of_required_attributes'
+            - '@akeneo.pim.automation.calculate_product_completeness_of_non_required_attributes'
+
+    akeneo.pim.automation.data_quality_insights.product_model.complete_evaluation_with_improvable_attributes:
+        class: Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.calculate_product_model_completeness_of_required_attributes'
+            - '@akeneo.pim.automation.calculate_product_model_completeness_of_non_required_attributes'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -189,14 +189,14 @@ services:
             - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage::CODE
 
     akeneo.pim.automation.data_quality_insights.product.complete_evaluation_with_improvable_attributes:
-        class: Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@akeneo.pim.automation.calculate_product_completeness_of_required_attributes'
             - '@akeneo.pim.automation.calculate_product_completeness_of_non_required_attributes'
 
     akeneo.pim.automation.data_quality_insights.product_model.complete_evaluation_with_improvable_attributes:
-        class: Akeneo\Pim\Automation\DataQualityInsights\back\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@akeneo.pim.automation.calculate_product_model_completeness_of_required_attributes'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
@@ -133,6 +133,7 @@ $rules = [
             'Doctrine\DBAL',
             'Doctrine\Common\Persistence\ObjectRepository',
             'Doctrine\ORM\Query\Expr',
+            'Doctrine\Persistence\ObjectRepository',
             'Psr\Log\LoggerInterface',
             'Symfony\Component\Config\FileLocator',
             'Symfony\Component\Console',

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesIntegration.php
@@ -51,6 +51,16 @@ final class TransformCriterionEvaluationResultCodesIntegration extends DataQuali
                         'de_DE' => 0,
                     ],
                 ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
+                    ],
+                    'mobile' => [
+                        'en_US' => 1,
+                        'de_DE' => 0,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -98,6 +108,16 @@ final class TransformCriterionEvaluationResultCodesIntegration extends DataQuali
                     ],
                     $mobileId => [
                         $enUsId => 6,
+                        $deDeId => 0,
+                    ],
+                ],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'] => [
+                    $ecommerceId => [
+                        $enUsId => 2,
+                        $frFrId => 1,
+                    ],
+                    $mobileId => [
+                        $enUsId => 1,
                         $deDeId => 0,
                     ],
                 ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
@@ -52,6 +52,16 @@ final class TransformCriterionEvaluationResultIdsIntegration extends DataQuality
                         $deDeId => 0,
                     ],
                 ],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'] => [
+                    $ecommerceId => [
+                        $enUsId => 2,
+                        $frFrId => 1,
+                    ],
+                    $mobileId => [
+                        $enUsId => 1,
+                        $deDeId => 0,
+                    ],
+                ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 $ecommerceId => [
@@ -99,6 +109,16 @@ final class TransformCriterionEvaluationResultIdsIntegration extends DataQuality
                     ],
                     'mobile' => [
                         'en_US' => 6,
+                        'de_DE' => 0,
+                    ],
+                ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
+                    ],
+                    'mobile' => [
+                        'en_US' => 1,
                         'de_DE' => 0,
                     ],
                 ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributesSpec.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\CriterionEvaluationResultStatusCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluation;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\CompletenessCalculationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+/**
+ * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CompleteEvaluationWithImprovableAttributesSpec extends ObjectBehavior
+{
+    public function let(
+        GetLocalesByChannelQueryInterface $localesByChannelQuery,
+        CalculateProductCompletenessInterface $calculateRequiredAttributesCompleteness,
+        CalculateProductCompletenessInterface $calculateNonRequiredAttributesCompleteness
+    ) {
+        $this->beConstructedWith($localesByChannelQuery, $calculateRequiredAttributesCompleteness, $calculateNonRequiredAttributesCompleteness);
+    }
+
+    public function it_completes_a_product_evaluation_with_improvable_attributes(
+        $localesByChannelQuery,
+        $calculateRequiredAttributesCompleteness,
+        $calculateNonRequiredAttributesCompleteness
+    ): void {
+        $productId = new ProductId(42);
+        $criteriaEvaluations = $this->givenProductCriteriaEvaluationsWithCompleteness($productId);
+
+        $channelCodeEcommerce = new ChannelCode('ecommerce');
+        $channelCodeMobile = new ChannelCode('mobile');
+        $localeCodeEn = new LocaleCode('en_US');
+
+        $localesByChannelQuery->getChannelLocaleCollection()->willReturn(new ChannelLocaleCollection([
+            'ecommerce' => ['en_US'],
+            'mobile' => ['en_US'],
+        ]));
+
+        $requiredAttributesCompletenessResult = new CompletenessCalculationResult();
+        $requiredAttributesCompletenessResult->addMissingAttributes($channelCodeEcommerce, $localeCodeEn, ['description', 'name']);
+        $requiredAttributesCompletenessResult->addMissingAttributes($channelCodeMobile, $localeCodeEn, []);
+
+        $nonRequiredAttributesCompletenessResult = new CompletenessCalculationResult();
+        $nonRequiredAttributesCompletenessResult->addMissingAttributes($channelCodeEcommerce, $localeCodeEn, ['title', 'meta_title']);
+
+        $calculateRequiredAttributesCompleteness->calculate($productId)->willReturn($requiredAttributesCompletenessResult);
+        $calculateNonRequiredAttributesCompleteness->calculate($productId)->willReturn($nonRequiredAttributesCompletenessResult);
+
+        $completedCriteriaEvaluations = $this->__invoke($criteriaEvaluations);
+        $completedCriteriaEvaluations->count()->shouldBe($criteriaEvaluations->count());
+
+        $completedRequiredCompletenessEvaluation = $completedCriteriaEvaluations->get(
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        );
+        $requiredCompletenessEvaluation = $criteriaEvaluations->get(
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        );
+        $completedRequiredCompletenessEvaluation->getResult()->getData()->shouldBe([
+            'total_number_of_attributes' => 12,
+            'attributes_with_rates' => [
+                'ecommerce' => [
+                    'en_US' => ['description' => 0, 'name' => 0]
+                ],
+                'mobile' => ['en_US' => []],
+            ]
+        ]);
+
+        $completedRequiredCompletenessEvaluation->getProductId()->shouldBe($productId);
+        $completedRequiredCompletenessEvaluation->getStatus()->shouldBe($requiredCompletenessEvaluation->getStatus());
+        $completedRequiredCompletenessEvaluation->getEvaluatedAt()->shouldBe($requiredCompletenessEvaluation->getEvaluatedAt());
+
+        $completedRequiredCompletenessEvaluation->getResult()->getRates()->shouldBe($requiredCompletenessEvaluation->getResult()->getRates());
+        $completedRequiredCompletenessEvaluation->getResult()->getStatus()->shouldBe($requiredCompletenessEvaluation->getResult()->getStatus());
+
+        $completedNonRequiredCompletenessEvaluation = $completedCriteriaEvaluations->get(
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        );
+        $completedNonRequiredCompletenessEvaluation->getResult()->getData()->shouldBe([
+            'total_number_of_attributes' => 7,
+            'attributes_with_rates' => [
+                'ecommerce' => [
+                    'en_US' => ['title' => 0, 'meta_title' => 0]
+                ],
+                'mobile' => ['en_US' => []],
+            ]
+        ]);
+
+        $spellingCriterionCode = new CriterionCode('consistency_spelling');
+        $completedCriteriaEvaluations->get($spellingCriterionCode)->shouldBe($criteriaEvaluations->get($spellingCriterionCode));
+    }
+
+    public function it_does_nothing_when_there_is_no_criterion_to_complete(
+        GetLocalesByChannelQueryInterface $localesByChannelQuery,
+        CalculateProductCompletenessInterface $calculateRequiredAttributesCompleteness,
+        CalculateProductCompletenessInterface $calculateNonRequiredAttributesCompleteness
+    ): void {
+        $productId = new ProductId(42);
+        $criteriaEvaluations = $this->givenProductCriteriaEvaluationsWithoutCompleteness($productId);
+
+        $localesByChannelQuery->getChannelLocaleCollection()->shouldNotBeCalled();
+        $calculateRequiredAttributesCompleteness->calculate(Argument::any())->shouldNotBeCalled();
+        $calculateNonRequiredAttributesCompleteness->calculate(Argument::any())->shouldNotBeCalled();
+
+        $this->__invoke($criteriaEvaluations)->shouldReturn($criteriaEvaluations);
+    }
+
+    private function givenProductCriteriaEvaluationsWithCompleteness(ProductId $productId): CriterionEvaluationCollection
+    {
+        $channelCodeEcommerce = new ChannelCode('ecommerce');
+        $channelCodeMobile = new ChannelCode('mobile');
+        $localeCodeEn = new LocaleCode('en_US');
+
+        $completenessOfRequiredAttributesRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(95))
+            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(70));
+
+        $completenessOfRequiredAttributesStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
+            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done());
+
+        $completenessOfNonRequiredAttributesRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(70));
+
+        $completenessOfNonRequiredAttributesStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done());
+
+        $evaluateSpellingRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(88))
+            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(100))
+        ;
+        $evaluateSpellingStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
+            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done())
+        ;
+        $evaluateSpellingData = [
+            "attributes_with_rates" => [
+                "ecommerce" => [
+                    "en_US" => ["description" => 86],
+                ],
+                "mobile" => [
+                    "en_US" => [],
+                ]
+            ]
+        ];
+
+        return (new CriterionEvaluationCollection())
+            ->add($this->generateCriterionEvaluation(
+                $productId,
+                EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+                CriterionEvaluationStatus::DONE,
+                $completenessOfRequiredAttributesRates,
+                $completenessOfRequiredAttributesStatus,
+                ['total_number_of_attributes' => 12]
+            ))
+            ->add($this->generateCriterionEvaluation(
+                $productId,
+                EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+                CriterionEvaluationStatus::DONE,
+                $completenessOfNonRequiredAttributesRates,
+                $completenessOfNonRequiredAttributesStatus,
+                ['total_number_of_attributes' => 7]
+            ))
+            ->add($this->generateCriterionEvaluation(
+                $productId,
+                'consistency_spelling',
+                CriterionEvaluationStatus::DONE,
+                $evaluateSpellingRates,
+                $evaluateSpellingStatus,
+                $evaluateSpellingData
+            )
+        );
+    }
+
+    private function givenProductCriteriaEvaluationsWithoutCompleteness(ProductId $productId): CriterionEvaluationCollection
+    {
+        $channelCodeEcommerce = new ChannelCode('ecommerce');
+        $channelCodeMobile = new ChannelCode('mobile');
+        $localeCodeEn = new LocaleCode('en_US');
+
+        $evaluateSpellingRates = (new ChannelLocaleRateCollection())
+            ->addRate($channelCodeEcommerce, $localeCodeEn, new Rate(88))
+            ->addRate($channelCodeMobile, $localeCodeEn, new Rate(100))
+        ;
+        $evaluateSpellingStatus = (new CriterionEvaluationResultStatusCollection())
+            ->add($channelCodeEcommerce, $localeCodeEn, CriterionEvaluationResultStatus::done())
+            ->add($channelCodeMobile, $localeCodeEn, CriterionEvaluationResultStatus::done())
+        ;
+        $evaluateSpellingData = [
+            "attributes_with_rates" => [
+                "ecommerce" => [
+                    "en_US" => ["description" => 86],
+                ],
+                "mobile" => [
+                    "en_US" => [],
+                ]
+            ]
+        ];
+
+        return (new CriterionEvaluationCollection())
+            ->add($this->generateCriterionEvaluation(
+                $productId,
+                'consistency_spelling',
+                CriterionEvaluationStatus::DONE,
+                $evaluateSpellingRates,
+                $evaluateSpellingStatus,
+                $evaluateSpellingData
+            )
+        );
+    }
+
+    private function generateCriterionEvaluation(ProductId $productId, string $code, string $status, ChannelLocaleRateCollection $resultRates, CriterionEvaluationResultStatusCollection $resultStatusCollection, array $resultData)
+    {
+        return new CriterionEvaluation(
+            new CriterionCode($code),
+            $productId,
+            new \DateTimeImmutable(),
+            new CriterionEvaluationStatus($status),
+            new CriterionEvaluationResult($resultRates, $resultStatusCollection, $resultData)
+        );
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/Enrichment/EvaluateCompletenessSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/Enrichment/EvaluateCompletenessSpec.php
@@ -60,17 +60,17 @@ final class EvaluateCompletenessSpec extends ObjectBehavior
         $expectedResult = (new Write\CriterionEvaluationResult())
             ->addRate($channelMobile, $localeEn, new Rate(100))
             ->addStatus($channelMobile, $localeEn, CriterionEvaluationResultStatus::done())
-            ->addRateByAttributes($channelMobile, $localeEn, [])
+            ->addData('number_of_improvable_attributes', $channelMobile, $localeEn, 0)
             ->addData('total_number_of_attributes', $channelMobile, $localeEn, 2)
 
             ->addRate($channelMobile, $localeFr, new Rate(85))
             ->addStatus($channelMobile, $localeFr, CriterionEvaluationResultStatus::done())
-            ->addRateByAttributes($channelMobile, $localeFr, ['name' => 0, 'weight' => 0])
+            ->addData('number_of_improvable_attributes', $channelMobile, $localeFr, 2)
             ->addData('total_number_of_attributes', $channelMobile, $localeFr, 6)
 
             ->addRate($channelPrint, $localeEn, new Rate(92))
             ->addStatus($channelPrint, $localeEn, CriterionEvaluationResultStatus::done())
-            ->addRateByAttributes($channelPrint, $localeEn, ['description' => 0])
+            ->addData('number_of_improvable_attributes', $channelPrint, $localeEn, 1)
             ->addData('total_number_of_attributes', $channelPrint, $localeEn, 3)
 
             ->addStatus($channelPrint, $localeFr, CriterionEvaluationResultStatus::notApplicable())

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
@@ -51,6 +51,12 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         'fr_FR' => 5,
                     ],
                 ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -176,6 +182,12 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         'en_US' => 3,
                     ],
                 ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -227,6 +239,13 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                         'fo_FO' => 3,
                     ],
                 ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
+                        'fo_FO' => 1,
+                    ],
+                ],
             ],
             'rates' => [
                 'ecommerce' => [
@@ -266,6 +285,12 @@ final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
                     1 => [
                         58 => 4,
                         90 => 5,
+                    ],
+                ],
+                3 => [
+                    1 => [
+                        58 => 2,
+                        90 => 1,
                     ],
                 ],
             ],

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsSpec.php
@@ -51,6 +51,12 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
                         90 => 5,
                     ],
                 ],
+                3 => [
+                    1 => [
+                        58 => 2,
+                        90 => 1,
+                    ],
+                ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 1 => [
@@ -190,7 +196,13 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
                     42 => [
                         58 => 6,
                     ],
-                ]
+                ],
+                3 => [
+                    1 => [
+                        58 => 2,
+                        90 => 1,
+                    ],
+                ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 1 => [
@@ -244,6 +256,12 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
                         987 => 6
                     ],
                 ],
+                3 => [
+                    1 => [
+                        58 => 2,
+                        90 => 1,
+                    ],
+                ],
             ],
             TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [
                 1 => [
@@ -283,6 +301,12 @@ final class TransformCriterionEvaluationResultIdsSpec extends ObjectBehavior
                     'ecommerce' => [
                         'en_US' => 4,
                         'fr_FR' => 5,
+                    ],
+                ],
+                'number_of_improvable_attributes' => [
+                    'ecommerce' => [
+                        'en_US' => 2,
+                        'fr_FR' => 1,
                     ],
                 ],
             ],


### PR DESCRIPTION
For the completeness criteria, we store in database the list of the codes of the attributes without value for each product, channel and locale. The problem is it can reach a huge volume of data.

To avoid that, these lists will not be persisted anymore, but re-calculated when needed (to display the recommendations in the PEF DQI tab)

We still need to persist the number of these attributes to calculate the key indicators. So we calculate and persist it in a new entry in the evaluation resust data.