### PR TITLE
PLG-782: Rework criterion results transformation from ids to codes

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -10,8 +10,8 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\Products
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\ChannelsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\LocalesInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
 use Doctrine\DBAL\Connection;
 
@@ -26,8 +26,8 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     public function __construct(
         private Connection                        $db,
         private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        private Channels                          $channels,
-        private Locales                           $locales
+        private ChannelsInterface                 $channels,
+        private LocalesInterface                  $locales
     ) {
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetCriteriaEvaluationsByProductIdQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetCriteriaEvaluationsByProductIdQuery.php
@@ -63,26 +63,27 @@ SQL;
 
         $criteriaEvaluations = new Read\CriterionEvaluationCollection();
         foreach ($rows as $rawCriterionEvaluation) {
+            $criterionCode = new CriterionCode($rawCriterionEvaluation['criterion_code']);
             $criteriaEvaluations->add(new Read\CriterionEvaluation(
-                new CriterionCode($rawCriterionEvaluation['criterion_code']),
+                $criterionCode,
                 ProductId::fromString($rawCriterionEvaluation['product_id']),
                 null !== $rawCriterionEvaluation['evaluated_at'] ? $this->clock->fromString($rawCriterionEvaluation['evaluated_at']) : null,
                 new CriterionEvaluationStatus($rawCriterionEvaluation['status']),
-                $this->hydrateCriterionEvaluationResult($rawCriterionEvaluation['result']),
+                $this->hydrateCriterionEvaluationResult($criterionCode, $rawCriterionEvaluation['result']),
             ));
         }
 
         return $criteriaEvaluations;
     }
 
-    private function hydrateCriterionEvaluationResult($rawResult): ?Read\CriterionEvaluationResult
+    private function hydrateCriterionEvaluationResult(CriterionCode $criterionCode, $rawResult): ?Read\CriterionEvaluationResult
     {
         if (null === $rawResult) {
             return null;
         }
 
         $rawResult = json_decode($rawResult, true, JSON_THROW_ON_ERROR);
-        $rawResult = $this->transformCriterionEvaluationResultIds->transformToCodes($rawResult);
+        $rawResult = $this->transformCriterionEvaluationResultIds->transformToCodes($criterionCode, $rawResult);
 
         return Read\CriterionEvaluationResult::fromArray($rawResult);
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationRatesByProductModelsAndCriterionQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationRatesByProductModelsAndCriterionQuery.php
@@ -47,20 +47,20 @@ SQL;
 
         $evaluationRates = [];
         while ($evaluationResult = $stmt->fetchAssociative()) {
-            $evaluationRates[$evaluationResult['product_id']] = $this->formatEvaluationRates($evaluationResult);
+            $evaluationRates[$evaluationResult['product_id']] = $this->formatEvaluationRates($criterionCode, $evaluationResult);
         }
 
         return $evaluationRates;
     }
 
-    private function formatEvaluationRates(array $evaluationResult): array
+    private function formatEvaluationRates(CriterionCode $criterionCode, array $evaluationResult): array
     {
         if (!isset($evaluationResult['rates'])) {
             return [];
         }
 
         $rates = json_decode($evaluationResult['rates'], true, 512, JSON_THROW_ON_ERROR);
-        $rates = $this->transformCriterionEvaluationResultIds->transformToCodes([TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => $rates]);
+        $rates = $this->transformCriterionEvaluationResultIds->transformToCodes($criterionCode, [TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => $rates]);
 
         return $rates['rates'] ?? [];
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationRatesByProductsAndCriterionQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationRatesByProductsAndCriterionQuery.php
@@ -18,8 +18,10 @@ use Doctrine\DBAL\Connection;
  */
 final class GetEvaluationRatesByProductsAndCriterionQuery implements GetEvaluationRatesByProductsAndCriterionQueryInterface
 {
-    public function __construct(private Connection $dbConnection, private TransformCriterionEvaluationResultIds $transformCriterionEvaluationResultIds)
-    {
+    public function __construct(
+        private Connection $dbConnection,
+        private TransformCriterionEvaluationResultIds $transformCriterionEvaluationResultIds
+    ) {
     }
 
     public function execute(ProductIdCollection $productIdCollection, CriterionCode $criterionCode): array
@@ -45,20 +47,20 @@ SQL;
 
         $evaluationRates = [];
         while ($evaluationResult = $stmt->fetchAssociative()) {
-            $evaluationRates[$evaluationResult['product_id']] = $this->formatEvaluationRates($evaluationResult);
+            $evaluationRates[$evaluationResult['product_id']] = $this->formatEvaluationRates($criterionCode, $evaluationResult);
         }
 
         return $evaluationRates;
     }
 
-    private function formatEvaluationRates(array $evaluationResult): array
+    private function formatEvaluationRates(CriterionCode $criterionCode, array $evaluationResult): array
     {
         if (!isset($evaluationResult['rates'])) {
             return [];
         }
 
         $rates = json_decode($evaluationResult['rates'], true, 512, JSON_THROW_ON_ERROR);
-        $rates = $this->transformCriterionEvaluationResultIds->transformToCodes([TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => $rates]);
+        $rates = $this->transformCriterionEvaluationResultIds->transformToCodes($criterionCode, [TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => $rates]);
 
         return $rates['rates'] ?? [];
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/AttributesInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/AttributesInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface AttributesInterface
+{
+    /**
+     * @param array<int> $attributesIds
+     * @return array<string>
+     */
+    public function getCodesByIds(array $attributesIds): array;
+
+    /**
+     * @param array<string> $attributesCodes
+     * @return array<int>
+     */
+    public function getIdsByCodes(array $attributesCodes): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/InMemoryAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/InMemoryAttributes.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class InMemoryAttributes implements AttributesInterface
+{
+    private array $attributesIdsByCodes;
+    private array $attributesCodesByIds;
+
+    /**
+     * @param array<string, int> $attributesIdsByCodes
+     */
+    public function __construct(array $attributesIdsByCodes)
+    {
+        $this->attributesIdsByCodes = $attributesIdsByCodes;
+        $this->attributesCodesByIds = array_flip($attributesIdsByCodes);
+    }
+
+    public function getCodesByIds(array $attributesIds): array
+    {
+        return array_flip(array_intersect($this->attributesIdsByCodes, $attributesIds));
+    }
+
+    public function getIdsByCodes(array $attributesCodes): array
+    {
+        return array_flip(array_intersect($this->attributesCodesByIds, $attributesCodes));
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/SqlAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Attributes/SqlAttributes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes;
 
 use Akeneo\Tool\Component\StorageUtils\Cache\LRUCache;
 use Doctrine\DBAL\Connection;
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Connection;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Attributes
+class SqlAttributes implements AttributesInterface
 {
     private const LRU_CACHE_SIZE = 1000;
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/ChannelsInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/ChannelsInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface ChannelsInterface
+{
+    public function getIdByCode(string $code): ?int;
+
+    public function getCodeById(int $id): ?string;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/InMemoryChannels.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/InMemoryChannels.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class InMemoryChannels implements ChannelsInterface
+{
+    private array $channelsIdsByCodes;
+    private array $channelsCodesByIds;
+
+    /**
+     * @param array<string, int> $channelsIdsByCodes
+     */
+    public function __construct(array $channelsIdsByCodes)
+    {
+        $this->channelsIdsByCodes = $channelsIdsByCodes;
+        $this->channelsCodesByIds = array_flip($channelsIdsByCodes);
+    }
+
+    public function getIdByCode(string $code): ?int
+    {
+        return $this->channelsIdsByCodes[$code] ?? null;
+    }
+
+    public function getCodeById(int $id): ?string
+    {
+        return $this->channelsCodesByIds[$id] ?? null;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/SqlChannels.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Channels/SqlChannels.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
 
 use Doctrine\DBAL\Connection;
 
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Connection;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Channels
+final class SqlChannels implements ChannelsInterface
 {
     private array $channelIdsByCodes;
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCommonCriterionResultDataIds.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCommonCriterionResultDataIds.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\AttributesInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class TransformCommonCriterionResultDataIds implements TransformResultDataIdsInterface
+{
+    public function __construct(
+        private TransformChannelLocaleDataIds $transformChannelLocaleDataIds,
+        private AttributesInterface $attributes,
+    ) {
+    }
+
+    public function transformToCodes(array $resultData): array
+    {
+        $dataByCodes = [];
+        foreach ($resultData as $dataType => $dataByIds) {
+            switch ($dataType) {
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates']:
+                    $dataByCodes['attributes_with_rates'] = $this->transformResultAttributeRatesIdsToCodes($dataByIds);
+                    break;
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes']:
+                    $dataByCodes['total_number_of_attributes'] =
+                        $this->transformChannelLocaleDataIds->transformToCodes($dataByIds, fn ($number) => $number);
+                    break;
+                case TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes']:
+                    $dataByCodes['number_of_improvable_attributes'] =
+                        $this->transformChannelLocaleDataIds->transformToCodes($dataByIds, fn ($number) => $number);
+                    break;
+            }
+        }
+
+        return $dataByCodes;
+    }
+
+    private function transformResultAttributeRatesIdsToCodes(array $resultAttributeIdsRates): array
+    {
+        return $this->transformChannelLocaleDataIds->transformToCodes($resultAttributeIdsRates, function (array $attributeRates) {
+            $attributeCodesRates = [];
+            $attributesCodes = $this->attributes->getCodesByIds(array_keys($attributeRates));
+
+            foreach ($attributeRates as $attributeId => $attributeRate) {
+                $attributeCode = $attributesCodes[$attributeId] ?? null;
+                if (null !== $attributeCode) {
+                    $attributeCodesRates[$attributeCode] = $attributeRate;
+                }
+            }
+
+            return $attributeCodesRates;
+        });
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCompletenessResultDataIds.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCompletenessResultDataIds.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class TransformCompletenessResultDataIds implements TransformResultDataIdsInterface
+{
+    public function __construct(
+        private TransformChannelLocaleDataIds $transformChannelLocaleDataIds,
+    ) {
+    }
+
+    public function transformToCodes(array $resultData): array
+    {
+        $dataByCodes = [];
+
+        $numberOfImprovableAttributes = $resultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes']] ?? null;
+        $improvableAttributes = $resultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates']] ?? null;
+        $totalNumberOfAttributes = $resultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes']] ?? null;
+
+        /**
+         * Since PLG-468 the list of the improvable attributes are no longer persisted. Only their number is persisted in the key "number_of_improvable_attributes"
+         * If the criterion has not been re-evaluated since this change, its result data still contains the key "attributes_with_rates"
+         * In this case the transformation consists in counting the number of elements in "attributes_with_rates" and putting this number in the key "number_of_improvable_attributes"
+         */
+        if (null !== $numberOfImprovableAttributes) {
+            $dataByCodes['number_of_improvable_attributes'] = $this->transformChannelLocaleDataIds->transformToCodes($numberOfImprovableAttributes, fn ($number) => $number);
+        } elseif (null !== $improvableAttributes) {
+            $dataByCodes['number_of_improvable_attributes'] = $this->transformChannelLocaleDataIds->transformToCodes($improvableAttributes, fn (array $attributesList) => count($attributesList));
+        }
+
+        if (null !== $totalNumberOfAttributes) {
+            $dataByCodes['total_number_of_attributes'] = $this->transformChannelLocaleDataIds->transformToCodes($totalNumberOfAttributes, fn ($total) => $total);
+        }
+
+        return $dataByCodes;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformResultDataIdsInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformResultDataIdsInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface TransformResultDataIdsInterface
+{
+    public function transformToCodes(array $resultData): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/InMemoryLocales.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/InMemoryLocales.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class InMemoryLocales implements LocalesInterface
+{
+    private array $localesIdsByCodes;
+    private array $localesCodesByIds;
+
+    /**
+     * @param array<string, int> $localesIdsByCodes
+     */
+    public function __construct(array $localesIdsByCodes)
+    {
+        $this->localesIdsByCodes = $localesIdsByCodes;
+        $this->localesCodesByIds = array_flip($localesIdsByCodes);
+    }
+
+    public function getIdByCode(string $code): ?int
+    {
+        return $this->localesIdsByCodes[$code] ?? null;
+    }
+
+    public function getCodeById(int $id): ?string
+    {
+        return $this->localesCodesByIds[$id] ?? null;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/LocalesInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/LocalesInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface LocalesInterface
+{
+    public function getIdByCode(string $code): ?int;
+
+    public function getCodeById(int $id): ?string;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/SqlLocales.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/Locales/SqlLocales.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
 
 use Doctrine\DBAL\Connection;
 
@@ -10,7 +10,7 @@ use Doctrine\DBAL\Connection;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Locales
+final class SqlLocales implements LocalesInterface
 {
     private array $localeIdsByCodes;
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformChannelLocaleDataIds.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformChannelLocaleDataIds.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\ChannelsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\LocalesInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TransformChannelLocaleDataIds
+{
+    public function __construct(
+        private ChannelsInterface $channels,
+        private LocalesInterface $locales
+    ) {
+    }
+
+    public function transformToCodes(array $channelLocaleData, \Closure $transformData): array
+    {
+        $channelLocaleDataByCodes = [];
+
+        foreach ($channelLocaleData as $channelId => $localeData) {
+            $channelCode = $this->channels->getCodeById($channelId);
+            if (null === $channelCode) {
+                continue;
+            }
+
+            foreach ($localeData as $localeId => $data) {
+                $localeCode = $this->locales->getCodeById($localeId);
+                if (null === $localeCode) {
+                    continue;
+                }
+
+                $channelLocaleDataByCodes[$channelCode][$localeCode] = $transformData($data);
+            }
+        }
+
+        return $channelLocaleDataByCodes;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodes.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\AttributesInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\ChannelsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\LocalesInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -31,17 +34,12 @@ final class TransformCriterionEvaluationResultCodes
         CriterionEvaluationResultStatus::NOT_APPLICABLE => 4,
     ];
 
-    private Attributes $attributes;
-
-    private Channels $channels;
-
-    private Locales $locales;
-
-    public function __construct(Attributes $attributes, Channels $channels, Locales $locales)
+    public function __construct(
+        private AttributesInterface $attributes,
+        private ChannelsInterface $channels,
+        private LocalesInterface $locales
+    )
     {
-        $this->attributes = $attributes;
-        $this->channels = $channels;
-        $this->locales = $locales;
     }
 
     public function transformToIds(array $evaluationResult): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -193,8 +193,8 @@ services:
         arguments:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
         tags:
             - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query}
 
@@ -203,8 +203,8 @@ services:
         arguments:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
         tags:
             - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/transformation.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/transformation.yml
@@ -1,24 +1,38 @@
 services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds:
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData\TransformCommonCriterionResultDataIds'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData\TransformCompletenessResultDataIds'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes:
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\SqlAttributes'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\SqlAttributes:
         arguments:
             - '@database_connection'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels:
         arguments:
             - '@database_connection'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales:
         arguments:
             - '@database_connection'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData\TransformCommonCriterionResultDataIds:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\SqlAttributes'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData\TransformCompletenessResultDataIds:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultIdsIntegration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Infrastructure\Persistence\Transformation;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds;
@@ -145,7 +146,7 @@ final class TransformCriterionEvaluationResultIdsIntegration extends DataQuality
             ]
         ];
 
-        $convertedEvaluationResult = $this->get(TransformCriterionEvaluationResultIds::class)->transformToCodes($evaluationResult);
+        $convertedEvaluationResult = $this->get(TransformCriterionEvaluationResultIds::class)->transformToCodes(new CriterionCode('enrichment_image'), $evaluationResult);
 
         $this->assertEquals($expectedEvaluationResult, $convertedEvaluationResult);
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Attributes/InMemoryAttributesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Attributes/InMemoryAttributesSpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryAttributesSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith([
+            'sku' => 1,
+            'name' => 2,
+            "description" => 42,
+        ]);
+    }
+
+    public function it_gets_attributes_ids_from_codes(): void
+    {
+        $this->getIdsByCodes(['name', 'description'])->shouldReturn(['name' => 2, 'description' => 42]);
+    }
+
+    public function it_gets_attributes_codes_from_ids(): void
+    {
+        $this->getCodesByIds([2, 42])->shouldReturn([2 => 'name', 42 => 'description']);
+    }
+
+    public function it_ignores_unknown_attributes(): void
+    {
+        $this->getIdsByCodes(['name', 'title' ,'description'])->shouldReturn(['name' => 2, 'description' => 42]);
+        $this->getCodesByIds([567, 2, 42])->shouldReturn([2 => 'name', 42 => 'description']);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Channels/InMemoryChannelsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Channels/InMemoryChannelsSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryChannelsSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith([
+            'ecommerce' => 1,
+            'mobile' => 2,
+        ]);
+    }
+
+    public function it_gets_a_channel_id_from_its_code(): void
+    {
+        $this->getIdByCode('mobile')->shouldReturn(2);
+    }
+
+    public function it_gets_a_channel_code_from_its_id(): void
+    {
+        $this->getCodeById(2)->shouldReturn('mobile');
+    }
+
+    public function it_returns_null_if_the_channel_does_not_exist(): void
+    {
+        $this->getIdByCode('print')->shouldReturn(null);
+        $this->getCodeById(42)->shouldReturn(null);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCommonCriterionResultDataIdsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCommonCriterionResultDataIdsSpec.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\InMemoryAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\InMemoryChannels;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\InMemoryLocales;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TransformCommonCriterionResultDataIdsSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $attributes = new InMemoryAttributes([
+            'name' => 12,
+            'description' => 34,
+        ]);
+
+        $channels = new InMemoryChannels([
+            'ecommerce' => 1,
+            'mobile' => 2,
+        ]);
+        $locales = new InMemoryLocales([
+            'en_US' => 58,
+            'fr_FR' => 90,
+        ]);
+
+        $transformChannelLocaleDataIds = new TransformChannelLocaleDataIds($channels, $locales);
+
+        $this->beConstructedWith($transformChannelLocaleDataIds, $attributes);
+    }
+
+    public function it_transforms_common_criterion_result_data_from_ids_to_codes()
+    {
+        $dataToTransform = [
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                1 => [
+                    58 => [
+                        12 => 50,
+                        34 => 0,
+                    ],
+                    90 => [
+                        34 => 20,
+                    ],
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                1 => [
+                    58 => 4,
+                    90 => 5,
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'] => [
+                1 => [
+                    58 => 2,
+                    90 => 1,
+                ],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'attributes_with_rates' => [
+                'ecommerce' => [
+                    'en_US' => [
+                        'name' => 50,
+                        'description' => 0,
+                    ],
+                    'fr_FR' => [
+                        'description' => 20,
+                    ],
+                ],
+            ],
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 4,
+                    'fr_FR' => 5,
+                ],
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 2,
+                    'fr_FR' => 1,
+                ],
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform)->shouldReturn($expectedTransformedData);
+    }
+
+    public function it_removes_unknown_attributes_from_result_data(): void
+    {
+        $dataToTransform = [
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                1 => [
+                    58 => [
+                        12 => 50,
+                        42 => 76,
+                        34 => 0,
+                    ],
+                    90 => [
+                        34 => 20,
+                    ],
+                ],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'attributes_with_rates' => [
+                'ecommerce' => [
+                    'en_US' => [
+                        'name' => 50,
+                        'description' => 0,
+                    ],
+                    'fr_FR' => [
+                        'description' => 20,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform)->shouldReturn($expectedTransformedData);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCompletenessResultDataIdsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/CriterionEvaluationResultData/TransformCompletenessResultDataIdsSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultData;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\InMemoryChannels;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\InMemoryLocales;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformChannelLocaleDataIds;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TransformCompletenessResultDataIdsSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $channels = new InMemoryChannels([
+            'ecommerce' => 1,
+            'mobile' => 2,
+        ]);
+        $locales = new InMemoryLocales([
+            'en_US' => 58,
+            'fr_FR' => 90,
+        ]);
+
+        $this->beConstructedWith(new TransformChannelLocaleDataIds($channels, $locales));
+    }
+
+    public function it_transforms_a_completeness_criterion_result_from_ids_to_codes(): void
+    {
+        $dataToTransform = [
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                1 => [
+                    58 => 4,
+                    90 => 5,
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'] => [
+                1 => [
+                    58 => 2,
+                    90 => 1,
+                ],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 2,
+                    'fr_FR' => 1,
+                ],
+            ],
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 4,
+                    'fr_FR' => 5,
+                ],
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform)->shouldReturn($expectedTransformedData);
+    }
+
+    public function it_transforms_a_deprecated_completeness_criterion_result_from_ids_to_codes(): void
+    {
+        $dataToTransform = [
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                1 => [
+                    58 => [
+                        12 => 50,
+                        34 => 0,
+                    ],
+                    90 => [
+                        34 => 20,
+                    ],
+                ],
+            ],
+            TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                1 => [
+                    58 => 4,
+                    90 => 5,
+                ],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 2,
+                    'fr_FR' => 1,
+                ],
+            ],
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 4,
+                    'fr_FR' => 5,
+                ],
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform)->shouldReturn($expectedTransformedData);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Locales/InMemoryLocalesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/Locales/InMemoryLocalesSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryLocalesSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $this->beConstructedWith([
+            'en_US' => 58,
+            'fr_FR' => 90,
+        ]);
+    }
+
+    public function it_gets_a_locale_id_from_its_id(): void
+    {
+        $this->getIdByCode('fr_FR')->shouldReturn(90);
+    }
+
+    public function it_gets_a_locale_code_from_its_id(): void
+    {
+        $this->getCodeById(90)->shouldReturn('fr_FR');
+    }
+
+    public function it_returns_null_if_the_locale_does_not_exist(): void
+    {
+        $this->getIdByCode('fo_BA')->shouldReturn(null);
+        $this->getCodeById(999)->shouldReturn(null);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformChannelLocaleDataIdsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformChannelLocaleDataIdsSpec.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\InMemoryChannels;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\InMemoryLocales;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TransformChannelLocaleDataIdsSpec extends ObjectBehavior
+{
+    public function let()
+    {
+        $channels = new InMemoryChannels([
+            'ecommerce' => 1,
+            'mobile' => 2,
+        ]);
+
+        $locales = new InMemoryLocales([
+            'en_US' => 58,
+            'fr_FR' => 90,
+        ]);
+
+        $this->beConstructedWith($channels, $locales);
+    }
+
+    public function it_transforms_channels_and_locales_with_data_from_ids_to_codes(): void
+    {
+        $dataToTransform = [
+            1 => [
+                58 => [12, 34],
+                90 => [34],
+            ],
+            2 => [
+                58 => [12, 34, 56],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'ecommerce' => [
+                'en_US' => 2,
+                'fr_FR' => 1,
+            ],
+            'mobile' => [
+                'en_US' => 3,
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform, fn ($elements) => count($elements))->shouldReturn($expectedTransformedData);
+    }
+
+    public function it_removes_unknown_channels_and_locales_during_transformation(): void
+    {
+        $dataToTransform = [
+            1 => [
+                58 => [12, 34],
+                789 => [34],
+                90 => [34],
+            ],
+            76 => [
+                58 => [12, 34, 56],
+            ],
+        ];
+
+        $expectedTransformedData = [
+            'ecommerce' => [
+                'en_US' => 2,
+                'fr_FR' => 1,
+            ],
+        ];
+
+        $this->transformToCodes($dataToTransform, fn ($elements) => count($elements))->shouldReturn($expectedTransformedData);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Transformation/TransformCriterionEvaluationResultCodesSpec.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Attributes\SqlAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\ChannelsInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\CriterionEvaluationResultTransformationFailedException;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\LocalesInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
 use PhpSpec\ObjectBehavior;
 
@@ -18,7 +18,7 @@ use PhpSpec\ObjectBehavior;
  */
 final class TransformCriterionEvaluationResultCodesSpec extends ObjectBehavior
 {
-    public function let(Attributes $attributes, Channels $channels, Locales $locales)
+    public function let(SqlAttributes $attributes, ChannelsInterface $channels, LocalesInterface $locales)
     {
         $this->beConstructedWith($attributes, $channels, $locales);
 


### PR DESCRIPTION
The goal is multiple:

1. Split the responsibilities of the main service to facilitate testing, readability and maintainability.
2. Handle the specificity of the two completeness criteria, that can have been persisted with a deprecated format (see PLG-468)
3. Make the service usable in the service that compute the Key-indicator on the completeness

I added "in memory" implementations for the queries on attributes, channels and locales to facilitate the tests. It allows to avoid using mocks for these queries in the specs.