### PR TITLE
PIM-10288: Fix product associations came duplicated in API

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - PIM-10270: Fix insufficient limit when fetching a lot of attribute groups in families settings
+- PIM-10288: Fix product associations came duplicated in API
 
 # 5.0.77 (2022-02-10)
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiers.php
@@ -59,7 +59,7 @@ FROM (
                            LEFT JOIN pim_catalog_group associated_group ON group_association.group_id = associated_group.id
                   WHERE product.identifier IN (?)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT product.identifier    as product_identifier,
                          association_type.code as association_type_code,
                          associated_group.code as associated_group_identifier

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiers.php
@@ -71,7 +71,7 @@ FROM (
                            INNER JOIN pim_catalog_group associated_group ON product_model_to_group.group_id = associated_group.id
                   WHERE product.identifier IN (?)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT product.identifier    as product_identifier,
                          association_type.code as association_type_code,
                          associated_group.code as associated_group_identifier

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiers.php
@@ -74,7 +74,7 @@ FROM (
                        INNER JOIN pim_catalog_product associated_product ON associated_product.id = association_to_product.product_id
                   WHERE product.identifier IN (?)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT
                       product.identifier as product_identifier,
                       association_type.code as association_type_code,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiers.php
@@ -61,7 +61,7 @@ FROM (
                        LEFT JOIN pim_catalog_product associated_product ON associated_product.id = association_to_product.product_id
                   WHERE product.identifier IN (?) 
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT
                       product.identifier as product_identifier,
                       association_type.code as association_type_code,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiers.php
@@ -69,7 +69,7 @@ FROM (
                            INNER JOIN pim_catalog_product_model associated_product_model ON product_model_to_product_model.product_model_id = associated_product_model.id
                   WHERE product.identifier IN (:productIdentifiers)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT product.identifier    as product_identifier,
                          association_type.code as association_type_code,
                          associated_product_model.code as associated_product_model_code

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiers.php
@@ -57,7 +57,7 @@ FROM (
                            LEFT JOIN pim_catalog_product_model associated_product_model ON product_model_association.product_model_id = associated_product_model.id
                   WHERE product.identifier IN (:productIdentifiers)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT product.identifier    as product_identifier,
                          association_type.code as association_type_code,
                          associated_product_model.code as associated_product_model_code

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
@@ -59,7 +59,7 @@ FROM (
                   LEFT JOIN pim_catalog_group associated_group ON product_model_to_group.group_id = associated_group.id
                   WHERE product_model.code IN (:productModelCodes)
                   AND association_type.is_quantified = false
-                  UNION DISTINCT
+                  UNION DISTINCT 
                   SELECT child_product_model.code as product_model_code,
                          association_type.code as association_type_code,
                          associated_group.code as associated_group_code

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodes.php
@@ -59,7 +59,7 @@ FROM (
                   LEFT JOIN pim_catalog_group associated_group ON product_model_to_group.group_id = associated_group.id
                   WHERE product_model.code IN (:productModelCodes)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT child_product_model.code as product_model_code,
                          association_type.code as association_type_code,
                          associated_group.code as associated_group_code

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
@@ -53,7 +53,7 @@ JSON_ARRAYAGG(associated_product_identifier) as associations_by_type
                            LEFT JOIN pim_catalog_product associated_product ON associated_product.id = association_to_product_model.product_id
                   WHERE product_model.code IN (:productModelCodes)
                   AND association_type.is_quantified = false
-                  UNION DISTINCT
+                  UNION DISTINCT 
                   SELECT
                       child_product_model.code as product_model_code,
                       association_type.code as association_type_code,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodes.php
@@ -53,7 +53,7 @@ JSON_ARRAYAGG(associated_product_identifier) as associations_by_type
                            LEFT JOIN pim_catalog_product associated_product ON associated_product.id = association_to_product_model.product_id
                   WHERE product_model.code IN (:productModelCodes)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT
                       child_product_model.code as product_model_code,
                       association_type.code as association_type_code,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodes.php
@@ -59,7 +59,7 @@ FROM (
                   LEFT JOIN pim_catalog_product_model associated_product_model ON product_model_to_product_model.product_model_id = associated_product_model.id
                   WHERE product_model.code IN (:productModelCodes)
                   AND association_type.is_quantified = false
-                  UNION ALL
+                  UNION DISTINCT
                   SELECT child_product_model.code    as product_model_code,
                          association_type.code as association_type_code,
                          associated_product_model.code as associated_product_model_code

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetGroupAssociationsByProductIdentifiersIntegration.php
@@ -50,7 +50,7 @@ class GetGroupAssociationsByProductIdentifiersIntegration extends TestCase
         $entityBuilder->createProduct('productC', 'aFamily', $this->getAssociationsFormatted(['groupA', 'groupB'], ['groupC']));
         $rootProductModel = $entityBuilder->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, $this->getAssociationsFormatted(['groupF'], ['groupA', 'groupC']));
         $subProductModel1 = $entityBuilder->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, $this->getAssociationsFormatted(['groupD'], [], ['groupB']));
-        $entityBuilder->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel1, $this->getAssociationsFormatted([], ['groupG'], [], ['groupE']));
+        $entityBuilder->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel1, $this->getAssociationsFormatted(['groupF'], ['groupG'], [], ['groupE']));
 
         $this->givenAssociationTypes(['A_NEW_TYPE']);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetProductAssociationsByProductIdentifiersIntegration.php
@@ -51,7 +51,7 @@ class GetProductAssociationsByProductIdentifiersIntegration extends TestCase
         $entityBuilder->createProduct('productG', 'aFamily', []);
         $rootProductModel = $entityBuilder->createProductModel('root_product_model', 'familyVariantWithTwoLevels', null, $this->getAssociationsFormatted(['productF'], ['productA', 'productC']));
         $subProductModel1 = $entityBuilder->createProductModel('sub_product_model_1', 'familyVariantWithTwoLevels', $rootProductModel, $this->getAssociationsFormatted(['productD'], [], ['productB']));
-        $entityBuilder->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel1, $this->getAssociationsFormatted([], ['productG'], [], ['productE']));
+        $entityBuilder->createVariantProduct('variant_product_1', 'aFamily', 'familyVariantWithTwoLevels', $subProductModel1, $this->getAssociationsFormatted(['productF'], ['productG'], [], ['productE']));
 
         $this->givenAssociationTypes(['A_NEW_TYPE']);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/Association/GetProductModelAssociationsByProductIdentifiersIntegration.php
@@ -53,7 +53,7 @@ class GetProductModelAssociationsByProductIdentifiersIntegration extends TestCas
         ]);
 
         $this->givenTheFollowingAssociationFromVariantProductToProductModels($subProductModels['sub_product_model'], [
-            'variant_product_1' => ['PACK' => ['productModelG'], 'UPSELL' => ['productModelE']]
+            'variant_product_1' => ['PACK' => ['productModelG'], 'UPSELL' => ['productModelE'],'X_SELL' => ['productModelF']]
         ]);
 
         $this->givenAssociationTypes(['A_NEW_TYPE']);

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetGroupAssociationsByProductModelCodesIntegration.php
@@ -39,7 +39,7 @@ class GetGroupAssociationsByProductModelCodesIntegration extends TestCase
                 'sub_product_models' => [
                     'sub_product_model_1_1' => [
                         'associations' => [
-                            'X_SELL' => ['groups' => ['groupD']],
+                            'X_SELL' => ['groups' => ['groupD', 'groupF']],
                             'SUBSTITUTION' => ['groups' => ['groupB']],
                         ],
                     ],

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductAssociationsByProductModelCodesIntegration.php
@@ -61,10 +61,7 @@ class GetProductAssociationsByProductModelCodesIntegration extends TestCase
             'sub_product_model' => $this->getAssociationsFormattedAfterFetch(['productD', 'productF'], ['productC', 'productA'], ['productB'])
         ];
 
-        PHPUnitAssert::assertEqualsCanonicalizing(
-            $this->recursiveSort($expected),
-            $this->recursiveSort($result)
-        );
+        PHPUnitAssert::assertEqualsCanonicalizing($expected,$result);
     }
 
     public function setUp(): void
@@ -100,7 +97,7 @@ class GetProductAssociationsByProductModelCodesIntegration extends TestCase
         $entityBuilder->createProductModel('product_model_with_one_association', 'familyVariant', null, $this->getAssociationsFormatted(['productA']));
         $entityBuilder->createProductModel('product_model_with_multiple_associations', 'familyVariant', null, $this->getAssociationsFormatted(['productB'], ['productA', 'productF']));
         $rootProductModel = $entityBuilder->createProductModel('root_product_model', 'familyVariant', null, $this->getAssociationsFormatted(['productF'], ['productA', 'productC']));
-        $entityBuilder->createProductModel('sub_product_model', 'familyVariant', $rootProductModel, $this->getAssociationsFormatted(['productD'], [], ['productB']));
+        $entityBuilder->createProductModel('sub_product_model', 'familyVariant', $rootProductModel, $this->getAssociationsFormatted(['productD', 'productF'], [], ['productB']));
     }
 
     private function getQuery(): GetProductAssociationsByProductModelCodes
@@ -158,16 +155,6 @@ class GetProductAssociationsByProductModelCodesIntegration extends TestCase
             'SUBSTITUTION' => ['products' => $substitutions],
             'UPSELL' => ['products' => $upsell],
         ]];
-    }
-
-
-    private function recursiveSort(&$array): bool
-    {
-        foreach ($array as &$value) {
-            if (is_array($value)) $this->recursiveSort($value);
-        }
-
-        return sort($array);
     }
 
     private function getAssociationsFormattedAfterFetch(array $crossSell = [], array $pack = [], array $substitutions = [], array $upsell = []): array

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetProductModelsAssociationsByProductModelCodesIntegration.php
@@ -119,7 +119,7 @@ class GetProductModelsAssociationsByProductModelCodesIntegration extends TestCas
                 'sub_product_models' => [
                     'sub_product_model_1_1' => [
                         'associations' => [
-                            'X_SELL' => ['product_models' => ['productModelD']],
+                            'X_SELL' => ['product_models' => ['productModelD', 'productModelF']],
                             'SUBSTITUTION' => ['product_models' => ['productModelB']],
                         ],
                     ],


### PR DESCRIPTION
When you add an association on a product model and its variant the associations come up twice in the API. This PR attempt to fix this behavior