### PR TITLE
RAB: Fix service API does not return ContraintValidation when attribute regex is not satisfied

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/handlers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/handlers.yml
@@ -6,3 +6,4 @@ services:
             - '@pim_catalog.builder.product'
             - '@pim_catalog.saver.product'
             - '@pim_catalog.updater.product'
+            - '@pim_catalog.validator.product'

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/UpsertProductHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/UpsertProductHandler.php
@@ -31,7 +31,8 @@ final class UpsertProductHandler
         private ProductRepositoryInterface $productRepository,
         private ProductBuilderInterface $productBuilder,
         private SaverInterface $productSaver,
-        private ObjectUpdaterInterface $productUpdater
+        private ObjectUpdaterInterface $productUpdater,
+        private ValidatorInterface $productValidator
     ) {
     }
 
@@ -55,7 +56,7 @@ final class UpsertProductHandler
 
         // This product validation is legacy. We should remove it as soon all validations will
         // be migrated on the command validation.
-        $violations = $this->validator->validate($product);
+        $violations = $this->productValidator->validate($product);
         if (0 < $violations->count()) {
             throw new LegacyViolationsException($violations);
         }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
@@ -29,9 +29,10 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ProductRepositoryInterface $productRepository,
         ProductBuilderInterface $productBuilder,
         SaverInterface $productSaver,
-        ObjectUpdaterInterface $productUpdater
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
     ) {
-        $this->beConstructedWith($validator, $productRepository, $productBuilder, $productSaver, $productUpdater);
+        $this->beConstructedWith($validator, $productRepository, $productBuilder, $productSaver, $productUpdater, $productValidator);
     }
 
     function it_is_intializable()
@@ -43,7 +44,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         ProductBuilderInterface $productBuilder,
-        SaverInterface $productSaver
+        SaverInterface $productSaver,
+        ValidatorInterface $productValidator,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
@@ -51,7 +53,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn(null);
         $productBuilder->createProduct('identifier1')->shouldBeCalledOnce()->willReturn($product);
-        $validator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productSaver->save($product)->shouldBeCalledOnce();
 
         $this->__invoke($command);
@@ -61,7 +63,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         ProductBuilderInterface $productBuilder,
-        SaverInterface $productSaver
+        SaverInterface $productSaver,
+        ValidatorInterface $productValidator,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
@@ -69,7 +72,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productBuilder->createProduct('identifier1')->shouldNotBeCalled();
-        $validator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productSaver->save($product)->shouldBeCalledOnce();
 
         $this->__invoke($command);
@@ -94,7 +97,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
     function it_throws_an_exception_when_product_is_not_valid(
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
-        SaverInterface $productSaver
+        SaverInterface $productSaver,
+        ValidatorInterface $productValidator
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
@@ -104,7 +108,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
-        $validator->validate($product)->shouldBeCalledOnce()->willReturn($violations);
+        $productValidator->validate($product)->shouldBeCalledOnce()->willReturn($violations);
         $productSaver->save($product)->shouldNotBeCalled();
 
         $this->shouldThrow(new LegacyViolationsException($violations))->during('__invoke', [$command]);
@@ -114,7 +118,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         SaverInterface $productSaver,
-        ObjectUpdaterInterface $productUpdater
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1', valuesUserIntent: [new SetTextValue('name', null, null, 'foo')]);
         $product = new Product();
@@ -124,7 +129,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $productUpdater->update($product, Argument::cetera())->shouldbeCalledOnce()->willThrow(
             InvalidPropertyException::expected('error', 'class')
         );
-        $validator->validate($product)->shouldNotBeCalled();
+        $productValidator->validate($product)->shouldNotBeCalled();
         $productSaver->save($product)->shouldNotBeCalled();
 
         $this->shouldThrow(LegacyViolationsException::class)->during('__invoke', [$command]);
@@ -134,7 +139,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         SaverInterface $productSaver,
-        ObjectUpdaterInterface $productUpdater
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1', valuesUserIntent: [new SetTextValue('name', null, null, 'foo')]);
         $product = new Product();
@@ -143,7 +149,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
 
         $productUpdater->update($product, Argument::cetera())->shouldbeCalledOnce();
-        $validator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $productSaver->save($product)->shouldBeCalledOnce();
 
         $this->__invoke($command);
@@ -153,7 +159,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         SaverInterface $productSaver,
-        ObjectUpdaterInterface $productUpdater
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
     ) {
         $unknownUserIntent = new class implements ValueUserIntent {
             public function attributeCode(): string
@@ -183,7 +190,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $productRepository->findOneByIdentifier('identifier')->shouldBeCalledOnce()->willReturn($product);
 
         $productUpdater->update($product, Argument::cetera())->shouldNotbeCalled();
-        $validator->validate($product)->shouldNotBeCalled();
+        $productValidator->validate($product)->shouldNotBeCalled();
         $productSaver->save($product)->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [$command]);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We tried to set an regex validation on an attribute, then enrich it with the new service API => we didn't have exception (no violation).

We tried to resave the product without changing any data and we have an error. There is a product validator, with weird Guesser that check those things so we used this validator. (same than the used in the ProductController)
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
