### PR TITLE
Apply association sorting in the versioned normalizer for better compare

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/ProductModelNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/ProductModelNormalizer.php
@@ -160,6 +160,10 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
                 $productModels[] = $productModel->getCode();
             }
 
+            asort($groups);
+            asort($products);
+            asort($productModels);
+
             $results[$columnPrefix . '-groups'] = implode(',', $groups);
             $results[$columnPrefix . '-products'] = implode(',', $products);
             $results[$columnPrefix . '-product_models'] = implode(',', $productModels);


### PR DESCRIPTION
Hi,

We have a case with a small catalog, when importing full file data, the version manager reports that changes have been made every time a product was imported, even if the product is the same. Creating unwanted version history changes. 

![image](https://user-images.githubusercontent.com/3798321/150754249-d2171081-0b97-453a-a43e-c3544fd0c7e2.png)


This change helps to mitigate that problem although maybe more a elegant solution might be possible.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
