### PR TITLE
PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@
 - PIM-10232: Fix "A new entity is found through the relationship" errors in jobs
 - PIM-10240: Fix error 500 on the API when inputting data:null for an existing price
 - PIM-10241: Fix user account disabled can connect regression
+- PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -74,7 +74,7 @@ final class ApplyProductSearchQueryParametersToPQB
                 $value = $filter['value'] ?? null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
-                    if (Operators::BETWEEN === $filter['operator'] && is_array($value)) {
+                    if ((Operators::BETWEEN === $filter['operator'] || Operators::NOT_BETWEEN === $filter['operator']) && is_array($value)) {
                         $values = [];
                         foreach ($value as $date) {
                             $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -74,7 +74,7 @@ final class ApplyProductSearchQueryParametersToPQB
                 $value = $filter['value'] ?? null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
-                    if ((Operators::BETWEEN === $filter['operator'] || Operators::NOT_BETWEEN === $filter['operator']) && is_array($value)) {
+                    if (in_array($filter['operator'], [Operators::BETWEEN, Operators::NOT_BETWEEN]) && is_array($value)) {
                         $values = [];
                         foreach ($value as $date) {
                             $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQBSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQBSpec.php
@@ -107,4 +107,44 @@ class ApplyProductSearchQueryParametersToPQBSpec extends ObjectBehavior
 
         $this->apply($pqb, $search, null, 'en_US', 'ecommerce');
     }
+
+    function it_adds_search_filter_for_not_between_filter(ProductQueryBuilderInterface $pqb)
+    {
+        $search = [
+            'created' => [
+                [
+                    'operator' => Operators::NOT_BETWEEN,
+                    'value' => ['2019-01-28 12:12:12', '2019-02-28 13:13:13'],
+                ],
+            ],
+            'updated' => [
+                [
+                    'operator' => Operators::NOT_BETWEEN,
+                    'value' => ['2019-01-28 12:12:12', '2019-02-28 13:13:13'],
+                ],
+            ],
+        ];
+
+        $pqb->addFilter(
+            'created',
+            Operators::NOT_BETWEEN,
+            [
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-01-28 12:12:12'),
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-02-28 13:13:13'),
+            ],
+            ['locale' => 'en_US', 'scope' => 'ecommerce']
+        )->shouldBeCalled();
+
+        $pqb->addFilter(
+            'updated',
+            Operators::NOT_BETWEEN,
+            [
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-01-28 12:12:12'),
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-02-28 13:13:13'),
+            ],
+            ['locale' => 'en_US', 'scope' => 'ecommerce']
+        )->shouldBeCalled();
+
+        $this->apply($pqb, $search, null, 'en_US', 'ecommerce');
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
I added the possibility to filter by updated and created NOT BETWEEN two dates. This fix contains a commit from your dear @Thijzer (thanks to her) https://github.com/akeneo/pim-community-dev/pull/16211. 

It should not be merged while Thijzer does not sign the Contributor Agreement


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
