### PR TITLE
PLG-761-no-impact-on-ui-when-productmodels-scores-will-be-computed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ coverage/*
 .phpunit.result.cache
 cypress/videos
 cypress/screenshots
+.nvmrc
 
 # The "lib/" folder must be ignored here to not be taken into account when the DSM is extracted to its own repository.
 # See ".github/actions/extract/entrypoint.sh"

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -52,13 +53,21 @@ class QualityScoreFilter extends AbstractFieldFilter implements FieldFilterInter
             throw InvalidPropertyException::dataExpected($field, sprintf('values among "%s"', implode('", "', Rank::LETTERS_MAPPING)), static::class);
         }
 
-        $clause = [
-            'terms' => [
-                sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values
-            ],
-        ];
+        $this->searchQueryBuilder->addMustNot(
+            [
+                'term' => [
+                    'document_type' => ProductModelInterface::class
+                ]
+            ]
+        );
 
-        $this->searchQueryBuilder->addFilter($clause);
+        $this->searchQueryBuilder->addFilter(
+            [
+                'terms' => [
+                    sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values
+                ]
+            ]
+        );
 
         return $this;
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/public/js/infrastructure/datagrid/cell/quality-score-badge-cell.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/public/js/infrastructure/datagrid/cell/quality-score-badge-cell.tsx
@@ -8,6 +8,12 @@ const StringCell = require('oro/datagrid/string-cell');
 
 class QualityScoreBadgeCell extends StringCell {
   render() {
+    if (this.model.attributes.document_type !== 'product') {
+      // PLG-720 -> PLG-761 : making sure we wont have quality score displayed for product-model before it's ready
+      // @TODO [PLG-750] remove this test
+      return this;
+    }
+
     const productQualityScore: string = this.formatter.fromRaw(this.model.get(this.column.get('name')));
 
     ReactDOM.render(

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
@@ -23,10 +23,18 @@ final class QualityScoreFilterSpec extends ObjectBehavior
 
     public function it_adds_filter_on_quality_score_with_letter_values($queryBuilder)
     {
+        $queryBuilder->addMustNot(
+            [
+                'term' => [
+                    'document_type' => 'Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface'
+                ],
+            ]
+        )->shouldBeCalled();
+
         $queryBuilder->addFilter(
             [
                 'terms' => [
-                   'data_quality_insights.scores.ecommerce.en_US' => [1, 2]
+                    'data_quality_insights.scores.ecommerce.en_US' => [1, 2]
                 ],
             ]
         )->shouldBeCalled();
@@ -36,10 +44,18 @@ final class QualityScoreFilterSpec extends ObjectBehavior
 
     public function it_adds_filter_on_quality_score_with_integer_values($queryBuilder)
     {
+        $queryBuilder->addMustNot(
+            [
+                'term' => [
+                    'document_type' => 'Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface'
+                ],
+            ]
+        )->shouldBeCalled();
+
         $queryBuilder->addFilter(
             [
                 'terms' => [
-                   'data_quality_insights.scores.ecommerce.en_US' => [1, 3]
+                    'data_quality_insights.scores.ecommerce.en_US' => [1, 3]
                 ],
             ]
         )->shouldBeCalled();

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchQueryBuilder.php
@@ -83,7 +83,7 @@ class SearchQueryBuilder
      *
      * Warning: in the context of the PIM, a request containing a should clause is subject to a lot of side effects.
      * For instance, in one filter you want to filter on the property A with 2 possible values: A = 1 || A = 2
-     * you could do the folowing:
+     * you could do the following:
      * `sqb->addShould([
      *  [
      *   'terms' => [
@@ -92,7 +92,7 @@ class SearchQueryBuilder
      *  ],
      *  [
      *   'terms' => [
-     *      'A' => 1
+     *      'A' => 2
      *    ]
      *  ]);`
      *
@@ -101,12 +101,12 @@ class SearchQueryBuilder
      * `sqb->addShould([
      *  [
      *   'terms' => [
-     *      'A' => 1
+     *      'B' => 1
      *    ]
      *  ],
      *  [
      *   'terms' => [
-     *      'A' => 1
+     *      'B' => 2
      *    ]
      *  ]);`
      *


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

make product grid ignore DQI score for product models (temporary) before the second release of the DQI for product models integrates master.

