### PR TITLE
CPM-504: Add ES reindexation

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
@@ -25,6 +25,7 @@ class MigrateToUuidCommand extends Command
         MigrateToUuidStep $migrateToUuidFillProductUuid,
         MigrateToUuidStep $migrateToUuidFillForeignUuid,
         MigrateToUuidStep $migrateToUuidFillJson,
+        MigrateToUuidStep $migrateToUuidReindexElasticsearch,
         private LoggerInterface $logger
     ) {
         parent::__construct();
@@ -34,6 +35,7 @@ class MigrateToUuidCommand extends Command
             $migrateToUuidFillProductUuid,
             $migrateToUuidFillForeignUuid,
             $migrateToUuidFillJson,
+            $migrateToUuidReindexElasticsearch,
         ];
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid;
 
 use Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\Utils\LogContext;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ElasticsearchProjection\GetElasticsearchProductProjection;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -20,6 +21,7 @@ class MigrateToUuidCommand extends Command
     private array $steps;
 
     public function __construct(
+        private GetElasticsearchProductProjection $getElasticsearchProductProjection,
         MigrateToUuidStep $migrateToUuidCreateColumns,
         MigrateToUuidStep $migrateToUuidAddTriggers,
         MigrateToUuidStep $migrateToUuidFillProductUuid,
@@ -55,6 +57,7 @@ class MigrateToUuidCommand extends Command
         $this->logger->notice('Migration start');
 
         foreach ($this->steps as $step) {
+            $this->getElasticsearchProductProjection->clearCache();
             $logContext = new LogContext($step);
             $context->logContext = $logContext;
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidReindexElasticsearch.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidReindexElasticsearch.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid;
+
+use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class MigrateToUuidReindexElasticsearch implements MigrateToUuidStep
+{
+    use MigrateToUuidTrait;
+
+    private const BATCH_SIZE = 500;
+
+    public function __construct(
+        private Connection $connection,
+        private Client $esClient,
+        private ProductIndexerInterface $productIndexer
+    ) {
+    }
+
+    public function getMissingCount(): int
+    {
+        return $this->getEsResult()['hits']['total']['value'];
+    }
+
+    public function addMissing(bool $dryRun, OutputInterface $output): bool
+    {
+        if (!$this->columnExists('pim_catalog_product', 'uuid')) {
+            $output->writeln('Can not execute this migration because there is no uuid column.');
+
+            return false;
+        }
+        
+        $productIdentifiers = $this->getProductIdentifiersToIndex();
+        $output->writeln('lezg');
+        while (count($productIdentifiers) > 0) {
+            $output->writeln(sprintf('    Will reindex %d products...', count($productIdentifiers)));
+            $this->productIndexer->indexFromProductIdentifiers($productIdentifiers, [
+                'index_refresh' => Refresh::enable()
+            ]);
+            $productIdentifiers = $this->getProductIdentifiersToIndex();
+        }
+
+        return true;
+    }
+
+    public function shouldBeExecuted(): bool
+    {
+        return $this->getMissingCount() > 0;
+    }
+
+    public function getDescription(): string
+    {
+        return 'Reindex products in Elasticsearch using uuid';
+    }
+
+    private function getEsResult(): array
+    {
+        return $this->esClient->search([
+            'query' => [
+                'regexp' => [
+                    'id' => ['value' => 'product_[0-9]+']
+                ]
+            ],
+            'fields' => ['identifier'],
+            '_source' => false,
+            'size' => self::BATCH_SIZE,
+        ]);
+    }
+
+    private function getProductIdentifiersToIndex(): array
+    {
+        return array_map(
+            fn (array $document): string => $document['fields']['identifier'][0],
+            $this->getEsResult()['hits']['hits']
+        );
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidReindexElasticsearch.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidReindexElasticsearch.php
@@ -39,9 +39,8 @@ final class MigrateToUuidReindexElasticsearch implements MigrateToUuidStep
 
             return false;
         }
-        
+
         $productIdentifiers = $this->getProductIdentifiersToIndex();
-        $output->writeln('lezg');
         while (count($productIdentifiers) > 0) {
             $output->writeln(sprintf('    Will reindex %d products...', count($productIdentifiers)));
             $this->productIndexer->indexFromProductIdentifiers($productIdentifiers, [
@@ -65,6 +64,10 @@ final class MigrateToUuidReindexElasticsearch implements MigrateToUuidStep
 
     private function getEsResult(): array
     {
+        /**
+         * The document to reindex still have the previous id in the product_123 format, with 123 as mysql id.
+         * The new documents will have an id like product_1e40-4c55-a415-89c7958b270d, with their uuid.
+         */
         return $this->esClient->search([
             'query' => [
                 'regexp' => [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAncestorProductModelCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Indexer responsible for the indexation of product entities and parent product model entities of the products.
@@ -49,11 +50,13 @@ class ProductAndAncestorsIndexer
      * we need to provide the ancestors' codes in order to reindex them.
      *
      * @param int[] $productIds
+     * @param UuidInterface[] $productUuids
      * @param string[] $ancestorProductModelCodes
      */
-    public function removeFromProductIdsAndReindexAncestors(array $productIds, array $ancestorProductModelCodes): void
+    public function removeFromProductIdsAndReindexAncestors(array $productIds, array $productUuids, array $ancestorProductModelCodes): void
     {
         $this->productIndexer->removeFromProductIds($productIds);
+        $this->productIndexer->removeFromProductUuids($productUuids);
         $this->productModelIndexer->indexFromProductModelCodes($ancestorProductModelCodes);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductProjectionInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
@@ -66,15 +67,7 @@ class ProductIndexer implements ProductIndexerInterface
                 $productIdentifiersChunk
             );
 
-            $normalizedProductProjections = (
-                static function (iterable $projections): iterable {
-                    foreach ($projections as $identifier => $projection) {
-                        yield $identifier => $projection->toArray();
-                    }
-                }
-            )($elasticsearchProductProjections);
-
-            $this->productAndProductModelClient->bulkIndexes($normalizedProductProjections, 'id', $indexRefresh);
+            $this->productAndProductModelClient->bulkIndexes($elasticsearchProductProjections, 'id', $indexRefresh);
         }
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProject
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Indexer responsible for the indexation of product entities. This indexer DOES NOT index product model ancestors that can
@@ -88,11 +89,29 @@ class ProductIndexer implements ProductIndexerInterface
      */
     public function removeFromProductIds(array $productIds): void
     {
+        if (0 === count($productIds)) {
+            return;
+        }
+
         $this->productAndProductModelClient->bulkDelete(array_map(
             function ($productId) {
                 return self::PRODUCT_IDENTIFIER_PREFIX . (string) $productId;
             },
             $productIds
+        ));
+    }
+
+    public function removeFromProductUuids(array $productUuids): void
+    {
+        if (0 === count($productUuids)) {
+            return;
+        }
+
+        $this->productAndProductModelClient->bulkDelete(array_map(
+            function ($productUuid) {
+                return self::PRODUCT_IDENTIFIER_PREFIX . $productUuid->toString();
+            },
+            $productUuids
         ));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriber.php
@@ -8,6 +8,9 @@ use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexe
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -19,12 +22,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInterface
 {
-    /** @var ProductAndAncestorsIndexer */
-    private $productAndAncestorsIndexer;
+    /**
+     * @var UuidInterface[]
+     */
+    private array $productUuidsCache = [];
 
-    public function __construct(ProductAndAncestorsIndexer $productAndAncestorsIndexer)
-    {
-        $this->productAndAncestorsIndexer = $productAndAncestorsIndexer;
+    public function __construct(
+        private ProductAndAncestorsIndexer $productAndAncestorsIndexer,
+        private Connection $connection
+    ) {
     }
 
     /**
@@ -33,12 +39,46 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
     public static function getSubscribedEvents() : array
     {
         return [
-            StorageEvents::POST_REMOVE   => ['deleteProduct'],
+            StorageEvents::PRE_REMOVE => ['setProductUuidCache'],
+            StorageEvents::PRE_REMOVE_ALL => ['setProductUuidsCache'],
+            StorageEvents::POST_REMOVE => ['deleteProduct'],
             StorageEvents::POST_REMOVE_ALL => ['deleteProducts'],
         ];
     }
 
-    public function deleteProduct(RemoveEvent $event) : void
+    public function setProductUuidCache(RemoveEvent $event): void
+    {
+        $product = $event->getSubject();
+        if (!$product instanceof ProductInterface) {
+            return;
+        }
+        // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
+        if (get_class($product) == 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProduct') {
+            return;
+        }
+        if (!$event->hasArgument('unitary') || true !== $event->getArgument('unitary')) {
+            return;
+        }
+
+        $this->setProductUuidsCacheInner([$event->getSubjectId()]);
+    }
+
+    public function setProductUuidsCache(RemoveEvent $event): void
+    {
+        $products = $event->getSubject();
+        if (!is_array($products) || !is_array($event->getSubjectId())) {
+            return;
+        }
+        $products = array_filter($products, function ($product) {
+            return $product instanceof ProductInterface
+                // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
+                && get_class($product) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProduct';
+        });
+
+        $this->setProductUuidsCacheInner(array_map(fn (ProductInterface $product): int => $product->getId(), $products));
+    }
+
+    public function deleteProduct(RemoveEvent $event): void
     {
         $product = $event->getSubject();
         if (!$product instanceof ProductInterface) {
@@ -54,6 +94,7 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
 
         $this->productAndAncestorsIndexer->removeFromProductIdsAndReindexAncestors(
             [$event->getSubjectId()],
+            $this->productUuidsCache,
             $this->getAncestorCodes([$product])
         );
     }
@@ -73,6 +114,7 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
         if (!empty($products)) {
             $this->productAndAncestorsIndexer->removeFromProductIdsAndReindexAncestors(
                 $event->getSubjectId(),
+                $this->productUuidsCache,
                 $this->getAncestorCodes($products)
             );
         }
@@ -90,5 +132,40 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
         }
 
         return array_unique($ancestorCodes, SORT_STRING);
+    }
+
+    private function setProductUuidsCacheInner(array $productIds): void
+    {
+        if (0 === count($productIds) || !$this->uuidColumnExists()) {
+            $this->productUuidsCache = [];
+
+            return;
+        }
+
+        $result = $this->connection->fetchFirstColumn(<<<SQL
+            SELECT BIN_TO_UUID(uuid) AS uuid
+            FROM pim_catalog_product
+            WHERE id IN (:product_ids)
+            AND uuid IS NOT NULL
+        SQL, [
+            'product_ids' => $productIds
+        ], [
+            'product_ids' => Connection::PARAM_INT_ARRAY
+        ]);
+
+        $this->productUuidsCache = array_map(
+            fn (string $uuid): UuidInterface => Uuid::fromString($uuid),
+            $result
+        );
+    }
+
+    private function uuidColumnExists(): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(<<<SQL
+            SHOW COLUMNS FROM pim_catalog_product LIKE 'uuid'
+        SQL
+        );
+
+        return count($rows) >= 1;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriber.php
@@ -161,7 +161,8 @@ final class ComputeProductsAndAncestorsSubscriber implements EventSubscriberInte
 
     private function uuidColumnExists(): bool
     {
-        $rows = $this->connection->fetchAllAssociative(<<<SQL
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
             SHOW COLUMNS FROM pim_catalog_product LIKE 'uuid'
         SQL
         );

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -47,6 +47,12 @@ services:
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillJson:
         parent: base_uuid_migration_step
 
+    Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidReindexElasticsearch:
+        arguments:
+            - '@database_connection'
+            - '@akeneo_elasticsearch.client.product_and_product_model'
+            - '@pim_catalog.elasticsearch.indexer.product'
+
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCommand:
         arguments:
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCreateColumns'
@@ -54,6 +60,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillProductUuid'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillForeignUuid'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillJson'
+            - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidReindexElasticsearch'
             - '@monolog.logger'
         tags:
             - { name: 'console.command' }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -56,6 +56,7 @@ services:
 
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCommand:
         arguments:
+            - '@akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCreateColumns'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidAddTriggers'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillProductUuid'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -50,6 +50,7 @@ services:
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidReindexElasticsearch:
         arguments:
             - '@database_connection'
+            - '@monolog.logger'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.elasticsearch.indexer.product'
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -68,6 +68,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Product\OnDelete\ComputeProductsAndAncestorsSubscriber'
         arguments:
             - '@akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors'
+            - '@database_connection'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -56,8 +56,8 @@ final class GetElasticsearchProductProjection implements GetElasticsearchProduct
             $rows
         );
         $diffIdentifiers = \array_diff(
-            array_map(fn (string $id): string => strtolower($id), $productIdentifiers),
-            array_map(fn (string $id): string => strtolower($id), $rowIdentifiers)
+            array_map('strtolower', $productIdentifiers),
+            array_map('strtolower', $rowIdentifiers)
         );
         if (\count($diffIdentifiers) > 0) {
             throw new ObjectNotFoundException(\sprintf('Product identifiers "%s" were not found.', \implode(',', $diffIdentifiers)));

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -393,6 +393,11 @@ SQL;
         return $rowsIndexedByProductIdentifier;
     }
 
+    public function clearCache(): void
+    {
+        $this->columnExistsCache = null;
+    }
+
     private function columnExists(string $tableName, string $columnName): bool
     {
         if ($this->columnExistsCache === null) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Storage/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Storage/Indexer/ProductIndexerInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -38,4 +39,9 @@ interface ProductIndexerInterface
      * @param int[] $productIds
      */
     public function removeFromProductIds(array $productIds): void;
+
+    /**
+     * @param UuidInterface[] $productUuids
+     */
+    public function removeFromProductUuids(array $productUuids): void;
 }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -120,12 +120,11 @@ class Client
         ];
         foreach ($documents as $document) {
             $extraActions = [];
-            $documentObject = $document;
             if ($document instanceof AffectedByMigrationProjection) {
-                $document = $document->toArray();
-                if ($documentObject->shouldBeMigrated()) {
-                    $extraActions[] = ['delete' => ['_index' => $this->indexName, '_id' => $documentObject->getFormerDocumentId()]];
+                if ($document->shouldBeMigrated()) {
+                    $extraActions[] = ['delete' => ['_index' => $this->indexName, '_id' => $document->getFormerDocumentId()]];
                 }
+                $document = $document->toArray();
             }
             $action = ['index' => ['_index' => $this->indexName]];
 

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Domain/Model/AffectedByMigrationProjection.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Domain/Model/AffectedByMigrationProjection.php
@@ -2,6 +2,15 @@
 
 namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Domain\Model;
 
+/**
+ * This interface represents an Elasticsearch projection of a document which should be migrated from its
+ * former document_id to a new one.
+ * The Elasticsearch client will catch these flagged projections to remove the document with the former document_id
+ * before inserting the new projection with the new document_id.
+ *
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
 interface AffectedByMigrationProjection
 {
     public function shouldBeMigrated(): bool;

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Domain/Model/AffectedByMigrationProjection.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Domain/Model/AffectedByMigrationProjection.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Domain\Model;
+
+interface AffectedByMigrationProjection
+{
+    public function shouldBeMigrated(): bool;
+
+    public function getFormerDocumentId(): string;
+
+    public function toArray(): array;
+}

--- a/tests/back/Pim/Enrichment/Integration/Product/MigrateToUuidCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/MigrateToUuidCommandIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
 use Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidAddTriggers;
 use Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidStep;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
@@ -148,7 +149,7 @@ final class MigrateToUuidCommandIntegration extends AbstractMigrateToUuidTestCas
             )->fetchFirstColumn()
         );
         // pim_data_quality_insights_product_score
-        ($this->get(EvaluateProducts::class))([$newProductId]);
+        ($this->get(EvaluateProducts::class))(ProductIdCollection::fromInts([$newProductId]));
         Assert::assertSame(
             [$newProductUuid],
             $this->connection->executeQuery('SELECT DISTINCT BIN_TO_UUID(product_uuid) FROM pim_data_quality_insights_product_score WHERE product_id = ?', [$newProductId])->fetchFirstColumn()
@@ -207,7 +208,7 @@ final class MigrateToUuidCommandIntegration extends AbstractMigrateToUuidTestCas
             )->fetchFirstColumn()
         );
         // pim_data_quality_insights_product_score
-        ($this->get(EvaluateProducts::class))([$newProductId]);
+        ($this->get(EvaluateProducts::class))(ProductIdCollection::fromInt($newProductId));
         Assert::assertSame(
             [$newProductUuid],
             $this->connection->executeQuery('SELECT DISTINCT BIN_TO_UUID(product_uuid) FROM pim_data_quality_insights_product_score WHERE product_id = ?', [$newProductId])->fetchFirstColumn()

--- a/tests/back/Pim/Enrichment/Integration/Product/UuidMigration/AddUuidSubscriberIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/UuidMigration/AddUuidSubscriberIntegration.php
@@ -44,7 +44,7 @@ final class AddUuidSubscriberIntegration extends AbstractMigrateToUuidTestCase
         $this->get('pim_enrich.product.message_bus')->dispatch(new UpsertProductCommand(
             userId: $adminUserId,
             productIdentifier: 'product_with_uuid',
-            valuesUserIntent: [new SetTextValue('a_text', null, null, 'test1')]
+            valueUserIntents: [new SetTextValue('a_text', null, null, 'test1')]
         ));
         $sql = "SELECT BIN_TO_UUID(uuid) FROM pim_catalog_product WHERE identifier = 'product_with_uuid'";
         $uuid = $this->connection->executeQuery($sql)->fetchOne();
@@ -55,7 +55,7 @@ final class AddUuidSubscriberIntegration extends AbstractMigrateToUuidTestCase
         $this->get('pim_enrich.product.message_bus')->dispatch(new UpsertProductCommand(
             userId: $adminUserId,
             productIdentifier: 'product_with_uuid',
-            valuesUserIntent: [new SetTextValue('a_text', null, null, 'test2')]
+            valueUserIntents: [new SetTextValue('a_text', null, null, 'test2')]
         ));
         $sql = "SELECT BIN_TO_UUID(uuid) FROM pim_catalog_product WHERE identifier = 'product_with_uuid'";
         $uuidAfterUpdate = $this->connection->executeQuery($sql)->fetchOne();

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/ReindexAffectedByMigrationProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/ReindexAffectedByMigrationProductIntegration.php
@@ -2,10 +2,10 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
 
-use Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\ProductSaver;
 use Akeneo\Pim\Enrichment\Component\Product\Builder\ProductBuilderInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 
@@ -45,7 +45,7 @@ class ReindexAffectedByMigrationProductIntegration extends TestCase
         return $this->catalog->useMinimalCatalog();
     }
 
-    private function getProductSaver(): ProductSaver
+    private function getProductSaver(): SaverInterface
     {
         return $this->get('pim_catalog.saver.product');
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/ReindexAffectedByMigrationProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/ReindexAffectedByMigrationProductIntegration.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\ProductAndProductModel;
+
+use Akeneo\Pim\Enrichment\Bundle\Doctrine\Common\Saver\ProductSaver;
+use Akeneo\Pim\Enrichment\Component\Product\Builder\ProductBuilderInterface;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+class ReindexAffectedByMigrationProductIntegration extends TestCase
+{
+    public function test_it_deletes_and_reindex_affected_by_migration_product()
+    {
+        $wasColumnDropped = false;
+        if ($this->uuidColumnExists()) {
+            $this->dropUuidColumn();
+            $wasColumnDropped = true;
+        }
+
+        $product = $this->getProductBuilder()->createProduct('foo');
+        $this->getProductSaver()->save($product);
+        $this->getElasticSearchClient()->refreshIndex();
+        Assert::equalTo($this->getElasticSearchClient()->count([])['count'], 1);
+        $formerProductId = $this->getElasticSearchClient()->search([])['hits']['hits'][0]['_id'];
+
+        $this->addUuidColumn();
+
+        $this->getElasticSearchProductProjection()->clearCache();
+        $this->getProductSaver()->save($product, ['force_save' => true]);
+        $this->getElasticSearchClient()->refreshIndex();
+        Assert::equalTo($this->getElasticSearchClient()->count([])['count'], 1);
+        $newProductId = $this->getElasticSearchClient()->search([])['hits']['hits'][0]['_id'];
+
+        Assert::assertNotEquals($formerProductId, $newProductId);
+
+        if (!$wasColumnDropped) {
+            $this->dropUuidColumn();
+        }
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getProductSaver(): ProductSaver
+    {
+        return $this->get('pim_catalog.saver.product');
+    }
+
+    private function getElasticSearchClient(): Client
+    {
+        return $this->get('akeneo_elasticsearch.client.product_and_product_model');
+    }
+
+    private function getProductBuilder(): ProductBuilderInterface
+    {
+        return $this->get('pim_catalog.builder.product');
+    }
+
+    private function getElasticSearchProductProjection()
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function addUuidColumn()
+    {
+        $this->getConnection()->executeQuery('ALTER TABLE pim_catalog_product ADD uuid BINARY(16) DEFAULT NULL AFTER id, LOCK=NONE, ALGORITHM=INPLACE');
+    }
+
+    private function dropUuidColumn()
+    {
+        $this->getConnection()->executeQuery('ALTER TABLE pim_catalog_product DROP COLUMN uuid, LOCK=NONE, ALGORITHM=INPLACE');
+    }
+
+    private function uuidColumnExists(): bool
+    {
+        $rows = $this->getConnection()->fetchAllAssociative('SHOW COLUMNS FROM pim_catalog_product LIKE "uuid"');
+
+        return count($rows) >= 1;
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
@@ -503,7 +503,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
         $id = $normalizedProductProjection->toArray()['id'];
         $split = preg_match('/^product_(?P<uuid>.*)$/', $id, $matches);
 
-        Assert::equalTo($split, 1);
+        Assert::assertSame(1, $split);
         Assert::assertTrue(Uuid::isValid($matches['uuid']));
         Assert::assertTrue($normalizedProductProjection->shouldBeMigrated());
 
@@ -527,7 +527,7 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
         $id = $normalizedProductProjection->toArray()['id'];
         $split = preg_match('/^product_(?P<id>\d*)$/', $id);
 
-        Assert::equalTo($split, 1);
+        Assert::assertSame(1, $split);
         Assert::assertFalse($normalizedProductProjection->shouldBeMigrated());
 
         if ($wasColumnDropped) {

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
@@ -70,9 +70,20 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer
     ) {
-        $productIndexer->removeFromProductIds([44, 56])->shouldBeCalled();
-        $productModelIndexer->indexFromProductModelCodes(['root_pm', 'sub_pm_1', 'sub_pm_2'])->shouldBeCalled();
+        $productIndexer
+            ->removeFromProductIds([44, 56])
+            ->shouldBeCalled();
+        $productIndexer
+            ->removeFromProductUuids(['d6d6051c-0c00-49cd-8219-c825c72a456e', '386f0ec8-4e4c-4028-acd7-e1195a13a3b5'])
+            ->shouldBeCalled();
+        $productModelIndexer
+            ->indexFromProductModelCodes(['root_pm', 'sub_pm_1', 'sub_pm_2'])
+            ->shouldBeCalled();
 
-        $this->removeFromProductIdsAndReindexAncestors([44, 56], ['root_pm', 'sub_pm_1', 'sub_pm_2']);
+        $this->removeFromProductIdsAndReindexAncestors(
+            [44, 56],
+            ['d6d6051c-0c00-49cd-8219-c825c72a456e', '386f0ec8-4e4c-4028-acd7-e1195a13a3b5'],
+            ['root_pm', 'sub_pm_1', 'sub_pm_2']
+        );
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductIndexerSpec.php
@@ -35,12 +35,11 @@ class ProductIndexerSpec extends ObjectBehavior
         GetElasticsearchProductProjectionInterface $getElasticsearchProductProjection
     ) {
         $identifier = 'foobar';
-        $getElasticsearchProductProjection->fromProductIdentifiers([$identifier])->willYield([$this->getElasticSearchProjection('identifier_1')]);
+        $iterable = [$this->getElasticSearchProjection('identifier_1')];
+        $getElasticsearchProductProjection->fromProductIdentifiers([$identifier])->willReturn($iterable);
         $productAndProductModelIndexClient
             ->bulkIndexes(
-                Argument::that(function ($projections) {
-                    return \iterator_to_array($projections) === [$this->getElasticSearchProjection('identifier_1')->toArray()];
-                }),
+                $iterable,
                 'id',
                 Refresh::disable()
             )->shouldBeCalled();
@@ -54,16 +53,11 @@ class ProductIndexerSpec extends ObjectBehavior
     ) {
         $identifiers = ['foo', 'bar', 'unknown'];
 
-        $getElasticsearchProductProjection->fromProductIdentifiers($identifiers)
-            ->willYield([$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')]);
+        $iterable = [$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')];
+        $getElasticsearchProductProjection->fromProductIdentifiers($identifiers)->willReturn($iterable);
 
         $productAndProductModelIndexClient->bulkIndexes(
-            Argument::that(function ($projections) {
-                return \iterator_to_array($projections) === [
-                    $this->getElasticSearchProjection('identifier_1')->toArray(),
-                    $this->getElasticSearchProjection('identifier_2')->toArray(),
-                ];
-            }),
+            $iterable,
             'id',
             Refresh::disable()
         )->shouldBeCalled();
@@ -78,16 +72,16 @@ class ProductIndexerSpec extends ObjectBehavior
         $identifiers = $this->getRangeIdentifiers(1, 1502);
 
         $getElasticsearchProductProjection->fromProductIdentifiers($this->getRangeIdentifiers(1, 500))
-            ->willYield([$this->getElasticSearchProjection('identifier_1')]);
+            ->willReturn([$this->getElasticSearchProjection('identifier_1')]);
         $getElasticsearchProductProjection->fromProductIdentifiers($this->getRangeIdentifiers(501, 1000))
-            ->willYield([$this->getElasticSearchProjection('identifier_2')]);
+            ->willReturn([$this->getElasticSearchProjection('identifier_2')]);
         $getElasticsearchProductProjection->fromProductIdentifiers($this->getRangeIdentifiers(1001, 1500))
-            ->willYield([$this->getElasticSearchProjection('identifier_3')]);
+            ->willReturn([$this->getElasticSearchProjection('identifier_3')]);
         $getElasticsearchProductProjection->fromProductIdentifiers($this->getRangeIdentifiers(1501, 1502))
-            ->willYield([$this->getElasticSearchProjection('identifier_4')]);
+            ->willReturn([$this->getElasticSearchProjection('identifier_4')]);
 
         $productAndProductModelIndexClient->bulkIndexes(
-            Argument::type(\Traversable::class),
+            Argument::any(),
             'id',
             Refresh::disable()
         )->shouldBeCalledTimes(4);
@@ -124,16 +118,13 @@ class ProductIndexerSpec extends ObjectBehavior
         Client $productAndProductModelIndexClient,
         GetElasticsearchProductProjectionInterface $getElasticsearchProductProjection
     ) {
+        $iterable = [$this->getElasticSearchProjection('identifier_1')];
         $getElasticsearchProductProjection
             ->fromProductIdentifiers(['identifier_1'])
-            ->willReturn([$this->getElasticSearchProjection('identifier_1')]);
+            ->willReturn($iterable);
 
         $productAndProductModelIndexClient->bulkIndexes(
-            Argument::that(function ($projections) {
-                return \iterator_to_array($projections) === [
-                    $this->getElasticSearchProjection('identifier_1')->toArray(),
-                ];
-            }),
+            $iterable,
             'id',
             Refresh::waitFor()
         )->shouldBeCalled();
@@ -147,16 +138,12 @@ class ProductIndexerSpec extends ObjectBehavior
     ) {
         $identifiers = ['foo', 'bar', 'unknown'];
 
+        $iterable = [$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')];
         $getElasticsearchProductProjection->fromProductIdentifiers($identifiers)
-            ->willReturn([$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')]);
+            ->willReturn($iterable);
 
         $productAndProductModelIndexClient->bulkIndexes(
-            Argument::that(function ($projections) {
-                return \iterator_to_array($projections) === [
-                    $this->getElasticSearchProjection('identifier_1')->toArray(),
-                    $this->getElasticSearchProjection('identifier_2')->toArray(),
-                ];
-            }),
+            $iterable,
             'id',
             Refresh::disable()
         )->shouldBeCalled();
@@ -170,16 +157,12 @@ class ProductIndexerSpec extends ObjectBehavior
     ) {
         $identifiers = ['foo', 'bar', 'unknown'];
 
+        $iterable = [$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')];
         $getElasticsearchProductProjection->fromProductIdentifiers($identifiers)
-            ->willReturn([$this->getElasticSearchProjection('identifier_1'), $this->getElasticSearchProjection('identifier_2')]);
+            ->willReturn($iterable);
 
         $productAndProductModelIndexClient->bulkIndexes(
-            Argument::that(function ($projections) {
-                return \iterator_to_array($projections) === [
-                    $this->getElasticSearchProjection('identifier_1')->toArray(),
-                    $this->getElasticSearchProjection('identifier_2')->toArray(),
-                ];
-            }),
+            $iterable,
             'id',
             Refresh::enable()
         )->shouldBeCalled();
@@ -191,6 +174,7 @@ class ProductIndexerSpec extends ObjectBehavior
     {
         return new ElasticsearchProductProjection(
             '1',
+            '1e40-4c55-a415-89c7958b270d',
             $identifier,
             new \DateTimeImmutable('2019-03-16 12:03:00', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-03-16 12:03:00', new \DateTimeZone('UTC')),

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnDelete/ComputeProductsAndAncestorsSubscriberSpec.php
@@ -8,14 +8,16 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 
 class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
 {
-    function let(ProductAndAncestorsIndexer $indexer)
+    function let(ProductAndAncestorsIndexer $indexer, Connection $connection)
     {
-        $this->beConstructedWith($indexer);
+        $this->beConstructedWith($indexer, $connection);
     }
 
     function it_is_initializable()
@@ -25,34 +27,38 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
 
     function it_subscribes_to_remove_events()
     {
+        $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::PRE_REMOVE);
+        $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::PRE_REMOVE_ALL);
         $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::POST_REMOVE);
         $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::POST_REMOVE_ALL);
     }
 
     function it_only_handles_products(ProductAndAncestorsIndexer $indexer)
     {
+        $indexer->removeFromProductIdsAndReindexAncestors(Argument::cetera())->shouldNotBeCalled();
+
         $this->deleteProduct(new RemoveEvent(42, new \stdClass(), ['unitary' => true]));
         $this->deleteProduct(new RemoveEvent([42, 23],  [new \stdClass(), new ProductModel()], ['unitary' => false]));
-
-        $indexer->removeFromProductIdsAndReindexAncestors(Argument::cetera())->shouldNotBeCalled();
     }
 
     function it_does_not_delete_single_products_on_non_unitary_events(ProductAndAncestorsIndexer $indexer)
     {
-        $indexer->removeFromProductIdsAndReindexAncestors(Argument::cetera())->shouldNotBeCalled();
-
         $this->deleteProduct(new RemoveEvent(new Product(), 42, ['unitary' => false]));
+
+        $indexer->removeFromProductIdsAndReindexAncestors(Argument::cetera())->shouldNotBeCalled();
     }
 
     function it_deletes_a_single_product_from_the_index(ProductAndAncestorsIndexer $indexer)
     {
-        $indexer->removeFromProductIdsAndReindexAncestors([42], [])->shouldBeCalled();
-
         $this->deleteProduct(new RemoveEvent(new Product(), 42, ['unitary' => true]));
+
+        $indexer->removeFromProductIdsAndReindexAncestors([42], [], [])->shouldBeCalled();
     }
 
-    function it_deletes_a_single_variant_product_from_the_index(ProductAndAncestorsIndexer $indexer)
-    {
+    function it_deletes_a_single_variant_product_from_the_index(
+        ProductAndAncestorsIndexer $indexer,
+        Connection $connection
+    ) {
         $rootProductModel = new ProductModel();
         $rootProductModel->setCode('root');
         $subProductModel = new ProductModel();
@@ -61,13 +67,24 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         $variantProduct = new Product();
         $variantProduct->setParent($subProductModel);
 
-        $indexer->removeFromProductIdsAndReindexAncestors([100], ['sub', 'root'])->shouldBeCalled();
+        $indexer->removeFromProductIdsAndReindexAncestors(
+            [100],
+            [Uuid::fromString('386f0ec8-4e4c-4028-acd7-e1195a13a3b5')],
+            ['sub', 'root']
+        )->shouldBeCalled();
 
-        $this->deleteProduct(new RemoveEvent($variantProduct, 100, ['unitary' => true]));
+        $connection->fetchAllAssociative(Argument::any())->willReturn(['The uuid column exists']);
+        $connection->fetchFirstColumn(Argument::any(), ['product_ids' => [100]], Argument::any())->willReturn(['386f0ec8-4e4c-4028-acd7-e1195a13a3b5']);
+
+        $event = new RemoveEvent($variantProduct, 100, ['unitary' => true]);
+        $this->setProductUuidCache($event);
+        $this->deleteProduct($event);
     }
 
-    function it_deletes_multiple_products_from_the_index(ProductAndAncestorsIndexer $indexer)
-    {
+    function it_deletes_multiple_products_from_the_index(
+        ProductAndAncestorsIndexer $indexer,
+        Connection $connection
+    ) {
         $rootProductModel = new ProductModel();
         $rootProductModel->setCode('root');
         $subProductModel1 = new ProductModel();
@@ -75,17 +92,38 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         $subProductModel1->setParent($rootProductModel);
         $variantProduct = new Product();
         $variantProduct->setParent($subProductModel1);
+        $variantProduct->setId(44);
         $subProductModel2 = new ProductModel();
         $subProductModel2->setCode('sub2');
         $subProductModel2->setParent($rootProductModel);
         $otherVariantProduct = new Product();
         $otherVariantProduct->setParent($subProductModel2);
+        $otherVariantProduct->setId(56);
 
-        $indexer->removeFromProductIdsAndReindexAncestors([44, 56, 99], ['sub1', 'root', 'sub2'])->shouldBeCalled();
+        $indexer->removeFromProductIdsAndReindexAncestors(
+            [44, 56],
+            [
+                Uuid::fromString('386f0ec8-4e4c-4028-acd7-e1195a13a3b5'),
+                Uuid::fromString('57e9847a-6c56-4403-9f1f-abde22ecb0a4'),
+            ],
+            ['sub1', 'root', 'sub2']
+        )->shouldBeCalled();
 
-        $this->deleteProducts(new RemoveEvent(
-            [$variantProduct, $otherVariantProduct, new Product()],
-            [44, 56, 99]
-        ));
+        $connection->fetchAllAssociative(Argument::any())->shouldBeCalled()->willReturn(['The uuid column exists']);
+        $connection
+            ->fetchFirstColumn(Argument::any(), ['product_ids' => [44, 56]], Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                '386f0ec8-4e4c-4028-acd7-e1195a13a3b5',
+                '57e9847a-6c56-4403-9f1f-abde22ecb0a4',
+            ]);
+
+        $event = new RemoveEvent(
+            [$variantProduct, $otherVariantProduct],
+            [44, 56]
+        );
+
+        $this->setProductUuidsCache($event);
+        $this->deleteProducts($event);
     }
 }


### PR DESCRIPTION
The goal is to:
- add a migration step to reindex all products
- each time a product is saved, we have to reindex it

The "original" products are indexed under "_id" and "id" fields (which are the same in the PIM) with mysql id like "product_1234"
When the product have a uuid, we have to index their "_id" and "id" fields with the uuid, like "product_1e40-4c55-a415-89c7958b270d"

The idea is to remove the previous one, then add the new one, in the same query.