### PR TITLE
CPM-390: Fix channel and locale change on save error

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/attributes.js
@@ -449,10 +449,15 @@ define([
       var needRendering = false;
       if (event.scope) {
         this.setScope(event.scope, {silent: true});
+        this.getRoot().trigger('pim_enrich:form:channel_switcher:change');
         needRendering = true;
       }
       if (event.locale) {
         this.setLocale(event.locale, {silent: true});
+        this.getRoot().trigger('pim_enrich:form:locale_switcher:change', {
+          localeCode: event.locale,
+          context: 'base_product',
+        });
         needRendering = true;
       }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/scope-switcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/scope-switcher.js
@@ -52,6 +52,10 @@ define([
         }.bind(this)
       );
 
+      this.listenTo(this.getRoot(), 'pim_enrich:form:channel_switcher:change', () => {
+        this.render();
+      });
+
       return BaseForm.prototype.configure.apply(this, arguments);
     },
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When there is an error on a field (localizable or scopable), the attribute are correctly updated on the errored locale or the errored scope. But the locale switcher and scope switcher remained on the previous value.
This PR fixes that behaviour by adding mediator events when an error occured on a field.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
