### PR TITLE
CPM-538: Remove the id of the product association when product does not exist

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillJson.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillJson.php
@@ -208,6 +208,9 @@ class MigrateToUuidFillJson implements MigrateToUuidStep
                                 } else {
                                     $formerAssociation[$associationName]['products'][$i]['uuid'] = $associatedProductUuid;
                                 }
+                            } else {
+                                // former association is cleared since product does not exist anymore
+                                \array_splice($formerAssociation[$associationName]['products'], $i, 1);
                             }
                         }
                     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/UuidNotFoundException.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/UuidNotFoundException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UuidNotFoundException extends \LogicException
+{
+    public const MESSAGE = 'No uuid found';
+
+    public function __construct()
+    {
+        parent::__construct(self::MESSAGE);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
- Fix: when a product is deleted the related pim_versioning_version column is not cleared so we added a join on the count and update methods used in MigrateToUuidFillForeignUuid step
- in the MigrateToUuidFillJson, we clear JSON when the related product inside association does not exist anymore

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
