### PR TITLE
CXP-1103: prevent inte test from failing randomly

### DIFF
--- a/tests/back/Platform/Integration/Analytics/Query/GetConnectedAppsIdentifiersQueryIntegration.php
+++ b/tests/back/Platform/Integration/Analytics/Query/GetConnectedAppsIdentifiersQueryIntegration.php
@@ -32,7 +32,7 @@ class GetConnectedAppsIdentifiersQueryIntegration extends TestCase
      */
     protected function getConfiguration(): ?Configuration
     {
-        return null;
+        return $this->catalog->useMinimalCatalog();
     }
 
     public function test_it_fetches_identifiers_of_connected_apps(): void


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This test recently failed on EE because when you don't specify fixtures, the database is not cleared.

![Screenshot_2022-03-01_21-00-08](https://user-images.githubusercontent.com/1421130/156240626-f87b87ae-a113-4679-9385-d61dfdcdaee6.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
