### PR TITLE
PIM-10287: Fix deprecated methods for Symfony table style

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10287: Fix deprecated methods for Symfony\Component\Console\Helper\TableStyle
+
 # 6.0.4 (2022-02-10)
 
 # 6.0.3 (2022-02-09)

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Command/Style/SystemInfoStyle.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Command/Style/SystemInfoStyle.php
@@ -29,9 +29,9 @@ class SystemInfoStyle extends SymfonyStyle
 
         $styleGuide = new TableStyle();
         $styleGuide
-            ->setHorizontalBorderChar('-')
-            ->setVerticalBorderChar('|')
-            ->setCrossingChar('+')
+            ->setHorizontalBorderChars('-', '-')
+            ->setVerticalBorderChars('|', '|')
+            ->setDefaultCrossingChar('+')
             ->setCellHeaderFormat('%s')
         ;
 


### PR DESCRIPTION
PIM-10287: Fix deprecated methods for Symfony\Component\Console\Helper\TableStyle

The kind of deprecation we should have detected before: https://github.com/symfony/console/blob/4.4/Helper/TableStyle.php#L273