### PR TITLE
RAC-1199: Remove unused translations

### DIFF
--- a/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/Resources/translations/messages.en_US.yml
@@ -6,5 +6,3 @@ pim_dashboard:
             title: Completeness Over Channels and Locales
         last_operations:
             title: Last operations
-            status: Status
-            type: Type

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/translations/jsmessages.en_US.yml
@@ -159,21 +159,7 @@ pim_import_export:
     widget:
         last_operations:
             empty: There is no operation to display for now.
-            date: Date
-            profile_name: Profile name
             details: Details
-            warning_count: Warnings
-            username: Username
-            job_type:
-                import: Import
-                export: Export
-                mass_edit: Mass edit
-                mass_edit_rule: Rules Settings
-                quick_export: Quick export
-                compute_family_variant_structure_changes: Compute family variant structure changes
-                compute_completeness_of_products_family: Compute completeness of products family
-                mass_delete: Mass delete products
-                clean_removed_attribute_job: Cleaning removed attribute values
             header.view_all: View all
     batch_status:
         1: Completed

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
@@ -49,12 +49,20 @@ const LastOperationsWidget = () => {
       {data !== null && data.length > 0 && (
         <Table>
           <Table.Header>
-            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.started_at')}</Table.HeaderCell>
+            <Table.HeaderCell>
+              {translate('akeneo_job_process_tracker.job_execution_list.table.headers.started_at')}
+            </Table.HeaderCell>
             <Table.HeaderCell>{translate('pim_common.type')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.job_name')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.username')}</Table.HeaderCell>
+            <Table.HeaderCell>
+              {translate('akeneo_job_process_tracker.job_execution_list.table.headers.job_name')}
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              {translate('akeneo_job_process_tracker.job_execution_list.table.headers.username')}
+            </Table.HeaderCell>
             <Table.HeaderCell>{translate('pim_common.status')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.warning_count')}</Table.HeaderCell>
+            <Table.HeaderCell>
+              {translate('akeneo_job_process_tracker.job_execution_list.table.headers.warning_count')}
+            </Table.HeaderCell>
             <Table.HeaderCell />
           </Table.Header>
           <Table.Body>
@@ -66,9 +74,7 @@ const LastOperationsWidget = () => {
               return (
                 <Table.Row key={`operation${operation.id}`}>
                   <Table.Cell>{operation.date}</Table.Cell>
-                  <Table.Cell>
-                    {translate(`akeneo_job_process_tracker.filter_type.${operation.type}`)}
-                  </Table.Cell>
+                  <Table.Cell>{translate(`akeneo_job_process_tracker.filter_type.${operation.type}`)}</Table.Cell>
                   <Table.Cell>{operation.label}</Table.Cell>
                   <Table.Cell>{operation.username}</Table.Cell>
                   <Table.Cell>
@@ -81,12 +87,7 @@ const LastOperationsWidget = () => {
                   <Table.Cell>{counter > 0 ? counter : '-'}</Table.Cell>
                   <TableActionCell>
                     {operation.canSeeReport && (
-                      <Button
-                        ghost={true}
-                        size="small"
-                        level="tertiary"
-                        onClick={() => redirectToJob(operation.id)}
-                      >
+                      <Button ghost={true} size="small" level="tertiary" onClick={() => redirectToJob(operation.id)}>
                         {translate('pim_import_export.widget.last_operations.details')}
                       </Button>
                     )}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
@@ -24,9 +24,9 @@ const LastOperationsWidget = () => {
           <>
             <SectionTitle.Spacer />
             <Button
-              ghost
-              size={'small'}
-              level={'tertiary'}
+              ghost={true}
+              size="small"
+              level="tertiary"
               title="Show job tracker"
               onClick={() => router.redirectToRoute('akeneo_job_process_tracker_index')}
             >
@@ -49,12 +49,12 @@ const LastOperationsWidget = () => {
       {data !== null && data.length > 0 && (
         <Table>
           <Table.Header>
-            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.date')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.started_at')}</Table.HeaderCell>
             <Table.HeaderCell>{translate('pim_common.type')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.profile_name')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.username')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.job_name')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.username')}</Table.HeaderCell>
             <Table.HeaderCell>{translate('pim_common.status')}</Table.HeaderCell>
-            <Table.HeaderCell>{translate('pim_import_export.widget.last_operations.warning_count')}</Table.HeaderCell>
+            <Table.HeaderCell>{translate('akeneo_job_process_tracker.job_execution_list.table.headers.warning_count')}</Table.HeaderCell>
             <Table.HeaderCell />
           </Table.Header>
           <Table.Body>
@@ -67,7 +67,7 @@ const LastOperationsWidget = () => {
                 <Table.Row key={`operation${operation.id}`}>
                   <Table.Cell>{operation.date}</Table.Cell>
                   <Table.Cell>
-                    {translate(`pim_import_export.widget.last_operations.job_type.${operation.type}`)}
+                    {translate(`akeneo_job_process_tracker.filter_type.${operation.type}`)}
                   </Table.Cell>
                   <Table.Cell>{operation.label}</Table.Cell>
                   <Table.Cell>{operation.username}</Table.Cell>
@@ -82,8 +82,7 @@ const LastOperationsWidget = () => {
                   <TableActionCell>
                     {operation.canSeeReport && (
                       <Button
-                        type="button"
-                        ghost
+                        ghost={true}
                         size="small"
                         level="tertiary"
                         onClick={() => redirectToJob(operation.id)}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/components/Widgets/LastOperationsWidget.tsx
@@ -74,7 +74,7 @@ const LastOperationsWidget = () => {
               return (
                 <Table.Row key={`operation${operation.id}`}>
                   <Table.Cell>{operation.date}</Table.Cell>
-                  <Table.Cell>{translate(`akeneo_job_process_tracker.filter_type.${operation.type}`)}</Table.Cell>
+                  <Table.Cell>{translate(`akeneo_job_process_tracker.type_filter.${operation.type}`)}</Table.Cell>
                   <Table.Cell>{operation.label}</Table.Cell>
                   <Table.Cell>{operation.username}</Table.Cell>
                   <Table.Cell>

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/translations/messages.en_US.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/translations/messages.en_US.yml
@@ -12,13 +12,3 @@ pim_datagrid:
       created: Datagrid view successfully created
       removed: Datagrid view successfully removed
       not_removable: You don't have the permission to remove this view
-  cells:
-    type:
-      quick_export: Quick Export
-      import: Import
-      export: Export
-      mass_edit: Mass Edit
-      mass_delete: Mass Delete
-      compute_family_variant_structure_changes: Compute family variant structure changes
-      compute_completeness_of_products_family: Compute completeness of products family
-      clean_removed_attribute_job: Cleaning removed attribute values


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The following translation are not used anymore since we have released the process tracker revamp, we need to cleanup it:

```
pim_dashboard.widget.last_operations.job_type.* (CE and EE)
pim_datagrid.cells.type.*
```


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
