### PR TITLE
PIM-10233: Refresh ES index after creating a product from the UI in order to well send product created event to event subscriptions

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10233: [Backport] Refresh ES index after creating a product from the UI in order to well send product created event to event subscriptions
+
 # 5.0.68 (2022-01-17)
 
 # 5.0.67 (2022-01-03)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -268,6 +268,7 @@ class ProductController
 
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
+            $this->productAndProductModelClient->refreshIndex();
 
             $normalizedProduct = $this->normalizer->normalize(
                 $product,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -222,6 +222,7 @@ class ProductController
 
         if (0 === $violations->count()) {
             $this->productSaver->save($product);
+            $this->productAndProductModelClient->refreshIndex();
 
             return new JsonResponse($this->normalizer->normalize(
                 $product,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
@@ -223,6 +223,7 @@ class ProductModelController
         }
 
         $this->productModelSaver->save($productModel);
+        $this->productAndProductModelClient->refreshIndex();
         $normalizedProductModel = $this->normalizeProductModel($productModel);
 
         return new JsonResponse($normalizedProductModel);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductModelController.php
@@ -254,6 +254,7 @@ class ProductModelController
 
         if (0 === $violations->count()) {
             $this->productModelSaver->save($productModel);
+            $this->productAndProductModelClient->refreshIndex();
             $normalizedProductModel = $this->normalizeProductModel($productModel);
 
             return new JsonResponse($normalizedProductModel);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\InternalApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class ProductCreationEndToEnd extends InternalApiTestCase
+{
+    private ProductQueryBuilderFactoryInterface $pqbFactory;
+    private GetConnectorProducts $getConnectorProductsQuery;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pqbFactory = $this->get('pim_catalog.query.product_query_builder_from_size_factory_external_api');
+        $this->getConnectorProductsQuery = $this->get('akeneo.pim.enrichment.product.connector.get_product_from_identifiers');
+        $this->authenticate($this->getAdminUser());
+    }
+
+    public function testThatWeCanFetchANewlyCreatedProductFromTheUI(): void
+    {
+        $identifier = 'new_product';
+        $this->createProductWithInternalApi($identifier);
+
+        $admin = $this->getAdminUser();
+        $pqb = $this->pqbFactory
+            ->create(['limit' => 1])
+            ->addFilter('identifier', Operators::EQUALS, $identifier);
+
+        $createdProduct = $this->getConnectorProductsQuery
+            ->fromProductQueryBuilder($pqb, $admin->getId(), null, null, null)
+            ->connectorProducts();
+
+        $this->assertCount(1, $createdProduct);
+        $this->assertContainsOnlyInstancesOf(ConnectorProduct::class, $createdProduct);
+        $this->assertEquals($identifier, $createdProduct[0]->identifier());
+    }
+
+    private function createProductWithInternalApi(string $identifier): void
+    {
+        $this->client->request(
+            'POST',
+            '/enrich/product/rest',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+            json_encode(['identifier' => $identifier])
+        );
+        $response = $this->client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    protected function getAdminUser(): UserInterface
+    {
+        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+    }
+}


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

Refresh ES index after creating a product from the UI and the API in order to well send product and product model created/updated event to event subscriptions.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
