### PR TITLE
PIM-10268: Fix identifier filter should not be displayed if user doesn't choose to display it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - PIM-10259: Fix Arabic text being reversed in product PDF exports
 - PIM-10277: Do not allow disabled user to login
 - PIM-10292: Fix error 500 when role page contain a validation errors
+- PIM-10268: SKU filter is always shown in the product grid
 
 ## Improvements
 - PIM-10293: add batch-size option to pim:completness:calculate command

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -29,6 +29,7 @@ $rules = [
         // TODO the feature use the datagrid
         'Oro\Bundle\DataGridBundle',
         'Oro\Bundle\PimDataGridBundle',
+        'Oro\Bundle\FilterBundle',
         // TODO: dependencies related to the front end, remove twig screens
         'Twig',
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Extension/RegisterIdentifierFilters.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Extension/RegisterIdentifierFilters.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Extension;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute\GetAttributeTranslations;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\UserManagement\Bundle\Context\UserContext;
+use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
+use Oro\Bundle\DataGridBundle\Event\BuildBefore;
+use Oro\Bundle\FilterBundle\Grid\Extension\Configuration;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RegisterIdentifierFilters
+{
+    public const PRODUCT_DATAGRID_NAME = 'product-grid';
+
+    public function __construct(
+        private GetAttributes $getAttributes,
+        private GetAttributeTranslations $getAttributeTranslations,
+        private UserContext $userContext,
+        private RequestParameters $requestParams,
+        private RequestStack $requestStack,
+    ) {
+    }
+
+    public function buildBefore(BuildBefore $event): void
+    {
+        $datagridConfiguration = $event->getConfig();
+
+        $attributeIdentifiers = array_filter($this->getAttributes->forType(AttributeTypes::IDENTIFIER));
+        $attributeCodes = array_keys($attributeIdentifiers);
+        $attributeTranslations = $this->getAttributeTranslations->byAttributeCodesAndLocale($attributeCodes, $this->getCurrentLocaleCode());
+
+        $filters = $datagridConfiguration->offsetGet(Configuration::FILTERS_KEY);
+        foreach ($attributeIdentifiers as $attributeCode => $attributeIdentifier) {
+            $filters['columns'][$attributeCode] = $this->buildFilter($attributeIdentifier, $attributeTranslations);
+        }
+
+        $datagridConfiguration->offsetAddToArray(Configuration::FILTERS_KEY, $filters);
+    }
+
+    private function buildFilter(Attribute $attribute, array $attributeTranslations): array
+    {
+        return [
+            'type' => 'product_value_string',
+            'ftype' => 'identifier',
+            'label' => $attributeTranslations[$attribute->code()] ?? sprintf('[%s]', $attribute->code()),
+            'data_name' => $attribute->code(),
+            'options' => [
+                'field_options' => [
+                    'attr' => [
+                        'choice_list' => true,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    private function getCurrentLocaleCode(): string
+    {
+        $dataLocale = $this->requestParams->get('dataLocale', null);
+        if ($dataLocale) {
+            return $dataLocale;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+        if ($request && $request->get('dataLocale')) {
+            return $request->get('dataLocale');
+        }
+
+        $userCatalogLocale = $this->userContext->getUser()->getCatalogLocale();
+        if ($userCatalogLocale) {
+            return $userCatalogLocale->getCode();
+        }
+
+        return 'en_US';
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid_actions.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid_actions.yml
@@ -5,6 +5,17 @@ parameters:
     pim_enrich.extension.action.type.toggle_product.class: 'Akeneo\Pim\Enrichment\Bundle\Extension\Action\ToggleProductAction'
 
 services:
+    pim_enrich.extension.register_identifier_filters:
+        class: Akeneo\Pim\Enrichment\Bundle\Extension\RegisterIdentifierFilters
+        arguments:
+            - '@akeneo.pim.structure.query.get_attributes'
+            - '@akeneo.pim.structure.query.get_attribute_translations'
+            - '@pim_user.context.user'
+            - '@oro_datagrid.datagrid.request_params'
+            - '@request_stack'
+        tags:
+            - { name: kernel.event_listener, event: oro_datagrid.datgrid.build.before.product-grid, method: buildBefore }
+
     pim_enrich.extension.action.type.navigate_product_and_product_model:
         public: true
         class: '%pim_enrich.extension.action.type.navigate_product_and_product_model.class%'

--- a/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datagrid/Configuration/Product/FiltersConfigurator.php
@@ -60,7 +60,7 @@ class FiltersConfigurator implements ConfiguratorInterface
             $filterConfig = $filterConfig + [
                 ProductFilterUtility::DATA_NAME_KEY => $attributeCode,
                 'label'                             => $attribute['label'],
-                'enabled'                           => (AttributeTypes::IDENTIFIER === $attributeType),
+                'enabled'                           => false,
                 'order'                             => $attribute['sortOrder'],
                 'group'                             => $attribute['group'],
                 'groupOrder'                        => $attribute['groupOrder']

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datagrid/Configuration/Product/FiltersConfiguratorSpec.php
@@ -56,7 +56,7 @@ class FiltersConfiguratorSpec extends ObjectBehavior
                 0            => 'identifier_config',
                 'data_name'  => 'sku',
                 'label'      => 'Sku',
-                'enabled'    => true,
+                'enabled'    => false,
                 'order'      => 1,
                 'group'      => 'General',
                 'groupOrder' => 1

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Extension/RegisterIdentifierFiltersSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Extension/RegisterIdentifierFiltersSpec.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\Extension;
+
+use Akeneo\Channel\Component\Model\LocaleInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute\GetAttributeTranslations;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\Attribute;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
+use Akeneo\UserManagement\Bundle\Context\UserContext;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
+use Oro\Bundle\DataGridBundle\Datagrid\RequestParameters;
+use Oro\Bundle\DataGridBundle\Event\BuildBefore;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RegisterIdentifierFiltersSpec extends ObjectBehavior
+{
+    public function let(
+        GetAttributes $getAttributes,
+        GetAttributeTranslations $getAttributeTranslations,
+        UserContext $userContext,
+        RequestParameters $requestParams,
+        RequestStack $requestStack,
+        UserInterface $user,
+        LocaleInterface $locale,
+        BuildBefore $buildBefore,
+        DatagridConfiguration $datagridConfiguration,
+    ) {
+        $locale->getCode()->willReturn('fr_FR');
+        $user->getCatalogLocale()->willReturn($locale);
+        $userContext->getUser()->willReturn($user);
+        $buildBefore->getConfig()->willReturn($datagridConfiguration);
+
+        $this->beConstructedWith($getAttributes, $getAttributeTranslations, $userContext, $requestParams, $requestStack);
+    }
+
+    public function it_add_attribute_identifier_as_filters(
+        BuildBefore $buildBefore,
+        DatagridConfiguration $datagridConfiguration,
+        GetAttributes $getAttributes,
+        GetAttributeTranslations $getAttributeTranslations,
+    ) {
+        $getAttributeTranslations->byAttributeCodesAndLocale(['sku'], 'fr_FR')->willReturn([
+            'sku' => 'Sku',
+        ]);
+
+        $getAttributes->forType('pim_catalog_identifier')->willReturn([
+            'sku' => new Attribute(
+                'sku',
+                AttributeTypes::IDENTIFIER,
+                [],
+                false,
+                false,
+                null,
+                null,
+                false,
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                [],
+            ),
+        ]);
+
+        $familyFilter = [
+            'type' => 'product_family',
+            'label' => 'pim_datagrid.filters.family.label',
+            'data_name' => 'family',
+            'options' => [
+                'field_options' => [
+                    'multiple' => true,
+                    'attr' => [
+                        'empty_choice' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        $datagridConfiguration->offsetGet('filters')->willReturn(['columns' => ['family' => $familyFilter]]);
+        $datagridConfiguration->offsetAddToArray('filters', [
+            'columns' => [
+                'family' => $familyFilter,
+                'sku' => [
+                    'type' => 'product_value_string',
+                    'ftype' => 'identifier',
+                    'label' => 'Sku',
+                    'data_name' => 'sku',
+                    'options' => [
+                        'field_options' => [
+                            'attr' => [
+                                'choice_list' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        ])->shouldBeCalled();
+
+        $this->buildBefore($buildBefore);
+    }
+
+    public function it_callback_to_attribute_code_if_label_is_not_found(
+        BuildBefore $buildBefore,
+        DatagridConfiguration $datagridConfiguration,
+        UserInterface $user,
+        GetAttributes $getAttributes,
+        GetAttributeTranslations $getAttributeTranslations,
+    ) {
+        $user->getCatalogLocale()->willReturn(null);
+        $getAttributeTranslations->byAttributeCodesAndLocale(['sku'], 'en_US')->willReturn([]);
+
+        $getAttributes->forType('pim_catalog_identifier')->willReturn([
+            'sku' => new Attribute(
+                'sku',
+                AttributeTypes::IDENTIFIER,
+                [],
+                false,
+                false,
+                null,
+                null,
+                false,
+                AttributeTypes::BACKEND_TYPE_TEXT,
+                [],
+            ),
+        ]);
+
+        $familyFilter = [
+            'type' => 'product_family',
+            'label' => 'pim_datagrid.filters.family.label',
+            'data_name' => 'family',
+            'options' => [
+                'field_options' => [
+                    'multiple' => true,
+                    'attr' => [
+                        'empty_choice' => true,
+                    ],
+                ],
+            ],
+        ];
+
+        $datagridConfiguration->offsetGet('filters')->willReturn(['columns' => ['family' => $familyFilter]]);
+        $datagridConfiguration->offsetAddToArray('filters', [
+            'columns' => [
+                'family' => $familyFilter,
+                'sku' => [
+                    'type' => 'product_value_string',
+                    'ftype' => 'identifier',
+                    'label' => '[sku]',
+                    'data_name' => 'sku',
+                    'options' => [
+                        'field_options' => [
+                            'attr' => [
+                                'choice_list' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        ])->shouldBeCalled();
+
+        $this->buildBefore($buildBefore);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- I removed the fact that the identifier is always displayed
- I added a listener in order to add the filter into the default list of filters (as the identifier can be other than sku we cannot add it manually in the grid config) 
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
