### PR TITLE
RAC-1202: Create endpoint to get product attributes for an Asset Family

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Cache/LRUCachedGetAttributes.php
@@ -57,6 +57,11 @@ final class LRUCachedGetAttributes implements GetAttributes, CachedQueryInterfac
         return $this->cache->getForKey($attributeCode, $fetchNonFoundAttributeCodes);
     }
 
+    public function forType(string $attributeType): array
+    {
+        return $this->getAttributes->forType($attributeType);
+    }
+
     public function clearCache(): void
     {
         $this->cache = new LRUCache(1000);

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -47,4 +47,38 @@ SQL;
 
         return $attributeTranslations;
     }
+
+    public function byAttributeCodes(array $attributeCodes): array
+    {
+        if (empty($attributeCodes)) {
+            return [];
+        }
+
+        $query = <<<SQL
+            SELECT
+                code,
+                CONCAT('{', GROUP_CONCAT(CONCAT('"', at.locale, '":"',at.label,'"')), '}') labels
+            FROM pim_catalog_attribute a
+                LEFT JOIN pim_catalog_attribute_translation at ON a.id = at.foreign_key
+            WHERE code IN (:attributeCodes)
+            GROUP BY code;
+        SQL;
+
+        $rows = $this->connection->executeQuery(
+            $query,
+            [
+                'attributeCodes' => $attributeCodes
+            ],
+            [
+                'attributeCodes' => Connection::PARAM_STR_ARRAY,
+            ]
+        )->fetchAllAssociative();
+
+        $attributeTranslations = [];
+        foreach ($rows as $attribute) {
+            $attributeTranslations[$attribute['code']] = $attribute['label'];
+        }
+
+        return $attributeTranslations;
+    }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -76,7 +76,7 @@ SQL;
 
         $attributeTranslations = [];
         foreach ($rows as $attribute) {
-            $attributeTranslations[$attribute['code']] = $attribute['label'];
+            $attributeTranslations[$attribute['code']] = json_decode($attribute['labels'], true);
         }
 
         return $attributeTranslations;

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -48,6 +48,9 @@ SQL;
         return $attributeTranslations;
     }
 
+    /**
+     * @return array<array{locale: string, label: string}>
+     */
     public function byAttributeCodes(array $attributeCodes): array
     {
         if (empty($attributeCodes)) {

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -57,11 +57,11 @@ SQL;
         $query = <<<SQL
             SELECT
                 code,
-                CONCAT('{', GROUP_CONCAT(CONCAT('"', at.locale, '":"',at.label,'"')), '}') labels
-            FROM pim_catalog_attribute a
-                LEFT JOIN pim_catalog_attribute_translation at ON a.id = at.foreign_key
-            WHERE code IN (:attributeCodes)
-            GROUP BY code;
+                JSON_OBJECTAGG(attribute_translation.locale, attribute_translation.label) as labels
+            FROM pim_catalog_attribute attribute
+                LEFT JOIN pim_catalog_attribute_translation attribute_translation ON attribute.id = attribute_translation.foreign_key
+            WHERE attribute.code IN (:attributeCodes)
+            GROUP BY attribute.code;
         SQL;
 
         $rows = $this->connection->executeQuery(

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -43,6 +43,7 @@ SELECT attribute.code,
        attribute.default_metric_unit,
        attribute.decimals_allowed,
        attribute.backend_type,
+       attribute.useable_as_grid_filter,
        COALESCE(locale_codes, JSON_ARRAY()) AS available_locale_codes
 FROM pim_catalog_attribute attribute
     LEFT JOIN locale_specific_codes on attribute.id = attribute_id    
@@ -70,7 +71,8 @@ SQL;
                 $rawAttribute['default_metric_unit'],
                 boolval($rawAttribute['decimals_allowed']),
                 $rawAttribute['backend_type'],
-                json_decode($rawAttribute['available_locale_codes'])
+                json_decode($rawAttribute['available_locale_codes']),
+                boolval($rawAttribute['useable_as_grid_filter'])
             );
         }
 
@@ -106,6 +108,7 @@ SQL;
                    attribute.default_metric_unit,
                    attribute.decimals_allowed,
                    attribute.backend_type,
+                   attribute.useable_as_grid_filter,
                    COALESCE(locale_codes, JSON_ARRAY()) AS available_locale_codes
             FROM pim_catalog_attribute attribute
             LEFT JOIN locale_specific_codes on attribute.id = attribute_id  
@@ -132,7 +135,8 @@ SQL;
                 $rawAttribute['default_metric_unit'],
                 boolval($rawAttribute['decimals_allowed']),
                 $rawAttribute['backend_type'],
-                json_decode($rawAttribute['available_locale_codes'])
+                json_decode($rawAttribute['available_locale_codes']),
+                boolval($rawAttribute['useable_as_grid_filter'])
             );
         }
 

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributes.php
@@ -91,6 +91,12 @@ SQL;
     public function forType(string $attributeType): array
     {
         $query = <<<SQL
+            WITH locale_specific_codes AS (
+                SELECT attribute_locale.attribute_id, JSON_ARRAYAGG(locale.code) AS locale_codes
+                FROM pim_catalog_attribute_locale attribute_locale
+                INNER JOIN pim_catalog_locale locale ON attribute_locale.locale_id = locale.id
+                GROUP BY attribute_locale.attribute_id
+            )
             SELECT attribute.code,
                    attribute.attribute_type,
                    attribute.properties,
@@ -102,6 +108,7 @@ SQL;
                    attribute.backend_type,
                    COALESCE(locale_codes, JSON_ARRAY()) AS available_locale_codes
             FROM pim_catalog_attribute attribute
+            LEFT JOIN locale_specific_codes on attribute.id = attribute_id  
             WHERE attribute.attribute_type = (:attribute_type)
         SQL;
 

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
@@ -7,4 +7,5 @@ namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute;
 interface GetAttributeTranslations
 {
     public function byAttributeCodesAndLocale(array $attributeCodes, string $locale): array;
+    public function byAttributeCodes(array $attributeCodes): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -9,58 +9,19 @@ namespace Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType;
  */
 final class Attribute
 {
-    /** @var string */
-    private $attributeCode;
-
-    /** @var string */
-    private $attributeType;
-
-    /** @var array */
-    private $attributeProperties;
-
-    /** @var bool */
-    private $isLocalizable;
-
-    /** @var bool */
-    private $isScopable;
-
-    /** @var null|string */
-    private $metricFamily;
-
-    /** @var null|string */
-    private $defaultMetricUnit;
-
-    /** @var null|bool */
-    private $decimalsAllowed;
-
-    /** @var string */
-    private $backendType;
-
-    /** @var string[] */
-    private $availableLocaleCodes;
-
     public function __construct(
-        string $attributeCode,
-        string $attributeType,
-        array $attributeProperties,
-        bool $isLocalizable,
-        bool $isScopable,
-        ?string $metricFamily,
-        ?string $defaultMetricUnit,
-        ?bool $decimalsAllowed,
-        string $backendType,
-        array $availableLocaleCodes
+        private string $attributeCode,
+        private string $attributeType,
+        private array $attributeProperties,
+        private bool $isLocalizable,
+        private bool $isScopable,
+        private ?string $metricFamily,
+        private ?string $defaultMetricUnit,
+        private ?bool $decimalsAllowed,
+        private string $backendType,
+        private array $availableLocaleCodes,
+        private ?bool $useableAsGridFilter
     ) {
-        $this->attributeCode = $attributeCode;
-        $this->attributeType = $attributeType;
-        $this->attributeProperties = $attributeProperties;
-        $this->isLocalizable = $isLocalizable;
-        $this->isScopable = $isScopable;
-        $this->metricFamily = $metricFamily;
-        $this->defaultMetricUnit = $defaultMetricUnit;
-        $this->decimalsAllowed = $decimalsAllowed;
-        $this->backendType = $backendType;
-        $this->availableLocaleCodes = $availableLocaleCodes;
     }
 
     public function code(): string
@@ -121,5 +82,10 @@ final class Attribute
     public function availableLocaleCodes(): array
     {
         return $this->availableLocaleCodes;
+    }
+
+    public function useableAsGridFilter(): ?bool
+    {
+        return $this->useableAsGridFilter;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -20,7 +20,7 @@ final class Attribute
         private ?bool $decimalsAllowed,
         private string $backendType,
         private array $availableLocaleCodes,
-        private ?bool $useableAsGridFilter
+        private ?bool $useableAsGridFilter = null
     ) {
     }
 

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/GetAttributes.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/GetAttributes.php
@@ -18,4 +18,9 @@ interface GetAttributes
     public function forCodes(array $attributeCodes): array;
 
     public function forCode(string $attributeCode): ?Attribute;
+
+    /**
+     * @return Attribute[]
+     */
+    public function forType(string $attributeType): array;
 }

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -56,4 +56,27 @@ class InMemoryGetAttributes implements GetAttributes
     {
         return $this->forCodes([$attributeCode])[$attributeCode] ?? null;
     }
+
+    public function forType(string $attributeType): array
+    {
+        $rawAttributes = $this->attributeRepository->findBy(['type' => $attributeType]);
+        $attributes = [];
+
+        foreach ($rawAttributes as $attribute) {
+            $attributes[$attribute->getCode()] = new Attribute(
+                $attribute->getCode(),
+                $attribute->getType(),
+                $attribute->getProperties(),
+                (bool) $attribute->isLocalizable(),
+                (bool) $attribute->isScopable(),
+                $attribute->getMetricFamily(),
+                $attribute->getDefaultMetricUnit(),
+                $attribute->isDecimalsAllowed(),
+                $attribute->getBackendType(),
+                []
+            );
+        }
+
+        return $attributes;
+    }
 }

--- a/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
+++ b/tests/back/Acceptance/Attribute/InMemoryGetAttributes.php
@@ -73,7 +73,7 @@ class InMemoryGetAttributes implements GetAttributes
                 $attribute->getDefaultMetricUnit(),
                 $attribute->isDecimalsAllowed(),
                 $attribute->getBackendType(),
-                []
+                $attribute->getAvailableLocaleCodes()
             );
         }
 

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributeTranslationsIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributeTranslationsIntegration.php
@@ -50,6 +50,50 @@ final class SqlGetAttributeTranslationsIntegration extends TestCase
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
+    public function test_it_gets_attribute_translations_by_giving_attribute_codes(): void
+    {
+        $query = $this->getQuery();
+
+        $this->givenAttributes([
+            [
+                'code' => 'a_boolean',
+                'type' => AttributeTypes::BOOLEAN,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other',
+                'labels' => [
+                    'en_US' => 'a boolean',
+                    'fr_FR' => 'un booléen'
+                ]
+            ],
+            [
+                'code' => 'a_textarea',
+                'type' => AttributeTypes::TEXTAREA,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other',
+                'labels' => [
+                    'en_US' => 'a textarea',
+                    'fr_FR' => 'une zone de texte'
+                ]
+            ]
+        ]);
+
+        $expected = [
+            'a_textarea' => [
+                'en_US' => 'a textarea',
+                'fr_FR' => 'une zone de texte'
+            ],
+            'a_boolean' => [
+                'en_US' => 'a boolean',
+                'fr_FR' => 'un booléen'
+            ],
+        ];
+        $actual = $query->byAttributeCodes(['a_boolean', 'a_textarea']);
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
@@ -74,7 +74,7 @@ final class SqlGetAttributesIntegration extends TestCase
 
     public function test_it_gets_attributes_by_giving_attribute_codes(): void
     {
-        $expected = $this->getExpected();
+        $expected = $this->getExpectedByAttributeCodes();
         $query = $this->getQuery();
         $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
         $this->assertEqualsCanonicalizing($expected, $actual);
@@ -82,13 +82,20 @@ final class SqlGetAttributesIntegration extends TestCase
 
     public function test_it_gets_attributes_by_giving_attribute_codes_with_cache(): void
     {
-        $expected = $this->getExpected();
+        $expected = $this->getExpectedByAttributeCodes();
         $query = $this->getCachedQuery();
         $actual = $query->forCodes(['a_text', 'a_boolean', 'a_textarea', 'unknown_attribute_code', '123', 'a_locale_specific_attribute', 'a_metric']);
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
-    public function getExpected(): array
+    public function test_it_gets_attributes_by_given_attribute_type(): void
+    {
+        $expected = $this->getExpectedByType();
+        $actual = $this->getQuery()->forType('pim_catalog_text');
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function getExpectedByAttributeCodes(): array
     {
         return [
             'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
@@ -98,6 +105,14 @@ final class SqlGetAttributesIntegration extends TestCase
             '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
             'a_locale_specific_attribute' => new Attribute('a_locale_specific_attribute', AttributeTypes::BOOLEAN, [], true, false, null, null, false, 'boolean', ['en_US']),
             'a_metric' => new Attribute('a_metric', AttributeTypes::METRIC, [], false, false, 'Length', 'CENTIMETER', true, 'metric', []),
+        ];
+    }
+
+    public function getExpectedByType(): array
+    {
+        return [
+            'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
+            '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
         ];
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Currently to list the linked product attribute on an asset edit form, we fetch the list of asset collection attributes from the structure REST endpoint.
As this is not a specialized endpoint, we fetch the first 20 asset collection attributes and then we filter the one corresponding to the current asset family.

Remove this direct call to an external endpoint and create a dedicated one in our bounded context.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
