### PR TITLE
PIM-10232: POC add cursor for identifier

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursor.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\ResultAwareInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\ResultInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+
+/**
+ * Cursor to iterate over all identifiers.
+ *
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class IdentifierCursor implements CursorInterface, ResultAwareInterface
+{
+    protected ?array $items = null;
+    protected int $count;
+    private array $searchAfter = [];
+
+    public function __construct(
+        private Client $esClient,
+        private array $esQuery,
+        private int $pageSize
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function current()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return current($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function key()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return key($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function valid()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return !empty($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        if (null === $this->items) {
+            $this->rewind();
+        }
+
+        return $this->count;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function next()
+    {
+        if (false === next($this->items)) {
+            $this->items = $this->getNextIdentifiers($this->esQuery)->all();
+            reset($this->items);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function rewind()
+    {
+        $this->searchAfter = [];
+        $this->items = $this->getNextIdentifiers($this->esQuery)->all();
+        reset($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html
+     */
+    protected function getNextIdentifiers(array $esQuery): IdentifierResults
+    {
+        $esQuery['size'] = $this->pageSize;
+        $identifiers = new IdentifierResults();
+
+        if (0 === $esQuery['size']) {
+            return $identifiers;
+        }
+
+        $sort = ['_id' => 'asc'];
+
+        if (isset($esQuery['sort'])) {
+            $sort = array_merge($esQuery['sort'], $sort);
+        }
+
+        $esQuery['sort'] = $sort;
+        $esQuery['track_total_hits'] = true;
+
+        if (!empty($this->searchAfter)) {
+            $esQuery['search_after'] = $this->searchAfter;
+        }
+
+        $response = $this->esClient->search($esQuery);
+        $this->result = new ElasticsearchResult($response);
+        $this->count = $response['hits']['total']['value'];
+
+        foreach ($response['hits']['hits'] as $hit) {
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+        }
+
+        $lastResult = end($response['hits']['hits']);
+
+        if (false !== $lastResult) {
+            $this->searchAfter = $lastResult['sort'];
+        }
+
+        return $identifiers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResult(): ResultInterface
+    {
+        if (null === $this->result) {
+            $this->getNextIdentifiers($this->esQuery);
+        }
+
+        return $this->result;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursorFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor;
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
@@ -8,8 +8,7 @@ use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
 /**
  * Cursor factory to instantiate an elasticsearch cursor
  *
- * @author    Marie Bochu <marie.bochu@akeneo.com>
- * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class IdentifierCursorFactory implements CursorFactoryInterface

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
@@ -13,6 +13,13 @@ services:
             - '%akeneo_elasticsearch.cursor.cursor.class%'
             - '%pim_job_product_batch_size%'
 
+    pim_catalog.factory.product_identifier_cursor:
+        class: 'Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor\IdentifierCursorFactory'
+        arguments:
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierCursor'
+            - '%pim_job_product_batch_size%'
+
     pim_catalog.factory.product_search_after_size_cursor:
         class: '%akeneo_elasticsearch.cursor.search_after_size_cursor_factory.class%'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
@@ -14,7 +14,7 @@ services:
             - '%pim_job_product_batch_size%'
 
     pim_catalog.factory.product_identifier_cursor:
-        class: 'Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor\IdentifierCursorFactory'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierCursorFactory'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierCursor'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -68,7 +68,7 @@ services:
         class: '%pim_catalog.tasklet.compute_completeness_of_products_family.class%'
         arguments:
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.query.product_identifier_query_builder_factory'
+            - '@pim_catalog.query.product_query_builder_factory'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
         public: false

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -68,7 +68,7 @@ services:
         class: '%pim_catalog.tasklet.compute_completeness_of_products_family.class%'
         arguments:
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
         public: false
@@ -207,13 +207,14 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyProductsTasklet'
         arguments:
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_connector.reader.file.csv_family'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
             - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
             - '@validator'
+            - '@pim_catalog.repository.product'
             - '%pim_job_product_batch_size%'
 
     pim_connector.tasklet.mass_edit_family.compute_completeness_of_family_products:
@@ -256,13 +257,14 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyProductsTasklet'
         arguments:
             - '@pim_catalog.repository.family'
-            - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_connector.reader.file.xlsx_family'
             - '@pim_catalog.saver.product'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
             - '@pim_catalog.entity_with_family_variant.keep_only_values_for_variation'
             - '@validator'
+            - '@pim_catalog.repository.product'
             - '%pim_job_product_batch_size%'
 
     pim_connector.tasklet.csv_attribute_group_import.ensure_attribute_group_order:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -67,6 +67,16 @@ services:
             - '@pim_catalog.factory.product_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
+    pim_catalog.query.product_identifier_query_builder_factory:
+        class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.product_registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_identifier_cursor'
+            - '@pim_catalog.query.product_query_builder_resolver'
+
     pim_catalog.query.product_query_builder_search_after_size_factory:
         class: '%pim_catalog.query.elasticsearch.product_query_builder_factory.class%'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTasklet.php
@@ -121,7 +121,7 @@ class ComputeDataRelatedToFamilyProductsTasklet implements TaskletInterface, Ini
         }
     }
 
-    private function updateAndSaveProducts(array $products)
+    private function updateAndSaveProducts(array $products): void
     {
         $productsToSave = [];
         foreach ($products as $product) {

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/IdentifierCursorFactory.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/IdentifierCursorFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor;
+
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
+
+/**
+ * Cursor factory to instantiate an elasticsearch cursor
+ *
+ * @author    Marie Bochu <marie.bochu@akeneo.com>
+ * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IdentifierCursorFactory implements CursorFactoryInterface
+{
+    public function __construct(
+        private Client $searchEngine,
+        private string $cursorClassName,
+        private int $pageSize
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createCursor($queryBuilder, array $options = [])
+    {
+        $pageSize = $options['page_size'] ?? $this->pageSize;
+        if (!isset($queryBuilder['_source'])) {
+            $queryBuilder['_source'] = [];
+        }
+        foreach (['identifier', 'document_type'] as $sourceItem) {
+            if (!\in_array($sourceItem,  $queryBuilder['_source'])) {
+                $queryBuilder['_source'][] = $sourceItem;
+            }
+        }
+
+        return new $this->cursorClassName($this->searchEngine, $queryBuilder, $pageSize);
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this POC we:
- add a cursor that returns only identifiers
- the jobs now should work with identifiers, meaning they must now hydrate the products if they need to

I also update the ComputeDataRelatedToFamilyProductsTasklet to demonstrate how it works, but **the fix of the PIM-10232 will be done when ALL jobs using PQB will be updated(!)**
