### PR TITLE
PIM-10223: Add missing "s" on "remove-orphans" option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           name: Setup tests results folder and log folder
           command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.cache/yarn ~/.composer
       - run:
-          name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+          name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
           command: |
               sudo chown -R 1000:1000 ../project
               sudo chown -R 1000:1000 ~/.composer
@@ -108,7 +108,7 @@ jobs:
             date +%F >> ~/akeneo-design-system.hash
       - run:
           name: Set DSM directory owner to circleci
-          command: sudo chown -R 1001:1001 << parameters.path_to_dsm >>
+          command: sudo chown -R circleci:circleci << parameters.path_to_dsm >>
       - restore_cache:
           name: Restore DSM cache
           key: dsm-lib-{{ checksum "~/akeneo-design-system.hash" }}
@@ -141,7 +141,7 @@ jobs:
           - attach_workspace:
                 at: ~/
           - run:
-                name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                 command: sudo chown -R 1000:1000 ../project
           - run:
                 name: No legacy translation format
@@ -269,7 +269,7 @@ jobs:
               name: Create yarn cache folder
               command: mkdir -p  ~/.cache/yarn
         - run:
-              name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+              name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
               command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
         - run:
             name: Front type checking
@@ -288,7 +288,7 @@ jobs:
       - attach_workspace:
           at: ~/
       - run:
-          name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+          name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
           command: sudo chown -R 1000:1000 ../project
       - run:
           name: Start containers

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)
+- PIM-10223: Add missing "s" on "remove-orphans" option in Makefile
 
 # 5.0.69 (2022-01-21)
 

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ pim-prod:
 
 .PHONY: up
 up:
-	$(DOCKER_COMPOSE) up -d --remove-orphan ${C}
+	$(DOCKER_COMPOSE) up -d --remove-orphans ${C}
 
 .PHONY: down
 down:

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -109,7 +109,7 @@ endif
 
 .PHONY: up
 up:
-	docker-compose up -d --remove-orphan
+	docker-compose up -d --remove-orphans
 
 .PHONY: down
 down:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix issue on the Makefile from the 5.0 that is missing an s in the "remove-orphans" option.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
