### PR TITLE
OCT-28: replace pubsub image with a light one

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       - 'pim'
 
   pubsub-emulator:
-    image: 'google/cloud-sdk:331.0.0'
+    image: 'google/cloud-sdk:375.0.0-emulators'
     command: 'gcloud --user-output-enabled --log-http beta emulators pubsub start --host-port=0.0.0.0:8085'
     networks:
       - 'pim'


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We don't need a 2.5GB docker image for the pubsub emulator.
It's time for a **diet** :tada: 

**1) Image size**

Before:
```console
tseho@akeneo ~/work/pim-community-dev $ docker-compose images | grep pubsub
pim-community-dev_pubsub-emulator_1   google/cloud-sdk    331.0.0    55ef8753037e   2.508 GB
```

After:
```console
tseho@akeneo ~/work/pim-community-dev $ docker-compose images | grep pubsub
pim-community-dev_pubsub-emulator_1   google/cloud-sdk     375.0.0-emulators    2a6c0a154d60   865.8 MB
```

**2) CI speed**

Before:
![Screenshot_2022-03-08_14-56-20](https://user-images.githubusercontent.com/1421130/157253759-08b74c8e-f1f2-4af5-8b57-6a6e6553a56c.png)

After:
![Screenshot_2022-03-08_14-56-37](https://user-images.githubusercontent.com/1421130/157253783-c6964d1d-0fd0-4c91-b50c-513d151bbf10.png)

_note:_ This will save precious seconds on the following steps:
- `test_back_phpunit`
- `test_back_behat_legacy`
- `test_back_performance`
- `test_back_missing_structure_migrations`
- `test_back_data_migrations`
- `test_onboarder_bundle`
- `test_database`
- `cypress_sanity_checks`

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
