### PR TITLE
Revert "Temporary CI fix: use phpunit's executable instead of composer one for onboarder tests"

### DIFF
--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -323,9 +323,6 @@ jobs:
                   name: Execute acceptance tests
                   command: PIM_CONTEXT=onboarder make test-acceptance
             - run:
-                  name: "[workaround to revert] Use phpunit executable instead of composer proxy"
-                  command: cd vendor/bin && rm -f ./phpunit && ln -s ../phpunit/phpunit/phpunit ./phpunit
-            - run:
                   name: Execute PHPUnit integration tests
                   command: PIM_CONTEXT=onboarder make test-integration
             - run:


### PR DESCRIPTION
This reverts commit 6087c18e3afc365f3112153540d5d4605b7d8605.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This temporary fix is not needed anymore now that PHPUnit v9.5.11 is released

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
