### PR TITLE
PIM-10292: Fix error 500 when role page contain a validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - PIM-10248: Fix NOT BETWEEN filter does not work on products and product models (created and updated property)
 - PIM-10259: Fix Arabic text being reversed in product PDF exports
 - PIM-10277: Do not allow disabled user to login
+- PIM-10292: Fix error 500 when role page contain a validation errors
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/views/Form/pim-fields.html.twig
@@ -179,9 +179,7 @@
         {% if form.parent %}
             {% set combinedError = '' %}
             {% for error in errors %}
-                {% set error = error.messagePluralization is null
-                    ? error.messageTemplate|trans(error.messageParameters, 'validators')
-                    : error.messageTemplate|trans(error.messagePluralization, error.messageParameters, 'validators') %}
+                {% set error = error.messageTemplate|trans(error.messageParameters, 'validators', null, error.messagePluralization) %}
                 {% set combinedError = (combinedError != '') ? combinedError ~ '; ' ~ error : error %}
             {% endfor %}
             <i class="AknIconButton AknIconButton--important icon-warning-sign validation-tooltip" data-placement="right" data-toggle="tooltip" data-original-title="{{ combinedError|trans }}"></i>


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I fixed the group page when a validation error occured, since we bump to 5.4 of Symfony we have this error, it's due to the fact that transChoice have been removed (cf: https://github.com/symfony/twig-bridge/blob/5.4/CHANGELOG.md#500)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
