### PR TITLE
CXP-1051: add php_cd on schema upgrades

### DIFF
--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -7,6 +7,7 @@ find-legacy-translations:
 
 .PHONY: coupling-back
 coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back connectivity-connection-coupling-back communication-channel-coupling-back job-coupling-back data-quality-insights-coupling-back
+	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=upgrades/.php_cd.php upgrades/schema
 
 ### Static tests
 static-back: check-pullup check-sf-services

--- a/upgrades/.php_cd.php
+++ b/upgrades/.php_cd.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Akeneo\CouplingDetector\Configuration\Configuration;
+use Akeneo\CouplingDetector\Configuration\DefaultFinder;
+use Akeneo\CouplingDetector\RuleBuilder;
+
+$finder = new DefaultFinder();
+$builder = new RuleBuilder();
+
+$rules = [
+    $builder->only(
+        [
+            // Expected dependencies for DBAL:
+            'Doctrine\DBAL',
+            'Doctrine\Migrations',
+            // Expected dependencies for ES:
+            'Elasticsearch\ClientBuilder',
+            'Elasticsearch\Namespaces\IndicesNamespace',
+            'Akeneo\Tool\Bundle\ElasticsearchBundle\Client',
+            // Required for accessing DBAL & ES services:
+            'Symfony\Component\DependencyInjection\ContainerAwareInterface',
+            'Symfony\Component\DependencyInjection\ContainerInterface',
+
+            // Dangerous dependencies, migrations shouldn't rely on services
+            'Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionCommand',
+            'Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionHandler',
+            'Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys',
+            'Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException',
+            'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials',
+            'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType',
+            'Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\SaveAsymmetricKeysQuery',
+            'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer',
+            'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer',
+            'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer',
+            'Akeneo\Pim\Enrichment\Component\Product\Factory\EmptyValuesCleaner',
+            'Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader',
+            'Akeneo\Tool\Component\Batch\Job\BatchStatus',
+            'Akeneo\Tool\Component\Batch\Job\ExitStatus',
+            'Doctrine\Common\Collections\ArrayCollection',
+            'Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager',
+            'Oro\Bundle\SecurityBundle\Model\AclPermission',
+            'Oro\Bundle\SecurityBundle\Model\AclPrivilege',
+            'Oro\Bundle\SecurityBundle\Model\AclPrivilegeIdentity',
+            'phpseclib\Crypt\RSA',
+            'phpseclib\File\X509',
+            'Symfony\Component\DependencyInjection\ParameterBag\ParameterBag',
+            'Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity',
+            'Webmozart\Assert\Assert',
+        ]
+    )->in('Pim\Upgrade\Schema'),
+];
+
+$config = new Configuration($rules, $finder);
+
+return $config;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We want to avoid having schema migrations relying on services.
This PR starts to enforce it but includes exceptions for all existing dependencies.
This should prevent having new migrations relying on more services than what's currently allowed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
