### PR TITLE
AOB-1445 : Implement findBy in memory and change spec

### DIFF
--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -80,20 +80,7 @@ class InMemoryProductRepository implements
      */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        $products = [];
-        foreach ($this->products as $product) {
-            $keepThisProduct= true;
-            foreach ($criteria as $value) {
-                if ($product->getIdentifier() !== $value) {
-                    $keepThisProduct = false;
-                    break;
-                }
-            }
-            if ($keepThisProduct) {
-                $products[] = $product;
-            }
-        }
-        return $products;
+        return $this->products->filter(fn (ProductInterface $product) => $product->getIdentifier() === $criteria['identifier'])->toArray();
     }
 
     public function findOneBy(array $criteria)

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -80,7 +80,20 @@ class InMemoryProductRepository implements
      */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        return array_filter((array)$this->products, fn($product)=> $product->getIdentifier() !== $criteria['identifier']);
+        $products = [];
+        foreach ($this->products as $product) {
+            $keepThisProduct= true;
+            foreach ($criteria as $value) {
+                if ($product->getIdentifier() !== $value) {
+                    $keepThisProduct = false;
+                    break;
+                }
+            }
+            if ($keepThisProduct) {
+                $products[] = $product;
+            }
+        }
+        return $products;
     }
 
     public function findOneBy(array $criteria)

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -12,6 +12,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class InMemoryProductRepository implements
     IdentifiableObjectRepositoryInterface,
@@ -76,7 +77,23 @@ class InMemoryProductRepository implements
 
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        throw new NotImplementedException(__METHOD__);
+        $products = [];
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
+            ->getPropertyAccessor();
+
+        foreach ($this->products as $product) {
+            $keepThisProduct= true;
+            foreach ($criteria as $key => $value) {
+                if ($propertyAccessor->getValue($product, $key) !== $value) {
+                    $keepThisProduct = false;
+                }
+            }
+            if ($keepThisProduct) {
+                $products[] = $product;
+            }
+        }
+
+        return $products;
     }
 
     public function findOneBy(array $criteria)

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -12,7 +12,6 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class InMemoryProductRepository implements
     IdentifiableObjectRepositoryInterface,
@@ -75,25 +74,13 @@ class InMemoryProductRepository implements
         return $this->products->toArray();
     }
 
+    /**
+     * We implement this method for onboarder v1 because we need it for an event subscriber
+     * and there is some integration tests that are using inmemory implem
+     */
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
     {
-        $products = [];
-        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
-            ->getPropertyAccessor();
-
-        foreach ($this->products as $product) {
-            $keepThisProduct= true;
-            foreach ($criteria as $key => $value) {
-                if ($propertyAccessor->getValue($product, $key) !== $value) {
-                    $keepThisProduct = false;
-                }
-            }
-            if ($keepThisProduct) {
-                $products[] = $product;
-            }
-        }
-
-        return $products;
+        return array_filter((array)$this->products, fn($product)=> $product->getIdentifier() !== $criteria['identifier']);
     }
 
     public function findOneBy(array $criteria)

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -150,15 +150,17 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
 
     function it_finds_products_by_criteria()
     {
-        foreach (['A', 'B', 'C'] as $identifier) {
-            $product = new Product();
-            $product->setIdentifier($identifier);
-            $this->save($product);
-        }
+        $productA = new Product();
+        $productA->setIdentifier('A');
+        $this->save($productA);
+
+        $productB = new Product();
+        $productB->setIdentifier('B');
+        $this->save($productB);
 
         $products = $this->findBy(['identifier' => 'A']);
         $products->shouldBeArray();
         $products->shouldHaveCount(1);
-        $products[0]->getIdentifier()->shouldBe('A');
+        $products->shouldHaveKeyWithValue('A', $productA);
     }
 }

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -105,7 +105,6 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
 
     function it_asserts_that_the_other_methods_are_not_implemented_yet()
     {
-        $this->shouldThrow(NotImplementedException::class)->during('findBy', [[]]);
         $this->shouldThrow(NotImplementedException::class)->during('findOneBy', [[]]);
         $this->shouldThrow(NotImplementedException::class)->during('getClassName', []);
         $this->shouldThrow(NotImplementedException::class)->during('getAvailableAttributeIdsToExport', [[]]);
@@ -147,5 +146,19 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $products->shouldHaveCount(2);
         $products[0]->getIdentifier()->shouldBe('A');
         $products[1]->getIdentifier()->shouldBe('B');
+    }
+
+    function it_finds_products_by_criteria()
+    {
+        foreach (['A', 'B', 'C'] as $identifier) {
+            $product = new Product();
+            $product->setIdentifier($identifier);
+            $this->save($product);
+        }
+
+        $products = $this->findBy(['identifier' => 'A']);
+        $products->shouldBeArray();
+        $products->shouldHaveCount(1);
+        $products[0]->getIdentifier()->shouldBe('A');
     }
 }


### PR DESCRIPTION
In pim-onboarder we use productRepository->findBy but him is not implemented in findby so some integration-test of pim was on error so i implemente in memory to correct integration test and change spec

