### PR TITLE
Fix automatic pull up in order to target 6.0 now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,8 +481,8 @@ workflows:
     jobs:
       - pull-up/pull-up:
           from: "5.0"
-          into: "master"
-          branch_prefix: "50_to_master"
+          into: "6.0"
+          branch_prefix: "50_to_60"
           checkout_ours: 'src/Akeneo/Platform/CommunityVersion.php **/translations/*.yml'
           github_token: MICHEL_TAG_TOKEN
           github_username: "micheltag"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Now 6.0 is tagged we can automatically have pull up into 6.0

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
