### PR TITLE
OCT-6: Fix Attribute Options Scope mapping

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Security/ScopeMapperRegistryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Security/ScopeMapperRegistryIntegration.php
@@ -125,11 +125,11 @@ class ScopeMapperRegistryIntegration extends TestCase
                 'pim_api_family_variant_list',
             ],
             'read_attribute_options' => [
-                'pim_api_attribute_options_list',
+                'pim_api_attribute_option_list',
             ],
             'write_attribute_options' => [
-                'pim_api_attribute_options_edit',
-                'pim_api_attribute_options_list',
+                'pim_api_attribute_option_edit',
+                'pim_api_attribute_option_list',
             ],
             'read_association_types' => [
                 'pim_api_association_type_list',

--- a/src/Akeneo/Pim/Structure/Component/Security/AttributeOptionsScopeMapper.php
+++ b/src/Akeneo/Pim/Structure/Component/Security/AttributeOptionsScopeMapper.php
@@ -17,10 +17,10 @@ class AttributeOptionsScopeMapper implements ScopeMapperInterface
 
     private const SCOPE_ACL_MAP = [
         self::SCOPE_READ_ATTRIBUTE_OPTIONS => [
-            'pim_api_attribute_options_list',
+            'pim_api_attribute_option_list',
         ],
         self::SCOPE_WRITE_ATTRIBUTE_OPTIONS => [
-            'pim_api_attribute_options_edit',
+            'pim_api_attribute_option_edit',
         ],
     ];
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix a typo in attribute options ACLs scope mapper.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
