### PR TITLE
CXP 1042 Display test apps in the Apps submenu

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -10,45 +10,23 @@ namespace Akeneo\Connectivity\Connection\Domain\Apps\Model;
  */
 final class ConnectedApp
 {
-    private string $id;
-    private string $name;
-    private string $connectionCode;
-    private ?string $logo;
-    private ?string $author;
-    /** @var string[] $scopes */
-    private array $scopes;
-    private string $userGroupName;
-    /** @var string[] $categories */
-    private array $categories;
-    private bool $certified;
-    private ?string $partner;
-
     /**
      * @param string[] $scopes
      * @param string[] $categories
      */
     public function __construct(
-        string $id,
-        string $name,
-        array $scopes,
-        string $connectionCode,
-        ?string $logo,
-        ?string $author,
-        string $userGroupName,
-        array $categories = [],
-        bool $certified = false,
-        ?string $partner = null
+        private string $id,
+        private string $name,
+        private array $scopes,
+        private string $connectionCode,
+        private ?string $logo,
+        private ?string $author,
+        private string $userGroupName,
+        private array $categories = [],
+        private bool $certified = false,
+        private ?string $partner = null,
+        private bool $test = false,
     ) {
-        $this->id = $id;
-        $this->name = $name;
-        $this->scopes = $scopes;
-        $this->connectionCode = $connectionCode;
-        $this->logo = $logo;
-        $this->author = $author;
-        $this->userGroupName = $userGroupName;
-        $this->categories = $categories;
-        $this->certified = $certified;
-        $this->partner = $partner;
     }
 
     public function getId(): string
@@ -134,6 +112,7 @@ final class ConnectedApp
             'categories' => $this->categories,
             'certified' => $this->certified,
             'partner' => $this->partner,
+            'test' => $this->test,
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -25,7 +25,7 @@ final class ConnectedApp
         private array $categories = [],
         private bool $certified = false,
         private ?string $partner = null,
-        private bool $test = false,
+        private bool $isTestApp = false,
     ) {
     }
 
@@ -112,7 +112,7 @@ final class ConnectedApp
             'categories' => $this->categories,
             'certified' => $this->certified,
             'partner' => $this->partner,
-            'test' => $this->test,
+            'is_test_app' => $this->isTestApp,
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
@@ -37,7 +37,7 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
                certified,
                partner,
                IF(akeneo_connectivity_test_app.client_id IS NULL, FALSE, TRUE) AS is_test_app
-        FROM akeneo_connectivity_connected_app as connected_app
+        FROM akeneo_connectivity_connected_app AS connected_app
         LEFT JOIN akeneo_connectivity_test_app ON akeneo_connectivity_test_app.client_id = connected_app.id
         ORDER BY name ASC
         SQL;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
@@ -27,7 +27,7 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
         $selectSQL = <<<SQL
         SELECT
                id,
-               akeneo_connectivity_connected_app.name,
+               connected_app.name,
                scopes,
                connection_code,
                logo,
@@ -36,9 +36,9 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
                categories,
                certified,
                partner,
-               IF(akeneo_connectivity_test_app.client_id IS NULL , FALSE, TRUE) AS test
-        FROM akeneo_connectivity_connected_app
-        LEFT JOIN akeneo_connectivity_test_app ON akeneo_connectivity_test_app.client_id = akeneo_connectivity_connected_app.id
+               IF(akeneo_connectivity_test_app.client_id IS NULL, FALSE, TRUE) AS is_test_app
+        FROM akeneo_connectivity_connected_app as connected_app
+        LEFT JOIN akeneo_connectivity_test_app ON akeneo_connectivity_test_app.client_id = connected_app.id
         ORDER BY name ASC
         SQL;
 
@@ -134,7 +134,7 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
             \json_decode($dataRow['categories'], true),
             (bool) $dataRow['certified'],
             $dataRow['partner'],
-            (bool) ($dataRow['test'] ?? false),
+            (bool) ($dataRow['is_test_app'] ?? false),
         );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/DbalConnectedAppRepository.php
@@ -25,8 +25,20 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
     public function findAll(): array
     {
         $selectSQL = <<<SQL
-        SELECT id, name, scopes, connection_code, logo, author, user_group_name, categories, certified, partner
+        SELECT
+               id,
+               akeneo_connectivity_connected_app.name,
+               scopes,
+               connection_code,
+               logo,
+               author,
+               user_group_name,
+               categories,
+               certified,
+               partner,
+               IF(akeneo_connectivity_test_app.client_id IS NULL , FALSE, TRUE) AS test
         FROM akeneo_connectivity_connected_app
+        LEFT JOIN akeneo_connectivity_test_app ON akeneo_connectivity_test_app.client_id = akeneo_connectivity_connected_app.id
         ORDER BY name ASC
         SQL;
 
@@ -121,7 +133,8 @@ class DbalConnectedAppRepository implements ConnectedAppRepositoryInterface
             $dataRow['user_group_name'],
             \json_decode($dataRow['categories'], true),
             (bool) $dataRow['certified'],
-            $dataRow['partner']
+            $dataRow['partner'],
+            (bool) ($dataRow['test'] ?? false),
         );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -66,12 +66,11 @@ akeneo_connectivity.connection:
                 title: Apps
                 total: '{0} No apps|{1} 1 app|[2,Inf] {{ total }} apps'
                 empty: No apps compatible with your version
-            test_apps:
-                title: My test apps
-                removed_user: Removed user
             unreachable: We can't reach the marketplace, please come back later.
             scroll_to_top: Scroll to the top
             test_apps:
+                title: My test apps
+                removed_user: Removed user
                 create_a_test_app: Create a test app
                 modal:
                     subtitle: Create a test app
@@ -100,13 +99,16 @@ akeneo_connectivity.connection:
                     empty: No apps connected yet.
                     check_marketplace: 'Check the {{ marketplaceLink }} to browse all the available content and install your first app.'
                     marketplace_link_anchor: Marketplace
+                test_apps:
+                    title: My test apps
+                    removed_user: Removed user
                 helper:
                     title: '[0,1] Your PIM is connected with {{ count }} app.|[2,Inf] Your PIM is connected with {{ count }} apps.'
                     description_1: New apps are developed regularly, so stay tuned and check our Marketplace page frequently to discover how to connect your PIM.
                     description_2: Eager to know more about Apps ?
                     link: Check out our Help Center for more information.
                 card:
-                    developed_by: Developed by
+                    developed_by: 'Developed by {{ author }}'
                     manage_app: Manage app
                     open_app: Open App
                 flash:

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
@@ -114,6 +114,7 @@ class GetAllConnectedAppsActionEndToEnd extends WebTestCase
                 'categories' => ['category A1', 'category A2'],
                 'certified' => false,
                 'partner' => 'partner A',
+                'test' => false,
             ],
             [
                 'id' => '2677e764-f852-4956-bf9b-1a1ec1b0d145',
@@ -126,6 +127,7 @@ class GetAllConnectedAppsActionEndToEnd extends WebTestCase
                 'categories' => ['category B1'],
                 'certified' => true,
                 'partner' => null,
+                'test' => false,
             ],
         ];
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetAllConnectedAppsActionEndToEnd.php
@@ -114,7 +114,7 @@ class GetAllConnectedAppsActionEndToEnd extends WebTestCase
                 'categories' => ['category A1', 'category A2'],
                 'certified' => false,
                 'partner' => 'partner A',
-                'test' => false,
+                'is_test_app' => false,
             ],
             [
                 'id' => '2677e764-f852-4956-bf9b-1a1ec1b0d145',
@@ -127,7 +127,7 @@ class GetAllConnectedAppsActionEndToEnd extends WebTestCase
                 'categories' => ['category B1'],
                 'certified' => true,
                 'partner' => null,
-                'test' => false,
+                'is_test_app' => false,
             ],
         ];
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
@@ -153,6 +153,7 @@ class GetConnectedAppActionEndToEnd extends WebTestCase
             'categories' => ['category A1', 'category A2'],
             'certified' => false,
             'partner' => 'partner A',
+            'test' => false,
         ];
 
         $this->client->request(

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/InternalApi/GetConnectedAppActionEndToEnd.php
@@ -153,7 +153,7 @@ class GetConnectedAppActionEndToEnd extends WebTestCase
             'categories' => ['category A1', 'category A2'],
             'certified' => false,
             'partner' => 'partner A',
-            'test' => false,
+            'is_test_app' => false,
         ];
 
         $this->client->request(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
@@ -98,7 +98,7 @@ class ConnectedAppSpec extends ObjectBehavior
             'categories' => ['E-commerce', 'print'],
             'certified' => true,
             'partner' => 'Akeneo partner',
-            'test' => true,
+            'is_test_app' => true,
         ]);
     }
 
@@ -128,7 +128,7 @@ class ConnectedAppSpec extends ObjectBehavior
             'categories' => ['E-commerce', 'print'],
             'certified' => true,
             'partner' => 'Akeneo partner',
-            'test' => false,
+            'is_test_app' => false,
         ]);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
@@ -13,7 +13,7 @@ use PhpSpec\ObjectBehavior;
  */
 class ConnectedAppSpec extends ObjectBehavior
 {
-    public function let()
+    public function let(): void
     {
         $this->beConstructedWith(
             '4028c158-d620-4903-9859-958b66a059e2',
@@ -25,7 +25,8 @@ class ConnectedAppSpec extends ObjectBehavior
             'app_123456abcdef',
             ['E-commerce', 'print'],
             true,
-            'Akeneo partner'
+            'Akeneo partner',
+            true,
         );
     }
 
@@ -84,7 +85,7 @@ class ConnectedAppSpec extends ObjectBehavior
         $this->getPartner()->shouldBe('Akeneo partner');
     }
 
-    public function it_is_normalizable()
+    public function it_is_normalizable(): void
     {
         $this->normalize()->shouldBe([
             'id' => '4028c158-d620-4903-9859-958b66a059e2',
@@ -97,6 +98,37 @@ class ConnectedAppSpec extends ObjectBehavior
             'categories' => ['E-commerce', 'print'],
             'certified' => true,
             'partner' => 'Akeneo partner',
+            'test' => true,
+        ]);
+    }
+
+    public function it_is_not_a_test_app_by_default(): void
+    {
+        $this->beConstructedWith(
+            '4028c158-d620-4903-9859-958b66a059e2',
+            'Example App',
+            ['Scope1', 'Scope2'],
+            'someConnectionCode',
+            'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/shopify-connector-logo-1200x.png?itok=mASOVlwC',
+            'Akeneo',
+            'app_123456abcdef',
+            ['E-commerce', 'print'],
+            true,
+            'Akeneo partner',
+        );
+
+        $this->normalize()->shouldBe([
+            'id' => '4028c158-d620-4903-9859-958b66a059e2',
+            'name' => 'Example App',
+            'scopes' => ['Scope1', 'Scope2'],
+            'connection_code' => 'someConnectionCode',
+            'logo' => 'https:\/\/marketplace.akeneo.com\/sites\/default\/files\/styles\/extension_logo_large\/public\/extension-logos\/shopify-connector-logo-1200x.png?itok=mASOVlwC',
+            'author' => 'Akeneo',
+            'user_group_name' => 'app_123456abcdef',
+            'categories' => ['E-commerce', 'print'],
+            'certified' => true,
+            'partner' => 'Akeneo partner',
+            'test' => false,
         ]);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -178,7 +178,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                 ]}
                 userButtons={<UserButtons />}
                 state={<FormState />}
-                imageSrc={connectedApp.logo}
+                imageSrc={connectedApp.logo ?? undefined}
             >
                 {connectedApp.name}
             </PageHeader>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -1,6 +1,6 @@
 import React, {FC} from 'react';
 import styled from 'styled-components';
-import {getColor, getFontSize, Button} from 'akeneo-design-system';
+import {getColor, getFontSize, Button, AppIllustration} from 'akeneo-design-system';
 import {useTranslate} from '../../../shared/translate';
 import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
@@ -107,18 +107,19 @@ const ConnectedAppCard: FC<Props> = ({item}) => {
     const connectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_edit', {
         connectionCode: item.connection_code,
     })}`;
+    const author =
+        item.author ?? translate('akeneo_connectivity.connection.connect.connected_apps.list.test_apps.removed_user');
+    const logo = item.logo ? <Logo src={item.logo} alt={item.name} /> : <AppIllustration width={100} height={100} />;
 
     return (
         <CardContainer>
-            <LogoContainer>
-                <Logo src={item.logo} alt={item.name} />
-            </LogoContainer>
+            <LogoContainer> {logo} </LogoContainer>
             <TextInformation>
                 <Name>{item.name}</Name>
                 <Author>
-                    {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by')}
-                    &nbsp;
-                    {item.author}
+                    {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by', {
+                        author,
+                    })}
                 </Author>
                 {item.categories.length > 0 && <Tag>{item.categories[0]}</Tag>}
             </TextInformation>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
@@ -10,6 +10,7 @@ import ConnectedAppsContainerHelper from './ConnectedAppsContainerHelper';
 import {ConnectedAppCard} from './ConnectedAppCard';
 import {NoConnectedApps} from './NoConnectedApps';
 import {CardGrid} from '../Section';
+import {ConnectedTestAppList} from './ConnectedTestAppList';
 
 const ScrollToTop = styled(IconButton)`
     position: fixed;
@@ -37,6 +38,10 @@ export const ConnectedAppsContainer: FC<Props> = ({connectedApps}) => {
     const ref = useRef(null);
     const scrollContainer = findScrollParent(ref.current);
     const displayScrollButton = useDisplayScrollTopButton(ref);
+
+    const connectedTestApps = connectedApps.filter((connectedApp: ConnectedApp) => connectedApp.test);
+    connectedApps = connectedApps.filter((connectedApp: ConnectedApp) => !connectedApp.test);
+
     const connectedAppCards = connectedApps.map((connectedApp: ConnectedApp) => (
         <ConnectedAppCard key={connectedApp.id} item={connectedApp} />
     ));
@@ -47,7 +52,9 @@ export const ConnectedAppsContainer: FC<Props> = ({connectedApps}) => {
     return (
         <>
             <div ref={ref} />
-            <ConnectedAppsContainerHelper count={connectedApps.length} />
+            <ConnectedAppsContainerHelper count={connectedApps.length + connectedTestApps.length} />
+
+            <ConnectedTestAppList connectedTestApps={connectedTestApps} />
 
             {featureFlag.isEnabled('marketplace_activate') && (
                 <>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
@@ -29,18 +29,18 @@ const ScrollToTop = styled(IconButton)`
 `;
 
 type Props = {
-    connectedApps: ConnectedApp[];
+    allConnectedApps: ConnectedApp[];
 };
 
-export const ConnectedAppsContainer: FC<Props> = ({connectedApps}) => {
+export const ConnectedAppsContainer: FC<Props> = ({allConnectedApps}) => {
     const translate = useTranslate();
     const featureFlag = useFeatureFlags();
     const ref = useRef(null);
     const scrollContainer = findScrollParent(ref.current);
     const displayScrollButton = useDisplayScrollTopButton(ref);
 
-    const connectedTestApps = connectedApps.filter((connectedApp: ConnectedApp) => connectedApp.test);
-    connectedApps = connectedApps.filter((connectedApp: ConnectedApp) => !connectedApp.test);
+    const connectedTestApps = allConnectedApps.filter((connectedApp: ConnectedApp) => connectedApp.test);
+    const connectedApps = allConnectedApps.filter((connectedApp: ConnectedApp) => !connectedApp.test);
 
     const connectedAppCards = connectedApps.map((connectedApp: ConnectedApp) => (
         <ConnectedAppCard key={connectedApp.id} item={connectedApp} />
@@ -52,7 +52,7 @@ export const ConnectedAppsContainer: FC<Props> = ({connectedApps}) => {
     return (
         <>
             <div ref={ref} />
-            <ConnectedAppsContainerHelper count={connectedApps.length + connectedTestApps.length} />
+            <ConnectedAppsContainerHelper count={allConnectedApps.length} />
 
             <ConnectedTestAppList connectedTestApps={connectedTestApps} />
 

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppsContainer.tsx
@@ -39,8 +39,8 @@ export const ConnectedAppsContainer: FC<Props> = ({allConnectedApps}) => {
     const scrollContainer = findScrollParent(ref.current);
     const displayScrollButton = useDisplayScrollTopButton(ref);
 
-    const connectedTestApps = allConnectedApps.filter((connectedApp: ConnectedApp) => connectedApp.test);
-    const connectedApps = allConnectedApps.filter((connectedApp: ConnectedApp) => !connectedApp.test);
+    const connectedTestApps = allConnectedApps.filter((connectedApp: ConnectedApp) => connectedApp.is_test_app);
+    const connectedApps = allConnectedApps.filter((connectedApp: ConnectedApp) => !connectedApp.is_test_app);
 
     const connectedAppCards = connectedApps.map((connectedApp: ConnectedApp) => (
         <ConnectedAppCard key={connectedApp.id} item={connectedApp} />

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedTestAppList.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedTestAppList.tsx
@@ -1,0 +1,45 @@
+import React, {FC} from 'react';
+import {SectionTitle} from 'akeneo-design-system';
+import {ConnectedApp} from '../../../model/Apps/connected-app';
+import {ConnectedAppCard} from './ConnectedAppCard';
+import {useTranslate} from '../../../shared/translate';
+import {useFeatureFlags} from '../../../shared/feature-flags';
+import {CardGrid} from '../Section';
+
+type Props = {
+    connectedTestApps: ConnectedApp[];
+};
+
+export const ConnectedTestAppList: FC<Props> = ({connectedTestApps}) => {
+    const translate = useTranslate();
+    const featureFlag = useFeatureFlags();
+
+    if (!featureFlag.isEnabled('app_developer_mode') || connectedTestApps.length === 0) {
+        return null;
+    }
+
+    const connectedAppCards = connectedTestApps.map((connectedApp: ConnectedApp) => (
+        <ConnectedAppCard key={connectedApp.id} item={connectedApp} />
+    ));
+
+    return (
+        <>
+            <SectionTitle>
+                <SectionTitle.Title>
+                    {translate('akeneo_connectivity.connection.connect.connected_apps.list.test_apps.title')}
+                </SectionTitle.Title>
+                <SectionTitle.Spacer />
+                <SectionTitle.Information>
+                    {translate(
+                        'akeneo_connectivity.connection.connect.connected_apps.list.apps.total',
+                        {
+                            total: connectedTestApps.length.toString(),
+                        },
+                        connectedTestApps.length
+                    )}
+                </SectionTitle.Information>
+            </SectionTitle>
+            <CardGrid>{connectedAppCards}</CardGrid>
+        </>
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/ConnectedAppsListPage.tsx
@@ -35,7 +35,7 @@ export const ConnectedAppsListPage: FC = () => {
             <PageContent>
                 {null === connectedApps && <ConnectedAppsContainerIsLoading />}
                 {false !== connectedApps && null !== connectedApps && (
-                    <ConnectedAppsContainer connectedApps={connectedApps} />
+                    <ConnectedAppsContainer allConnectedApps={connectedApps} />
                 )}
             </PageContent>
         </>

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
@@ -3,11 +3,12 @@ export type ConnectedApp = {
     name: string;
     scopes: string[];
     connection_code: string;
-    logo: string;
-    author: string;
+    logo: string | null;
+    author: string | null;
     user_group_name: string;
     categories: string[];
     certified: boolean;
     partner: string | null;
     activate_url?: string;
+    test: boolean;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/connected-app.ts
@@ -10,5 +10,5 @@ export type ConnectedApp = {
     certified: boolean;
     partner: string | null;
     activate_url?: string;
-    test: boolean;
+    is_test_app: boolean;
 };

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppAuthorizations.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppAuthorizations.test.tsx
@@ -57,6 +57,7 @@ test('The connected app authorizations renders with scopes', async () => {
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
+        test: false,
     };
 
     renderWithProviders(<ConnectedAppAuthorizations connectedApp={connectedApp} />);
@@ -100,6 +101,7 @@ test('The connected app authorizations renders without scopes', async () => {
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
+        test: false,
     };
 
     renderWithProviders(<ConnectedAppAuthorizations connectedApp={connectedApp} />);

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppAuthorizations.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppAuthorizations.test.tsx
@@ -57,7 +57,7 @@ test('The connected app authorizations renders with scopes', async () => {
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(<ConnectedAppAuthorizations connectedApp={connectedApp} />);
@@ -101,7 +101,7 @@ test('The connected app authorizations renders without scopes', async () => {
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(<ConnectedAppAuthorizations connectedApp={connectedApp} />);

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -107,6 +107,7 @@ const connectedApp = {
     categories: ['e-commerce', 'print'],
     certified: false,
     partner: null,
+    test: false,
 };
 
 test('The connected app container renders without permissions tab', async () => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppContainer.test.tsx
@@ -107,7 +107,7 @@ const connectedApp = {
     categories: ['e-commerce', 'print'],
     certified: false,
     partner: null,
-    test: false,
+    is_test_app: false,
 };
 
 test('The connected app container renders without permissions tab', async () => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
@@ -18,6 +18,7 @@ test('Connected App Settings renders monitoring settings and authorizations', ()
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
+        test: false,
     };
 
     const monitoringSettings = {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppSettings.test.tsx
@@ -18,7 +18,7 @@ test('Connected App Settings renders monitoring settings and authorizations', ()
         categories: ['e-commerce', 'print'],
         certified: false,
         partner: null,
-        test: false,
+        is_test_app: false,
     };
 
     const monitoringSettings = {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ErrorMonitoring/ConnectAppErrorMonitoring.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ErrorMonitoring/ConnectAppErrorMonitoring.test.tsx
@@ -47,6 +47,7 @@ const connectedApp = {
     categories: ['e-commerce', 'print'],
     certified: false,
     partner: null,
+    test: false,
 };
 
 test('It renders the app errors', async done => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ErrorMonitoring/ConnectAppErrorMonitoring.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ErrorMonitoring/ConnectAppErrorMonitoring.test.tsx
@@ -47,7 +47,7 @@ const connectedApp = {
     categories: ['e-commerce', 'print'],
     certified: false,
     partner: null,
-    test: false,
+    is_test_app: false,
 };
 
 test('It renders the app errors', async done => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
@@ -5,11 +5,17 @@ import fetchMock from 'jest-fetch-mock';
 import {renderWithProviders, historyMock} from '../../../../test-utils';
 import {ConnectedAppCard} from '@src/connect/components/ConnectedApps/ConnectedAppCard';
 import {SecurityContext} from '@src/shared/security';
+import {AppIllustration} from 'akeneo-design-system';
 
 beforeEach(() => {
     fetchMock.resetMocks();
     historyMock.reset();
 });
+
+jest.mock('akeneo-design-system', () => ({
+    ...jest.requireActual('akeneo-design-system'),
+    AppIllustration: jest.fn(() => null),
+}));
 
 test('The connected app card renders', async () => {
     const item = {
@@ -24,6 +30,7 @@ test('The connected app card renders', async () => {
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
+        test: false,
     };
 
     renderWithProviders(<ConnectedAppCard item={item} />);
@@ -31,7 +38,9 @@ test('The connected app card renders', async () => {
 
     expect(screen.queryByText('App A')).toBeInTheDocument();
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by' + ' author A')
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by?author=author+A'
+        )
     ).toBeInTheDocument();
     expect(screen.queryByText('category A1')).toBeInTheDocument();
     expect(screen.queryByText('category A2')).toBeNull();
@@ -63,6 +72,7 @@ test('The Manage App button is disabled when the user doesnt have the permission
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
+        test: false,
     };
 
     renderWithProviders(
@@ -100,6 +110,7 @@ test('The Open App button is disabled when the user doesnt have the permission t
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
+        test: false,
     };
 
     renderWithProviders(
@@ -115,4 +126,55 @@ test('The Open App button is disabled when the user doesnt have the permission t
     openAppButton.not.toHaveAttribute('href');
     openAppButton.toHaveAttribute('disabled');
     openAppButton.toHaveAttribute('aria-disabled', 'true');
+});
+
+test('The connected app card displays removed user as author when author is null', async () => {
+    const item = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'App A',
+        scopes: ['scope A1'],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.test/path/to/logo/a',
+        author: null,
+        user_group_name: 'app_123456abcde',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+        activate_url: 'http://www.example.com/activate',
+        test: false,
+    };
+
+    renderWithProviders(<ConnectedAppCard item={item} />);
+    await waitFor(() => screen.getByText('App A'));
+
+    expect(screen.queryByText('App A')).toBeInTheDocument();
+    expect(
+        screen.queryByText(
+            'akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by?author=akeneo_connectivity.connection.connect.connected_apps.list.test_apps.removed_user'
+        )
+    ).toBeInTheDocument();
+});
+
+test('The connected app card displays app illustration when logo is null', async () => {
+    const item = {
+        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+        name: 'App A',
+        scopes: ['scope A1'],
+        connection_code: 'connectionCodeA',
+        logo: null,
+        author: 'author A',
+        user_group_name: 'app_123456abcde',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+        activate_url: 'http://www.example.com/activate',
+        test: false,
+    };
+
+    renderWithProviders(<ConnectedAppCard item={item} />);
+    await waitFor(() => screen.getByText('App A'));
+
+    expect(screen.queryByText('App A')).toBeInTheDocument();
+    expect(screen.queryByAltText('App A')).not.toBeInTheDocument();
+    expect(AppIllustration).toHaveBeenCalled();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsCard.test.tsx
@@ -30,7 +30,7 @@ test('The connected app card renders', async () => {
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(<ConnectedAppCard item={item} />);
@@ -72,7 +72,7 @@ test('The Manage App button is disabled when the user doesnt have the permission
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(
@@ -110,7 +110,7 @@ test('The Open App button is disabled when the user doesnt have the permission t
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(
@@ -141,7 +141,7 @@ test('The connected app card displays removed user as author when author is null
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(<ConnectedAppCard item={item} />);
@@ -168,7 +168,7 @@ test('The connected app card displays app illustration when logo is null', async
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: false,
+        is_test_app: false,
     };
 
     renderWithProviders(<ConnectedAppCard item={item} />);

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
@@ -50,7 +50,7 @@ const connectedApps = [
         categories: [],
         certified: true,
         partner: null,
-        test: false,
+        is_test_app: false,
     },
     {
         id: 'app_id_b',
@@ -63,7 +63,7 @@ const connectedApps = [
         categories: [],
         certified: true,
         partner: null,
-        test: true,
+        is_test_app: true,
     },
     {
         id: 'app_id_c',
@@ -76,7 +76,7 @@ const connectedApps = [
         categories: [],
         certified: true,
         partner: null,
-        test: true,
+        is_test_app: true,
     },
     {
         id: 'app_id_d',
@@ -89,7 +89,7 @@ const connectedApps = [
         categories: [],
         certified: true,
         partner: null,
-        test: false,
+        is_test_app: false,
     },
 ];
 

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
@@ -94,7 +94,7 @@ const connectedApps = [
 ];
 
 test('The connected apps list renders with 2 connected apps card and 2 connected test app', async () => {
-    renderWithProviders(<ConnectedAppsContainer connectedApps={connectedApps} />);
+    renderWithProviders(<ConnectedAppsContainer allConnectedApps={connectedApps} />);
     await waitFor(() => screen.getByText('Helper mock'));
 
     expect(ConnectedAppsContainerHelper).toBeCalledWith({count: 4}, {});
@@ -118,7 +118,7 @@ test('The connected apps list renders with 2 connected apps card and 2 connected
 });
 
 test('The connected apps list renders without connected apps', async () => {
-    renderWithProviders(<ConnectedAppsContainer connectedApps={[]} />);
+    renderWithProviders(<ConnectedAppsContainer allConnectedApps={[]} />);
     await waitFor(() => screen.getByText('Helper mock'));
 
     expect(ConnectedAppsContainerHelper).toBeCalledWith({count: 0}, {});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppsContainer.test.tsx
@@ -2,8 +2,17 @@ import React from 'react';
 import '@testing-library/jest-dom/extend-expect';
 import {screen, waitFor} from '@testing-library/react';
 import fetchMock from 'jest-fetch-mock';
-import {renderWithProviders, historyMock, MockFetchResponses, mockFetchResponses} from '../../../../test-utils';
+import {historyMock, renderWithProviders} from '../../../../test-utils';
 import {ConnectedAppsContainer} from '@src/connect/components/ConnectedApps/ConnectedAppsContainer';
+import ConnectedAppsContainerHelper from '@src/connect/components/ConnectedApps/ConnectedAppsContainerHelper';
+import {ConnectedTestAppList} from '@src/connect/components/ConnectedApps/ConnectedTestAppList';
+import {ConnectedAppCard} from '@src/connect/components/ConnectedApps/ConnectedAppCard';
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+    historyMock.reset();
+    jest.clearAllMocks();
+});
 
 jest.mock('@src/shared/feature-flags/use-feature-flags', () => ({
     useFeatureFlags: () => {
@@ -13,98 +22,118 @@ jest.mock('@src/shared/feature-flags/use-feature-flags', () => ({
     },
 }));
 
-beforeEach(() => {
-    fetchMock.resetMocks();
-    historyMock.reset();
-});
+jest.mock('@src/connect/components/ConnectedApps/ConnectedAppsContainerHelper', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApps/ConnectedAppsContainerHelper'),
+    __esModule: true,
+    default: jest.fn(() => <h1>Helper mock</h1>),
+}));
 
-test('The connected apps list renders with 2 connected apps card', async () => {
-    const connectedApps = [
-        {
-            id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
-            name: 'App A',
-            scopes: ['scope A1'],
-            connection_code: 'connectionCodeA',
-            logo: 'http://www.example.test/path/to/logo/a',
-            author: 'author A',
-            user_group_name: 'app_123456abcde',
-            categories: ['category A1', 'category A2'],
-            certified: false,
-            partner: 'partner A',
-        },
-        {
-            id: '2677e764-f852-4956-bf9b-1a1ec1b0d145',
-            name: 'App B',
-            scopes: ['scope B1', 'scope B2'],
-            connection_code: 'connectionCodeB',
-            logo: 'http://www.example.test/path/to/logo/b',
-            author: 'author B',
-            user_group_name: 'app_7891011ghijklm',
-            categories: ['category B1'],
-            certified: true,
-            partner: null,
-        },
-    ];
+jest.mock('@src/connect/components/ConnectedApps/ConnectedAppCard', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApps/ConnectedAppCard'),
+    ConnectedAppCard: jest.fn(() => null),
+}));
 
+jest.mock('@src/connect/components/ConnectedApps/ConnectedTestAppList', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApps/ConnectedTestAppList'),
+    ConnectedTestAppList: jest.fn(() => null),
+}));
+
+const connectedApps = [
+    {
+        id: 'app_id_a',
+        name: 'App A',
+        scopes: [],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.test/path/to/logo/a',
+        author: 'author A',
+        user_group_name: 'user_group_a',
+        categories: [],
+        certified: true,
+        partner: null,
+        test: false,
+    },
+    {
+        id: 'app_id_b',
+        name: 'App B',
+        scopes: [],
+        connection_code: 'connectionCodeB',
+        logo: 'http://www.example.test/path/to/logo/b',
+        author: 'author B',
+        user_group_name: 'user_group_b',
+        categories: [],
+        certified: true,
+        partner: null,
+        test: true,
+    },
+    {
+        id: 'app_id_c',
+        name: 'App C',
+        scopes: [],
+        connection_code: 'connectionCodeC',
+        logo: 'http://www.example.test/path/to/logo/c',
+        author: 'author C',
+        user_group_name: 'user_group_c',
+        categories: [],
+        certified: true,
+        partner: null,
+        test: true,
+    },
+    {
+        id: 'app_id_d',
+        name: 'App D',
+        scopes: [],
+        connection_code: 'connectionCodeD',
+        logo: 'http://www.example.test/path/to/logo/d',
+        author: 'author D',
+        user_group_name: 'user_group_d',
+        categories: [],
+        certified: true,
+        partner: null,
+        test: false,
+    },
+];
+
+test('The connected apps list renders with 2 connected apps card and 2 connected test app', async () => {
     renderWithProviders(<ConnectedAppsContainer connectedApps={connectedApps} />);
-    await waitFor(() => screen.getByText('App A'));
+    await waitFor(() => screen.getByText('Helper mock'));
 
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.title', {exact: false})
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.description_1')
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.description_2')
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.link')
-    ).toBeInTheDocument();
+    expect(ConnectedAppsContainerHelper).toBeCalledWith({count: 4}, {});
+
+    expect(ConnectedTestAppList).toHaveBeenCalledWith(
+        {
+            connectedTestApps: [connectedApps[1], connectedApps[2]],
+        },
+        {}
+    );
+
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.title')
     ).toBeInTheDocument();
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.total', {exact: false})
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.total?total=2')
     ).toBeInTheDocument();
-    expect(
-        screen.queryAllByText('akeneo_connectivity.connection.connect.connected_apps.list.card.manage_app')
-    ).toHaveLength(2);
-    expect(screen.queryByText('App A')).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by' + ' author A')
-    ).toBeInTheDocument();
-    expect(screen.queryByText('category A1')).toBeInTheDocument();
-    expect(screen.queryByText('category A2')).toBeNull();
-    expect(screen.queryByText('App B')).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.developed_by' + ' author B')
-    ).toBeInTheDocument();
-    expect(screen.queryByText('category B1')).toBeInTheDocument();
+
+    expect(ConnectedAppCard).toHaveBeenNthCalledWith(1, {item: connectedApps[0]}, {});
+    expect(ConnectedAppCard).toHaveBeenNthCalledWith(2, {item: connectedApps[3]}, {});
 });
 
 test('The connected apps list renders without connected apps', async () => {
     renderWithProviders(<ConnectedAppsContainer connectedApps={[]} />);
-    await waitFor(() => screen.getByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.empty'));
+    await waitFor(() => screen.getByText('Helper mock'));
 
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.title', {exact: false})
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.description_1')
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.description_2')
-    ).toBeInTheDocument();
-    expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.helper.link')
-    ).toBeInTheDocument();
+    expect(ConnectedAppsContainerHelper).toBeCalledWith({count: 0}, {});
+
+    expect(ConnectedTestAppList).toHaveBeenCalledWith({connectedTestApps: []}, {});
+
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.title')
     ).toBeInTheDocument();
     expect(
-        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.total', {exact: false})
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.total?total=0')
     ).toBeInTheDocument();
+
+    expect(ConnectedAppCard).not.toHaveBeenCalled();
+
     expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.empty')
     ).toBeInTheDocument();

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedTestAppList.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedTestAppList.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import {screen} from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import {ConnectedAppCard} from '@src/connect/components/ConnectedApps/ConnectedAppCard';
+import {renderWithProviders} from '../../../../test-utils';
+import {ConnectedTestAppList} from '@src/connect/components/ConnectedApps/ConnectedTestAppList';
+import {useFeatureFlags} from '@src/shared/feature-flags';
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+jest.mock('@src/shared/feature-flags/use-feature-flags', () => ({
+    ...jest.requireActual('@src/shared/feature-flags/use-feature-flags'),
+    useFeatureFlags: jest.fn(() => {
+        return {
+            isEnabled: () => true,
+        };
+    }),
+}));
+
+jest.mock('@src/connect/components/ConnectedApps/ConnectedAppCard', () => ({
+    ...jest.requireActual('@src/connect/components/ConnectedApps/ConnectedAppCard'),
+    ConnectedAppCard: jest.fn(() => null),
+}));
+
+const connectedTestApps = [
+    {
+        id: 'test_id_a',
+        name: 'App A',
+        scopes: [],
+        connection_code: 'connectionCodeA',
+        logo: 'http://www.example.test/path/to/logo/a',
+        author: 'author A',
+        user_group_name: 'user_group_a',
+        categories: ['category A1', 'category A2'],
+        certified: false,
+        partner: 'partner A',
+        activate_url: 'http://www.example.com/activate',
+        test: true,
+    },
+    {
+        id: 'test_id_b',
+        name: 'App B',
+        scopes: [],
+        connection_code: 'connectionCodeB',
+        logo: 'http://www.example.test/path/to/logo/b',
+        author: 'author B',
+        user_group_name: 'user_group_b',
+        categories: [],
+        certified: false,
+        partner: 'partner B',
+        activate_url: 'http://www.example.com/activate',
+        test: true,
+    },
+];
+
+test('it renders list of connected apps', () => {
+    renderWithProviders(<ConnectedTestAppList connectedTestApps={connectedTestApps} />);
+
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.test_apps.title')
+    ).toBeInTheDocument();
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.apps.total', {exact: false})
+    ).toBeInTheDocument();
+
+    expect(ConnectedAppCard).toHaveBeenNthCalledWith(1, {item: connectedTestApps[0]}, {});
+    expect(ConnectedAppCard).toHaveBeenNthCalledWith(2, {item: connectedTestApps[1]}, {});
+});
+
+test('it does not render if list is empty', () => {
+    renderWithProviders(<ConnectedTestAppList connectedTestApps={[]} />);
+
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.test_apps.title')
+    ).not.toBeInTheDocument();
+
+    expect(ConnectedAppCard).not.toHaveBeenCalled();
+});
+
+test('it does not render if feature flag is disabled', () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({isEnabled: () => false}));
+
+    renderWithProviders(<ConnectedTestAppList connectedTestApps={connectedTestApps} />);
+
+    expect(
+        screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.test_apps.title')
+    ).not.toBeInTheDocument();
+
+    expect(ConnectedAppCard).not.toHaveBeenCalled();
+});

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedTestAppList.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedTestAppList.test.tsx
@@ -37,7 +37,7 @@ const connectedTestApps = [
         certified: false,
         partner: 'partner A',
         activate_url: 'http://www.example.com/activate',
-        test: true,
+        is_test_app: true,
     },
     {
         id: 'test_id_b',
@@ -51,7 +51,7 @@ const connectedTestApps = [
         certified: false,
         partner: 'partner B',
         activate_url: 'http://www.example.com/activate',
-        test: true,
+        is_test_app: true,
     },
 ];
 

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppsListPage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/ConnectedAppsListPage.test.tsx
@@ -66,7 +66,7 @@ test('The connected apps list page renders with 2 connected apps card', async ()
 
     renderWithProviders(<ConnectedAppsListPage />);
 
-    await waitFor(() => expect(ConnectedAppsContainer).toHaveBeenCalledWith({connectedApps}, {}));
+    await waitFor(() => expect(ConnectedAppsContainer).toHaveBeenCalledWith({allConnectedApps: connectedApps}, {}));
 });
 
 test('The connected apps list page renders with internal api errors', async () => {


### PR DESCRIPTION
CXP 1042 Display test apps in the Apps submenu

![image](https://user-images.githubusercontent.com/7101819/148813437-031aedc8-3c9c-44c0-9e12-d1f4fa3c5aa8.png)

- Added `test` property to API response for GetAllConnectedApps
- Added display for connected test apps in a dedicated section
- Refactored front test suite
- Updated connected card to handle empty author and logo