### PR TITLE
PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)
+
 # 5.0.69 (2022-01-21)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQB.php
@@ -74,7 +74,7 @@ final class ApplyProductSearchQueryParametersToPQB
                 $value = $filter['value'] ?? null;
 
                 if (in_array($propertyCode, ['created', 'updated'])) {
-                    if (Operators::BETWEEN === $filter['operator'] && is_array($value)) {
+                    if (in_array($filter['operator'], [Operators::BETWEEN, Operators::NOT_BETWEEN]) && is_array($value)) {
                         $values = [];
                         foreach ($value as $date) {
                             $values[] = \DateTime::createFromFormat('Y-m-d H:i:s', $date);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQBSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ApplyProductSearchQueryParametersToPQBSpec.php
@@ -107,4 +107,44 @@ class ApplyProductSearchQueryParametersToPQBSpec extends ObjectBehavior
 
         $this->apply($pqb, $search, null, 'en_US', 'ecommerce');
     }
+
+    function it_adds_search_filter_for_not_between_filter(ProductQueryBuilderInterface $pqb)
+    {
+        $search = [
+            'created' => [
+                [
+                    'operator' => Operators::NOT_BETWEEN,
+                    'value' => ['2019-01-28 12:12:12', '2019-02-28 13:13:13'],
+                ],
+            ],
+            'updated' => [
+                [
+                    'operator' => Operators::NOT_BETWEEN,
+                    'value' => ['2019-01-28 12:12:12', '2019-02-28 13:13:13'],
+                ],
+            ],
+        ];
+
+        $pqb->addFilter(
+            'created',
+            Operators::NOT_BETWEEN,
+            [
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-01-28 12:12:12'),
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-02-28 13:13:13'),
+            ],
+            ['locale' => 'en_US', 'scope' => 'ecommerce']
+        )->shouldBeCalled();
+
+        $pqb->addFilter(
+            'updated',
+            Operators::NOT_BETWEEN,
+            [
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-01-28 12:12:12'),
+                \DateTime::createFromFormat('Y-m-d H:i:s', '2019-02-28 13:13:13'),
+            ],
+            ['locale' => 'en_US', 'scope' => 'ecommerce']
+        )->shouldBeCalled();
+
+        $this->apply($pqb, $search, null, 'en_US', 'ecommerce');
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Same than https://github.com/akeneo/pim-community-dev/pull/16223. Because I didn't see that version affected if 5.0. My bad

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
