### PR TITLE
Fix UTCDateTimeType::convertToPHPValue() to handle datetime argument

### DIFF
--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeType.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeType.php
@@ -37,8 +37,8 @@ class UTCDateTimeType extends DateTimeType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        if (null === $value) {
-            return null;
+        if (null === $value || $value instanceof \DateTimeInterface) {
+            return $value;
         }
 
         $val = \DateTime::createFromFormat(


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

`UTCDateTimeType::convertToPHPValue()` can be passed a \DateTime as first argument, (cf https://github.com/doctrine-extensions/DoctrineExtensions/blob/a9fd83ad6e908e7180a719f174ded0b27aec2556/src/Timestampable/Mapping/Event/Adapter/ORM.php#L35), we need to handle that case
(NB: [UTCDateTimeImmutableType](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/DBAL/Types/UTCDateTimeImmutableType.php) already handles it)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
