### PR TITLE
PIM-10232: Quick fix on the "Error a new entity was found in the relationship..." error during jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@
 - PIM-10218: Remove previous scope filter before moving the new one
 - PIM-10215: Fixed last operation widget job type translation key
 - PIM-10233: Fix the saved value by an empty wysiwyg
+- PIM-10232: Fix "A new entity is found through the relationship" errors in jobs
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Cursor/SequentialEditProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Cursor/SequentialEditProduct.php
@@ -21,7 +21,7 @@ class SequentialEditProduct extends Cursor implements CursorInterface
      *
      * @return array
      */
-    protected function getNextItems(array $esQuery)
+    protected function getNextItems(array $esQuery): array
     {
         $identifiers = $this->getNextIdentifiers($esQuery);
         if (empty($identifiers)) {
@@ -36,9 +36,9 @@ class SequentialEditProduct extends Cursor implements CursorInterface
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html
      */
-    protected function getNextIdentifiers(array $esQuery)
+    protected function getNextIdentifiers(array $esQuery, int $size = null)
     {
-        $esQuery['size'] = $this->pageSize;
+        $esQuery['size'] = $size ?? $this->pageSize;
 
         if (0 === $esQuery['size']) {
             return [];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
@@ -100,16 +100,12 @@ abstract class AbstractCursor implements CursorInterface
             return [];
         }
 
-        $hydratedProducts = \count($identifierResults->getProductIdentifiers()) === 0
-            ? []
-            : $this->productRepository->getItemsFromIdentifiers(
-                $identifierResults->getProductIdentifiers()
-            );
-        $hydratedProductModels = \count($identifierResults->getProductModelIdentifiers()) === 0
-            ? []
-            : $this->productModelRepository->getItemsFromIdentifiers(
-                $identifierResults->getProductModelIdentifiers()
-            );
+        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductIdentifiers()
+        );
+        $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(
+            $identifierResults->getProductModelIdentifiers()
+        );
         $hydratedItems = array_merge($hydratedProducts, $hydratedProductModels);
 
         $orderedItems = [];

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
@@ -91,17 +91,25 @@ abstract class AbstractCursor implements CursorInterface
      */
     protected function getNextItems(array $esQuery): array
     {
-        $identifierResults = $this->getNextIdentifiers($esQuery);
+        return $this->getNextItemsFromIdentifiers($this->getNextIdentifiers($esQuery));
+    }
+
+    protected function getNextItemsFromIdentifiers(IdentifierResults $identifierResults): array
+    {
         if ($identifierResults->isEmpty()) {
             return [];
         }
 
-        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
-            $identifierResults->getProductIdentifiers()
-        );
-        $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(
-            $identifierResults->getProductModelIdentifiers()
-        );
+        $hydratedProducts = \count($identifierResults->getProductIdentifiers()) === 0
+            ? []
+            : $this->productRepository->getItemsFromIdentifiers(
+                $identifierResults->getProductIdentifiers()
+            );
+        $hydratedProductModels = \count($identifierResults->getProductModelIdentifiers()) === 0
+            ? []
+            : $this->productModelRepository->getItemsFromIdentifiers(
+                $identifierResults->getProductModelIdentifiers()
+            );
         $hydratedItems = array_merge($hydratedProducts, $hydratedProductModels);
 
         $orderedItems = [];

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/AbstractCursor.php
@@ -92,9 +92,13 @@ abstract class AbstractCursor implements CursorInterface
      *
      * @return array
      */
-    protected function getNextItems(array $esQuery)
+    protected function getNextItems(array $esQuery): array
     {
-        $identifiers = $this->getNextIdentifiers($esQuery);
+        return $this->getNextItemsFromIdentifiers($this->getNextIdentifiers($esQuery));
+    }
+
+    protected function getNextItemsFromIdentifiers(array $identifiers): array
+    {
         if (empty($identifiers)) {
             return [];
         }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
@@ -58,8 +58,7 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
      */
     public function next()
     {
-        $next = next($this->items);
-        if (false === $next) {
+        if (false === next($this->items)) {
             $this->fetchedItemsCount += count($this->items);
             $this->items = $this->getNextItems($this->esQuery);
             reset($this->items);

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Cursor/SearchAfterSizeCursor.php
@@ -58,7 +58,8 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
      */
     public function next()
     {
-        if (false === next($this->items)) {
+        $next = next($this->items);
+        if (false === $next) {
             $this->fetchedItemsCount += count($this->items);
             $this->items = $this->getNextItems($this->esQuery);
             reset($this->items);
@@ -66,13 +67,43 @@ class SearchAfterSizeCursor extends AbstractCursor implements CursorInterface
     }
 
     /**
+     * Get the next items (hydrated from doctrine repository).
+     *
+     * PIM-102132: The quick-and-dirty fix here is to always return "pageSize" items (except of course when no more result is found).
+     * Before the fix we could return less than the "pageSize" count, when ES and MySQL are de-synchronized (= there
+     * is more result in ES than in MySQL).
+     * Returning fewer results can cause some UoW issues (c.f. ticket)
+     */
+    protected function getNextItems(array $esQuery): array
+    {
+        $pageSize = min($this->pageSize, $this->limit);
+
+        $totalItems = [];
+        $try = 0;
+        do {
+            $try++;
+
+            $numberOfIdentifiersToFind = $pageSize - \count($totalItems);
+            $identifiers = $this->getNextIdentifiers($esQuery, $numberOfIdentifiersToFind);
+            $totalItems = \array_merge($totalItems, $this->getNextItemsFromIdentifiers($identifiers));
+            if (\count($identifiers) < $numberOfIdentifiersToFind) {
+                // There is no more result, we can stop the loop.
+                break;
+            }
+        } while (\count($totalItems) < $pageSize && $try <= 5);
+
+        return $totalItems;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.x/search-request-search-after.html
      */
-    protected function getNextIdentifiers(array $esQuery)
+    protected function getNextIdentifiers(array $esQuery, int $size = null)
     {
-        $size = $this->limit > $this->pageSize ? $this->pageSize : $this->limit;
+        $pageSize = $size ?? $this->pageSize;
+        $size = $this->limit > $pageSize ? $pageSize : $this->limit;
         if ($this->fetchedItemsCount + $size > $this->limit) {
             $size = $this->limit - $this->fetchedItemsCount;
         }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/Cursor/SearchAfterSizeCursorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Cursor\SearchAfterSizeCursor;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
@@ -91,17 +92,6 @@ class SearchAfterSizeCursorSpec extends ObjectBehavior
                     ]
                 ]
             ]);
-        $esClient->search(
-            [
-                'size' => 2,
-                'sort' => ['_id' => 'asc'],
-                'search_after' => ['fum']
-            ])->willReturn([
-                'hits' => [
-                    'total' => 4,
-                    'hits' => []
-                ]
-            ]);
 
         $page1 = [$productBaz, $productFoo];
         $page2 = [$productFum];
@@ -113,6 +103,63 @@ class SearchAfterSizeCursorSpec extends ObjectBehavior
         $productBaz->getIdentifier()->willReturn('baz');
         $productFum->getIdentifier()->willReturn('fum');
 
+        for ($i = 0; $i < 2; $i++) {
+            if ($i > 0) {
+                $this->next()->shouldReturn(null);
+            }
+            $this->valid()->shouldReturn(true);
+            $this->current()->shouldReturn($data[$i]);
+
+            $n = 0 === $i%2 ? 0 : $i;
+            $this->key()->shouldReturn($n);
+        }
+
+        $this->next()->shouldReturn(null);
+        $this->valid()->shouldReturn(false);
+
+        // check behaviour after the end of data
+        $this->current()->shouldReturn(null);
+        $this->key()->shouldReturn(null);
+    }
+
+    /**
+     * PIM-10232
+     */
+    function it_is_iterable_and_returns_page_size_results(
+        Client $esClient,
+        CursorableRepositoryInterface $repository
+    ) {
+        $productBaz = new Product();
+        $productBaz->setIdentifier('baz');
+        $productFum = new Product();
+        $productFum->setIdentifier('fum');
+        $esClient->search(
+            [
+                'track_total_hits' => true,
+                'size' => 1,
+                'sort' => ['_id' => 'asc'],
+                'search_after' => ['foo'],
+            ])
+            ->willReturn([
+                'hits' => [
+                    'total' => ['value' => 4, 'relation' => 'eq'],
+                    'hits' => [
+                        [
+                            '_source' => ['identifier' => 'fum'],
+                            'sort' => ['fum']
+                        ]
+                    ]
+                ]
+            ]);
+
+        $this->shouldImplement(\Iterator::class);
+
+        $repository->getItemsFromIdentifiers(['baz', 'foo'])->willReturn([$productBaz]);
+        $repository->getItemsFromIdentifiers(['fum'])->willReturn([$productFum]);
+
+        $data = [$productBaz, $productFum];
+
+        $this->rewind()->shouldReturn(null);
         for ($i = 0; $i < 2; $i++) {
             if ($i > 0) {
                 $this->next()->shouldReturn(null);

--- a/tests/back/Pim/Enrichment/Integration/PQB/UpdateProductsWhenElasticsearchIsDesynchronisedIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/UpdateProductsWhenElasticsearchIsDesynchronisedIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Test\Integration\Configuration;
+
+final class UpdateProductsWhenElasticsearchIsDesynchronisedIntegration extends AbstractProductQueryBuilderTestCase
+{
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @test
+     * See https://akeneo.atlassian.net/browse/PIM-10232
+     * In this test we simulate an Elasticsearch desynchro and a job that updates products per batch of 100.
+     * If the "Doctrine\ORM\ORMInvalidArgumentException: A new entity was found through the relationship..." error
+     * does not occur, the test is green.
+     */
+    public function it_can_enable_all_products(): void
+    {
+        // Remove a product in DB to simulate a desynchro between ES and MySQL
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('product_0');
+        self::assertNotNull($product);
+        $this->get('database_connection')->executeQuery(
+            'DELETE FROM pim_catalog_product WHERE id = :product_id',
+            ['product_id' => $product->getId()]
+        );
+
+        $batchSize = $this->getParameter('pim_job_product_batch_size');
+        $pqb = $this->get('pim_catalog.query.product_query_builder_factory')->create();
+        $pqb->addFilter('enabled', Operators::EQUALS, false);
+        $products = $pqb->execute();
+
+        $batchedProducts = [];
+        /** @var ProductInterface $product */
+        foreach ($products as $product) {
+            $product->setEnabled(true);
+            $batchedProducts[] = $product;
+
+            if ($batchSize <= \count($batchedProducts)) {
+                $this->get('pim_catalog.saver.product')->saveAll($batchedProducts);
+                $batchedProducts = [];
+                $this->get('pim_connector.doctrine.cache_clearer')->clear();
+            }
+        }
+        if (0 > \count($batchedProducts)) {
+            $this->get('pim_catalog.saver.product')->saveAll($batchedProducts);
+            $this->get('pim_connector.doctrine.cache_clearer')->clear();
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $products = [];
+        for ($i = 0; $i < 210; $i++) {
+            $product = $this->get('pim_catalog.builder.product')->createProduct(\sprintf('product_%d', $i), null);
+            $this->get('pim_catalog.updater.product')->update($product, [
+                'enabled' => false,
+                'values' => [],
+            ]);
+            $products[] = $product;
+        }
+        $this->get('pim_catalog.saver.product')->saveAll($products);
+
+        $this->esProductClient->refreshIndex();
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
@@ -232,9 +232,11 @@ class CursorSpec extends ObjectBehavior
         $product->getIdentifier()->willReturn('a-product2');
         $productRepository->getItemsFromIdentifiers(['a-product'])->willReturn([]);
         $productRepository->getItemsFromIdentifiers(['a-product2'])->willReturn([$product]);
+        $productRepository->getItemsFromIdentifiers([])->willReturn([]);
 
         $rootProductModel->getCode()->willReturn('a-root-product-model');
         $productModelRepository->getItemsFromIdentifiers(['a-root-product-model'])->willReturn([$rootProductModel]);
+        $productModelRepository->getItemsFromIdentifiers([])->willReturn([]);
 
         // Second round
         $esClient->search(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/CursorSpec.php
@@ -216,4 +216,103 @@ class CursorSpec extends ObjectBehavior
         $this->current()->shouldReturn(false);
         $this->key()->shouldReturn(null);
     }
+
+    /**
+     * PIM-10232
+     */
+    function it_is_iterable_and_returns_page_size_results(
+        Client $esClient,
+        CursorableRepositoryInterface $productRepository,
+        CursorableRepositoryInterface $productModelRepository,
+        ProductInterface $variantProduct,
+        ProductModelInterface $subProductModel,
+        ProductInterface $product,
+        ProductModelInterface $rootProductModel
+    ) {
+        $product->getIdentifier()->willReturn('a-product2');
+        $productRepository->getItemsFromIdentifiers(['a-product'])->willReturn([]);
+        $productRepository->getItemsFromIdentifiers(['a-product2'])->willReturn([$product]);
+
+        $rootProductModel->getCode()->willReturn('a-root-product-model');
+        $productModelRepository->getItemsFromIdentifiers(['a-root-product-model'])->willReturn([$rootProductModel]);
+
+        // Second round
+        $esClient->search(
+            [
+                'size' => 2,
+                'sort' => ['_id' => 'asc'],
+                'search_after' => ['#a-sub-product-model'],
+                'track_total_hits' => true,
+            ])
+            ->willReturn([
+                'hits' => [
+                    'total' => ['value' => 4],
+                    'hits' => [
+                        [
+                            '_source' => ['identifier' => 'a-root-product-model', 'document_type' => ProductModelInterface::class],
+                            'sort' => ['#a-root-product-model']
+                        ],
+                        [
+                            '_source' => ['identifier' => 'a-product', 'document_type' => ProductInterface::class],
+                            'sort' => ['#a-product']
+                        ],
+                    ]
+                ]
+            ]);
+        // Second round try #2 because "a-product" is not found in DB. So we ask to fetch 1 more item
+        $esClient->search(
+            [
+                'size' => 1,
+                'sort' => ['_id' => 'asc'],
+                'search_after' => ['#a-product'],
+                'track_total_hits' => true,
+            ])->willReturn([
+            'hits' => [
+                'total' => ['value' => 4],
+                'hits' => [
+                    [
+                        '_source' => ['identifier' => 'a-product2', 'document_type' => ProductInterface::class],
+                        'sort' => ['#a-product2'],
+                    ],
+                ],
+            ],
+        ]);
+        // Third round
+        $esClient->search(
+            [
+                'size' => 2,
+                'sort' => ['_id' => 'asc'],
+                'search_after' => ['#a-product2'],
+                'track_total_hits' => true,
+            ])->willReturn([
+            'hits' => [
+                'total' => ['value' => 4],
+                'hits' => [],
+            ],
+        ]);
+
+        $page1 = [$variantProduct, $subProductModel];
+        $page2 = [$rootProductModel, $product];
+        $data = array_merge($page1, $page2);
+
+        $this->shouldImplement(\Iterator::class);
+
+        $this->rewind()->shouldReturn(null);
+        for ($i = 0; $i < 4; $i++) {
+            if ($i > 0) {
+                $this->next()->shouldReturn(null);
+            }
+            $this->valid()->shouldReturn(true);
+            $this->current()->shouldReturn($data[$i]);
+
+            $this->key()->shouldReturn($i%2);
+        }
+
+        $this->next()->shouldReturn(null);
+        $this->valid()->shouldReturn(false);
+
+        // check behaviour after the end of data
+        $this->current()->shouldReturn(false);
+        $this->key()->shouldReturn(null);
+    }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-10232

**What's happening?**

Given a job that needs to iterate on products to make some product updates, it generally uses a PQB that hydrates products per batch of 100, and returns them one by one.
When 100 products are hydrated with doctrine ORM, they are also in the doctrine's Unit of Work.
The job treat them also per batch of 100, and clears the Doctrine UoW after each batch of 100.

So now what's happening if there is a desynchro between ES and MySQL, for example a product is returned by ES but unknown in MySQL?
The ES query returns 100 products, but MySQL returns 99 products. The cursor have 99 products in memory. So when the job ask for the 100th product, the cursor do a new ES query to ask the next 100 products, and begin to return the first one.
The job has now exactly 100 products, so it treats them and clear the UoW. Now the UoW is cleared BUT the cursor still have products in memory (99 in this case). The next time this product will be treated, the UoW will tell it does not know them and throws the "Error a new entity was found in the relationship..." error.


**The fix**

The goal is to fix the cursors to always returns 100 entities (except there is no more results of indeed). That will fix the bugs in several jobs.

Before:
- ES returns 100 identifiers
- We hydrate them but only 99 entities can be found in the DB
- Error later in the jobs because of UOW clear

After:
- ES returns 100 identifiers
- We hydrate them but only 99 entities can be found in the DB
- We ask ES one more identifier
- We hydrate it and now the cursor have 100 entities
- No error in the jobs

The situation is still fragile and we plan to work on a better and cleaner fix. But it fixes quickly the bug and give us some time to work on it. 

The cursors that use "search_after" method are fixed. Other that use "from/to" are not fixed (and we cannot fix it with the same method) but this is not a problem: they are used in API/datagrid use cases, where the bug is not relevant.


**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
