### PR TITLE
RAC-1203: Job detail page display 'Time spent' instead of displaying the estimated time when job status is 'IN PROGRESS'

### DIFF
--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/components/common/JobExecutionStatus.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/components/common/JobExecutionStatus.tsx
@@ -34,7 +34,7 @@ const JobExecutionStatus = ({
   const translate = useTranslate();
 
   let label = translate(`akeneo_job.job_status.${status}`);
-  if (['STARTING', 'STARTED', 'IN_PROGRESS'].includes(status)) {
+  if (['STARTING', 'IN_PROGRESS'].includes(status)) {
     label = `${label} ${currentStep}/${totalSteps}`;
   }
 

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionDetail/JobExecution.test.ts
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionDetail/JobExecution.test.ts
@@ -96,7 +96,7 @@ describe('job execution', () => {
     expect(isJobFinished(getJobWithStatus('ABANDONED'))).toBe(true);
     expect(isJobFinished(getJobWithStatus('UNKNOWN'))).toBe(true);
     expect(isJobFinished(getJobWithStatus('STARTING'))).toBe(false);
-    expect(isJobFinished(getJobWithStatus('STARTED'))).toBe(false);
+    expect(isJobFinished(getJobWithStatus('IN_PROGRESS'))).toBe(false);
     expect(isJobFinished(getJobWithStatus('STOPPING'))).toBe(false);
   });
 });

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionDetail/JobExecution.ts
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/models/JobExecutionDetail/JobExecution.ts
@@ -91,7 +91,7 @@ const getDownloadLinks = (jobExecutionArchives: JobExecutionArchives | null): Do
 };
 
 const isJobFinished = (jobExecution: JobExecution | null): boolean =>
-  null !== jobExecution && !['STARTING', 'STARTED', 'STOPPING'].includes(jobExecution.tracking.status);
+  null !== jobExecution && !['STARTING', 'IN_PROGRESS', 'STOPPING'].includes(jobExecution.tracking.status);
 
 export {getDownloadLinks, isJobFinished};
 export type {JobExecution, JobExecutionArchives, JobExecutionTracking, JobInstance, StepExecutionTracking};

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.test.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.test.tsx
@@ -23,14 +23,14 @@ const jobExecution: JobExecution = {
   tracking: {
     error: false,
     warning: false,
-    status: 'STARTED',
+    status: 'IN_PROGRESS',
     currentStep: 1,
     totalSteps: 1,
     steps: [
       {
         jobName: 'csv_product_export',
         stepName: 'export',
-        status: 'STARTED',
+        status: 'IN_PROGRESS',
         isTrackable: true,
         hasWarning: false,
         hasError: false,
@@ -121,7 +121,7 @@ test('it renders the job execution detail page', () => {
   renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
-  expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
+  expect(screen.getByText('akeneo_job.job_status.IN_PROGRESS 1/1')).toBeInTheDocument();
 });
 
 test('it renders the job execution export detail page', () => {
@@ -130,7 +130,7 @@ test('it renders the job execution export detail page', () => {
   renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
-  expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
+  expect(screen.getByText('akeneo_job.job_status.IN_PROGRESS 1/1')).toBeInTheDocument();
 });
 
 test('it renders the job execution import detail page', () => {
@@ -139,7 +139,7 @@ test('it renders the job execution import detail page', () => {
   renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
-  expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
+  expect(screen.getByText('akeneo_job.job_status.IN_PROGRESS 1/1')).toBeInTheDocument();
 });
 
 test('it stops the job execution', () => {

--- a/src/Akeneo/Tool/Component/Batch/Job/BatchStatus.php
+++ b/src/Akeneo/Tool/Component/Batch/Job/BatchStatus.php
@@ -46,27 +46,16 @@ class BatchStatus
     const ABANDONED = 7;
     const UNKNOWN = 8;
 
-    protected static $statusLabels = [
+    protected static array $statusLabels = [
         self::COMPLETED => 'COMPLETED',
         self::STARTING  => 'STARTING',
-        self::STARTED   => 'STARTED',
+        self::STARTED   => 'IN_PROGRESS',
         self::STOPPING  => 'STOPPING',
         self::STOPPED   => 'STOPPED',
         self::FAILED    => 'FAILED',
         self::ABANDONED => 'ABANDONED',
         self::UNKNOWN   => 'UNKNOWN'
     ];
-
-    /**
-     * Get all labels associative array
-     * @static
-     *
-     * @return array
-     */
-    public static function getAllLabels()
-    {
-        return array_flip(self::$statusLabels);
-    }
 
     /**
      * Set the current status

--- a/src/Akeneo/Tool/Component/Batch/spec/Job/BatchStatusSpec.php
+++ b/src/Akeneo/Tool/Component/Batch/spec/Job/BatchStatusSpec.php
@@ -111,20 +111,4 @@ class BatchStatusSpec extends ObjectBehavior
         $this->beConstructedWith(BatchStatus::STARTING);
         $this->isUnsuccessful()->shouldReturn(false);
     }
-
-    function it_provides_status_labels()
-    {
-        $this::getAllLabels()->shouldReturn(
-            [
-                'COMPLETED' => BatchStatus::COMPLETED,
-                'STARTING' => BatchStatus::STARTING,
-                'STARTED' => BatchStatus::STARTED,
-                'STOPPING' => BatchStatus::STOPPING,
-                'STOPPED' => BatchStatus::STOPPED,
-                'FAILED' => BatchStatus::FAILED,
-                'ABANDONED' => BatchStatus::ABANDONED,
-                'UNKNOWN' => BatchStatus::UNKNOWN
-            ]
-        );
-    }
 }

--- a/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
+++ b/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
@@ -241,7 +241,7 @@ SQL;
     private function expectedJobExecutionTrackingInProgress(): JobExecutionTracking
     {
         $expectedJobExecutionTracking = new JobExecutionTracking();
-        $expectedJobExecutionTracking->status = 'STARTED';
+        $expectedJobExecutionTracking->status = 'IN_PROGRESS';
         $expectedJobExecutionTracking->currentStep = 2;
         $expectedJobExecutionTracking->totalSteps = 3;
 
@@ -251,7 +251,7 @@ SQL;
         $expectedStepExecutionTracking1->hasWarning = true;
 
         $expectedStepExecutionTracking2 = $this->getImportStepExecutionTracking();
-        $expectedStepExecutionTracking2->status = 'STARTED';
+        $expectedStepExecutionTracking2->status = 'IN_PROGRESS';
         $expectedStepExecutionTracking2->duration = 7;
         $expectedStepExecutionTracking2->processedItems = 10;
         $expectedStepExecutionTracking2->totalItems = 100;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- I fixed a regression made when we have modified STARTED by IN_PROGRESS, in the process detail we didn't display anymore the estimated time we display the time spent (cf screenshoot)
![Screenshot from 2022-01-07 16-48-47](https://user-images.githubusercontent.com/7239572/148569415-3a680ac1-4fee-4ce3-969d-569f49fc8884.png)

With this fix i fixed the status label used to know what to display to the user. 
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
