### PR TITLE
CPM-537: Add condition on quantifiedAssociationsType for MigrateToFillUuidFillJson step

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillJson.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillJson.php
@@ -38,7 +38,19 @@ class MigrateToUuidFillJson implements MigrateToUuidStep
 
     public function shouldBeExecuted(): bool
     {
-        // TODO Add "if there is no quantified_associations type, continue"
+        $sqlQuantified = <<<SQL
+            SELECT EXISTS(
+               SELECT 1
+               FROM pim_catalog_association_type
+               WHERE is_quantified = 1
+            ) as quantified_association
+        SQL;
+
+        $hasQuantifiedAssociationsType = $this->connection->executeQuery($sqlQuantified)->fetchOne();
+        if (!(bool) $hasQuantifiedAssociationsType) {
+            return false;
+        }
+
         $sql = <<<SQL
             SELECT EXISTS(
                 SELECT 1


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Add a condition for the `shouldBeExecuted` method inside the `MigrateToUuidFillJson` step in order to avoid a long request by checking if any quantified association type exists.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
