### PR TITLE
CXP-1047: Add test app table

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/InstallSubscriber.php
@@ -9,6 +9,7 @@ use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnection
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionAuditTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionEventsApiRequestCountTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateConnectionTableQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateTestAppTableQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateUserConsentTable;
 use Akeneo\Connectivity\Connection\Infrastructure\Install\Query\CreateWrongCredentialsCombinationQuery;
 use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
@@ -43,13 +44,14 @@ class InstallSubscriber implements EventSubscriberInterface
 
     public function createConnectionsTable(): void
     {
-        $this->dbalConnection->exec(CreateConnectionTableQuery::QUERY);
-        $this->dbalConnection->exec(CreateConnectionAuditTableQuery::QUERY);
-        $this->dbalConnection->exec(CreateWrongCredentialsCombinationQuery::QUERY);
-        $this->dbalConnection->exec(CreateConnectionAuditErrorTableQuery::QUERY);
-        $this->dbalConnection->exec(CreateConnectionEventsApiRequestCountTableQuery::QUERY);
-        $this->dbalConnection->exec(CreateAppTableQuery::QUERY);
-        $this->dbalConnection->exec(CreateUserConsentTable::QUERY);
+        $this->dbalConnection->executeStatement(CreateConnectionTableQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateConnectionAuditTableQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateWrongCredentialsCombinationQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateConnectionAuditErrorTableQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateConnectionEventsApiRequestCountTableQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateAppTableQuery::QUERY);
+        $this->dbalConnection->executeStatement(CreateUserConsentTable::QUERY);
+        $this->dbalConnection->executeStatement(CreateTestAppTableQuery::QUERY);
     }
 
     public function loadFixtures(InstallerEvent $installerEvent): void

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateTestAppTableQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Install/Query/CreateTestAppTableQuery.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Install\Query;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CreateTestAppTableQuery
+{
+    const QUERY = <<<SQL
+        CREATE TABLE IF NOT EXISTS akeneo_connectivity_test_app(
+            client_id VARCHAR(36) NOT NULL PRIMARY KEY,
+            client_secret VARCHAR(100) NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            activate_url VARCHAR(255) NOT NULL,
+            callback_url VARCHAR(255) NOT NULL,
+            user_id INT DEFAULT NULL,
+            CONSTRAINT `FK_TESTAPPUSERID` FOREIGN KEY (`user_id`) REFERENCES `oro_user` (`id`) ON DELETE SET NULL
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+    SQL;
+}

--- a/upgrades/schema/Version_6_0_20220103100000_add_test_app_table.php
+++ b/upgrades/schema/Version_6_0_20220103100000_add_test_app_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20220103100000_add_test_app_table extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+        CREATE TABLE IF NOT EXISTS akeneo_connectivity_test_app(
+            client_id VARCHAR(36) NOT NULL PRIMARY KEY,
+            client_secret VARCHAR(100) NOT NULL,
+            name VARCHAR(255) NOT NULL,
+            activate_url VARCHAR(255) NOT NULL,
+            callback_url VARCHAR(255) NOT NULL,
+            user_id INT DEFAULT NULL,
+            CONSTRAINT `FK_TESTAPPUSERID` FOREIGN KEY (`user_id`) REFERENCES `oro_user` (`id`) ON DELETE SET NULL
+        ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB ROW_FORMAT = DYNAMIC
+        SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

I've left `user_id` nullable with `ON DELETE SET NULL` because if we have a `DELETE CASCADE` on it, and the related user is deleted, it would delete his test apps, not the related connected apps.

I think it's better that users are required to use our Command+Handler through the UI to delete a test app, it will take care of side effects instead of leaving the database in a unexpected state.

It's easy to display in the UI that the creator of the test app was deleted, if the value is null.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
