### PR TITLE
Temporary CI fix: use phpunit's executable instead of composer one for onboarder tests

### DIFF
--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -298,7 +298,7 @@ jobs:
                       rm -f docker-compose.override.yml
                       PIM_VERSION=master SETUP_FOR_CI=1 PIM_CONTEXT=onboarder make setup-onboarder-parameters
                       PIM_VERSION=master PIM_CONTEXT=onboarder make setup-onboarder-tests
-                      docker-compose run --rm php php /usr/local/bin/composer dumpautoload
+                      docker-compose run --rm php php /usr/local/bin/composer dumpautoload --no-interaction
             - run:
                   name: Change owner of PIM as some files have been created with wrong owner
                   command: sudo chown -R 1000:1000 ~/project
@@ -322,6 +322,9 @@ jobs:
             - run:
                   name: Execute acceptance tests
                   command: PIM_CONTEXT=onboarder make test-acceptance
+            - run:
+                  name: "[workaround to revert] Use phpunit executable instead of composer proxy"
+                  command: cd vendor/bin && rm -f ./phpunit && ln -s ../phpunit/phpunit/phpunit ./phpunit
             - run:
                   name: Execute PHPUnit integration tests
                   command: PIM_CONTEXT=onboarder make test-integration


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

See https://github.com/sebastianbergmann/phpunit/issues/4847. 

**This fix should be reverted as soon as either PHPUnit 9.5.11 or composer 2.2.2 is released.**

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
