### PR TITLE
CPM-467: Fix MeasureConverter for small numbers

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -116,6 +116,8 @@ class MeasureConverter
             return '0';
         }
 
+        $processedValue = \number_format($value, static::SCALE, '.', '');
+
         switch ($operator) {
             case "div":
                 if ($operand !== '0') {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -116,7 +116,11 @@ class MeasureConverter
             return '0';
         }
 
-        $processedValue = \number_format($value, static::SCALE, '.', '');
+        $scientificPosition = strpos($value, 'E');
+        $num_decimals = $scientificPosition === false ?
+            strlen(substr(strrchr($value, "."), 1)):
+            substr($value, $scientificPosition + 2, strlen($value));
+        $processedValue = \number_format($value, $num_decimals, '.', '');
 
         switch ($operator) {
             case "div":

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -110,17 +110,15 @@ class MeasureConverter
      */
     protected function applyOperation($value, $operator, $operand)
     {
-        $processedValue = (string) $value;
+        if (is_float($value)) {
+            $processedValue = \number_format($value, static::SCALE, '.', '');
+        } else {
+            $processedValue = (string) $value;
+        }
 
         if (!is_numeric($processedValue)) {
             return '0';
         }
-
-        $scientificPosition = strpos($value, 'E');
-        $num_decimals = $scientificPosition === false ?
-            strlen(substr(strrchr($value, "."), 1)):
-            substr($value, $scientificPosition + 2, strlen($value));
-        $processedValue = \number_format($value, $num_decimals, '.', '');
 
         switch ($operator) {
             case "div":

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
@@ -78,6 +78,15 @@ YAML;
         )->shouldReturn('1.000000000000');
     }
 
+    public function it_converts_a_very_small_value_to_a_standard_unit()
+    {
+        $this->setFamily('Weight');
+        $this->convertBaseToStandard(
+            'KILOGRAM',
+            1.0E-7
+        )->shouldReturn('0.000100000000');
+    }
+
     public function it_converts_a_standard_value_to_a_final_unit()
     {
         $this->setFamily('Weight');


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When converting a small number, it's cast to '1.0E-7' (scientific notation) which was not compatible with bc math functions.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
