### PR TITLE
RAC-1213: Remove useless condition in VariantProductRatio query

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
@@ -70,7 +70,7 @@ SQL;
     {
         return <<<SQL
                 FROM pim_catalog_product_model AS root_product_model
-                INNER JOIN pim_catalog_product product ON product.product_model_id = root_product_model.id AND product.product_model_id IS NOT NULL
+                INNER JOIN pim_catalog_product product ON product.product_model_id = root_product_model.id
 SQL;
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Following this discussion : https://github.com/akeneo/pim-community-dev/pull/16264#discussion_r800809073
Removing this condition does not occurs 500 error. The error log reported by me is a warning that have been thrown before querying the variant product ratio and have any relation with the query.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
