### PR TITLE
PIM-10220 Fixed array indexed keys for AssociationsNormalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@
 - PIM-10192: Retry mechanism in delete action of ES documents
 - PIM-10214: Fix cannot create a measurement attribute if measurement family or unit code is too long
 - PIM-10210: Fix notifications can't be displayed
+- PIM-10220: Fixed issues where association has NaN error
 - PIM-10217: Fix cannot quick export product model when id is not present in grid context
 
 ## New features

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/AssociationsNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Standard/Product/AssociationsNormalizer.php
@@ -111,7 +111,7 @@ class AssociationsNormalizer implements NormalizerInterface, CacheableSupportsMe
         }
 
         $data = array_map(function ($association) {
-            $association['products'] = array_unique($association['products']);
+            $association['products'] = array_values(array_unique($association['products']));
             return $association;
         }, $data);
 


### PR DESCRIPTION
Fixes : [PIM-10220](https://akeneo.atlassian.net/browse/PIM-10220)
AssociationsNormalizer filters code duplicates for associations products. However in some cases array is not indexed using integers as keys but strings producing following results:
![image](https://user-images.githubusercontent.com/7101819/147476952-7bee830c-569e-4409-ae48-ad1e18319c62.png)
This leads to a front end issues where an array is expected but object is given

This fix addresses this issue:
![image](https://user-images.githubusercontent.com/7101819/147477014-346c7a16-b7ad-4104-8db0-732da24ceee5.png)
