### PR TITLE
PIM-10281: Update Circle CI machine executors

### DIFF
--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -12,7 +12,7 @@ aliases:
                   username: _json_key  # default username when using a JSON key file to authenticate
                   password: $GCLOUD_SERVICE_KEY_DEV  # JSON service account you created, do not encode to base64
 
-    - &executor-machine: ubuntu-2004:202111-02
+executor-machine: &executor-machine 'ubuntu-2004:202111-02'
 
 commands:
     set_gcloud_config_dev:

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -12,6 +12,8 @@ aliases:
                   username: _json_key  # default username when using a JSON key file to authenticate
                   password: $GCLOUD_SERVICE_KEY_DEV  # JSON service account you created, do not encode to base64
 
+    - &executor-machine: ubuntu-2004:202111-02
+
 commands:
     set_gcloud_config_dev:
         description: "Authenticate on GCP services and set config and key to be used by other tools that need to authenticate."
@@ -54,7 +56,7 @@ commands:
 jobs:
     checkout_ee:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - add_ssh_keys:
                   fingerprints:
@@ -98,7 +100,7 @@ jobs:
 
     checkout_ce:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - checkout
             - install_yq
@@ -119,7 +121,7 @@ jobs:
                 type: string
                 default: front-packages
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/
@@ -276,7 +278,7 @@ jobs:
         environment:
             <<: *envVarsDeployDev
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         resource_class: medium
         working_directory: ~/project
         steps:

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -1,7 +1,10 @@
+aliases:
+    - &executor-machine: ubuntu-2004:202111-02
+
 jobs:
     test_front_connectivity:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
             docker_layer_caching: true
         steps:
             -   attach_workspace:
@@ -27,7 +30,7 @@ jobs:
 
     test_back_connectivity:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
             docker_layer_caching: true
         steps:
             -   attach_workspace:
@@ -72,7 +75,7 @@ jobs:
 
     test_marketplace_activate_e2e:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             -   attach_workspace:
                     at: ~/
@@ -102,7 +105,7 @@ jobs:
 
     test_octopus_code_quality:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -1,5 +1,4 @@
-aliases:
-    - &executor-machine: ubuntu-2004:202111-02
+executor-machine: &executor-machine 'ubuntu-2004:202111-02'
 
 jobs:
     test_front_connectivity:

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -1,7 +1,10 @@
+aliases:
+    - &executor-machine: ubuntu-2004:202111-02
+
 jobs:
     test_back_static_and_acceptance:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/
@@ -38,7 +41,7 @@ jobs:
 
     test_back_phpunit:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         parallelism: 20
         steps:
             - attach_workspace:
@@ -70,7 +73,7 @@ jobs:
 
     cypress_sanity_checks:
         machine:
-            image: ubuntu-1604:201903-01
+            image: *executor-machine
         resource_class: large
         steps:
             - attach_workspace:
@@ -103,7 +106,7 @@ jobs:
 
     test_back_behat_legacy:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         parallelism: 40
         steps:
             - attach_workspace:
@@ -159,7 +162,7 @@ jobs:
 
     test_front_static_acceptance_and_integration:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/
@@ -181,7 +184,7 @@ jobs:
 
     test_back_performance:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/
@@ -207,7 +210,7 @@ jobs:
 
     test_back_missing_structure_migrations:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             -   attach_workspace:
                     at: ~/
@@ -234,7 +237,7 @@ jobs:
 
     test_back_data_migrations:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         steps:
             - attach_workspace:
                   at: ~/
@@ -262,7 +265,7 @@ jobs:
 
     test_onboarder_bundle:
         machine:
-            image: ubuntu-2004:202101-01
+            image: *executor-machine
         environment:
             FLAG_ONBOARDER_ENABLED: 1
         steps:
@@ -343,7 +346,7 @@ jobs:
 
     test_database:
         machine:
-            image: ubuntu-2004:202010-01
+            image: *executor-machine
         parallelism: 1
         steps:
             - attach_workspace:

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -1,5 +1,4 @@
-aliases:
-    - &executor-machine: ubuntu-2004:202111-01
+executor-machine: &executor-machine 'ubuntu-2004:202111-02'
 
 jobs:
     test_back_static_and_acceptance:

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -1,5 +1,5 @@
 aliases:
-    - &executor-machine: ubuntu-2004:202111-02
+    - &executor-machine: ubuntu-2004:202111-01
 
 jobs:
     test_back_static_and_acceptance:


### PR DESCRIPTION
CircleCI’s Ubuntu 14.04 and 16.04 images will be permanently unavailable as of May 31, 2022. Migrate to a newer image today.

https://circleci.com/blog/ubuntu-14-16-image-deprecation/


--- EDIT ---

After review from teammates (thank you @StevenVAIDIE ), I rewrote the Circle CI config to change the machine executor to make it easier to change in the following PR.
I'd love to have only one occurence of the alias array to not repeat it in several files, but it is not supported by the `yq` merge operation