### PR TITLE
BH-1056: Upgrade phpseclib to v3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
             "": "src/"
         },
         "psr-4": {
-            "Pim\\Upgrade\\": "upgrades/",
+            "Pim\\Upgrade\\Schema\\": "upgrades/schema/",
             "Akeneo\\Connectivity\\Connection\\": "src/Akeneo/Connectivity/Connection/back",
             "Akeneo\\Platform\\CommunicationChannel\\": "src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back",
             "Akeneo\\Pim\\Automation\\DataQualityInsights\\": "src/Akeneo/Pim/Automation/DataQualityInsights/back",
@@ -98,7 +98,7 @@
         "monolog/monolog": "1.25.5",
         "ocramius/proxy-manager": "2.11.1",
         "oneup/flysystem-bundle": "^4.0.0",
-        "phpseclib/phpseclib": "2.0.31",
+        "phpseclib/phpseclib": "^3.0",
         "psr/event-dispatcher": "^1.0.0",
         "ramsey/uuid": "^3.7",
         "ramsey/uuid-doctrine": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e58f58cdc489f481ec032d5bf5fab70",
+    "content-hash": "aca1afe527c5d861e4c535a6d7cfcbdb",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -2835,16 +2835,16 @@
         },
         {
             "name": "google/cloud-pubsub",
-            "version": "v1.36.1",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-cloud-php-pubsub.git",
-                "reference": "9f0e91ab98103b2224deb75e839fa9f746dd6fb4"
+                "reference": "b3e9e9a535c74effa522700520323413fe8a2fe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-pubsub/zipball/9f0e91ab98103b2224deb75e839fa9f746dd6fb4",
-                "reference": "9f0e91ab98103b2224deb75e839fa9f746dd6fb4",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-pubsub/zipball/b3e9e9a535c74effa522700520323413fe8a2fe8",
+                "reference": "b3e9e9a535c74effa522700520323413fe8a2fe8",
                 "shasum": ""
             },
             "require": {
@@ -2883,9 +2883,9 @@
             ],
             "description": "Cloud PubSub Client for PHP",
             "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-pubsub/tree/v1.36.1"
+                "source": "https://github.com/googleapis/google-cloud-php-pubsub/tree/v1.37.0"
             },
-            "time": "2022-05-13T22:51:50+00:00"
+            "time": "2022-05-18T19:48:28+00:00"
         },
         {
             "name": "google/common-protos",
@@ -2932,23 +2932,23 @@
         },
         {
             "name": "google/gax",
-            "version": "v1.12.1",
+            "version": "v1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/gax-php.git",
-                "reference": "c853202dcbaaba105c51200af0c903b69cdea6b5"
+                "reference": "38ea1c12e7d24caeb3abbcac44a6a3536a8ef2a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/c853202dcbaaba105c51200af0c903b69cdea6b5",
-                "reference": "c853202dcbaaba105c51200af0c903b69cdea6b5",
+                "url": "https://api.github.com/repos/googleapis/gax-php/zipball/38ea1c12e7d24caeb3abbcac44a6a3536a8ef2a7",
+                "reference": "38ea1c12e7d24caeb3abbcac44a6a3536a8ef2a7",
                 "shasum": ""
             },
             "require": {
                 "google/auth": "^1.18.0",
                 "google/common-protos": "^1.0||^2.0",
                 "google/grpc-gcp": "^0.2",
-                "google/protobuf": "^3.12.2, !=3.20.0",
+                "google/protobuf": "^3.12.2",
                 "grpc/grpc": "^1.13",
                 "guzzlehttp/promises": "^1.3",
                 "guzzlehttp/psr7": "^1.7.0||^2",
@@ -2979,9 +2979,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/gax-php/issues",
-                "source": "https://github.com/googleapis/gax-php/tree/v1.12.1"
+                "source": "https://github.com/googleapis/gax-php/tree/v1.12.2"
             },
-            "time": "2022-04-20T16:46:29+00:00"
+            "time": "2022-05-17T03:48:18+00:00"
         },
         {
             "name": "google/grpc-gcp",
@@ -3515,6 +3515,61 @@
             "time": "2022-04-13T08:02:27+00:00"
         },
         {
+            "name": "khaled.alshamaa/ar-php",
+            "version": "v6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/khaled-alshamaa/ar-php.git",
+                "reference": "a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/khaled-alshamaa/ar-php/zipball/a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a",
+                "reference": "a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "9.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ArPHP\\I18N\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Khaled Al-Sham'aa",
+                    "email": "khaled@ar-php.org",
+                    "homepage": "http://www.ar-php.org"
+                }
+            ],
+            "description": "Set of functionalities enable Arabic website developers to serve professional search, present and process Arabic content in PHP",
+            "homepage": "https://github.com/khaled-alshamaa/ar-php",
+            "keywords": [
+                "arabic",
+                "arabic-calendar",
+                "arabic-glyphs",
+                "arabic-numbers",
+                "arabic-segments-identifier",
+                "arabic-sentiment",
+                "arabic-sql-query"
+            ],
+            "support": {
+                "issues": "https://github.com/khaled-alshamaa/ar-php/issues",
+                "source": "https://github.com/khaled-alshamaa/ar-php/tree/v6.2.0"
+            },
+            "time": "2021-06-20T18:15:36+00:00"
+        },
+        {
             "name": "laminas/laminas-code",
             "version": "4.5.1",
             "source": {
@@ -4004,29 +4059,31 @@
         },
         {
             "name": "maennchen/zipstream-php",
-            "version": "2.1.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maennchen/ZipStream-PHP.git",
-                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58"
+                "reference": "211e9ba1530ea5260b45d90c9ea252f56ec52729"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/c4c5803cc1f93df3d2448478ef79394a5981cc58",
-                "reference": "c4c5803cc1f93df3d2448478ef79394a5981cc58",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/211e9ba1530ea5260b45d90c9ea252f56ec52729",
+                "reference": "211e9ba1530ea5260b45d90c9ea252f56ec52729",
                 "shasum": ""
             },
             "require": {
                 "myclabs/php-enum": "^1.5",
-                "php": ">= 7.1",
+                "php": "^7.4 || ^8.0",
                 "psr/http-message": "^1.0",
                 "symfony/polyfill-mbstring": "^1.0"
             },
             "require-dev": {
                 "ext-zip": "*",
-                "guzzlehttp/guzzle": ">= 6.3",
+                "guzzlehttp/guzzle": "^6.5.3 || ^7.2.0",
                 "mikey179/vfsstream": "^1.6",
-                "phpunit/phpunit": ">= 7.5"
+                "php-coveralls/php-coveralls": "^2.4",
+                "phpunit/phpunit": "^8.5.8 || ^9.4.2",
+                "vimeo/psalm": "^4.1"
             },
             "type": "library",
             "autoload": {
@@ -4063,7 +4120,7 @@
             ],
             "support": {
                 "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
-                "source": "https://github.com/maennchen/ZipStream-PHP/tree/master"
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/2.2.1"
             },
             "funding": [
                 {
@@ -4071,7 +4128,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2020-05-30T13:11:16+00:00"
+            "time": "2022-05-18T15:52:06+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -4375,6 +4432,73 @@
             "time": "2022-03-01T10:34:45+00:00"
         },
         {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "9229e15f2e6ba772f0c55dd6986c563b937170a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/9229e15f2e6ba772f0c55dd6986c563b937170a8",
+                "reference": "9229e15f2e6ba772f0c55dd6986c563b937170a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2022-01-17T05:32:27+00:00"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v9.99.100",
             "source": {
@@ -4515,25 +4639,25 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "2.0.31",
+            "version": "3.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4"
+                "reference": "2f0b7af658cbea265cbb4a791d6c29a6613f98ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/233a920cb38636a43b18d428f9a8db1f0a1a08f4",
-                "reference": "233a920cb38636a43b18d428f9a8db1f0a1a08f4",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2f0b7af658cbea265cbb4a791d6c29a6613f98ef",
+                "reference": "2f0b7af658cbea265cbb4a791d6c29a6613f98ef",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
             },
             "require-dev": {
-                "phing/phing": "~2.7",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.0|^9.4",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpunit/phpunit": "*"
             },
             "suggest": {
                 "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
@@ -4547,7 +4671,7 @@
                     "phpseclib/bootstrap.php"
                 ],
                 "psr-4": {
-                    "phpseclib\\": "phpseclib/"
+                    "phpseclib3\\": "phpseclib/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -4604,7 +4728,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/2.0.31"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.14"
             },
             "funding": [
                 {
@@ -4620,7 +4744,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-06T13:56:45+00:00"
+            "time": "2022-04-04T05:15:45+00:00"
         },
         {
             "name": "psr/cache",
@@ -13078,16 +13202,16 @@
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "2.10.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "a3f03b3c158a3a7014c6ba553b0cb83bf7da19c4"
+                "reference": "d1bc565b23c2040fafde398a8a5db083c47928c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/a3f03b3c158a3a7014c6ba553b0cb83bf7da19c4",
-                "reference": "a3f03b3c158a3a7014c6ba553b0cb83bf7da19c4",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/d1bc565b23c2040fafde398a8a5db083c47928c0",
+                "reference": "d1bc565b23c2040fafde398a8a5db083c47928c0",
                 "shasum": ""
             },
             "require": {
@@ -13173,7 +13297,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-05-04T15:16:15+00:00"
+            "time": "2022-05-17T10:57:52+00:00"
         },
         {
             "name": "league/container",
@@ -18101,5 +18225,5 @@
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -3515,61 +3515,6 @@
             "time": "2022-04-13T08:02:27+00:00"
         },
         {
-            "name": "khaled.alshamaa/ar-php",
-            "version": "v6.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/khaled-alshamaa/ar-php.git",
-                "reference": "a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/khaled-alshamaa/ar-php/zipball/a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a",
-                "reference": "a3eb0dfe14ea9ba0fa291673c52ae7a75749e35a",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "9.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "ArPHP\\I18N\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Khaled Al-Sham'aa",
-                    "email": "khaled@ar-php.org",
-                    "homepage": "http://www.ar-php.org"
-                }
-            ],
-            "description": "Set of functionalities enable Arabic website developers to serve professional search, present and process Arabic content in PHP",
-            "homepage": "https://github.com/khaled-alshamaa/ar-php",
-            "keywords": [
-                "arabic",
-                "arabic-calendar",
-                "arabic-glyphs",
-                "arabic-numbers",
-                "arabic-segments-identifier",
-                "arabic-sentiment",
-                "arabic-sql-query"
-            ],
-            "support": {
-                "issues": "https://github.com/khaled-alshamaa/ar-php/issues",
-                "source": "https://github.com/khaled-alshamaa/ar-php/tree/v6.2.0"
-            },
-            "time": "2021-06-20T18:15:36+00:00"
-        },
-        {
             "name": "laminas/laminas-code",
             "version": "4.5.1",
             "source": {

--- a/config/openssl.cnf
+++ b/config/openssl.cnf
@@ -1,0 +1,5 @@
+# minimalist openssl.cnf file for use with phpseclib
+
+RANDFILE = /tmp/phpseclib.rnd
+
+[ v3_ca ]

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -55,4 +55,4 @@ parameters:
     webhook_active_event_subscriptions_limit: 3
     webhook_requests_limit: 4000
 
-    openssl_config_path: '%pim_ce_dev_src_folder_location%/config/openssl.conf'
+    openssl_config_path: '%pim_ce_dev_src_folder_location%/config/openssl.cnf'

--- a/config/services/pim_parameters.yml
+++ b/config/services/pim_parameters.yml
@@ -54,3 +54,5 @@ parameters:
     webhook_max_bulk_size: 10
     webhook_active_event_subscriptions_limit: 3
     webhook_requests_limit: 4000
+
+    openssl_config_path: '%pim_ce_dev_src_folder_location%/config/openssl.conf'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AsymmetricKeysGenerator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AsymmetricKeysGenerator.php
@@ -14,7 +14,9 @@ use phpseclib3\File\X509;
  */
 class AsymmetricKeysGenerator implements AsymmetricKeysGeneratorInterface
 {
-    public function __construct(private string $openSSLConfigPath) { }
+    public function __construct(private string $openSSLConfigPath)
+    {
+    }
 
     public function generate(): AsymmetricKeys
     {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AsymmetricKeysGenerator.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AsymmetricKeysGenerator.php
@@ -5,8 +5,8 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Apps;
 
 use Akeneo\Connectivity\Connection\Domain\Apps\AsymmetricKeysGeneratorInterface;
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -14,29 +14,33 @@ use phpseclib\File\X509;
  */
 class AsymmetricKeysGenerator implements AsymmetricKeysGeneratorInterface
 {
+    public function __construct(private string $openSSLConfigPath) { }
+
     public function generate(): AsymmetricKeys
     {
-        $privKey = new RSA();
-        $keys = $privKey->createKey();
-        $privateKey = $keys['privatekey'];
-        $publicKey = $keys['publickey'];
-
-        $pubKey = new RSA();
-        $pubKey->loadKey($publicKey);
-        $pubKey->setPublicKey();
+        /*
+         * Following algorithm is the implementation documented by the phpseclib library
+         * in order to generate self-signed public key and private key.
+         * ( see http://phpseclib.sourceforge.net/x509/guide.html#selfsigned )
+         */
+        RSA::setOpenSSLConfigPath($this->openSSLConfigPath);
+        /** @var RSA\PrivateKey $privateKey */
+        $privateKey = RSA::createKey();
+        $publicKey = $privateKey->getPublicKey();
 
         $subject = new X509();
         $subject->setEndDate('99991231235959Z');
         $subject->setDNProp('id-at-organizationName', 'Akeneo');
-        $subject->setPublicKey($pubKey);
+        $subject->setPublicKey($publicKey);
 
         $issuer = new X509();
-        $issuer->setPrivateKey($privKey);
+        $issuer->setPrivateKey($privateKey);
         $issuer->setDn($subject->getDN());
 
         $x509 = new X509();
+        $x509->makeCA();
         $result = $x509->sign($issuer, $subject);
 
-        return AsymmetricKeys::create($x509->saveX509($result), $privateKey);
+        return AsymmetricKeys::create($x509->saveX509($result), $privateKey->toString('PKCS1'));
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
@@ -31,6 +31,8 @@ services:
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\AsymmetricKeysGenerator:
         public: true
+        arguments:
+            - '%openssl_config_path%'
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup:
         arguments:

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/AsymmetricKeysGeneratorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/AsymmetricKeysGeneratorSpec.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Apps;
@@ -15,7 +16,7 @@ class AsymmetricKeysGeneratorSpec extends ObjectBehavior
 {
     public function let()
     {
-        $this->beConstructedWith('/srv/pim/config/openssl.cnf');
+        $this->beConstructedWith(__DIR__ . '/openssl.cnf');
     }
 
     public function it_is_an_asymmetric_keys_generator(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/AsymmetricKeysGeneratorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/AsymmetricKeysGeneratorSpec.php
@@ -13,6 +13,11 @@ use PhpSpec\ObjectBehavior;
  */
 class AsymmetricKeysGeneratorSpec extends ObjectBehavior
 {
+    public function let()
+    {
+        $this->beConstructedWith('/srv/pim/config/openssl.cnf');
+    }
+
     public function it_is_an_asymmetric_keys_generator(): void
     {
         $this->shouldHaveType(AsymmetricKeysGenerator::class);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/openssl.cnf
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/openssl.cnf
@@ -1,0 +1,5 @@
+# minimalist openssl.cnf file for use with phpseclib
+
+RANDFILE = /tmp/phpseclib.rnd
+
+[ v3_ca ]

--- a/symfony.lock
+++ b/symfony.lock
@@ -372,6 +372,9 @@
     "openlss/lib-array2xml": {
         "version": "1.0.0"
     },
+    "paragonie/constant_time_encoding": {
+        "version": "v2.4.0"
+    },
     "paragonie/random_compat": {
         "version": "v2.0.18"
     },

--- a/upgrades/.php_cd.php
+++ b/upgrades/.php_cd.php
@@ -27,11 +27,11 @@ $rules = [
             // Dangerous dependencies, migrations shouldn't rely on services
             'Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionCommand',
             'Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnectionHandler',
-            'Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys',
             'Akeneo\Connectivity\Connection\Domain\Settings\Exception\ConstraintViolationListException',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType',
             'Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\SaveAsymmetricKeysQuery',
+            'Akeneo\Connectivity\Connection\Infrastructure\Apps\AsymmetricKeysGenerator',
             'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductIndexer',
             'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer',
             'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelIndexer',

--- a/upgrades/schema/Version_6_0_20211214000000_add_openid_keys_into_pim_configuration.php
+++ b/upgrades/schema/Version_6_0_20211214000000_add_openid_keys_into_pim_configuration.php
@@ -3,21 +3,27 @@ declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
-use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\AsymmetricKeysGenerator;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\SaveAsymmetricKeysQuery;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\Migrations\AbstractMigration;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
-
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Version_6_0_20211214000000_add_openid_keys_into_pim_configuration extends AbstractMigration
+class Version_6_0_20211214000000_add_openid_keys_into_pim_configuration extends AbstractMigration implements ContainerAwareInterface
 {
+    private ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
     public function up(Schema $schema): void
     {
         $query = <<<SQL
@@ -26,7 +32,8 @@ class Version_6_0_20211214000000_add_openid_keys_into_pim_configuration extends 
             ON DUPLICATE KEY UPDATE `values`= :asymmetricKeys
             SQL;
 
-        $asymmetricKeys = $this->generate();
+        $generator = $this->container->get(AsymmetricKeysGenerator::class);
+        $asymmetricKeys = $generator->generate();
 
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
 
@@ -45,31 +52,5 @@ class Version_6_0_20211214000000_add_openid_keys_into_pim_configuration extends 
     public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
-    }
-
-    private function generate(): AsymmetricKeys
-    {
-        $privKey = new RSA();
-        $keys = $privKey->createKey();
-        $privateKey = $keys['privatekey'];
-        $publicKey = $keys['publickey'];
-
-        $pubKey = new RSA();
-        $pubKey->loadKey($publicKey);
-        $pubKey->setPublicKey();
-
-        $subject = new X509();
-        $subject->setEndDate('99991231235959Z');
-        $subject->setDNProp('id-at-organizationName', 'Akeneo');
-        $subject->setPublicKey($pubKey);
-
-        $issuer = new X509();
-        $issuer->setPrivateKey($privKey);
-        $issuer->setDn($subject->getDN());
-
-        $x509 = new X509();
-        $result = $x509->sign($issuer, $subject);
-
-        return AsymmetricKeys::create($x509->saveX509($result), $privateKey);
     }
 }


### PR DESCRIPTION
Upgrade phpseclib to be less prone to security breach and allow us to configure the `.rnd` file path ([here](https://github.com/akeneo/pim-community-dev/pull/16149/files#diff-67cbf1d31bcf9bb04169cf1e1736d9c0f99be6d1bb16a5f0777e94465d87926bR3))

Putting it in the /tmp directory avoid to create it at the project root and add it to the repo if we forget to ignore it.

See also the official for v3 imrovements: https://phpseclib.com/docs/why#phpseclib-30-vs-phspeclib-10--20