### PR TITLE
PIM-10217: Fix cannot quick export product model when id is not present in grid context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@
 - PIM-10208: Fix currency settings page crashing when label is not found
 - PIM-10192: Retry mechanism in delete action of ES documents
 - PIM-10210: Fix notifications can't be displayed
+- PIM-10211: Fix cannot quick export product model when id is not present in grid context
 
 ## New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@
 - PIM-10208: Fix currency settings page crashing when label is not found
 - PIM-10192: Retry mechanism in delete action of ES documents
 - PIM-10210: Fix notifications can't be displayed
-- PIM-10211: Fix cannot quick export product model when id is not present in grid context
+- PIM-10217: Fix cannot quick export product model when id is not present in grid context
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/QuickExport/ProductAndProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/QuickExport/ProductAndProductModelProcessor.php
@@ -140,6 +140,8 @@ class ProductAndProductModelProcessor extends AbstractProcessor
                 );
             } elseif (in_array($codeProperty, $selectedProperties) || 'identifier' === $codeProperty) {
                 $propertiesToExport[$codeProperty] = $property;
+            } elseif ('code' === $codeProperty) {
+                $propertiesToExport['identifier'] = $property;
             }
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductModelWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductModelWriter.php
@@ -33,6 +33,6 @@ class ProductModelWriter extends AbstractItemMediaWriter
      */
     protected function getItemIdentifier(array $productModel): string
     {
-        return $productModel['code'];
+        return $productModel['code'] ?? $productModel['identifier'];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductModelWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Xlsx/ProductModelWriter.php
@@ -28,6 +28,6 @@ class ProductModelWriter extends AbstractItemMediaWriter
      */
     protected function getItemIdentifier(array $productModel): string
     {
-        return $productModel['code'];
+        return $productModel['code'] ?? $productModel['identifier'];
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When a user launch a quick export of a product model with a grid context without id (code), the job fails because the `ProductModelWriter` does not have the code to retrieve media file. 
This PR uses the same way as the product quick export and set a `identifier` (which will not be added into exported file) property that will be use to fallback if code is not exported.

I'm not thrilled about this solution, feel free to suggest me a cleaner one.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
