### PR TITLE
CXP-1046: Add form Create a test app

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -75,6 +75,23 @@ akeneo_connectivity.connection:
                     title: App information
                     description: If you need help, please check our article
                     link: How to test my App before publishing it?
+                    fields:
+                        name: Name
+                        activate_url: Activate url
+                        callback_url: Callback url
+                    constraint:
+                        name:
+                            required: A test app name is required.
+                            invalid: A test app name may contain only letters, numbers and underscores.
+                            too_long: A test app name is too long. It should have 250 characters or less.
+                        activate_url:
+                            required: An "Activate URL" is required.
+                            invalid: An "Activate URL" must be a valid URL.
+                            too_long: An "Activate URL" is too long. It should have 250 characters or less.
+                        callback_url:
+                            required: A "Callback URL" is required.
+                            invalid: A "Callback URL" must be a valid URL.
+                            too_long: A "Callback URL" is too long. It should have 250 characters or less.
         connected_apps:
             list:
                 apps:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -68,30 +68,27 @@ akeneo_connectivity.connection:
                 empty: No apps compatible with your version
             unreachable: We can't reach the marketplace, please come back later.
             scroll_to_top: Scroll to the top
-            test_app:
+            test_apps:
                 create_a_test_app: Create a test app
                 modal:
                     subtitle: Create a test app
-                    title: App information
-                    description: If you need help, please check our article
-                    link: How to test my App before publishing it?
-                    fields:
-                        name: Name
-                        activate_url: Activate url
-                        callback_url: Callback url
-                    constraint:
-                        name:
-                            required: A test app name is required.
-                            invalid: A test app name may contain only letters, numbers and underscores.
-                            too_long: A test app name is too long. It should have 250 characters or less.
-                        activate_url:
-                            required: An "Activate URL" is required.
-                            invalid: An "Activate URL" must be a valid URL.
-                            too_long: An "Activate URL" is too long. It should have 250 characters or less.
-                        callback_url:
-                            required: A "Callback URL" is required.
-                            invalid: A "Callback URL" must be a valid URL.
-                            too_long: A "Callback URL" is too long. It should have 250 characters or less.
+                    app_information:
+                        title: App information
+                        description: If you need help, please check our article
+                        link: How to test my App before publishing it?
+                        fields:
+                            name: Name
+                            activate_url: Activate url
+                            callback_url: Callback url
+                        constraint:
+                            name:
+                                required: A test app name is required.
+                            activate_url:
+                                required: An "Activate URL" is required.
+                            callback_url:
+                                required: A "Callback URL" is required.
+                    credentials :
+                        title: Credentials
         connected_apps:
             list:
                 apps:

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppCredentials.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppCredentials.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {useTranslate} from '../../../shared/translate';
+import styled from '../../../common/styled-with-theme';
+import {getColor} from 'akeneo-design-system';
+
+const Title = styled.h2`
+    color: ${getColor('grey', 140)};
+    font-size: 28px;
+    font-weight: normal;
+    line-height: 28px;
+    margin: 0;
+`;
+
+export const CreateTestAppCredentials = () => {
+    const translate = useTranslate();
+
+    return (
+        <>
+            <Title>
+                {translate('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.credentials.title')}
+            </Title>
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppForm.tsx
@@ -1,37 +1,179 @@
-import React from 'react';
-import {TextInput} from 'akeneo-design-system';
-import {useFormik} from 'formik';
+import React, {FC, useState} from 'react';
+import {Button, Field, getColor, getFontSize, Helper, Modal, TextInput} from 'akeneo-design-system';
+import {useTranslate} from '../../../shared/translate';
+import styled from '../../../common/styled-with-theme';
+import {TestAppCredentials} from '../../../model/Apps/test-app-credentials';
 
-import {Translate, useTranslate} from '../../../shared/translate';
+const Title = styled.h2`
+    color: ${getColor('grey', 140)};
+    font-size: 28px;
+    font-weight: normal;
+    line-height: 28px;
+    margin: 0;
+`;
 
-export const CreateTestAppForm = () => {
+const FormHelper = styled.div`
+    color: ${getColor('grey', 120)};
+    font-size: ${getFontSize('default')};
+    font-weight: normal;
+    line-height: 18px;
+    margin: 17px 0 17px 0;
+`;
+
+const Link = styled.a`
+    color: ${getColor('brand', 100)};
+    text-decoration: underline;
+`;
+
+const Form = styled.form`
+    > * {
+        margin: 20px 10px 0px 0px;
+    }
+`;
+
+type Props = {
+    onCancel: () => void;
+    setCredentials: (credentials: TestAppCredentials) => void;
+};
+
+type TestApp = {
+    name: string;
+    activateUrl: string;
+    callbackUrl: string;
+};
+
+type FormErrors = {
+    name: string | null;
+    activateUrl: string | null;
+    callbackUrl: string | null;
+};
+
+export const CreateTestAppForm: FC<Props> = ({onCancel, setCredentials}) => {
     const translate = useTranslate();
+    const [testApp, setTestApp] = useState<TestApp>({name: '', activateUrl: '', callbackUrl: ''});
+    const [errors, setErrors] = useState<FormErrors>({name: null, activateUrl: null, callbackUrl: null});
 
-    const formik = useFormik({
-        initialValues: {
-            name: '',
-            activate_url: '',
-            callback_url: '',
-        },
-        onSubmit: (values) => {
-            console.log(values);
+    const onNameChange = (newName: string) => {
+        setTestApp(testApp => ({
+            ...testApp,
+            name: newName,
+        }));
+    };
+
+    const onActivateUrlChange = (newActivateUrl: string) => {
+        setTestApp(testApp => ({
+            ...testApp,
+            activateUrl: newActivateUrl,
+        }));
+    };
+
+    const onCallbackUrlChange = (newCallbackUrl: string) => {
+        setTestApp(testApp => ({
+            ...testApp,
+            callbackUrl: newCallbackUrl,
+        }));
+    };
+
+    const handleCreate = () => {
+        const currentErrors: FormErrors = {
+            name:
+                '' === testApp.name
+                    ? translate(
+                          'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.name.required'
+                      )
+                    : null,
+            activateUrl:
+                '' === testApp.activateUrl
+                    ? translate(
+                          'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.activate_url.required'
+                      )
+                    : null,
+            callbackUrl:
+                '' === testApp.callbackUrl
+                    ? translate(
+                          'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.callback_url.required'
+                      )
+                    : null,
+        };
+
+        setErrors(currentErrors);
+
+        if (null !== currentErrors.name || null !== currentErrors.activateUrl || null !== currentErrors.callbackUrl) {
+            return;
         }
-    });
+
+        // TODO: call api endpoint to fetch credentials
+        setCredentials({
+            clientId: 'clientId',
+            clientSecret: 'clientSecret',
+        });
+    };
 
     return (
-        <form onSubmit={formik.handleSubmit}>
-            <label htmlFor="name">
-                <Translate id='akeneo_connectivity.connection.connect.marketplace.test_app.modal.fields.name' />
-                &nbsp;
-                <Translate id='pim_common.required_label' />
-            </label>
-            <TextInput
-                id='name'
-                name='name'
-                type='text'
-                value={formik.values.name}
-                onChange={formik.handleChange}
-            />
-        </form>
+        <>
+            <Title>
+                {translate('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.title')}
+            </Title>
+            <FormHelper>
+                <p>
+                    {translate(
+                        'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.description'
+                    )}
+                    <span className='cline-any cline-neutral'>&nbsp;</span>
+                    <Link href={'https://help.akeneo.com/pim/articles/manage-your-apps.html#create-a-test-app'}>
+                        {translate(
+                            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.link'
+                        )}
+                    </Link>
+                </p>
+            </FormHelper>
+
+            <Form>
+                <Field
+                    requiredLabel={translate('pim_common.required_label')}
+                    label={translate(
+                        'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.name'
+                    )}
+                >
+                    <TextInput invalid={null !== errors.name} onChange={onNameChange} data-testid={'name-input'} />
+                    {errors.name ? <Helper level='error'>{errors.name}</Helper> : null}
+                </Field>
+                <Field
+                    requiredLabel={translate('pim_common.required_label')}
+                    label={translate(
+                        'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.activate_url'
+                    )}
+                >
+                    <TextInput
+                        invalid={null !== errors.activateUrl}
+                        onChange={onActivateUrlChange}
+                        data-testid={'activate-url-input'}
+                    />
+                    {errors.activateUrl ? <Helper level='error'>{errors.activateUrl}</Helper> : null}
+                </Field>
+                <Field
+                    requiredLabel={translate('pim_common.required_label')}
+                    label={translate(
+                        'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.callback_url'
+                    )}
+                >
+                    <TextInput
+                        invalid={null !== errors.callbackUrl}
+                        onChange={onCallbackUrlChange}
+                        data-testid={'callback-url-input'}
+                    />
+                    {errors.callbackUrl ? <Helper level='error'>{errors.callbackUrl}</Helper> : null}
+                </Field>
+            </Form>
+
+            <Modal.BottomButtons>
+                <Button onClick={onCancel} level='tertiary'>
+                    {translate('pim_common.cancel')}
+                </Button>
+                <Button onClick={handleCreate} level='primary'>
+                    {translate('pim_common.create')}
+                </Button>
+            </Modal.BottomButtons>
+        </>
     );
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/CreateTestAppForm.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {TextInput} from 'akeneo-design-system';
+import {useFormik} from 'formik';
+
+import {Translate, useTranslate} from '../../../shared/translate';
+
+export const CreateTestAppForm = () => {
+    const translate = useTranslate();
+
+    const formik = useFormik({
+        initialValues: {
+            name: '',
+            activate_url: '',
+            callback_url: '',
+        },
+        onSubmit: (values) => {
+            console.log(values);
+        }
+    });
+
+    return (
+        <form onSubmit={formik.handleSubmit}>
+            <label htmlFor="name">
+                <Translate id='akeneo_connectivity.connection.connect.marketplace.test_app.modal.fields.name' />
+                &nbsp;
+                <Translate id='pim_common.required_label' />
+            </label>
+            <TextInput
+                id='name'
+                name='name'
+                type='text'
+                value={formik.values.name}
+                onChange={formik.handleChange}
+            />
+        </form>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
@@ -77,7 +77,7 @@ export const MarketplacePage: FC = () => {
     const CreateTestAppButton = () => {
         return !featureFlag.isEnabled('app_developer_mode') ? null : (
             <ApplyButton classNames={['AknButtonList-item']} onClick={handleCreateTestApp}>
-                <Translate id='akeneo_connectivity.connection.connect.marketplace.test_app.create_a_test_app' />
+                <Translate id='akeneo_connectivity.connection.connect.marketplace.test_apps.create_a_test_app' />
             </ApplyButton>
         );
     };

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/TestAppCreatePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/TestAppCreatePage.tsx
@@ -4,6 +4,7 @@ import {Modal, AppIllustration, Button, getColor, getFontSize} from 'akeneo-desi
 import styled from '../../common/styled-with-theme';
 import {useTranslate} from '../../shared/translate';
 import {useRouter} from '../../shared/router/use-router';
+import {CreateTestAppForm} from '../components/TestApp/CreateTestAppForm';
 
 const Subtitle = styled.h3`
     color: ${getColor('brand', 100)};
@@ -61,6 +62,7 @@ export const TestAppCreatePage = () => {
                     </Link>
                 </p>
             </Helper>
+            <CreateTestAppForm/>
             <Modal.BottomButtons>
                 <Button onClick={handleCancel} level='tertiary'>
                     {translate('pim_common.cancel')}

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/TestAppCreatePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/TestAppCreatePage.tsx
@@ -1,10 +1,12 @@
-import React, {useCallback} from 'react';
+import React, {useCallback, useState} from 'react';
 import {useHistory} from 'react-router';
-import {Modal, AppIllustration, Button, getColor, getFontSize} from 'akeneo-design-system';
+import {Modal, AppIllustration, getColor, getFontSize} from 'akeneo-design-system';
 import styled from '../../common/styled-with-theme';
 import {useTranslate} from '../../shared/translate';
 import {useRouter} from '../../shared/router/use-router';
 import {CreateTestAppForm} from '../components/TestApp/CreateTestAppForm';
+import {TestAppCredentials} from '../../model/Apps/test-app-credentials';
+import {CreateTestAppCredentials} from '../components/TestApp/CreateTestAppCredentials';
 
 const Subtitle = styled.h3`
     color: ${getColor('brand', 100)};
@@ -14,63 +16,27 @@ const Subtitle = styled.h3`
     margin: 0 0 6px 0;
 `;
 
-const Title = styled.h2`
-    color: ${getColor('grey', 140)};
-    font-size: 28px;
-    font-weight: normal;
-    line-height: 28px;
-    margin: 0;
-`;
-
-const Helper = styled.div`
-    color: ${getColor('grey', 120)};
-    font-size: ${getFontSize('default')};
-    font-weight: normal;
-    line-height: 18px;
-    margin: 17px 0 17px 0;
-`;
-
-const Link = styled.a`
-    color: ${getColor('brand', 100)};
-    text-decoration: underline;
-`;
-
 export const TestAppCreatePage = () => {
     const history = useHistory();
     const generateUrl = useRouter();
     const translate = useTranslate();
+    const [credentials, setCredentials] = useState<TestAppCredentials | null>(null);
 
-    // TODO : handle the click
-    const handleCreate = () => null;
-
-    const handleCancel = useCallback(() => {
+    const handleCloseModal = useCallback(() => {
         history.push(generateUrl('akeneo_connectivity_connection_connect_marketplace'));
     }, [history, generateUrl]);
 
     return (
-        <Modal onClose={handleCancel} illustration={<AppIllustration />} closeTitle={translate('pim_common.cancel')}>
+        <Modal
+            onClose={handleCloseModal}
+            illustration={<AppIllustration />}
+            closeTitle={translate('pim_common.cancel')}
+        >
             <Subtitle>
-                {translate('akeneo_connectivity.connection.connect.marketplace.test_app.modal.subtitle')}
+                {translate('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.subtitle')}
             </Subtitle>
-            <Title>{translate('akeneo_connectivity.connection.connect.marketplace.test_app.modal.title')}</Title>
-            <Helper>
-                <p>
-                    {translate('akeneo_connectivity.connection.connect.marketplace.test_app.modal.description')}
-                    <span className='cline-any cline-neutral'>&nbsp;</span>
-                    <Link href={'https://help.akeneo.com/pim/articles/manage-your-apps.html#create-a-test-app'}>
-                        {translate('akeneo_connectivity.connection.connect.marketplace.test_app.modal.link')}
-                    </Link>
-                </p>
-            </Helper>
-            <CreateTestAppForm/>
-            <Modal.BottomButtons>
-                <Button onClick={handleCancel} level='tertiary'>
-                    {translate('pim_common.cancel')}
-                </Button>
-                <Button onClick={handleCreate} level='primary'>
-                    {translate('pim_common.create')}
-                </Button>
-            </Modal.BottomButtons>
+            {null === credentials && <CreateTestAppForm onCancel={handleCloseModal} setCredentials={setCredentials} />}
+            {null !== credentials && <CreateTestAppCredentials />}
         </Modal>
     );
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/test-app-credentials.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/test-app-credentials.ts
@@ -1,0 +1,4 @@
+export type TestAppCredentials = {
+    clientId: string;
+    clientSecret: string;
+};

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/TestApp/CreateTestAppCredentials.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/TestApp/CreateTestAppCredentials.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {screen} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import {renderWithProviders, historyMock} from '../../../../test-utils';
+import {CreateTestAppCredentials} from '@src/connect/components/TestApp/CreateTestAppCredentials';
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
+
+test('it displays the credentials', () => {
+    renderWithProviders(<CreateTestAppCredentials />);
+
+    expect(
+        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.credentials.title')
+    ).toBeInTheDocument();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/TestApp/CreateTestAppForm.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/TestApp/CreateTestAppForm.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import '@testing-library/jest-dom/extend-expect';
+import {screen} from '@testing-library/react';
+import fetchMock from 'jest-fetch-mock';
+import {renderWithProviders, historyMock} from '../../../../test-utils';
+import {CreateTestAppForm} from '@src/connect/components/TestApp/CreateTestAppForm';
+import userEvent from '@testing-library/user-event';
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
+
+test('it displays the form', () => {
+    const onCancel = jest.fn();
+    const setCredentials = jest.fn();
+
+    renderWithProviders(<CreateTestAppForm onCancel={onCancel} setCredentials={setCredentials} />);
+
+    expect(
+        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.title')
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.description'
+        )
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.link')
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.name'
+        )
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.activate_url'
+        )
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.fields.callback_url'
+        )
+    ).toBeInTheDocument();
+    expect(screen.getByText('pim_common.cancel')).toBeInTheDocument();
+    expect(screen.getByText('pim_common.create')).toBeInTheDocument();
+
+    expect(
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.name.required'
+        )
+    ).not.toBeInTheDocument();
+    expect(
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.activate_url.required'
+        )
+    ).not.toBeInTheDocument();
+    expect(
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.callback_url.required'
+        )
+    ).not.toBeInTheDocument();
+});
+
+test('it displays errors when required fields are not fulfilled', () => {
+    const onCancel = jest.fn();
+    const setCredentials = jest.fn();
+
+    renderWithProviders(<CreateTestAppForm onCancel={onCancel} setCredentials={setCredentials} />);
+
+    userEvent.click(screen.getByText('pim_common.create'));
+
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.name.required'
+        )
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.activate_url.required'
+        )
+    ).toBeInTheDocument();
+    expect(
+        screen.getByText(
+            'akeneo_connectivity.connection.connect.marketplace.test_apps.modal.app_information.constraint.callback_url.required'
+        )
+    ).toBeInTheDocument();
+});
+
+test('it calls the onCancel props when the cancel button is clicked', () => {
+    const onCancel = jest.fn();
+    const setCredentials = jest.fn();
+
+    renderWithProviders(<CreateTestAppForm onCancel={onCancel} setCredentials={setCredentials} />);
+
+    userEvent.click(screen.getByText('pim_common.cancel'));
+
+    expect(onCancel).toHaveBeenCalled();
+});
+
+test('it sets credentials when the form is successfully submitted', () => {
+    const onCancel = jest.fn();
+    const setCredentials = jest.fn();
+
+    renderWithProviders(<CreateTestAppForm onCancel={onCancel} setCredentials={setCredentials} />);
+
+    userEvent.type(screen.getByTestId('name-input'), 'My TestApp name');
+    userEvent.type(screen.getByTestId('activate-url-input'), 'https://example.com/activate-url');
+    userEvent.type(screen.getByTestId('callback-url-input'), 'https://example.com/callback-url');
+    userEvent.click(screen.getByText('pim_common.create'));
+
+    expect(setCredentials).toHaveBeenCalledWith({
+        clientId: 'clientId',
+        clientSecret: 'clientSecret',
+    });
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/MarketplacePage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/MarketplacePage.test.tsx
@@ -32,7 +32,7 @@ test('The marketplace page display the developer mode when enabled', async () =>
     await waitFor(() => expect(Marketplace).toHaveBeenCalled());
     expect(screen.queryByText('akeneo_connectivity.connection.developer_mode')).toBeInTheDocument();
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.marketplace.test_app.create_a_test_app')
+        screen.queryByText('akeneo_connectivity.connection.connect.marketplace.test_apps.create_a_test_app')
     ).toBeInTheDocument();
 });
 
@@ -46,7 +46,7 @@ test('The marketplace page do not display the developer mode when not enabled', 
     await waitFor(() => expect(Marketplace).toHaveBeenCalled());
     expect(screen.queryByText('akeneo_connectivity.connection.developer_mode')).not.toBeInTheDocument();
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.marketplace.test_app.create_a_test_app')
+        screen.queryByText('akeneo_connectivity.connection.connect.marketplace.test_apps.create_a_test_app')
     ).not.toBeInTheDocument();
 });
 
@@ -58,7 +58,7 @@ test('It redirect when the "create a test app" button is clicked', async () => {
     renderWithProviders(<MarketplacePage />);
 
     await waitFor(() => expect(Marketplace).toHaveBeenCalled());
-    userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_app.create_a_test_app'));
+    userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_apps.create_a_test_app'));
 
     expect(historyMock.history.location.pathname).toBe(
         '/akeneo_connectivity_connection_connect_marketplace_test_app_create'

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/TestAppCreatePage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/TestAppCreatePage.test.tsx
@@ -4,6 +4,9 @@ import {screen} from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../test-utils';
 import {TestAppCreatePage} from '@src/connect/pages/TestAppCreatePage';
+import {CreateTestAppForm} from '@src/connect/components/TestApp/CreateTestAppForm';
+import {CreateTestAppCredentials} from '@src/connect/components/TestApp/CreateTestAppCredentials';
+import {TestAppCredentials} from '@src/model/Apps/test-app-credentials';
 import userEvent from '@testing-library/user-event';
 
 beforeEach(() => {
@@ -12,17 +15,49 @@ beforeEach(() => {
     jest.clearAllMocks();
 });
 
-test('The "test app create page" renders and I can cancel', () => {
+type CreateTestAppFormProps = {
+    onCancel: () => void;
+    setCredentials: (credentials: TestAppCredentials) => void;
+};
+jest.mock('@src/connect/components/TestApp/CreateTestAppForm', () => ({
+    ...jest.requireActual('@src/connect/components/TestApp/CreateTestAppForm'),
+    CreateTestAppForm: jest.fn(({onCancel, setCredentials}: CreateTestAppFormProps) => {
+        const handleClick = () => {
+            setCredentials({
+                clientId: 'clientId',
+                clientSecret: 'clientSecret',
+            });
+        };
+
+        return (
+            <div data-testid='submit-form' onClick={handleClick}>
+                create TestApp form
+            </div>
+        );
+    }),
+}));
+
+jest.mock('@src/connect/components/TestApp/CreateTestAppCredentials', () => ({
+    ...jest.requireActual('@src/connect/components/TestApp/CreateTestAppCredentials'),
+    CreateTestAppCredentials: jest.fn(() => null),
+}));
+
+test('it renders the form without credentials and display them when form is submitted', () => {
     renderWithProviders(<TestAppCreatePage />);
 
     expect(
-        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_app.modal.title')
-    ).toBeInTheDocument();
-    expect(
-        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_app.modal.subtitle')
+        screen.getByText('akeneo_connectivity.connection.connect.marketplace.test_apps.modal.subtitle')
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText('pim_common.cancel'));
+    expect(CreateTestAppForm).toHaveBeenCalled();
+    expect(CreateTestAppCredentials).not.toHaveBeenCalled();
 
-    expect(historyMock.history.location.pathname).toBe('/akeneo_connectivity_connection_connect_marketplace');
+    userEvent.click(screen.getByTestId('submit-form'));
+
+    expect(CreateTestAppCredentials).toHaveBeenCalledWith(
+        {
+            // TODO : called with credentials
+        },
+        {}
+    );
 });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Display the form
- Display errors on required fields
- Redirect to credentials screen when the form is submitted
- Close modal when the "cancel" button is clicked

![image](https://user-images.githubusercontent.com/4290650/148581307-4acbcd8d-6252-4d63-9a78-5c1ed82b73c0.png)

![image](https://user-images.githubusercontent.com/4290650/148581257-a9e7b000-c2ac-4fe2-828a-3b40f97bc700.png)


This will be done in the [CXP-1049: [Front] Display generated credentials](https://akeneo.atlassian.net/browse/CXP-1049) : 
- Call "create test app" API endpoint
- Display API errors

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
