### PR TITLE
PIM-10240: Fix 500 error to a proper 422 error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@
 - PIM-10215: Fixed last operation widget job type translation key
 - PIM-10233: Fix the saved value by an empty wysiwyg
 - PIM-10232: Fix "A new entity is found through the relationship" errors in jobs
+- PIM-10240: Fix error 500 on the API when inputting data:null for an existing price
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -29,6 +29,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProd
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormat;
 use Akeneo\Pim\Structure\Component\Repository\ExternalApi\AttributeRepositoryInterface;
 use Akeneo\Tool\Bundle\ApiBundle\Cache\WarmupQueryCache;
 use Akeneo\Tool\Bundle\ApiBundle\Checker\DuplicateValueChecker;
@@ -208,7 +209,8 @@ class ProductController
         RemoveParentInterface $removeParent,
         GetProductsWithCompletenessesInterface $getProductsWithCompletenesses,
         LoggerInterface $apiProductAclLogger,
-        SecurityFacade $security
+        SecurityFacade $security,
+        private ValidatorInterface $validator
     ) {
         $this->normalizer = $normalizer;
         $this->channelRepository = $channelRepository;
@@ -386,6 +388,15 @@ class ProductController
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
         $data = $this->getDecodedContent($request->getContent());
+        $violations = $this->validator->validate($data, new PayloadFormat());
+        if (0 < $violations->count()) {
+            $firstViolation = $violations->get(0);
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products__code_',
+                sprintf('%s Check the expected format on the API documentation.', $firstViolation->getMessage()),
+                new \LogicException($firstViolation->getMessage())
+            );
+        }
 
         try {
             $this->duplicateValueChecker->check($data);
@@ -438,6 +449,15 @@ class ProductController
         }
 
         $data = $this->getDecodedContent($request->getContent());
+        $violations = $this->validator->validate($data, new PayloadFormat());
+        if (0 < $violations->count()) {
+            $firstViolation = $violations->get(0);
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products__code_',
+                sprintf('%s Check the expected format on the API documentation.', $firstViolation->getMessage()),
+                new \LogicException($firstViolation->getMessage())
+            );
+        }
 
         try {
             $this->duplicateValueChecker->check($data);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -392,7 +392,7 @@ class ProductController
         if (0 < $violations->count()) {
             $firstViolation = $violations->get(0);
             throw new DocumentedHttpException(
-                Documentation::URL . 'patch_products__code_',
+                Documentation::URL . 'post_products',
                 sprintf('%s Check the expected format on the API documentation.', $firstViolation->getMessage()),
                 new \LogicException($firstViolation->getMessage())
             );
@@ -404,7 +404,7 @@ class ProductController
             $this->eventDispatcher->dispatch(new TechnicalErrorEvent($e));
 
             throw new DocumentedHttpException(
-                Documentation::URL . 'patch_products__code_',
+                Documentation::URL . 'post_products',
                 sprintf('%s Check the expected format on the API documentation.', $e->getMessage()),
                 $e
             );

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -74,6 +74,7 @@ services:
             - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
             - '@monolog.logger.pim_api_acl'
             - '@oro_security.security_facade'
+            - '@validator'
 
     pim_api.controller.product_model:
         public: true

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -369,3 +369,9 @@ services:
             - '@akeneo.pim.enrichment.product.query.find_non_existing_product_model_codes_query'
         tags:
             - { name: validator.constraint_validator, alias: pim_connector.validator.constraints.quantified_associations_validator }
+
+    Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormatValidator:
+        arguments:
+            - '@pim_catalog.repository.attribute'
+        tags:
+            - { name: validator.constraint_validator }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormat.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormat.php
@@ -2,19 +2,14 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Akeneo PIM Enterprise Edition.
- *
- * (c) 2022 Akeneo SAS (https://www.akeneo.com)
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 final class PayloadFormat extends Constraint
 {
     public string $message = 'Property "values" expects an array as data, "%s" given.';

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormat.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormat.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi;
+
+use Symfony\Component\Validator\Constraint;
+
+final class PayloadFormat extends Constraint
+{
+    public string $message = 'Property "values" expects an array as data, "%s" given.';
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
@@ -109,11 +109,10 @@ final class PayloadFormatValidator extends ConstraintValidator
                 new All([
                     new Type(['type' => 'array', 'message' => \sprintf('Property "%s" expect to be an array of array', $attributeCode)]),
                     new Collection([
-                        'extraFieldsMessage' => \sprintf('Property "%s" does not expect the {{ field }} field', $attributeCode),
+                        'allowExtraFields' => true, // To avoid BC break
                         'missingFieldsMessage' => \sprintf(
                             'Property "%s" expects an array with the key {{ field }}. Check the expected format on the API documentation.',
                             $attributeCode,
-
                         ),
                         'fields' => [
                             'locale' => [new Type(['type' => 'string', 'message' => \sprintf(self::WRONG_LOCALE_FORMAT, $attributeCode)])],

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\ConstraintValidator;
+
+final class PayloadFormatValidator extends ConstraintValidator
+{
+    /** @var array<string, string> */
+    private array $attributeTypeByCodes = [];
+    private const WRONG_LOCALE_FORMAT = 'Property "%s" expects an array with the key "locale" as string. Check the expected format on the API documentation.';
+    private const WRONG_SCOPE_FORMAT = 'Property "%s" expects an array with the key "scope" as string. Check the expected format on the API documentation.';
+
+    public function __construct(private AttributeRepositoryInterface $attributeRepository)
+    {
+    }
+
+    public function validate($data, Constraint $constraint): void
+    {
+        $values = \is_array($data['values'] ?? null) ? $data['values'] : [];
+        $this->cacheAttributeTypeByCodes(\array_keys($values));
+
+        $contextualValidator = $this->context->getValidator()->inContext($this->context);
+
+        $contextualValidator->validate($data, [
+            new Type(['type' => 'array']),
+            new NotNull(),
+            new Collection([
+                'allowExtraFields' => true,
+                'allowMissingFields' => true,
+                'fields' => [
+                    'values' => [
+                        new Collection([
+                            'allowExtraFields' => true,
+                            'fields' => $this->getValuesConstraints($values),
+                        ]),
+                    ],
+                ],
+            ]),
+        ]);
+    }
+
+    /**
+     * @param string[] $attributeCodes
+     */
+    private function cacheAttributeTypeByCodes(array $attributeCodes): void
+    {
+        if ([] === $attributeCodes) {
+            return;
+        }
+
+        $codesToFetch = array_diff($attributeCodes, array_keys($this->attributeTypeByCodes));
+        $this->attributeTypeByCodes += $this->attributeRepository->getAttributeTypeByCodes($codesToFetch);
+    }
+
+    /**
+     * @return Constraint[]
+     */
+    private function getValuesConstraints(array $values): array
+    {
+        $constraintsByAttribute = [];
+        foreach ($values as $attributeCode => $valuesForAttribute) {
+            $attributeType = $this->attributeTypeByCodes[$attributeCode] ?? null;
+            $dataConstraints = [];
+
+            if (AttributeTypes::PRICE_COLLECTION === $attributeType) {
+                $wrongDataFormatMessage = \sprintf('The data format sent for the "%s" attribute is wrong. Please, fill in one value per amount field.', $attributeCode);
+
+                $dataConstraints = [
+                    new Type(['type' => 'array', 'message' => $wrongDataFormatMessage]),
+                    new NotNull(['message' => $wrongDataFormatMessage]),
+                    new All([
+                        new Collection([
+                            'fields' => [
+                                'amount' => [
+                                    new Type(['type' => ['string', 'int', 'float', 'null'], 'message' => $wrongDataFormatMessage]),
+                                ],
+                                'currency' => [
+                                    new Type(['type' => 'string', 'message' => $wrongDataFormatMessage]),
+                                    new NotNull(['message' => $wrongDataFormatMessage]),
+                                ],
+                            ],
+                        ]),
+                    ]),
+                ];
+            }
+
+            $constraintsByAttribute[$attributeCode] = [
+                new All([
+                    new Collection([
+                        'extraFieldsMessage' => \sprintf('Property "%s" does not expect the {{ field }} field', $attributeCode),
+                        'missingFieldsMessage' => \sprintf(
+                            'Property "%s" expects an array with the key {{ field }}. Check the expected format on the API documentation.',
+                            $attributeCode,
+
+                        ),
+                        'fields' => [
+                            'locale' => [new Type(['type' => 'string', 'message' => \sprintf(self::WRONG_LOCALE_FORMAT, $attributeCode)])],
+                            'scope' => [new Type(['type' => 'string', 'message' => \sprintf(self::WRONG_SCOPE_FORMAT, $attributeCode)])],
+                            'data' => $dataConstraints,
+                        ],
+                    ]),
+                ]),
+            ];
+        }
+
+        return $constraintsByAttribute;
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
@@ -46,18 +46,13 @@ final class PayloadFormatValidatorIntegration extends TestCase
         $payload = [
             'values' => [
                 'a_text' => [
-                    ['locale' => null, 'scope' => null, 'foo' => 'bar'],
+                    ['locale' => null, 'scope' => null],
                 ],
             ],
         ];
         $violations = $this->validator->validate($payload, new PayloadFormat());
         self::assertStringContainsString(
             'Property "a_text" expects an array with the key "data". Check the expected format on the API documentation.',
-            (string) $violations,
-            \sprintf('Violation message is not found, have: %s', $violations)
-        );
-        self::assertStringContainsString(
-            'Property "a_text" does not expect the "foo" field',
             (string) $violations,
             \sprintf('Violation message is not found, have: %s', $violations)
         );

--- a/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Validation;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormat;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class PayloadFormatValidatorIntegration extends TestCase
+{
+    private ValidatorInterface $validator;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /** @test */
+    public function it_validates_a_valid_payload(): void
+    {
+        $this->assertNoViolationForPayload([]);
+        $this->assertNoViolationForPayload(['foo' => 'bar']);
+        $this->assertNoViolationForPayload([
+            'values' => [
+                'a_text' => [
+                    ['locale' => null, 'scope' => null, 'data' => 'foo'],
+                ],
+                'price' => [
+                    ['locale' => 'en_US', 'scope' => null, 'data' => [['amount' => 100, 'currency' => 'USD']]],
+                    ['locale' => 'fr_FR', 'scope' => null, 'data' => [['amount' => '100', 'currency' => 'USD']]],
+                ],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_adds_violations_when_validate_a_wrong_value_format(): void
+    {
+        $payload = [
+            'values' => [
+                'a_text' => [
+                    ['locale' => null, 'scope' => null, 'foo' => 'bar'],
+                ],
+            ],
+        ];
+        $violations = $this->validator->validate($payload, new PayloadFormat());
+        self::assertStringContainsString(
+            'Property "a_text" expects an array with the key "data". Check the expected format on the API documentation.',
+            (string) $violations,
+            \sprintf('Violation message is not found, have: %s', $violations)
+        );
+        self::assertStringContainsString(
+            'Property "a_text" does not expect the "foo" field',
+            (string) $violations,
+            \sprintf('Violation message is not found, have: %s', $violations)
+        );
+
+        $payload = [
+            'values' => [
+                'a_text' => ['locale' => null, 'scope' => null, 'foo' => 'bar'],
+            ],
+        ];
+        $violations = $this->validator->validate($payload, new PayloadFormat());
+        self::assertStringContainsString(
+            'Property "a_text" expect to be an array of array',
+            (string) $violations,
+            \sprintf('Violation message is not found, have: %s', $violations)
+        );
+    }
+
+    /** @test */
+    public function it_adds_violations_when_validate_a_wrong_price_value_format(): void
+    {
+        $payloads = [];
+        $payloads[] = [
+            'values' => [
+                'a_price' => [
+                    ['locale' => null, 'scope' => null, 'data' => 100],
+                ],
+            ],
+        ];
+        $payloads[] = [
+            'values' => [
+                'a_price' => [
+                    ['locale' => null, 'scope' => null, 'data' => null],
+                ],
+            ],
+        ];
+        $payloads[] = [
+            'values' => [
+                'a_price' => [
+                    ['locale' => null, 'scope' => null, 'data' => [['amount' => [], 'currency' => 'USD']]],
+                ],
+            ],
+        ];
+        $payloads[] = [
+            'values' => [
+                'a_price' => [
+                    ['locale' => null, 'scope' => null, 'data' => [['amount' => 100, 'currency' => []]]],
+                ],
+            ],
+        ];
+
+        foreach ($payloads as $payload) {
+            $violations = $this->validator->validate($payload, new PayloadFormat());
+            self::assertStringContainsString(
+                'The data format sent for the "a_price" attribute is wrong. Please, fill in one value per amount field.',
+                (string) $violations,
+                \sprintf('Violation message is not found, have: %s', $violations)
+            );
+        }
+    }
+
+    private function assertNoViolationForPayload(array $payload): void
+    {
+        $violations = $this->validator->validate($payload, new PayloadFormat());
+        self::assertSame(0, $violations->count(), \sprintf('Violations are found: %s', $violations));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = $this->get('validator');
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ExternalApi/PayloadFormatValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ExternalApi/PayloadFormatValidatorSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormat;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormatValidator;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+class PayloadFormatValidatorSpec extends ObjectBehavior
+{
+    function let(AttributeRepositoryInterface $attributeRepository, ExecutionContextInterface $context)
+    {
+        $this->beConstructedWith($attributeRepository);
+        $this->initialize($context);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PayloadFormatValidator::class);
+        $this->shouldImplement(ConstraintValidatorInterface::class);
+    }
+
+    function it_throws_an_error_when_constrain_is_wrong()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [[], new Type('array')]);
+    }
+
+    function it_fetches_attribute_types_and_calls_validation_on_constraints(
+        AttributeRepositoryInterface $attributeRepository,
+        ExecutionContextInterface $context,
+        ValidatorInterface $validator,
+        ContextualValidatorInterface $contextualValidator,
+    ) {
+        $payload = [
+            'values' => [
+                'sku' => [
+                    ['locale' => null, 'scope' => null, 'data' => 'foo'],
+                ],
+                'price' => [
+                    ['locale' => null, 'scope' => null, 'data' => [['amount' => 100, 'currency' => 'USD']]],
+                ],
+            ],
+        ];
+
+        $attributeRepository->getAttributeTypeByCodes(['sku', 'price'])->shouldBeCalledOnce()->willReturn([
+            'sku' => AttributeTypes::IDENTIFIER,
+            'price' => AttributeTypes::PRICE_COLLECTION,
+        ]);
+
+        $context->getValidator()->shouldBeCalledOnce()->willReturn($validator);
+        $validator->inContext($context)->shouldBeCalledOnce()->willReturn($contextualValidator);
+        $contextualValidator->validate($payload, Argument::type('array'))->shouldBeCalledOnce();
+
+        $this->validate($payload, new PayloadFormat());
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-10240

When giving null for a price value data, we have a 500 error, because we expect an array. In this PR we now return a 422 error and a good message. 

In our API we don't validate the payload directly. We catch exceptions to return a 422 error when:
- we check duplicate values
- we filter values
- we try to update the product with the values
- we validate the product before saving it

So the validation of the payload format is checked in different places, and some validations are clearly missing.

To handle that I start a PayloadFormatValidator that is responsible to validate the format.
Using a json-schema was a possibility but we cannot specify the error message we want for each case.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
