### PR TITLE
PIM-10222 removed class name for pre-selected category

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10222: Fixed selected category glitch on product grid category filter
+
 # 5.0.66 (2021-12-22)
 
 # 5.0.65 (2021-12-22)

--- a/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/Normalizer/ChildCategory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Category/CategoryTree/Normalizer/ChildCategory.php
@@ -53,7 +53,7 @@ class ChildCategory
         }
 
         if ($category->selectedAsFilter()) {
-            $state .= ' toselect jstree-checked';
+            $state .= ' toselect';
         }
 
         return $state;

--- a/tests/back/Pim/Enrichment/Specification/Component/Category/CategoryTree/Normalizer/ChildCategorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Category/CategoryTree/Normalizer/ChildCategorySpec.php
@@ -36,7 +36,7 @@ class ChildCategorySpec extends ObjectBehavior
                         'data-code' => 'child_2',
                     ],
                     'data' => 'Child 2 (1)',
-                    'state' => 'leaf toselect jstree-checked',
+                    'state' => 'leaf toselect',
                     'children' => [],
                 ]],
             ],


### PR DESCRIPTION
Fixes [PIM-10222](https://akeneo.atlassian.net/browse/PIM-10222)

Selecting any category to filter product grid then reloading to set another category, produces a selection glitch :
![image](https://user-images.githubusercontent.com/7101819/147584608-5047c24a-9622-4ca4-8c02-ef29b183e358.png)

This is due to class name `jstree-checked` added to the DOM:
```HTML
<li id="node_14" data-code="print_scan" class="jstree-closed jstree-checked">
    <ins class="jstree-icon">&nbsp;</ins>
    <a href="#" class=""><ins class="jstree-icon">&nbsp;</ins>Print and scan (294)</a>
</li>
``` 
Note: `jstree-checked`  is used by checkbox plugin from jstree and not used in this case 

The PR address the issue by deleting class name that is added to selected node state
