### PR TITLE
Fix make Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts idempotent

### DIFF
--- a/upgrades/schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts.php
+++ b/upgrades/schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts.php
@@ -5,20 +5,27 @@ namespace Pim\Upgrade\Schema;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts extends AbstractMigration
 {
     public function up(Schema $schema) : void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+        $this->skipIf(
+            $this->hasColumn($schema, 'consecutive_authentication_failure_counter') && $this->hasColumn($schema, 'authentication_failure_reset_date'),
+            'consecutive_authentication_failure_counter & authentication_failure_reset_date column already exists in oro_user'
+        );
 
         $this->addSql('alter table oro_user add consecutive_authentication_failure_counter int default 0');
-        $this->addSql('alter table oro_user add authentication_failure_reset_date datetime  default null ');
+        $this->addSql('alter table oro_user add authentication_failure_reset_date datetime  default null');
     }
 
     public function down(Schema $schema) : void
-    {}
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function hasColumn(Schema $schema, string $columnName)
+    {
+        return $schema->getTable('oro_user')->hasColumn($columnName);
+    }
 }

--- a/upgrades/test_schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts_Integration.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+final class Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts_Integration  extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    const MIGRATION_LABEL = '_5_0_20220201155016_add_user_account_locking_after_too_many_attempts';
+
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_connection_attempt_information_to_the_oro_user_table(): void
+    {
+        $this->dropColumnIfExists();
+        Assert::assertEquals(false, $this->columnExists());
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertEquals(true, $this->columnExists());
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->dropColumnIfExists();
+        Assert::assertEquals(false, $this->columnExists());
+
+        /** TODO pull up 6.0 replace by $this->reExecuteMigration(self::MIGRATION_LABEL) as doctrine migration handle this correctly */
+        $this->createColumn();
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertEquals(true, $this->columnExists());
+    }
+
+    private function dropColumnIfExists(): void
+    {
+        if ($this->columnExists()) {
+            $this->connection->executeQuery('ALTER TABLE oro_user DROP COLUMN consecutive_authentication_failure_counter;');
+            $this->connection->executeQuery('ALTER TABLE oro_user DROP COLUMN authentication_failure_reset_date;');
+        }
+
+        Assert::assertEquals(false, $this->columnExists());
+    }
+
+    private function columnExists(): bool
+    {
+        $columns = $this->connection->getSchemaManager()->listTableColumns('oro_user');
+
+        return isset($columns['consecutive_authentication_failure_counter'], $columns['authentication_failure_reset_date']);
+    }
+
+    /** TODO pull up 6.0 remove this function */
+    private function createColumn(): void
+    {
+        $this->connection->executeUpdate('alter table oro_user add consecutive_authentication_failure_counter int default 0');
+        $this->connection->executeUpdate('alter table oro_user add authentication_failure_reset_date datetime  default null');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I modify Version_5_0_20220201155016_add_user_account_locking_after_too_many_attempts to make it idempotent and add test as in master we pulled up this with an error.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
