### PR TITLE
CXP-1039: returns a test app in GetAppQuery when necessary

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -13,8 +13,8 @@ final class ConnectedApp
     private string $id;
     private string $name;
     private string $connectionCode;
-    private string $logo;
-    private string $author;
+    private ?string $logo;
+    private ?string $author;
     /** @var string[] $scopes */
     private array $scopes;
     private string $userGroupName;
@@ -32,8 +32,8 @@ final class ConnectedApp
         string $name,
         array $scopes,
         string $connectionCode,
-        string $logo,
-        string $author,
+        ?string $logo,
+        ?string $author,
         string $userGroupName,
         array $categories = [],
         bool $certified = false,
@@ -74,12 +74,12 @@ final class ConnectedApp
         return $this->connectionCode;
     }
 
-    public function getLogo(): string
+    public function getLogo(): ?string
     {
         return $this->logo;
     }
 
-    public function getAuthor(): string
+    public function getAuthor(): ?string
     {
         return $this->author;
     }
@@ -113,8 +113,8 @@ final class ConnectedApp
      *  name: string,
      *  scopes: array<string>,
      *  connection_code: string,
-     *  logo: string,
-     *  author: string,
+     *  logo: string|null,
+     *  author: string|null,
      *  user_group_name: string,
      *  categories: array<string>,
      *  certified: bool,

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/DTO/GetAllTestAppsResult.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/DTO/GetAllTestAppsResult.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Domain\Marketplace\DTO;
+
+use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetAllTestAppsResult
+{
+    private int $total;
+
+    /** @var array<App> */
+    private array $apps;
+
+    /**
+     * @param array<App> $apps
+     */
+    private function __construct(int $total, array $apps)
+    {
+        foreach ($apps as $app) {
+            if (!$app instanceof App) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Expected an array of "%s", got "%s".',
+                    App::class,
+                    gettype($app)
+                ));
+            }
+        }
+        $this->total = $total;
+        $this->apps = $apps;
+    }
+
+    /**
+     * @param array<App> $apps
+     */
+    public static function create(int $total, array $apps): self
+    {
+        return new self($total, $apps);
+    }
+
+    /**
+     * @param array<string> $queryParameters
+     */
+    public function withPimUrlSource(array $queryParameters): self
+    {
+        return self::create(
+            $this->total,
+            array_map(function (App $app) use ($queryParameters) {
+                return $app->withPimUrlSource($queryParameters);
+            }, $this->apps),
+        );
+    }
+
+    /**
+     * @return array{total:int, apps:array}
+     */
+    public function normalize(): array
+    {
+        $normalizedApps = [];
+
+        foreach ($this->apps as $app) {
+            $normalizedApps[] = $app->normalize();
+        }
+
+        return [
+            'total' => $this->total,
+            'apps' => $normalizedApps,
+        ];
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
@@ -38,7 +38,6 @@ class App
     private const TEST_APP_REQUIRED_KEYS = [
         'id',
         'name',
-        'author',
         'activate_url',
         'callback_url',
     ];
@@ -93,7 +92,7 @@ class App
      * @param array{
      *     id: string,
      *     name: string,
-     *     author: string|null,
+     *     author?: string,
      *     activate_url: string,
      *     callback_url: string,
      *     connected?: bool,
@@ -112,7 +111,7 @@ class App
         $self->id = $values['id'];
         $self->name = $values['name'];
         $self->logo = null;
-        $self->author = $values['author'];
+        $self->author = $values['author'] ?? null;
         $self->partner = null;
         $self->description = null;
         $self->url = null;

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
@@ -12,11 +12,11 @@ class App
 {
     private string $id;
     private string $name;
-    private string $logo;
-    private string $author;
+    private ?string $logo;
+    private ?string $author;
     private ?string $partner;
     private ?string $description;
-    private string $url;
+    private ?string $url;
     private bool $certified;
     /** @var array<string> */
     private array $categories;
@@ -24,13 +24,21 @@ class App
     private string $callbackUrl;
     private bool $connected;
 
-    private const REQUIRED_KEYS = [
+    private const MARKETPLACE_REQUIRED_KEYS = [
         'id',
         'name',
         'logo',
         'author',
         'url',
         'categories',
+        'activate_url',
+        'callback_url',
+    ];
+
+    private const TEST_APP_REQUIRED_KEYS = [
+        'id',
+        'name',
+        'author',
         'activate_url',
         'callback_url',
     ];
@@ -57,7 +65,7 @@ class App
      */
     public static function fromWebMarketplaceValues(array $values): self
     {
-        foreach (self::REQUIRED_KEYS as $key) {
+        foreach (self::MARKETPLACE_REQUIRED_KEYS as $key) {
             if (!isset($values[$key])) {
                 throw new \InvalidArgumentException(sprintf('Missing property "%s" in given app', $key));
             }
@@ -74,6 +82,42 @@ class App
         $self->url = $values['url'];
         $self->categories = $values['categories'];
         $self->certified = $values['certified'] ?? false;
+        $self->activateUrl = $values['activate_url'];
+        $self->callbackUrl = $values['callback_url'];
+        $self->connected = $values['connected'] ?? false;
+
+        return $self;
+    }
+
+    /**
+     * @param array{
+     *     id: string,
+     *     name: string,
+     *     author: string|null,
+     *     activate_url: string,
+     *     callback_url: string,
+     *     connected?: bool,
+     * } $values
+     */
+    public static function fromTestAppValues(array $values): self
+    {
+        foreach (self::TEST_APP_REQUIRED_KEYS as $key) {
+            if (!isset($values[$key])) {
+                throw new \InvalidArgumentException(sprintf('Missing property "%s" in given app', $key));
+            }
+        }
+
+        $self = new self();
+
+        $self->id = $values['id'];
+        $self->name = $values['name'];
+        $self->logo = null;
+        $self->author = $values['author'];
+        $self->partner = null;
+        $self->description = null;
+        $self->url = null;
+        $self->categories = [];
+        $self->certified = false;
         $self->activateUrl = $values['activate_url'];
         $self->callbackUrl = $values['callback_url'];
         $self->connected = $values['connected'] ?? false;

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Marketplace/Model/App.php
@@ -130,6 +130,11 @@ class App
     public function withAnalytics(array $queryParameters): self
     {
         $values = $this->normalize();
+
+        if (null === $values['url']) {
+            return $this;
+        }
+
         $values['url'] = static::appendQueryParametersToUrl($values['url'], $queryParameters);
 
         /* @phpstan-ignore-next-line */
@@ -178,11 +183,11 @@ class App
      * @return array{
      *  id: string,
      *  name: string,
-     *  logo: string,
-     *  author: string,
+     *  logo: string|null,
+     *  author: string|null,
      *  partner: string|null,
      *  description: string|null,
-     *  url: string,
+     *  url: string|null,
      *  categories: array<string>,
      *  certified: bool,
      *  activate_url: string,
@@ -228,12 +233,12 @@ class App
         return $this->name;
     }
 
-    public function getLogo(): string
+    public function getLogo(): ?string
     {
         return $this->logo;
     }
 
-    public function getAuthor(): string
+    public function getAuthor(): ?string
     {
         return $this->author;
     }
@@ -248,7 +253,7 @@ class App
         return $this->description;
     }
 
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/GetAllTestAppsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/GetAllTestAppsQuery.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Marketplace;
+
+use Akeneo\Connectivity\Connection\Domain\Marketplace\DTO\GetAllTestAppsResult;
+use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetAllTestAppsQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function execute(): GetAllTestAppsResult
+    {
+        $query = <<<SQL
+SELECT 
+    app.client_id AS id,
+    app.name,
+    IF(app.user_id IS NOT NULL, CONCAT_WS(' ', user.name_prefix, user.first_name, user.middle_name, user.last_name, user.name_suffix), NULL) AS author,
+    app.activate_url,
+    app.callback_url
+FROM akeneo_connectivity_test_app AS app
+LEFT JOIN oro_user user on user.id = app.user_id
+SQL;
+
+        $rows = $this->connection->fetchAllAssociative($query);
+
+        return GetAllTestAppsResult::create(
+            count($rows),
+            array_map(function ($row) {
+                return App::fromTestAppValues($row);
+            }, $rows)
+        );
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/GetTestAppQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/GetTestAppQuery.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Marketplace;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetTestAppQuery
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     name: string,
+     *     author: string|null,
+     *     activate_url: string,
+     *     callback_url: string,
+     * }|null
+     */
+    public function execute(string $id): ?array
+    {
+        $query = <<<SQL
+SELECT 
+    app.client_id AS id,
+    app.name,
+    IF(app.user_id IS NOT NULL, CONCAT_WS(' ', user.name_prefix, user.first_name, user.middle_name, user.last_name, user.name_suffix), NULL) AS author,
+    app.activate_url,
+    app.callback_url
+FROM akeneo_connectivity_test_app AS app
+LEFT JOIN oro_user user on user.id = app.user_id
+WHERE app.client_id = :id
+SQL;
+
+        return $this->connection->fetchAssociative(
+            $query,
+            [
+                'id' => $id,
+            ]
+        ) ?: null;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/marketplace.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/marketplace.yml
@@ -67,3 +67,10 @@ services:
         class: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAppQuery
         arguments:
             - '@akeneo_connectivity.connection.marketplace.web_marketplace_api'
+            - '@akeneo_connectivity.connection.app_developer_mode.feature'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/marketplace.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/marketplace.yml
@@ -74,3 +74,8 @@ services:
         class: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery
         arguments:
             - '@database_connection'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAllTestAppsQuery:
+        class: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAllTestAppsQuery
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetAllTestAppsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetAllTestAppsQueryIntegration.php
@@ -7,6 +7,7 @@ namespace Akeneo\Connectivity\Connection\Tests\Integration\Marketplace;
 use Akeneo\Connectivity\Connection\Domain\Marketplace\DTO\GetAllTestAppsResult;
 use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAllTestAppsQuery;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;
@@ -18,6 +19,7 @@ use Doctrine\DBAL\Connection;
 class GetAllTestAppsQueryIntegration extends TestCase
 {
     private Connection $connection;
+    private ConnectedAppLoader $connectedAppLoader;
     private GetAllTestAppsQuery $query;
 
     protected function setUp(): void
@@ -25,6 +27,7 @@ class GetAllTestAppsQueryIntegration extends TestCase
         parent::setUp();
 
         $this->connection = $this->get('database_connection');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
         $this->query = $this->get(GetAllTestAppsQuery::class);
     }
 
@@ -43,6 +46,7 @@ class GetAllTestAppsQueryIntegration extends TestCase
             'callback_url' => 'http://shopware.example.com/callback',
             'user_id' => $this->findUserId('admin'),
         ]);
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens('100eedac-ff5c-497b-899d-e2d64b6c59f9', 'foo');
         $this->createTestApp([
             'client_id' => '42b9ecb1-ddd7-4874-9ad6-21a02d08ed50',
             'client_secret' => 'foobar',
@@ -62,6 +66,7 @@ class GetAllTestAppsQueryIntegration extends TestCase
                     'author' => 'John Doe',
                     'activate_url' => 'http://shopware.example.com/activate',
                     'callback_url' => 'http://shopware.example.com/callback',
+                    'connected' => true,
                 ]),
                 App::fromTestAppValues([
                     'id' => '42b9ecb1-ddd7-4874-9ad6-21a02d08ed50',
@@ -69,6 +74,7 @@ class GetAllTestAppsQueryIntegration extends TestCase
                     'author' => null,
                     'activate_url' => 'http://shopware.example.com/activate',
                     'callback_url' => 'http://shopware.example.com/callback',
+                    'connected' => false,
                 ]),
             ]),
             $result

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetTestAppQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetTestAppQueryIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Tests\Integration\Marketplace;
 
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;
@@ -16,6 +17,7 @@ use Doctrine\DBAL\Connection;
 class GetTestAppQueryIntegration extends TestCase
 {
     private Connection $connection;
+    private ConnectedAppLoader $connectedAppLoader;
     private GetTestAppQuery $query;
 
     protected function setUp(): void
@@ -23,6 +25,7 @@ class GetTestAppQueryIntegration extends TestCase
         parent::setUp();
 
         $this->connection = $this->get('database_connection');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
         $this->query = $this->get(GetTestAppQuery::class);
     }
 
@@ -49,6 +52,7 @@ class GetTestAppQueryIntegration extends TestCase
             'author' => 'John Doe',
             'activate_url' => 'http://shopware.example.com/activate',
             'callback_url' => 'http://shopware.example.com/callback',
+            'connected' => false,
         ], $result);
     }
 
@@ -70,6 +74,30 @@ class GetTestAppQueryIntegration extends TestCase
             'author' => null,
             'activate_url' => 'http://shopware.example.com/activate',
             'callback_url' => 'http://shopware.example.com/callback',
+            'connected' => false,
+        ], $result);
+    }
+
+    public function test_it_returns_a_test_app_which_is_connected()
+    {
+        $this->createTestApp([
+            'client_id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'client_secret' => 'foobar',
+            'name' => 'My test app',
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+            'user_id' => null,
+        ]);
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens('100eedac-ff5c-497b-899d-e2d64b6c59f9', 'foo');
+
+        $result = $this->query->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9');
+        $this->assertEquals([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'My test app',
+            'author' => null,
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+            'connected' => true,
         ], $result);
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetTestAppQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/GetTestAppQueryIntegration.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Marketplace;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetTestAppQueryIntegration extends TestCase
+{
+    private Connection $connection;
+    private GetTestAppQuery $query;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->get('database_connection');
+        $this->query = $this->get(GetTestAppQuery::class);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    public function test_it_returns_a_test_app_with_an_user()
+    {
+        $this->createTestApp([
+            'client_id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'client_secret' => 'foobar',
+            'name' => 'My test app',
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+            'user_id' => 1,
+        ]);
+
+        $result = $this->query->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9');
+        $this->assertEquals([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'My test app',
+            'author' => 'John Doe',
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+        ], $result);
+    }
+
+    public function test_it_returns_a_test_app_without_an_user()
+    {
+        $this->createTestApp([
+            'client_id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'client_secret' => 'foobar',
+            'name' => 'My test app',
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+            'user_id' => null,
+        ]);
+
+        $result = $this->query->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9');
+        $this->assertEquals([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'My test app',
+            'author' => null,
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+        ], $result);
+    }
+
+    /**
+     * @param array{
+     *     client_id: string,
+     *     client_secret: string,
+     *     name: string,
+     *     activate_url: string,
+     *     callback_url: string,
+     *     user_id: string|null,
+     * } $data
+     */
+    private function createTestApp(array $data): void
+    {
+        $this->connection->insert('akeneo_connectivity_test_app', $data);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Marketplace/Model/AppSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Marketplace/Model/AppSpec.php
@@ -94,4 +94,32 @@ class AppSpec extends ObjectBehavior
             'connected' => false,
         ]);
     }
+
+    public function it_is_instantiable_with_test_values()
+    {
+        $this->beConstructedThrough('fromTestAppValues', [
+            [
+                'id' => 'ce8cf07f-321e-4dd2-a52f-30ac00881ba7',
+                'name' => 'Shopify App',
+                'author' => 'Akeneo',
+                'activate_url' => 'https:\/\/fake.shopify.akeneo.com\/activate',
+                'callback_url' => 'https:\/\/fake.shopify.akeneo.com\/oauth2\/callback',
+            ],
+        ]);
+
+        $this->normalize()->shouldBe([
+            'id' => 'ce8cf07f-321e-4dd2-a52f-30ac00881ba7',
+            'name' => 'Shopify App',
+            'logo' => null,
+            'author' => 'Akeneo',
+            'partner' => null,
+            'description' => null,
+            'url' => null,
+            'categories' => [],
+            'certified' => false,
+            'activate_url' => 'https:\/\/fake.shopify.akeneo.com\/activate',
+            'callback_url' => 'https:\/\/fake.shopify.akeneo.com\/oauth2\/callback',
+            'connected' => false,
+        ]);
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Marketplace;
+
+use Akeneo\Connectivity\Connection\Domain\Marketplace\Model\App;
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetAppQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\GetTestAppQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApiInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetAppQuerySpec extends ObjectBehavior
+{
+    public function let(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+        FeatureFlag $appDeveloperModeFeatureFlag,
+        GetTestAppQuery $getTestAppQuery,
+    ) {
+        $appDeveloperModeFeatureFlag->isEnabled()->willReturn(false);
+
+        $this->beConstructedWith(
+            $webMarketplaceApi,
+            $appDeveloperModeFeatureFlag,
+            $getTestAppQuery,
+        );
+    }
+
+    public function it_is_instantiable(): void
+    {
+        $this->shouldHaveType(GetAppQuery::class);
+    }
+
+    public function it_returns_a_known_marketplace_app(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+    ): void {
+        $webMarketplaceApi->getApp('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'Akeneo Shopware 6 App by EIKONA Media',
+            'logo' => 'https://marketplace.akeneo.com/sites/default/files/styles/app_logo_large/public/app-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+            'author' => 'EIKONA Media GmbH',
+            'partner' => 'Akeneo Preferred Partner',
+            'description' => 'With the new "Akeneo-Shopware-6-App" from EIKONA Media, you can smoothly export all your product data from Akeneo to Shopware. The app uses the standard interfaces provided for data exchange. Benefit from up-to-date product data in all your e-commerce channels and be faster on the market.',
+            'url' => 'https://marketplace.akeneo.com/app/akeneo-shopware-6-app-eikona-media',
+            'categories' => [
+                'E-commerce',
+            ],
+            'certified' => false,
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+        ]);
+
+        $this->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->shouldBeLike(
+            App::fromWebMarketplaceValues([
+                'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+                'name' => 'Akeneo Shopware 6 App by EIKONA Media',
+                'logo' => 'https://marketplace.akeneo.com/sites/default/files/styles/app_logo_large/public/app-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+                'author' => 'EIKONA Media GmbH',
+                'partner' => 'Akeneo Preferred Partner',
+                'description' => 'With the new "Akeneo-Shopware-6-App" from EIKONA Media, you can smoothly export all your product data from Akeneo to Shopware. The app uses the standard interfaces provided for data exchange. Benefit from up-to-date product data in all your e-commerce channels and be faster on the market.',
+                'url' => 'https://marketplace.akeneo.com/app/akeneo-shopware-6-app-eikona-media',
+                'categories' => [
+                    'E-commerce',
+                ],
+                'certified' => false,
+                'activate_url' => 'http://shopware.example.com/activate',
+                'callback_url' => 'http://shopware.example.com/callback',
+            ])
+        );
+    }
+
+    public function it_returns_null_if_unknown_marketplace_app(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+    ): void {
+        $webMarketplaceApi->getApp('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);
+
+        $this->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->shouldReturn(null);
+    }
+
+    public function it_returns_a_known_test_app_if_developer_mode_is_enabled(
+        FeatureFlag $appDeveloperModeFeatureFlag,
+        GetTestAppQuery $getTestAppQuery,
+    ): void {
+        $appDeveloperModeFeatureFlag->isEnabled()->willReturn(true);
+        $getTestAppQuery->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'My Test App',
+            'author' => 'John Doe',
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+        ]);
+
+        $this->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->shouldBeLike(
+            App::fromTestAppValues([
+                'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+                'name' => 'My Test App',
+                'author' => 'John Doe',
+                'activate_url' => 'http://shopware.example.com/activate',
+                'callback_url' => 'http://shopware.example.com/callback',
+            ])
+        );
+    }
+
+    public function it_returns_null_if_unknown_test_app_and_marketplace_app(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+        FeatureFlag $appDeveloperModeFeatureFlag,
+        GetTestAppQuery $getTestAppQuery,
+    ): void
+    {
+        $appDeveloperModeFeatureFlag->isEnabled()->willReturn(true);
+        $getTestAppQuery->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);
+        $webMarketplaceApi->getApp('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);
+
+        $this->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->shouldReturn(null);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
@@ -110,8 +110,7 @@ class GetAppQuerySpec extends ObjectBehavior
         WebMarketplaceApiInterface $webMarketplaceApi,
         FeatureFlag $appDeveloperModeFeatureFlag,
         GetTestAppQuery $getTestAppQuery,
-    ): void
-    {
+    ): void {
         $appDeveloperModeFeatureFlag->isEnabled()->willReturn(true);
         $getTestAppQuery->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);
         $webMarketplaceApi->getApp('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/GetAppQuerySpec.php
@@ -74,6 +74,48 @@ class GetAppQuerySpec extends ObjectBehavior
         );
     }
 
+    public function it_returns_a_known_marketplace_app_even_when_developer_mode_is_enabled(
+        WebMarketplaceApiInterface $webMarketplaceApi,
+        FeatureFlag $appDeveloperModeFeatureFlag,
+        GetTestAppQuery $getTestAppQuery,
+    ): void {
+        $appDeveloperModeFeatureFlag->isEnabled()->willReturn(true);
+        $getTestAppQuery->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn(null);
+        $webMarketplaceApi->getApp('100eedac-ff5c-497b-899d-e2d64b6c59f9')->willReturn([
+            'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            'name' => 'Akeneo Shopware 6 App by EIKONA Media',
+            'logo' => 'https://marketplace.akeneo.com/sites/default/files/styles/app_logo_large/public/app-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+            'author' => 'EIKONA Media GmbH',
+            'partner' => 'Akeneo Preferred Partner',
+            'description' => 'With the new "Akeneo-Shopware-6-App" from EIKONA Media, you can smoothly export all your product data from Akeneo to Shopware. The app uses the standard interfaces provided for data exchange. Benefit from up-to-date product data in all your e-commerce channels and be faster on the market.',
+            'url' => 'https://marketplace.akeneo.com/app/akeneo-shopware-6-app-eikona-media',
+            'categories' => [
+                'E-commerce',
+            ],
+            'certified' => false,
+            'activate_url' => 'http://shopware.example.com/activate',
+            'callback_url' => 'http://shopware.example.com/callback',
+        ]);
+
+        $this->execute('100eedac-ff5c-497b-899d-e2d64b6c59f9')->shouldBeLike(
+            App::fromWebMarketplaceValues([
+                'id' => '100eedac-ff5c-497b-899d-e2d64b6c59f9',
+                'name' => 'Akeneo Shopware 6 App by EIKONA Media',
+                'logo' => 'https://marketplace.akeneo.com/sites/default/files/styles/app_logo_large/public/app-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+                'author' => 'EIKONA Media GmbH',
+                'partner' => 'Akeneo Preferred Partner',
+                'description' => 'With the new "Akeneo-Shopware-6-App" from EIKONA Media, you can smoothly export all your product data from Akeneo to Shopware. The app uses the standard interfaces provided for data exchange. Benefit from up-to-date product data in all your e-commerce channels and be faster on the market.',
+                'url' => 'https://marketplace.akeneo.com/app/akeneo-shopware-6-app-eikona-media',
+                'categories' => [
+                    'E-commerce',
+                ],
+                'certified' => false,
+                'activate_url' => 'http://shopware.example.com/activate',
+                'callback_url' => 'http://shopware.example.com/callback',
+            ])
+        );
+    }
+
     public function it_returns_null_if_unknown_marketplace_app(
         WebMarketplaceApiInterface $webMarketplaceApi,
     ): void {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The `GetAppQuery` is at the center of our Wizard.
It is called before the connect and during the Wizard.

By hooking into it, we can check if there is a test App matching the id of the App being connected.
We can also reuse our `App` DTO by adding a new named constructor.

This way, there is no need to rewrite other parts of the Wizard process.

Also, the WebMarketplaceApi service stays unchanged.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
