### PR TITLE
PIM-10275: Missing translation key when error occured during association deletion

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10275: Missing translation key when error occured during association deletion
+
 # 5.0.80 (2022-02-23)
 
 # 5.0.79 (2022-02-21)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/association_type.yml
@@ -1,7 +1,7 @@
 datagrid:
     association-type-grid:
         options:
-            entityHint: association type
+            entityHint: association_type
             locale_parameter: localeCode
             manageFilters: false
         source:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- I fixed the invalid entityHint in order to use the existing error key when an error occured on association type deletion
- This entityHint is only used for confirmation modal and error notification message 

![Screenshot from 2022-02-23 15-23-49](https://user-images.githubusercontent.com/7239572/155338153-8525d27e-4925-4b93-80f7-63dd91ec86de.png)

**Definition Of Done (for Core Developer only)**


- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
