### PR TITLE
PLG-782: Rework compute products enrichment status KI

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
@@ -14,5 +14,21 @@ interface ComputeProductsKeyIndicator
 {
     public function getName(): string;
 
+    /**
+     * @return array<int, array<string, array<string, bool>>> Enrichment status by product/product-model channel and locale
+     *
+     * Example of return:
+     * [
+     *      42 => [
+     *          'ecommerce' => [
+     *              'en_US' => true,
+     *              'fr_FR' => false,
+     *          ],
+     *          'mobile' => [
+     *              'en_US' => true,
+     *          ],
+     *      ],
+     * ]
+     */
     public function compute(ProductIdCollection $productIdCollection): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQueryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetEvaluationResultsByProductsAndCriterionQueryInterface
+{
+    /**
+     * @return array<int, ?CriterionEvaluationResult>
+     */
+    public function execute(ProductIdCollection $productIdCollection, CriterionCode $criterionCode): array;
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductModelCompleteness.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductModelCompleteness.php
@@ -18,7 +18,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInt
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class CalculateProductModelCompleteness implements \Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface
+class CalculateProductModelCompleteness implements CalculateProductCompletenessInterface
 {
     /** @var GetCompletenessProductMasks */
     private $getCompletenessProductMasks;
@@ -54,6 +54,7 @@ class CalculateProductModelCompleteness implements \Akeneo\Pim\Automation\DataQu
             $localeCode = new LocaleCode($completeness->localeCode());
             $result->addRate($channelCode, $localeCode, new Rate($completeness->ratio()));
             $result->addMissingAttributes($channelCode, $localeCode, $completeness->missingAttributeCodes());
+            $result->addTotalNumberOfAttributes($channelCode, $localeCode, $completeness->requiredCount());
         }
 
         return $result;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -7,13 +7,12 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Q
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\ChannelsInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\LocalesInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
-use Doctrine\DBAL\Connection;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -24,10 +23,8 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     private const GOOD_ENRICHMENT_RATIO = 80;
 
     public function __construct(
-        private Connection                        $db,
         private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        private ChannelsInterface                 $channels,
-        private LocalesInterface                  $locales
+        private GetEvaluationResultsByProductsAndCriterionQueryInterface $getEvaluationResultsByProductsAndCriterionQuery,
     ) {
     }
 
@@ -39,15 +36,10 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     public function compute(ProductIdCollection $productIdCollection): array
     {
         $channelsLocales = $this->getLocalesByChannelQuery->getArray();
-        $productIds = $productIdCollection->toArrayInt();
-        $productsEvaluations = $this->getProductsEvaluations($productIds);
+        $productsEvaluationResults = $this->getProductsCompletenessResults($productIdCollection);
         $productsEnrichmentStatus = [];
-        foreach ($productIds as $productId) {
-            if (!isset($productsEvaluations[$productId])) {
-                continue;
-            }
-
-            $productsEnrichmentStatus[$productId] = $this->computeForChannelsLocales($productsEvaluations[$productId], $channelsLocales);
+        foreach ($productIdCollection->toArrayInt() as $productId) {
+            $productsEnrichmentStatus[$productId] = $this->computeForChannelsLocales($productsEvaluationResults[$productId], $channelsLocales);
         }
 
         return $productsEnrichmentStatus;
@@ -57,63 +49,59 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     {
         $enrichmentStatus = [];
         foreach ($channelsLocales as $channel => $locales) {
-            $channelId = $this->channels->getIdByCode($channel);
-            if (null === $channelId) {
-                continue;
-            }
-
             foreach ($locales as $locale) {
-                $localeId = $this->locales->getIdByCode($locale);
-                if (null === $localeId) {
-                    continue;
-                }
-
-                $enrichmentStatus[$channel][$locale] = $this->computeEnrichmentStatus($evaluations, $channelId, $localeId);
+                $enrichmentStatus[$channel][$locale] = $this->computeEnrichmentStatus(
+                    $evaluations[EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE] ?? null,
+                    $evaluations[EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE] ?? null,
+                    $channel,
+                    $locale
+                );
             }
         }
 
         return $enrichmentStatus;
     }
 
-    private function computeEnrichmentStatus(array $evaluations, int $channelId, int $localeId): ?bool
-    {
-        $nonRequiredAttributesEvaluation = $evaluations[EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE] ?? [];
-        $requiredAttributesEvaluation = $evaluations[EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE] ?? [];
+    private function computeEnrichmentStatus(
+        ?CriterionEvaluationResult $nonRequiredAttributesEvaluationResult,
+        ?CriterionEvaluationResult $requiredAttributesEvaluationResult,
+        string $channel,
+        string $locale
+    ): ?bool {
+        $nonRequiredAttributesEvaluation = null !== $nonRequiredAttributesEvaluationResult ? $nonRequiredAttributesEvaluationResult->getData() : [];
+        $requiredAttributesEvaluationData = null !== $requiredAttributesEvaluationResult ? $requiredAttributesEvaluationResult->getData() : [];
 
-        //Handle the products without family (so the completeness couldn't be calculated)
-        if (
-            !isset($nonRequiredAttributesEvaluation['number_of_improvable_attributes'][$channelId][$localeId]) ||
-            !isset($requiredAttributesEvaluation['number_of_improvable_attributes'][$channelId][$localeId]) ||
-            !isset($nonRequiredAttributesEvaluation['total_number_of_attributes'][$channelId][$localeId]) ||
-            !isset($requiredAttributesEvaluation['total_number_of_attributes'][$channelId][$localeId])
-        ) {
+        $totalNumberOfAttributes =
+            ($nonRequiredAttributesEvaluation['total_number_of_attributes'][$channel][$locale] ?? 0)
+            + ($requiredAttributesEvaluationData['total_number_of_attributes'][$channel][$locale] ?? 0);
+
+        // It can happen when the product has not been evaluated yet, or when all the attributes are deactivated, or when a product doesn't have a family.
+        if (0 === $totalNumberOfAttributes) {
             return null;
         }
 
-        $missingNonRequiredAttributesNumber = $nonRequiredAttributesEvaluation['number_of_improvable_attributes'][$channelId][$localeId];
-        $missingRequiredAttributesNumber = $requiredAttributesEvaluation['number_of_improvable_attributes'][$channelId][$localeId];
-        $numberOfNonRequiredAttributes = $nonRequiredAttributesEvaluation['total_number_of_attributes'][$channelId][$localeId];
-        $numberOfRequiredAttributes = $requiredAttributesEvaluation['total_number_of_attributes'][$channelId][$localeId];
+        $numberOfMissingAttributes =
+            ($nonRequiredAttributesEvaluation['number_of_improvable_attributes'][$channel][$locale] ?? 0)
+            + ($requiredAttributesEvaluationData['number_of_improvable_attributes'][$channel][$locale] ?? 0);
 
-        return $this->computeEnrichmentRatioStatus($numberOfNonRequiredAttributes + $numberOfRequiredAttributes, $missingNonRequiredAttributesNumber + $missingRequiredAttributesNumber);
+        $enrichmentRatio = ($totalNumberOfAttributes - $numberOfMissingAttributes) / $totalNumberOfAttributes * 100;
+
+        return $enrichmentRatio >= self::GOOD_ENRICHMENT_RATIO;
     }
 
-    private function computeEnrichmentRatioStatus(int $familyNumberOfAttributes, $numberOfMissingAttributes): bool
+    private function getProductsCompletenessResults(ProductIdCollection $productIds): array
     {
-        if ($familyNumberOfAttributes === 0) {
-            return true;
-        }
-
-        return ($familyNumberOfAttributes - $numberOfMissingAttributes) / $familyNumberOfAttributes * 100 >= self::GOOD_ENRICHMENT_RATIO;
-    }
-
-    private function getProductsEvaluations(array $productIds): array
-    {
-        $requiredAttributesEvaluations = $this->getProductsEvaluationsByCriterion(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE, $productIds);
-        $nonRequiredAttributesEvaluations = $this->getProductsEvaluationsByCriterion(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE, $productIds);
+        $requiredAttributesEvaluations = $this->getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        );
+        $nonRequiredAttributesEvaluations = $this->getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE),
+        );
 
         $productsEvaluations = [];
-        foreach ($productIds as $productId) {
+        foreach ($productIds->toArrayInt() as $productId) {
             $productsEvaluations[$productId] = [
                 EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE => $requiredAttributesEvaluations[$productId] ?? null,
                 EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE => $nonRequiredAttributesEvaluations[$productId] ?? null,
@@ -121,44 +109,5 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
         }
 
         return $productsEvaluations;
-    }
-
-    private function getProductsEvaluationsByCriterion(string $criterionCode, array $productIds): array
-    {
-        $query = <<<SQL
-SELECT product_id, result
-FROM pim_data_quality_insights_product_criteria_evaluation
-WHERE product_id IN(:productIds) AND criterion_code = :criterionCode
-SQL;
-
-        $stmt = $this->db->executeQuery(
-            $query,
-            [
-                'productIds' => $productIds,
-                'criterionCode' => $criterionCode,
-            ],
-            [
-                'productIds' => Connection::PARAM_INT_ARRAY,
-            ]
-        );
-
-        $evaluations = [];
-        while ($evaluation = $stmt->fetchAssociative()) {
-            $evaluationResult = isset($evaluation['result']) ? json_decode($evaluation['result'], true) : null;
-            $evaluationResultData = $evaluationResult[TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data']] ?? [];
-
-            $evaluations[$evaluation['product_id']] = [
-                'total_number_of_attributes' => $evaluationResultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes']] ?? 0,
-            ];
-
-            if (isset($evaluationResultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes']])) {
-                $evaluations[$evaluation['product_id']]['number_of_improvable_attributes'] = $evaluationResultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes']];
-            } elseif (isset($evaluationResultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates']])) {
-                // The data 'attributes_with_rates' is deprecated, but can still exist because of no migration data. (See PLG-468)
-                $evaluations[$evaluation['product_id']]['number_of_improvable_attributes'] = count($evaluationResultData[TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates']]);
-            }
-        }
-
-        return $evaluations;
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -33,6 +33,9 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
         return ProductsWithGoodEnrichment::CODE;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function compute(ProductIdCollection $productIdCollection): array
     {
         $channelsLocales = $this->getLocalesByChannelQuery->getArray();

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductModelsAndCriterionQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductModelsAndCriterionQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetEvaluationResultsByProductModelsAndCriterionQuery implements GetEvaluationResultsByProductsAndCriterionQueryInterface
+{
+    public function __construct(
+        private Connection $dbConnection,
+        private TransformCriterionEvaluationResultIds $transformCriterionEvaluationResultIds
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ProductIdCollection $productIdCollection, CriterionCode $criterionCode): array
+    {
+        $query = <<<SQL
+SELECT product_id, result
+FROM pim_data_quality_insights_product_model_criteria_evaluation
+WHERE product_id IN (:productModelIds) AND criterion_code = :criterionCode;
+SQL;
+
+        $stmt = $this->dbConnection->executeQuery(
+            $query,
+            [
+                'productModelIds' => $productIdCollection->toArrayInt(),
+                'criterionCode' => $criterionCode,
+            ],
+            [
+                'productModelIds' => Connection::PARAM_INT_ARRAY,
+            ]
+        );
+
+        $evaluationResults = [];
+        while ($evaluation = $stmt->fetchAssociative()) {
+            $evaluationResults[\intval($evaluation['product_id'])] = $this->hydrateEvaluationResult($criterionCode, $evaluation['result']);
+        }
+
+        return $evaluationResults;
+    }
+
+    private function hydrateEvaluationResult(CriterionCode $criterionCode, ?string $rawResult): ?Read\CriterionEvaluationResult
+    {
+        if (null === $rawResult) {
+            return null;
+        }
+
+        $rawResult = json_decode($rawResult, true, JSON_THROW_ON_ERROR);
+        $rawResult = $this->transformCriterionEvaluationResultIds->transformToCodes($criterionCode, $rawResult);
+
+        return Read\CriterionEvaluationResult::fromArray($rawResult);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQuery.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetEvaluationResultsByProductsAndCriterionQuery implements GetEvaluationResultsByProductsAndCriterionQueryInterface
+{
+    public function __construct(
+        private Connection $dbConnection,
+        private TransformCriterionEvaluationResultIds $transformCriterionEvaluationResultIds
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(ProductIdCollection $productIdCollection, CriterionCode $criterionCode): array
+    {
+        $query = <<<SQL
+SELECT product_id, result
+FROM pim_data_quality_insights_product_criteria_evaluation
+WHERE product_id IN (:productIds) AND criterion_code = :criterionCode;
+SQL;
+
+        $stmt = $this->dbConnection->executeQuery(
+            $query,
+            [
+                'productIds' => $productIdCollection->toArrayInt(),
+                'criterionCode' => $criterionCode,
+            ],
+            [
+                'productIds' => Connection::PARAM_INT_ARRAY,
+            ]
+        );
+
+        $evaluationResults = [];
+        while ($evaluation = $stmt->fetchAssociative()) {
+            $evaluationResults[\intval($evaluation['product_id'])] = $this->hydrateEvaluationResult($criterionCode, $evaluation['result']);
+        }
+
+        return $evaluationResults;
+    }
+
+    private function hydrateEvaluationResult(CriterionCode $criterionCode, ?string $rawResult): ?Read\CriterionEvaluationResult
+    {
+        if (null === $rawResult) {
+            return null;
+        }
+
+        $rawResult = json_decode($rawResult, true, JSON_THROW_ON_ERROR);
+        $rawResult = $this->transformCriterionEvaluationResultIds->transformToCodes($criterionCode, $rawResult);
+
+        return Read\CriterionEvaluationResult::fromArray($rawResult);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -9,7 +9,7 @@ services:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresQuery'
-            - '@akeneo.pim.automation.data_quality_insights.compute_products_key_indicators'
+            - '@akeneo.pim.automation.data_quality_insights.compute_product_models_key_indicators'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetDataQualityInsightsPropertiesForProductProjection:
         arguments:
@@ -23,7 +23,7 @@ services:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductModelIdsFromProductModelCodesQuery'
-            - '@akeneo.pim.automation.data_quality_insights.compute_products_key_indicators'
+            - '@akeneo.pim.automation.data_quality_insights.compute_product_models_key_indicators'
         tags:
             - { name: 'akeneo.pim.enrichment.product_model.query.indexing_additional_properties' }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -199,10 +199,8 @@ services:
     akeneo.pim.automation.data_quality_insights.query.compute_product_models_enrichment_status_query:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery
         arguments:
-            - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductModelsAndCriterionQuery'
         tags:
             - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query }
 
@@ -253,6 +251,7 @@ services:
             - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'
 
-#    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelsEvaluationsDataByCriterion:
-#        arguments:
-#            - '@database_connection'
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductModelsAndCriterionQuery:
+        arguments:
+            - '@database_connection'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -191,10 +191,8 @@ services:
     akeneo.pim.automation.data_quality_insights.query.compute_products_enrichment_status_query:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery
         arguments:
-            - '@database_connection'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Channels\SqlChannels'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\Locales\SqlLocales'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQuery'
         tags:
             - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query}
 
@@ -250,10 +248,11 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\HasUpToDateProductModelEvaluationQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresQuery'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductsEvaluationsDataByCriterion:
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQuery:
         arguments:
             - '@database_connection'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultIds'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelsEvaluationsDataByCriterion:
-        arguments:
-            - '@database_connection'
+#    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelsEvaluationsDataByCriterion:
+#        arguments:
+#            - '@database_connection'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Enrichment/CalculateProductModelCompletenessIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Enrichment/CalculateProductModelCompletenessIntegration.php
@@ -75,6 +75,8 @@ class CalculateProductModelCompletenessIntegration extends CompletenessTestCase
 
         $expectedMissingAttributes = ['ecommerce' => ['en_US' => ['a_required_text', 'a_required_textarea']]];
         $this->assertEquals($expectedMissingAttributes, $completenessResult->getMissingAttributes()->toArray());
+        $expectedTotalNumberOfAttributes = ['ecommerce' => ['en_US' => 2]];
+        $this->assertEquals($expectedTotalNumberOfAttributes, $completenessResult->getTotalNumberOfAttributes()->toArray());
 
         $expectedRates = ['ecommerce' => ['en_US' => 0]];
         $this->assertEquals($expectedRates, $completenessResult->getRates()->toArrayInt());
@@ -97,6 +99,7 @@ class CalculateProductModelCompletenessIntegration extends CompletenessTestCase
 
         $expectedMissingAttributes = ['ecommerce' => ['en_US' => ['a_required_textarea']]];
         $this->assertEquals($expectedMissingAttributes, $completenessResult->getMissingAttributes()->toArray());
+        $this->assertEquals($expectedTotalNumberOfAttributes, $completenessResult->getTotalNumberOfAttributes()->toArray());
 
         $expectedRates = ['ecommerce' => ['en_US' => 50]];
         $this->assertEquals($expectedRates, $completenessResult->getRates()->toArrayInt());

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductModelsEnrichmentStatusQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductModelsEnrichmentStatusQueryIntegration.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Infrastructure\Persistence\Query\KeyIndicator;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProductModels;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ComputeProductModelsEnrichmentStatusQueryIntegration extends DataQualityInsightsTestCase
+{
+    public function test_it_computes_the_enrichment_status_of_product_models()
+    {
+        $this->createChannel('ecommerce', ['locales' => ['en_US', 'fr_FR']]);
+        $this->createChannel('mobile', ['locales' => ['en_US']]);
+
+        $this->createAttribute('name', ['scopable' => true, 'localizable' => true]);
+        $this->createAttribute('description', ['scopable' => true, 'localizable' => true]);
+        $this->createAttribute('image', ['scopable' => true, 'localizable' => false]);
+
+        $this->createSimpleSelectAttributeWithOptions('color', ['red', 'blue']);
+        $this->createSimpleSelectAttributeWithOptions('size', ['XL', 'M', 'L']);
+
+        $this->createFamily('a_family', [
+            'attributes' => ['name', 'description', 'color', 'size', 'image'],
+            'attribute_requirements' => [
+                'ecommerce' => ['name', 'image'],
+                'mobile' => ['name'],
+            ],
+        ]);
+        $this->createFamilyVariant('a_family_variant', 'a_family', [
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['image'],
+                ],
+                [
+                    'level' => 2,
+                    'axes' => ['size'],
+                    'attributes' => ['sku'],
+                ],
+            ],
+        ]);
+
+        $productModelId = $this->createProductModel('a_product_model', 'a_family_variant', [
+            'values' => [
+                'name' => [
+                    ['scope' => 'ecommerce', 'locale' => 'en_US', 'data' => 'A product model'],
+                    ['scope' => 'mobile', 'locale' => 'en_US', 'data' => 'A product model'],
+                    ['scope' => 'ecommerce', 'locale' => 'fr_FR', 'data' => 'Un produit modèle'],
+                ],
+                'description' => [
+                    ['scope' => 'ecommerce', 'locale' => 'en_US', 'data' => 'Whatever the description'],
+                    ['scope' => 'mobile', 'locale' => 'en_US', 'data' => 'Whatever'],
+                ],
+            ]
+        ])->getId();
+
+        $subProductModelId = $this->createSubProductModel('a_sub_product_model', 'a_family_variant', 'a_product_model', [
+            'values' => [
+                'color' => [
+                    ['scope' => null, 'locale' => null, 'data' => 'red']
+                ],
+                'image' => [
+                    ['scope' => 'mobile', 'locale' => null, 'data' => 'red-ziggy.png']
+                ]
+            ]
+        ])->getId();
+
+        $expectedEnrichmentStatus = [
+            $productModelId => [
+                'ecommerce' => [
+                    'en_US' => true,
+                    'fr_FR' => false,
+                ],
+                'mobile' => [
+                    'en_US' => true,
+                ]
+            ],
+            $subProductModelId => [
+                'ecommerce' => [
+                    'en_US' => false,
+                    'fr_FR' => false,
+                ],
+                'mobile' => [
+                    'en_US' => true,
+                ]
+            ]
+        ];
+
+        $productModelIds = ProductIdCollection::fromInts([$productModelId, $subProductModelId]);
+        ($this->get(EvaluateProductModels::class))($productModelIds);
+
+        $productModelsEnrichmentStatus = $this->get('akeneo.pim.automation.data_quality_insights.query.compute_product_models_enrichment_status_query')
+            ->compute($productModelIds);
+
+        $this->assertEqualsCanonicalizing($expectedEnrichmentStatus, $productModelsEnrichmentStatus);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductModelsAndCriterionQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductModelsAndCriterionQueryIntegration.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProductModels;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductModelsAndCriterionQuery;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetEvaluationResultsByProductModelsAndCriterionQueryIntegration extends DataQualityInsightsTestCase
+{
+    public function test_it_gets_evaluation_results_by_products_and_criterion(): void
+    {
+        $this->createChannel('ecommerce', ['locales' => ['en_US', 'fr_FR']]);
+        $this->createAttribute('name', ['scopable' => true, 'localizable' => true]);
+        $this->createAttribute('image', ['scopable' => true, 'localizable' => false]);
+        $this->createSimpleSelectAttributeWithOptions('color', ['red', 'blue']);
+
+        $this->createFamily('a_family', ['attributes' => ['name', 'color', 'image']]);
+        $this->createFamilyVariant('a_family_variant', 'a_family', [
+            'variant_attribute_sets' => [
+                [
+                    'level' => 1,
+                    'axes' => ['color'],
+                    'attributes' => ['image'],
+                ],
+            ],
+        ]);
+
+        $productModelWithEvaluation = $this->givenAnEvaluatedProductModel();
+        $productModelWithPendingEvaluation = $this->givenAProductModelWithPendingEvaluation();
+        $productModelWithoutAnyEvaluation = $this->givenAProductModelWithoutAnyEvaluation();
+
+        $results = $this->get(GetEvaluationResultsByProductModelsAndCriterionQuery::class)->execute(
+            ProductIdCollection::fromInts([$productModelWithEvaluation, $productModelWithPendingEvaluation, $productModelWithoutAnyEvaluation]),
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        );
+
+        $this->assertArrayHasKey($productModelWithEvaluation, $results, 'There should be an element for the evaluated product model in the results');
+        $this->assertInstanceOf(CriterionEvaluationResult::class, $results[$productModelWithEvaluation], 'The result for the evaluated product model should be an instance of CriterionEvaluationResult');
+
+        $this->assertArrayHasKey($productModelWithPendingEvaluation, $results, 'There should be an element for the product model with pending evaluation in the results');
+        $this->assertNull($results[$productModelWithPendingEvaluation], 'The result for the product model with pending evaluation should be null');
+
+        $this->assertArrayNotHasKey($productModelWithoutAnyEvaluation, $results, 'There should not be a result for the product model without evaluation');
+    }
+
+    private function givenAnEvaluatedProductModel(): int
+    {
+        $productModelId = $this->createProductModel('an_evaluated_product_model', 'a_family_variant', [
+            'values' => [
+                'name' => [
+                    ['scope' => 'ecommerce', 'locale' => 'en_US', 'data' => 'Foo'],
+                    ['scope' => 'ecommerce', 'locale' => 'fr_FR', 'data' => 'Bar'],
+                ],
+            ]
+        ])->getId();
+
+        ($this->get(EvaluateProductModels::class))(ProductIdCollection::fromInt($productModelId));
+
+        return $productModelId;
+    }
+
+    private function givenAProductModelWithPendingEvaluation(): int
+    {
+        return $this->createProductModel('a_product_model_with_pending_evaluation', 'a_family_variant')->getId();
+    }
+
+    private function givenAProductModelWithoutAnyEvaluation(): int
+    {
+        $productModelId = $this->createProductModel('a_product_model_without_evaluation', 'a_family_variant')->getId();
+        $this->deleteProductModelCriterionEvaluations($productModelId);
+
+        return $productModelId;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetEvaluationResultsByProductsAndCriterionQueryIntegration.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQuery;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetEvaluationResultsByProductsAndCriterionQueryIntegration extends DataQualityInsightsTestCase
+{
+    public function test_it_gets_evaluation_results_by_products_and_criterion(): void
+    {
+        $this->createChannel('ecommerce', ['locales' => ['en_US', 'fr_FR']]);
+        $this->createAttribute('name', ['scopable' => true, 'localizable' => true]);
+        $this->createFamily('a_family', ['attributes' => ['name']]);
+
+        $productWithEvaluation = $this->givenAnEvaluatedProduct();
+        $productWithPendingEvaluation = $this->givenAProductWithPendingEvaluation();
+        $productWithoutAnyEvaluation = $this->givenAProductWithoutAnyEvaluation();
+
+        $results = $this->get(GetEvaluationResultsByProductsAndCriterionQuery::class)->execute(
+            ProductIdCollection::fromInts([$productWithEvaluation, $productWithPendingEvaluation, $productWithoutAnyEvaluation]),
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        );
+
+        $this->assertArrayHasKey($productWithEvaluation, $results, 'There should be an element for the evaluated product in the results');
+        $this->assertInstanceOf(CriterionEvaluationResult::class, $results[$productWithEvaluation], 'The result for the evaluated product should be an instance of CriterionEvaluationResult');
+
+        $this->assertArrayHasKey($productWithPendingEvaluation, $results, 'There should be an element for the product with pending evaluation in the results');
+        $this->assertNull($results[$productWithPendingEvaluation], 'The result for the product with pending evaluation should be null');
+
+        $this->assertArrayNotHasKey($productWithoutAnyEvaluation, $results, 'There should not be result for the product without evaluation');
+    }
+
+    private function givenAnEvaluatedProduct(): int
+    {
+        $productId = $this->createProduct('an_evaluated_product', [
+            'family' => 'a_family',
+            'values' => [
+                'name' => [
+                    ['scope' => 'ecommerce', 'locale' => 'en_US', 'data' => 'Foo'],
+                    ['scope' => 'ecommerce', 'locale' => 'fr_FR', 'data' => 'Bar'],
+                ],
+            ]
+        ])->getId();
+
+        ($this->get(EvaluateProducts::class))(ProductIdCollection::fromInt($productId));
+
+        return $productId;
+    }
+
+    private function givenAProductWithPendingEvaluation(): int
+    {
+        return $this->createProduct('a_product_with_pending_evaluation', ['family' => 'a_family'])->getId();
+    }
+
+    private function givenAProductWithoutAnyEvaluation(): int
+    {
+        $productId = $this->createProduct('a_product_without_evaluation', ['family' => 'a_family'])->getId();
+        $this->deleteProductCriterionEvaluations($productId);
+
+        return $productId;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuerySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuerySpec.php
@@ -1,0 +1,326 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\CriterionEvaluationResultStatusCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\CriterionEvaluationResult;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ComputeProductsEnrichmentStatusQuerySpec extends ObjectBehavior
+{
+    public function let(
+        GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
+        GetEvaluationResultsByProductsAndCriterionQueryInterface $getEvaluationResultsByProductsAndCriterionQuery
+    ) {
+        $getLocalesByChannelQuery->getArray()->willReturn([
+            'ecommerce' => ['en_US', 'fr_FR'],
+            'mobile' => ['en_US'],
+        ]);
+
+        $this->beConstructedWith($getLocalesByChannelQuery, $getEvaluationResultsByProductsAndCriterionQuery);
+    }
+
+    public function it_computes_enrichment_status_for_a_list_of_products($getEvaluationResultsByProductsAndCriterionQuery)
+    {
+        $productIds = ProductIdCollection::fromInts([42, 56]);
+
+        $requiredAttributesResultDataProduct42 = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 5,
+                    'fr_FR' => 5,
+                ],
+                'mobile' => [
+                    'en_US' => 2
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 1,
+                    'fr_FR' => 1,
+                ],
+                'mobile' => [
+                    'en_US' => 0
+                ]
+            ],
+        ];
+
+        $nonRequiredAttributesResultDataProduct42 = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 5,
+                    'fr_FR' => 5,
+                ],
+                'mobile' => [
+                    'en_US' => 8
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 0,
+                    'fr_FR' => 1,
+                ],
+                'mobile' => [
+                    'en_US' => 5
+                ]
+            ],
+        ];
+
+        $requiredAttributesResultDataProduct56 = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 2,
+                    'fr_FR' => 2,
+                ],
+                'mobile' => [
+                    'en_US' => 5,
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 0,
+                    'fr_FR' => 1,
+                ],
+                'mobile' => [
+                    'en_US' => 2,
+                ]
+            ],
+        ];
+
+        $nonRequiredAttributesResultDataProduct56 = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 8,
+                    'fr_FR' => 8,
+                ],
+                'mobile' => [
+                    'en_US' => 5,
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 0,
+                    'fr_FR' => 2,
+                ],
+                'mobile' => [
+                    'en_US' => 0,
+                ]
+            ],
+        ];
+
+        $expectedResults = [
+            42 => [
+                'ecommerce' => [
+                    'en_US' => true,
+                    'fr_FR' => true,
+                ],
+                'mobile' => [
+                    'en_US' => false
+                ]
+            ],
+            56 => [
+                'ecommerce' => [
+                    'en_US' => true,
+                    'fr_FR' => false,
+                ],
+                'mobile' => [
+                    'en_US' => true
+                ]
+            ]
+        ];
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $requiredAttributesResultDataProduct42
+            ),
+            56 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $requiredAttributesResultDataProduct56
+            ),
+        ]);
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $nonRequiredAttributesResultDataProduct42
+            ),
+            56 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $nonRequiredAttributesResultDataProduct56
+            ),
+        ]);
+
+        $this->compute($productIds)->shouldReturn($expectedResults);
+    }
+
+    public function it_does_not_compute_products_without_evaluations($getEvaluationResultsByProductsAndCriterionQuery): void
+    {
+        $productIds = ProductIdCollection::fromInt(33);
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        )->willReturn([]);
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        )->willReturn([]);
+
+        $this->compute($productIds)->shouldReturn([
+            33 => [
+                'ecommerce' => [
+                    'en_US' => null,
+                    'fr_FR' => null,
+                ],
+                'mobile' => [
+                    'en_US' => null
+                ]
+            ]
+        ]);
+    }
+
+    public function it_computes_enrichment_status_for_products_with_only_required_attributes($getEvaluationResultsByProductsAndCriterionQuery): void
+    {
+        $productIds = ProductIdCollection::fromInt(42);
+
+        $requiredAttributesResultDataProduct = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 10,
+                    'fr_FR' => 10,
+                ],
+                'mobile' => [
+                    'en_US' => 5
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 1,
+                    'fr_FR' => 4,
+                ],
+                'mobile' => [
+                    'en_US' => 3
+                ]
+            ],
+        ];
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $requiredAttributesResultDataProduct
+            ),
+        ]);
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                []
+            ),
+        ]);
+
+        $this->compute($productIds)->shouldReturn([
+            42 => [
+                'ecommerce' => [
+                    'en_US' => true,
+                    'fr_FR' => false,
+                ],
+                'mobile' => [
+                    'en_US' => false
+                ]
+            ],
+        ]);
+    }
+
+    public function it_computes_enrichment_status_for_products_without_required_attributes($getEvaluationResultsByProductsAndCriterionQuery): void
+    {
+        $productIds = ProductIdCollection::fromInt(42);
+
+        $nonRequiredAttributesResultDataProduct = [
+            'total_number_of_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 10,
+                    'fr_FR' => 10,
+                ],
+                'mobile' => [
+                    'en_US' => 5
+                ]
+            ],
+            'number_of_improvable_attributes' => [
+                'ecommerce' => [
+                    'en_US' => 1,
+                    'fr_FR' => 4,
+                ],
+                'mobile' => [
+                    'en_US' => 3
+                ]
+            ],
+        ];
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                []
+            ),
+        ]);
+
+        $getEvaluationResultsByProductsAndCriterionQuery->execute(
+            $productIds,
+            new CriterionCode(EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE)
+        )->willReturn([
+            42 => new CriterionEvaluationResult(
+                new ChannelLocaleRateCollection(),
+                new CriterionEvaluationResultStatusCollection(),
+                $nonRequiredAttributesResultDataProduct
+            ),
+        ]);
+
+        $this->compute($productIds)->shouldReturn([
+            42 => [
+                'ecommerce' => [
+                    'en_US' => true,
+                    'fr_FR' => false,
+                ],
+                'mobile' => [
+                    'en_US' => false
+                ]
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
Rework the service that compute the Key-Indicator on the enrichment status to be able to use it for the product models.

- Extract the MySQL query
- Use the "transformer" service to manipulate a object `CriterionEvaluationResult` instead of an array of raw data
- Add a unit test