### PR TITLE
PIM-10304: Handle case of empty locale passed to LocaleSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 - PIM-10259: Fix Arabic text being reversed in product PDF exports
 - PIM-10277: Do not allow disabled user to login
 - PIM-10292: Fix error 500 when role page contain a validation errors
-- PIM-10268: SKU filter is always shown in the product grid
 - PIM-10304: Handle case of empty locale passed to LocaleSelector
+- PIM-10268: SKU filter is always shown in the product grid
 
 ## Improvements
 - PIM-10293: add batch-size option to pim:completness:calculate command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PIM-10277: Do not allow disabled user to login
 - PIM-10292: Fix error 500 when role page contain a validation errors
 - PIM-10268: SKU filter is always shown in the product grid
+- PIM-10304: Handle case of empty locale passed to LocaleSelector
 
 ## Improvements
 - PIM-10293: add batch-size option to pim:completness:calculate command

--- a/front-packages/shared/src/components/LocaleSelector.tsx
+++ b/front-packages/shared/src/components/LocaleSelector.tsx
@@ -45,6 +45,10 @@ const LocaleSelector = ({value, values, completeValues, onChange}: LocaleSelecto
   const [isOpen, open, close] = useBooleanState();
   const selectedLocale: Locale = values.find(locale => locale.code === value) || values[0];
 
+  if(!selectedLocale) {
+    return null;
+  }
+
   const handleChange = (localeCode: LocaleCode) => onChange?.(localeCode);
 
   return (

--- a/front-packages/shared/src/components/LocaleSelector.tsx
+++ b/front-packages/shared/src/components/LocaleSelector.tsx
@@ -45,7 +45,7 @@ const LocaleSelector = ({value, values, completeValues, onChange}: LocaleSelecto
   const [isOpen, open, close] = useBooleanState();
   const selectedLocale: Locale = values.find(locale => locale.code === value) || values[0];
 
-  if(!selectedLocale) {
+  if (!selectedLocale) {
     return null;
   }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Sometimes, the LocaleSelector could receives an empty array of locale, this PR handle this case.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
