### PR TITLE
CPM-517: Add Assert notNull in LightEntityWithFamilyVariantNormalizer

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizer.php
@@ -16,6 +16,7 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * "Light" version of the EntityWithFamilyVariantNormalizer, it only returns the needed information
@@ -112,6 +113,15 @@ final class LightEntityWithFamilyVariantNormalizer implements NormalizerInterfac
         $valuesForLocale = [];
         foreach ($this->attributesProvider->getAxes($entity) as $axisAttribute) {
             $value = $entity->getValue($axisAttribute->getCode());
+            Assert::notNull(
+                $value,
+                \sprintf(
+                    'No value found for %s attribute (type: %s, code: %s)',
+                    $axisAttribute->getCode(),
+                    $axisAttribute->getType(),
+                    $axisAttribute->getCode()
+                )
+            );
             $normalizedValue = (string)$value;
 
             $attributeNormalizer = $this->getAttributeLabelsNormalizer($axisAttribute);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
LightEntityWithFamilyVariantNormalizer normalize method raises errors, `Akeneo\Pim\Enrichment\ReferenceEntity\Component\Normalizer\ReferenceEntityAxisLabelNormalizer::normalize(): Argument #1 ($value) must be of type Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface, null given` so in order to get more informations about the payload creating this error, we add an assert with current values.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
