### PR TITLE
CXP-1044: hide ACL groups based on feature flag

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/acl_groups.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/acl_groups.yml
@@ -27,3 +27,4 @@ pim_enrich.acl_group.product_model:
 
 pim_system.acl_group.developer_mode:
     order: 400
+    feature: app_developer_mode

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/twig.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/twig.yml
@@ -6,5 +6,6 @@ services:
         class: '%pim_user.twig.acl_groups_extension.class%'
         arguments:
             - '%kernel.bundles%'
+            - '@feature_flags'
         tags:
             - { name: twig.extension }

--- a/tests/back/UserManagement/Integration/Bundle/ApplyFeatureFlagOnAclGroupsIntegration.php
+++ b/tests/back/UserManagement/Integration/Bundle/ApplyFeatureFlagOnAclGroupsIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\UserManagement\Integration\Bundle;
+
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Registry;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Bundle\Twig\AclGroupsExtension;
+use AkeneoTest\UserManagement\Integration\Fixtures\FeatureFlagOnAclGroupsTestBundle\FeatureFlagOnAclGroupsTestBundle;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ApplyFeatureFlagOnAclGroupsIntegration extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getConfiguration(): ?Configuration
+    {
+        return null;
+    }
+
+    public function testTheTwigExtensionHidesAclGroupsWithDisabledFeatureFlag()
+    {
+        $extension = $this->createAclGroupsExtension([
+            'foo' => false,
+        ]);
+
+        $this->assertEquals([
+            'action' => [
+                [
+                    'name' => 'test.acl_group.no_feature_flag',
+                    'order' => 10,
+                ],
+            ],
+        ], $extension->getAclGroups());
+    }
+
+    public function testTheTwigExtensionShowsAclGroupsWithEnabledFeatureFlag()
+    {
+        $extension = $this->createAclGroupsExtension([
+            'foo' => true,
+        ]);
+
+        $this->assertEquals([
+            'action' => [
+                [
+                    'name' => 'test.acl_group.no_feature_flag',
+                    'order' => 10,
+                ],
+                [
+                    'name' => 'test.acl_group.with_feature_flag',
+                    'order' => 20,
+                ],
+            ],
+        ], $extension->getAclGroups());
+    }
+
+    /**
+     * @param array<string, bool> $flags
+     */
+    private function createAclGroupsExtension(array $flags): AclGroupsExtension
+    {
+        $registry = new Registry();
+        foreach ($flags as $flag => $enabled) {
+            $registry->add($flag, new FakeFeatureFlag($enabled));
+        }
+        $features = new FeatureFlags($registry);
+        return new AclGroupsExtension(
+            [
+                'FeatureFlagOnAclGroupsTestBundle' => FeatureFlagOnAclGroupsTestBundle::class,
+            ],
+            $features,
+        );
+    }
+}

--- a/tests/back/UserManagement/Integration/Fixtures/FeatureFlagOnAclGroupsTestBundle/FeatureFlagOnAclGroupsTestBundle.php
+++ b/tests/back/UserManagement/Integration/Fixtures/FeatureFlagOnAclGroupsTestBundle/FeatureFlagOnAclGroupsTestBundle.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\UserManagement\Integration\Fixtures\FeatureFlagOnAclGroupsTestBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class FeatureFlagOnAclGroupsTestBundle extends Bundle
+{
+
+}

--- a/tests/back/UserManagement/Integration/Fixtures/FeatureFlagOnAclGroupsTestBundle/Resources/config/acl_groups.yml
+++ b/tests/back/UserManagement/Integration/Fixtures/FeatureFlagOnAclGroupsTestBundle/Resources/config/acl_groups.yml
@@ -1,0 +1,5 @@
+test.acl_group.no_feature_flag:
+    order: 10
+test.acl_group.with_feature_flag:
+    order: 20
+    feature: foo


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We added added a new ACL Group, but when you don't have the flag `FLAG_APP_DEVELOPER_MODE_ENABLED`, it look like this:
(it's visible but empty)

![Screenshot_2022-01-14_13-28-54](https://user-images.githubusercontent.com/1421130/149515904-51dde6d2-f6c7-496a-9e84-77ea282ddba4.png)

With the solution present in this PR, an ACL group can be hidden, based on a feature flag.

After, it's back to normal:
![Screenshot_2022-01-14_13-29-20](https://user-images.githubusercontent.com/1421130/149515986-83ba62f1-fd54-478a-afd9-f472817c0a14.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
