### PR TITLE
CPM-512: Fix Measurement display by removing uppercase

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/TableInput/TableInputMeasurement/TableInputMeasurement.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TableInput/TableInputMeasurement/TableInputMeasurement.tsx
@@ -43,7 +43,6 @@ const TableInputMeasurementUnit = styled(SelectInput)`
     & > div {
       background: none;
       color: ${getColor('grey', 100)};
-      text-transform: uppercase;
 
       & > input {
         border: none;
@@ -52,10 +51,6 @@ const TableInputMeasurementUnit = styled(SelectInput)`
       }
     }
   }
-`;
-
-const MeasurementReadOnlyUnit = styled.span`
-  text-transform: uppercase;
 `;
 
 type TableInputMeasurementProps = {
@@ -92,7 +87,7 @@ const TableInputMeasurement: React.FC<TableInputMeasurementProps> = ({
 
   return readOnly ? (
     <TableInputReadOnlyCell>
-      {amount} <MeasurementReadOnlyUnit>{selectedUnit?.symbol || selectedUnit?.label}</MeasurementReadOnlyUnit>
+      {amount} <span>{selectedUnit?.symbol || selectedUnit?.label}</span>
     </TableInputReadOnlyCell>
   ) : (
     <TableInputMeasurementContainer {...rest}>


### PR DESCRIPTION
Fix Measurement display by removing uppercase

Exemple : mHz and MHz... which are not the same units, are displayed both MHZ
Exemple 2 : are (a) and acre (A) are displayed both A

![Screenshot from 2022-02-10 18-13-10](https://user-images.githubusercontent.com/42606611/153461494-e24cebe8-6d1d-4f0e-8f73-17fe6f188db8.png)

