### PR TITLE
CXP 1040 Handle no app logo for the PageHeader

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
@@ -21,6 +21,35 @@ const AknTitleContainerBreadcrumbs = styled.div.attrs(() => ({className: 'AknTit
     min-height: 32px;
 `;
 
+const Header = styled.header`
+    position: sticky;
+    top: 0;
+    padding: 40px 40px 20px;
+    background: white;
+    z-index: 10;
+
+    .AknImage-display {
+        max-width: 100%;
+    }
+`;
+
+const IllustrationContainer = styled.div`
+    position: relative;
+    width: 142px;
+    height: 142px;
+    border: 1px solid #ccd1d8;
+    margin-right: 20px;
+    border-radius: 4px;
+    display: flex;
+    overflow: hidden;
+    flex-basis: 142px;
+    flex-shrink: 0;
+
+    & > * {
+        width: 100%;
+    }
+`;
+
 export const PageHeader = ({
     children: title,
     breadcrumb,
@@ -70,32 +99,3 @@ export const PageHeader = ({
         </div>
     </Header>
 );
-
-const Header = styled.header`
-    position: sticky;
-    top: 0;
-    padding: 40px 40px 20px;
-    background: white;
-    z-index: 10;
-
-    .AknImage-display {
-        max-width: 100%;
-    }
-`;
-
-const IllustrationContainer = styled.div`
-    position: relative;
-    width: 142px;
-    height: 142px;
-    border: 1px solid #ccd1d8;
-    margin-right: 20px;
-    border-radius: 4px;
-    display: flex;
-    overflow: hidden;
-    flex-basis: 142px;
-    flex-shrink: 0;
-
-    & > * {
-        width: 100%;
-    }
-`;

--- a/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/common/components/PageHeader.tsx
@@ -1,4 +1,4 @@
-import React, {PropsWithChildren, ReactElement, ReactNode, Fragment} from 'react';
+import React, {PropsWithChildren, ReactElement, ReactNode, Fragment, cloneElement} from 'react';
 import styled from 'styled-components';
 
 type Props = PropsWithChildren<{
@@ -7,6 +7,7 @@ type Props = PropsWithChildren<{
     userButtons?: ReactNode;
     state?: ReactNode;
     imageSrc?: string;
+    imageIllustration?: ReactElement;
     tag?: ReactNode;
 }>;
 
@@ -20,13 +21,28 @@ const AknTitleContainerBreadcrumbs = styled.div.attrs(() => ({className: 'AknTit
     min-height: 32px;
 `;
 
-export const PageHeader = ({children: title, breadcrumb, buttons, userButtons, state, imageSrc, tag}: Props) => (
+export const PageHeader = ({
+    children: title,
+    breadcrumb,
+    buttons,
+    userButtons,
+    state,
+    imageSrc,
+    imageIllustration,
+    tag,
+}: Props) => (
     <Header>
         <div className='AknTitleContainer-line'>
             {imageSrc && (
                 <div className='AknImage AknImage--readOnly'>
                     <img className='AknImage-display' src={imageSrc} />
                 </div>
+            )}
+
+            {imageSrc === undefined && imageIllustration && (
+                <IllustrationContainer>
+                    {cloneElement(imageIllustration, {width: 142, height: 142})}
+                </IllustrationContainer>
             )}
 
             <div className='AknTitleContainer-mainContainer'>
@@ -64,5 +80,22 @@ const Header = styled.header`
 
     .AknImage-display {
         max-width: 100%;
+    }
+`;
+
+const IllustrationContainer = styled.div`
+    position: relative;
+    width: 142px;
+    height: 142px;
+    border: 1px solid #ccd1d8;
+    margin-right: 20px;
+    border-radius: 4px;
+    display: flex;
+    overflow: hidden;
+    flex-basis: 142px;
+    flex-shrink: 0;
+
+    & > * {
+        width: 100%;
     }
 `;

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/ConnectedAppContainer.tsx
@@ -1,5 +1,5 @@
 import React, {FC, useCallback, useEffect, useState} from 'react';
-import {Breadcrumb, TabBar, useTabBar} from 'akeneo-design-system';
+import {AppIllustration, Breadcrumb, TabBar, useTabBar} from 'akeneo-design-system';
 import {Translate, useTranslate} from '../../../shared/translate';
 import {ConnectedApp} from '../../../model/Apps/connected-app';
 import {useRouter} from '../../../shared/router/use-router';
@@ -179,6 +179,7 @@ export const ConnectedAppContainer: FC<Props> = ({connectedApp}) => {
                 userButtons={<UserButtons />}
                 state={<FormState />}
                 imageSrc={connectedApp.logo ?? undefined}
+                imageIllustration={connectedApp.logo ? undefined : <AppIllustration />}
             >
                 {connectedApp.name}
             </PageHeader>


### PR DESCRIPTION
Test  apps have no logo image,  we should display AppIllustration  instead. 
Since `PageHeader` is used to display connected (Test) App settings, it should be able to display Illustration if logo path is not provided

![image](https://user-images.githubusercontent.com/7101819/149130863-4a2b3548-0983-4a0f-a1c7-9dc5fc549dc0.png)
