### PR TITLE
Fix circleci permissions

### DIFF
--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -32,6 +32,7 @@ fi
 
 mkdir /tmp/structure_changes
 mkdir -p ~/.composer
+sudo chown 1000:1000 ~/.composer
 
 ## STEP 1: install 5.0 database and index
 echo "##"
@@ -44,6 +45,7 @@ cp composer.lock /tmp/composer.lock
 echo "Checkout EE 5.0 branch..."
 git branch -D real50 || true
 git checkout -b real50 --track origin/5.0
+sudo chown 1000:1000 -R .
 
 echo "Creation of image with php 7.3..."
 make php-image-dev
@@ -55,6 +57,7 @@ echo "Copy CE migrations into EE to install 5.0 branch..."
 cp -R vendor/akeneo/pim-community-dev/upgrades/schema/* upgrades/schema
 
 echo "Enable Onboarder bundle on 5.0 branch..."
+sudo chown 1000:1000 composer.json
 docker-compose run -u www-data --rm php php /usr/local/bin/composer config repositories.onboarder '{ "type": "vcs", "url": "https://github.com/akeneo/pim-onboarder.git", "branch": "master" }'
 docker-compose run -u www-data --rm php php -d memory_limit=5G /usr/local/bin/composer require "akeneo/pim-onboarder:^4.2.1"
 if [ -d "vendor/akeneo/pim-onboarder" ]; then
@@ -89,6 +92,7 @@ echo "Checkout EE PR branch (or master if it does not exist)..."
 git checkout $PR_BRANCH || git checkout master
 cp /tmp/composer.lock ./composer.lock
 touch composer.lock
+sudo chown 1000:1000 -R .
 make vendor
 
 echo "Copy CE migrations into EE to launch branch migrations..."

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -174,7 +174,7 @@ jobs:
                   keys:
                       - backend-dependency-cache-{{ checksum "~/back-dependency.hash" }}
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: |
                       sudo chown -R 1000:1000 ../project ~/.composer ~/.cache/
             - run:

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -174,6 +174,10 @@ jobs:
                   keys:
                       - backend-dependency-cache-{{ checksum "~/back-dependency.hash" }}
             - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: |
+                      sudo chown -R 1000:1000 ../project ~/.composer ~/.cache/
+            - run:
                   name: Install back and front dependencies
                   command: make dependencies
                   environment:
@@ -194,6 +198,9 @@ jobs:
                       find << parameters.path_to_front_packages >>/../src/Akeneo/Platform/Job/front/process-tracker -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/process-tracker.hash
                       find << parameters.path_to_front_packages >>/../src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/front -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/catalog-volume-monitoring.hash
                       echo "$(date +%F) << parameters.path_to_front_packages >>" | tee -a ~/akeneo-design-system.hash ~/measurement.hash ~/shared.hash ~/catalog-volume-monitoring.hash ~/process-tracker.hash
+            - run:
+                  name: Set directories owner to circleci
+                  command: sudo chown -R 1001:1001 .
             - restore_cache:
                   name: Restore front package DSM cache
                   key: front-packages-dsm-{{ checksum "~/akeneo-design-system.hash" }}
@@ -209,6 +216,9 @@ jobs:
             - restore_cache:
                   name: Restore micro-frontend Catalog Volume Monitoring cache
                   key: micro-frontend-catalog-volume-monitoring-{{ checksum "~/catalog-volume-monitoring.hash" }}
+            - run:
+                  name: Set directories owner to docker
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Build front-packages
                   command: make front-packages

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -200,7 +200,7 @@ jobs:
                       echo "$(date +%F) << parameters.path_to_front_packages >>" | tee -a ~/akeneo-design-system.hash ~/measurement.hash ~/shared.hash ~/catalog-volume-monitoring.hash ~/process-tracker.hash
             - run:
                   name: Set directories owner to circleci
-                  command: sudo chown -R 1001:1001 .
+                  command: sudo chown -R circleci:circleci .
             - restore_cache:
                   name: Restore front package DSM cache
                   key: front-packages-dsm-{{ checksum "~/akeneo-design-system.hash" }}

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -10,7 +10,7 @@ jobs:
                     name: Create yarn cache folder
                     command: mkdir -p  ~/.cache/yarn
             -   run:
-                    name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                     command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             -   run:
                     name: Pull docker image for node
@@ -33,7 +33,7 @@ jobs:
             -   attach_workspace:
                     at: ~/
             -   run:
-                    name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                     command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker image for php
@@ -107,7 +107,7 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: sudo chown -R 1000:1000 ../project
             - run:
                   name: PHP Insights results

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -10,6 +10,9 @@ jobs:
                     name: Create yarn cache folder
                     command: mkdir -p  ~/.cache/yarn
             -   run:
+                    name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                    command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
+            -   run:
                     name: Pull docker image for node
                     command: docker-compose pull node
             -   run:
@@ -29,6 +32,9 @@ jobs:
         steps:
             -   attach_workspace:
                     at: ~/
+            -   run:
+                    name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                    command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker image for php
                     command: docker-compose pull php
@@ -71,6 +77,9 @@ jobs:
             -   attach_workspace:
                     at: ~/
             -   run:
+                    name: Change owner on project dir in order to archive the project into the workspace
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
                     name: Start containers
                     command: |
                         docker load -i php-pim-image.tar
@@ -97,6 +106,9 @@ jobs:
         steps:
             - attach_workspace:
                   at: ~/
+            - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: PHP Insights results
                   command: make connectivity-connection-insight

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -6,6 +6,9 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: sudo chown -R 1000:1000 ../project
+            - run:
                   name: No legacy translation format
                   command: PIM_CONTEXT=test make find-legacy-translations
             - run:
@@ -41,6 +44,9 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: sudo chown -R 1000:1000 ../project
+            - run:
                   name: Start containers
                   command: |
                       docker load -i php-pim-image.tar
@@ -70,8 +76,14 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: sudo chown -R 1000:1000 ../project
+            - run:
                   name: Create yarn cache folder
                   command: mkdir -p  ~/.cache/yarn
+            - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             - run:
                   name: Start containers
                   command: |
@@ -105,6 +117,9 @@ jobs:
                       fi
                       echo "Behat Suite to run: "$TESTSUITE
                       echo "export TESTSUITE=$TESTSUITE" >> $BASH_ENV
+            - run:
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Start containers
                   command: |
@@ -152,6 +167,9 @@ jobs:
                   name: Create yarn cache folder
                   command: mkdir -p  ~/.cache/yarn
             - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
+            - run:
                   name: Front type checking
                   command: make javascript-dev-strict
             - run:
@@ -167,6 +185,9 @@ jobs:
         steps:
             - attach_workspace:
                   at: ~/
+            - run:
+                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Start containers
                   command: |
@@ -205,6 +226,9 @@ jobs:
                         cd vendor/akeneo/pim-community-dev
                         git checkout -- .
             -   run:
+                    name: Change owner on project dir after restoring cache
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
                     name: Test missing database and index structure migrations
                     command: vendor/akeneo/pim-community-dev/.circleci/detect_structure_changes.sh $CIRCLE_BRANCH
 
@@ -214,6 +238,9 @@ jobs:
         steps:
             - attach_workspace:
                   at: ~/
+            - run:
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Start containers
                   command: |
@@ -242,8 +269,12 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
-                  name: Create missing directories
-                  command: mkdir -p ~/.cache/yarn ~/.composer
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: |
+                      mkdir -p ~/.cache/yarn ~/.composer
+                      sudo chown -R 1000:1000 ../project
+                      sudo chown -R 1000:1000 ~/.composer
+                      sudo chown -R 1000:1000 ~/.cache/yarn
             - run:
                   name: Create an empty service account
                   command: |
@@ -268,6 +299,9 @@ jobs:
                       PIM_VERSION=master SETUP_FOR_CI=1 PIM_CONTEXT=onboarder make setup-onboarder-parameters
                       PIM_VERSION=master PIM_CONTEXT=onboarder make setup-onboarder-tests
                       docker-compose run --rm php php /usr/local/bin/composer dumpautoload --no-interaction
+            - run:
+                  name: Change owner of PIM as some files have been created with wrong owner
+                  command: sudo chown -R 1000:1000 ~/project
             - run:
                   name: Execute static analysis
                   command: PIM_CONTEXT=onboarder make test-static-analysis
@@ -317,6 +351,9 @@ jobs:
         steps:
             - attach_workspace:
                   at: ~/
+            - run:
+                  name: Change owner on project dir in order to archive the project into the workspace
+                  command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Start containers
                   command: |

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -6,7 +6,7 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: sudo chown -R 1000:1000 ../project
             - run:
                   name: No legacy translation format
@@ -82,7 +82,7 @@ jobs:
                   name: Create yarn cache folder
                   command: mkdir -p  ~/.cache/yarn
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             - run:
                   name: Start containers
@@ -167,7 +167,7 @@ jobs:
                   name: Create yarn cache folder
                   command: mkdir -p  ~/.cache/yarn
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             - run:
                   name: Front type checking
@@ -186,7 +186,7 @@ jobs:
             - attach_workspace:
                   at: ~/
             - run:
-                  name: Change owner on project dir (default user = circleci (1001) and docker needs uid 1000)
+                  name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                   command: sudo chown -R 1000:1000 ../project
             - run:
                   name: Start containers


### PR DESCRIPTION
- Rollback https://github.com/akeneo/pim-community-dev/pull/16209
- Fix chown 1001

The uid of circleci user appears to be random. We thought it was changed to 1000, that's why we removed the chown.  
In this PR the chown are back, and the "chown 1001:1001" (1001 was the supposed uid of circleci) are fixed in "chown circleci:circleci"