### PR TITLE
RAC-1223: [Backport] RAC-1215: fix error when attributeOption doesn't have label

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,9 +1,11 @@
 # 6.0.x
 
 ## Bug fixes
+
 - PLG-776: Fix Option page broken issue with small screen when creating a new option
 - PIM-10305: Do not allow disabled user to login
 - PLG-781: Fix migration task related to calculating product quality scores to be independent of the JobExecution implementation
+- RAC-1223: [Backport] RAC-1215: fix error when attributeOption doesn't have label
 
 # 6.0.7 (2022-02-25)
 

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Sql/SqlSearchAttributeOptions.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Sql/SqlSearchAttributeOptions.php
@@ -53,10 +53,9 @@ WITH filtered_option_codes AS (
     SELECT DISTINCT option.id, option.code, option.sort_order
     FROM pim_catalog_attribute_option `option`
     INNER JOIN pim_catalog_attribute `attribute` ON option.attribute_id = attribute.id
-    LEFT JOIN pim_catalog_attribute_option_value `option_value` ON option.id = option_value.option_id
+    LEFT JOIN pim_catalog_attribute_option_value `option_value` ON option.id = option_value.option_id $localeCondition
     WHERE attribute.code = :attribute_code
         AND (option.code LIKE :search OR option_value.value LIKE :search)
-        $localeCondition
         $includeCondition
         $excludeCondition
     ORDER BY $order
@@ -113,10 +112,9 @@ SQL;
 SELECT COUNT(DISTINCT option.id)
 FROM pim_catalog_attribute_option `option`
 INNER JOIN pim_catalog_attribute `attribute` ON option.attribute_id = attribute.id
-LEFT JOIN pim_catalog_attribute_option_value `option_value` ON option.id = option_value.option_id
+LEFT JOIN pim_catalog_attribute_option_value `option_value` ON option.id = option_value.option_id $localeCondition
 WHERE attribute.code = :attribute_code
     AND (option.code LIKE :search OR option_value.value LIKE :search)
-    $localeCondition
     $includeCondition
     $excludeCondition
 SQL;

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Sql/SqlSearchAttributeOptions.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Sql/SqlSearchAttributeOptions.php
@@ -95,7 +95,7 @@ SQL;
         return array_map(
             static fn (array $attributeOption) => new AttributeOption(
                 $attributeOption['code'],
-                json_decode($attributeOption['labels'], true),
+                null !== $attributeOption['labels'] ? json_decode($attributeOption['labels'], true) : [],
             ),
             $attributeOptions,
         );

--- a/tests/back/Pim/Structure/Integration/AttributeOption/SqlSearchAttributeOptionsIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeOption/SqlSearchAttributeOptionsIntegration.php
@@ -21,11 +21,48 @@ final class SqlSearchAttributeOptionsIntegration extends TestCase
         $this->sqlSearchAttributeOptions = $this->get('akeneo.pim.structure.query.search_attribute_options');
 
         $this->createAttributes(['color']);
+        $this->createAttributeOptions('color', 'yellow', [], 6);
         $this->createAttributeOptions('color', 'red', ['fr_FR' => 'Rouge', 'en_US' => 'Red'], 5);
         $this->createAttributeOptions('color', 'black', ['fr_FR' => 'Noir', 'en_US' => 'Black'], 4);
         $this->createAttributeOptions('color', 'blue', ['fr_FR' => 'Bleu', 'en_US' => 'Blue'], 3);
         $this->createAttributeOptions('color', 'brown', ['fr_FR' => 'Brun', 'en_US' => 'Brown'], 2);
         $this->createAttributeOptions('color', 'white', ['fr_FR' => 'Blanc', 'en_US' => 'White'], 1);
+    }
+
+    public function test_it_should_return_all_options_without_or_without_locales(): void
+    {
+        $searchParameters = new SearchAttributeOptionsParameters();
+        $searchResult = $this->sqlSearchAttributeOptions->search('color', $searchParameters);
+
+        self::assertEquals([
+            'matches_count' => 6,
+            'items' => [
+                [
+                    'code' => 'white',
+                    'labels' => ['fr_FR' => 'Blanc', 'en_US' => 'White'],
+                ],
+                [
+                    'code' => 'brown',
+                    'labels' => ['fr_FR' => 'Brun', 'en_US' => 'Brown'],
+                ],
+                [
+                    'code' => 'blue',
+                    'labels' => ['fr_FR' => 'Bleu', 'en_US' => 'Blue'],
+                ],
+                [
+                    'code' => 'black',
+                    'labels' => ['fr_FR' => 'Noir', 'en_US' => 'Black'],
+                ],
+                [
+                    'code' => 'red',
+                    'labels' => ['fr_FR' => 'Rouge', 'en_US' => 'Red'],
+                ],
+                [
+                    'code' => 'yellow',
+                    'labels' => [],
+                ],
+            ]
+        ], $searchResult->normalize());
     }
 
     public function test_it_searches_attribute_option_codes_on_all_locales(): void

--- a/tests/back/Pim/Structure/Integration/AttributeOption/SqlSearchAttributeOptionsIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeOption/SqlSearchAttributeOptionsIntegration.php
@@ -29,9 +29,46 @@ final class SqlSearchAttributeOptionsIntegration extends TestCase
         $this->createAttributeOptions('color', 'white', ['fr_FR' => 'Blanc', 'en_US' => 'White'], 1);
     }
 
-    public function test_it_should_return_all_options_without_or_without_locales(): void
+    public function test_it_should_return_all_options_without_locale(): void
     {
         $searchParameters = new SearchAttributeOptionsParameters();
+        $searchResult = $this->sqlSearchAttributeOptions->search('color', $searchParameters);
+
+        self::assertEquals([
+            'matches_count' => 6,
+            'items' => [
+                [
+                    'code' => 'white',
+                    'labels' => ['fr_FR' => 'Blanc', 'en_US' => 'White'],
+                ],
+                [
+                    'code' => 'brown',
+                    'labels' => ['fr_FR' => 'Brun', 'en_US' => 'Brown'],
+                ],
+                [
+                    'code' => 'blue',
+                    'labels' => ['fr_FR' => 'Bleu', 'en_US' => 'Blue'],
+                ],
+                [
+                    'code' => 'black',
+                    'labels' => ['fr_FR' => 'Noir', 'en_US' => 'Black'],
+                ],
+                [
+                    'code' => 'red',
+                    'labels' => ['fr_FR' => 'Rouge', 'en_US' => 'Red'],
+                ],
+                [
+                    'code' => 'yellow',
+                    'labels' => [],
+                ],
+            ]
+        ], $searchResult->normalize());
+    }
+
+    public function test_it_should_return_all_options_with_locale(): void
+    {
+        $searchParameters = new SearchAttributeOptionsParameters();
+        $searchParameters->setLocale('en_US');
         $searchResult = $this->sqlSearchAttributeOptions->search('color', $searchParameters);
 
         self::assertEquals([


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Cherry picked from commit 1e291ffa1a0bacf174708416e7f44b5b450a460d)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
