### PR TITLE
Cpm 444 ignore mocks

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -251,6 +251,10 @@ const webpackConfig = {
       'process.env.NODE_ENV': isProd ? JSON.stringify('production') : JSON.stringify('development'),
       'process.env.EDITION': JSON.stringify(process.env.EDITION),
     }),
+
+    new webpack.IgnorePlugin({
+      resourceRegExp: /__mocks__/
+    })
   ],
 };
 


### PR DESCRIPTION
We discovered that the folders __mocks__ were exported during the webpack build. This PR removes all the "__mocks__" folders from wepback build.

build before the update: 
main.min.js   8.69 MiB    main  [emitted]              main
               
build after: 
main.min.js   8.64 MiB    main  [emitted]              main
                          
                          
