### PR TITLE
PLG-728: Use DQI public API to fetch quality scores

### DIFF
--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -156,8 +156,8 @@ $rules = [
 
         // Required to add quality scores into external API normalized products.
         'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
-        'Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresByIdentifiersQueryInterface',
-        'Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection',
+        'Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query',
+        'Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model',
 
         // TIP-915: PIM/Enrichment should not be linked to AttributeOption
         // TIP-916: Do not check if entities exist in PQB filters or sorters

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductModel\OnSave\ApiAggregat
 use Akeneo\Pim\Enrichment\Component\Product\Command\ProductModel\RemoveProductModelCommand;
 use Akeneo\Pim\Enrichment\Component\Product\Command\ProductModel\RemoveProductModelHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\GetProductModelsWithQualityScoresInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductModelsQuery;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductModelsQueryHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\Validator\ListProductModelsQueryValidator;
@@ -85,6 +86,7 @@ class ProductModelController
     private SecurityFacade $security;
     private RemoveProductModelHandler $removeProductModelHandler;
     private ValidatorInterface $validator;
+    private GetProductModelsWithQualityScoresInterface $getProductModelsWithQualityScores;
 
     public function __construct(
         ProductQueryBuilderFactoryInterface $pqbFactory,
@@ -113,7 +115,8 @@ class ProductModelController
         LoggerInterface $apiProductAclLogger,
         SecurityFacade $security,
         RemoveProductModelHandler $removeProductModelHandler,
-        ValidatorInterface $validator
+        ValidatorInterface $validator,
+        GetProductModelsWithQualityScoresInterface $getProductModelsWithQualityScores
     ) {
         $this->pqbFactory = $pqbFactory;
         $this->pqbSearchAfterFactory = $pqbSearchAfterFactory;
@@ -142,16 +145,18 @@ class ProductModelController
         $this->security = $security;
         $this->removeProductModelHandler = $removeProductModelHandler;
         $this->validator = $validator;
+        $this->getProductModelsWithQualityScores = $getProductModelsWithQualityScores;
     }
 
     /**
+     * @param Request $request
      * @param string $code
      *
      * @throws NotFoundHttpException
      *
      * @return JsonResponse
      */
-    public function getAction(string $code): JsonResponse
+    public function getAction(Request $request, string $code): JsonResponse
     {
         $this->denyAccessUnlessAclIsGranted('pim_api_product_list');
 
@@ -160,6 +165,10 @@ class ProductModelController
             Assert::isInstanceOf($user, UserInterface::class);
 
             $productModel = $this->getConnectorProductModels->fromProductModelCode($code, $user->getId());
+
+            if ($request->query->getAlpha('with_quality_scores', 'false') === 'true') {
+                $productModel = $this->getProductModelsWithQualityScores->fromConnectorProductModel($productModel);
+            }
         } catch (ObjectNotFoundException $e) {
             throw new NotFoundHttpException(sprintf('Product model "%s" does not exist or you do not have permission to access it.', $code));
         }
@@ -310,6 +319,7 @@ class ProductModelController
         $query->searchChannelCode = $request->query->get('search_scope', null);
         $query->searchAfter = $request->query->get('search_after', null);
         $query->userId = $user->getId();
+        $query->withQualityScores = $request->query->getAlpha('with_quality_scores', 'false');
 
         try {
             $this->listProductModelsQueryValidator->validate($query);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
@@ -39,6 +39,7 @@ services:
             - '@akeneo.pim.enrichment.product.connector.get_product_models_from_codes'
             - '@pim_catalog.repository.cached_channel'
             - '@akeneo.pim.enrichment.product_model.query.find_id'
+            - '@akeneo.pim.enrichment.use_cases.get_product_models_with_quality_scores'
 
     pim_enrich.connector.use_cases.validator.list_product_models:
         class: Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\Validator\ListProductModelsQueryValidator
@@ -126,3 +127,9 @@ services:
         class: Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\GetProductsWithCompletenesses
         arguments:
             - '@akeneo.pim.enrichment.product.query.get_product_completenesses'
+
+    akeneo.pim.enrichment.use_cases.get_product_models_with_quality_scores:
+        class: Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\GetProductModelsWithQualityScores
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductModelScoresQuery'
+            - '@akeneo.pim.automation.data_quality_insights.feature'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
@@ -119,7 +119,7 @@ services:
     akeneo.pim.enrichment.use_cases.get_products_with_quality_scores:
         class: Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\GetProductsWithQualityScores
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductScoresByIdentifiersQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductScoresQuery'
             - '@akeneo.pim.automation.data_quality_insights.feature'
 
     akeneo.pim.enrichment.use_cases.get_products_with_completenesses:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -107,6 +107,7 @@ services:
             - '@oro_security.security_facade'
             - '@Akeneo\Pim\Enrichment\Component\Product\Command\ProductModel\RemoveProductModelHandler'
             - '@validator'
+            - '@akeneo.pim.enrichment.use_cases.get_product_models_with_quality_scores'
 
     pim_api.controller.category:
         public: true

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductModels.php
@@ -172,7 +172,8 @@ final class SqlGetConnectorProductModels implements Query\GetConnectorProductMod
                 $row['associations'] ?? [],
                 $row['quantified_associations'] ?? [],
                 $row['category_codes'],
-                $filteredValuesIndexedByProductModelCode[$productModelCode]
+                $filteredValuesIndexedByProductModelCode[$productModelCode],
+                null
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
@@ -60,7 +60,7 @@ final class ConnectorProduct
     /** @var ReadValueCollection */
     private $values;
 
-    private ?ChannelLocaleRateCollection $qualityScores;
+    private ?QualityScoreCollection $qualityScores;
 
     private ?ProductCompletenessCollection $completenesses;
 
@@ -78,7 +78,7 @@ final class ConnectorProduct
         array $quantifiedAssociations,
         array $metadata,
         ReadValueCollection $values,
-        ?ChannelLocaleRateCollection $qualityScores,
+        ?QualityScoreCollection $qualityScores,
         ?ProductCompletenessCollection $completenesses
     ) {
         $this->id = $id;
@@ -168,7 +168,7 @@ final class ConnectorProduct
         return $this->values->getAttributeCodes();
     }
 
-    public function qualityScores(): ?ChannelLocaleRateCollection
+    public function qualityScores(): ?QualityScoreCollection
     {
         return $this->qualityScores;
     }
@@ -264,7 +264,7 @@ final class ConnectorProduct
         );
     }
 
-    public function buildWithQualityScores(ChannelLocaleRateCollection $productQualityScores): self
+    public function buildWithQualityScores(QualityScoreCollection $productQualityScores): self
     {
         return new self(
             $this->id,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProductModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel;
 
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 
@@ -15,68 +16,21 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
  */
 final class ConnectorProductModel
 {
-    /** @var int */
-    private $id;
-
-    /** @var string */
-    private $code;
-
-    /** @var \DateTimeInterface */
-    private $createdDate;
-
-    /** @var \DateTimeInterface */
-    private $updatedDate;
-
-    /** @var null|string */
-    private $parentCode;
-
-    /** @var string */
-    private $familyCode;
-
-    /** @var string */
-    private $familyVariantCode;
-
-    /** @var array */
-    private $metadata;
-
-    /** @var array */
-    private $associations;
-
-    /** @var array */
-    private $quantifiedAssociations;
-
-    /** @var array */
-    private $categoryCodes;
-
-    /** @var ReadValueCollection */
-    private $values;
-
     public function __construct(
-        int $id,
-        string $code,
-        \DateTimeInterface $createdDate,
-        \DateTimeInterface $updatedDate,
-        ?string $parentCode,
-        string $familyCode,
-        string $familyVariantCode,
-        array $metadata,
-        array $associations,
-        array $quantifiedAssociations,
-        array $categoryCodes,
-        ReadValueCollection $values
+        private int $id,
+        private string $code,
+        private \DateTimeInterface $createdDate,
+        private \DateTimeInterface $updatedDate,
+        private ?string $parentCode,
+        private string $familyCode,
+        private string $familyVariantCode,
+        private array $metadata,
+        private array $associations,
+        private array $quantifiedAssociations,
+        private array $categoryCodes,
+        private ReadValueCollection $values,
+        private ?QualityScoreCollection $qualityScores
     ) {
-        $this->id = $id;
-        $this->code = $code;
-        $this->createdDate = $createdDate;
-        $this->updatedDate = $updatedDate;
-        $this->parentCode = $parentCode;
-        $this->familyCode = $familyCode;
-        $this->familyVariantCode = $familyVariantCode;
-        $this->metadata = $metadata;
-        $this->associations = $associations;
-        $this->quantifiedAssociations = $quantifiedAssociations;
-        $this->categoryCodes = $categoryCodes;
-        $this->values = $values;
     }
 
     public function id(): int
@@ -137,6 +91,11 @@ final class ConnectorProductModel
     public function values(): ReadValueCollection
     {
         return $this->values;
+    }
+
+    public function qualityScores(): ?QualityScoreCollection
+    {
+        return $this->qualityScores;
     }
 
     public function attributeCodesInValues(): array
@@ -204,7 +163,8 @@ final class ConnectorProductModel
             $this->associations,
             $this->quantifiedAssociations,
             array_values(array_intersect($this->categoryCodes, $categoryCodesToKeep)),
-            $this->values
+            $this->values,
+            $this->qualityScores
         );
     }
 
@@ -233,7 +193,8 @@ final class ConnectorProductModel
             $this->associations,
             $this->quantifiedAssociations,
             $this->categoryCodes,
-            $values
+            $values,
+            $this->qualityScores
         );
     }
 
@@ -264,7 +225,8 @@ final class ConnectorProductModel
             $filteredAssociations,
             $this->quantifiedAssociations,
             $this->categoryCodes,
-            $this->values
+            $this->values,
+            $this->qualityScores
         );
     }
 
@@ -295,7 +257,8 @@ final class ConnectorProductModel
             $filteredAssociations,
             $this->quantifiedAssociations,
             $this->categoryCodes,
-            $this->values
+            $this->values,
+            $this->qualityScores
         );
     }
 
@@ -327,7 +290,8 @@ final class ConnectorProductModel
             $this->associations,
             $filteredQuantifiedAssociations,
             $this->categoryCodes,
-            $this->values
+            $this->values,
+            $this->qualityScores
         );
     }
 
@@ -358,7 +322,8 @@ final class ConnectorProductModel
             $this->associations,
             $filteredQuantifiedAssociations,
             $this->categoryCodes,
-            $this->values
+            $this->values,
+            $this->qualityScores
         );
     }
 
@@ -376,7 +341,27 @@ final class ConnectorProductModel
             $this->associations,
             $this->quantifiedAssociations,
             $this->categoryCodes,
-            $this->values
+            $this->values,
+            $this->qualityScores
+        );
+    }
+
+    public function buildWithQualityScores(?QualityScoreCollection $productQualityScores): ConnectorProductModel
+    {
+        return new self(
+            $this->id,
+            $this->code,
+            $this->createdDate,
+            $this->updatedDate,
+            $this->parentCode,
+            $this->familyCode,
+            $this->familyVariantCode,
+            $this->metadata,
+            $this->associations,
+            $this->quantifiedAssociations,
+            $this->categoryCodes,
+            $this->values,
+            $productQualityScores
         );
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductModelsWithQualityScores.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductModelsWithQualityScores.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase;
+
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductModelsWithQualityScores implements GetProductModelsWithQualityScoresInterface
+{
+    public function __construct(
+        private GetProductModelScoresQueryInterface $getProductModelScoresQuery,
+        private FeatureFlag $dataQualityInsightsFeature
+    ) {
+    }
+
+    public function fromConnectorProductModel(ConnectorProductModel $productModel): ConnectorProductModel
+    {
+        if (!$this->dataQualityInsightsFeature->isEnabled()) {
+            return $productModel->buildWithQualityScores(new QualityScoreCollection([]));
+        }
+
+        return $productModel->buildWithQualityScores(
+            $this->getProductModelScoresQuery->byProductModelCode($productModel->code())
+        );
+    }
+
+    public function fromConnectorProductModelList(ConnectorProductModelList $connectorProductModelList, ?string $channel = null, array $locales = []): ConnectorProductModelList
+    {
+        if (!$this->dataQualityInsightsFeature->isEnabled()) {
+            return $this->returnProductModelsWithEmptyQualityScores($connectorProductModelList);
+        }
+
+        $productModelsQualityScores = $this->getProductsQualityScores($connectorProductModelList);
+
+        $productModelsWithQualityScores = array_map(function (ConnectorProductModel $productModel) use ($productModelsQualityScores, $channel, $locales) {
+            if (!isset($productModelsQualityScores[$productModel->code()])) {
+                return $productModel->buildWithQualityScores(new QualityScoreCollection([]));
+            }
+
+            $productQualityScores = $this->filterProductModelQualityScores($productModelsQualityScores[$productModel->code()], $channel, $locales);
+            return $productModel->buildWithQualityScores($productQualityScores);
+        }, $connectorProductModelList->connectorProductModels());
+
+        return new ConnectorProductModelList($connectorProductModelList->totalNumberOfProductModels(), $productModelsWithQualityScores);
+    }
+
+    private function returnProductModelsWithEmptyQualityScores(ConnectorProductModelList $connectorProductModelList): ConnectorProductModelList
+    {
+        return new ConnectorProductModelList(
+            $connectorProductModelList->totalNumberOfProductModels(),
+            array_map(
+                fn (ConnectorProductModel $productModel) => $productModel->buildWithQualityScores(new QualityScoreCollection([])),
+                $connectorProductModelList->connectorProductModels()
+            )
+        );
+    }
+
+    private function getProductsQualityScores(ConnectorProductModelList $connectorProductModelList): array
+    {
+        $productModelCodes = array_map(
+            fn (ConnectorProductModel $connectorProductModel) => $connectorProductModel->code(),
+            $connectorProductModelList->connectorProductModels()
+        );
+
+        return $this->getProductModelScoresQuery->byProductModelCodes($productModelCodes);
+    }
+
+    private function filterProductModelQualityScores(QualityScoreCollection $productModelQualityScores, ?string $channel, array $locales): QualityScoreCollection
+    {
+        if (null === $channel && empty($locales)) {
+            return $productModelQualityScores;
+        }
+
+        $filteredQualityScores = [];
+        foreach ($productModelQualityScores->qualityScores as $scoreChannel => $scoresLocales) {
+            if ($channel !== null && $channel !== $scoreChannel) {
+                continue;
+            }
+            foreach ($scoresLocales as $scoreLocale => $score) {
+                if (empty($locales) || in_array($scoreLocale, $locales)) {
+                    $filteredQualityScores[$scoreChannel][$scoreLocale] = $score;
+                }
+            }
+        }
+
+        return new QualityScoreCollection($filteredQualityScores);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductModelsWithQualityScoresInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductModelsWithQualityScoresInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetProductModelsWithQualityScoresInterface
+{
+    public function fromConnectorProductModel(ConnectorProductModel $productModel): ConnectorProductModel;
+
+    public function fromConnectorProductModelList(ConnectorProductModelList $connectorProductModelList, ?string $channel = null, array $locales = []): ConnectorProductModelList;
+}

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductsWithQualityScoresInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/GetProductsWithQualityScoresInterface.php
@@ -15,6 +15,4 @@ interface GetProductsWithQualityScoresInterface
     public function fromConnectorProduct(ConnectorProduct $product): ConnectorProduct;
 
     public function fromConnectorProductList(ConnectorProductList $connectorProductList, ?string $channel = null, array $locales = []): ConnectorProductList;
-
-    public function fromNormalizedProduct(string $productIdentifier, array $normalizedProduct, ?string $channel = null, array $locales = []): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductModelsQuery.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductModelsQuery.php
@@ -49,6 +49,8 @@ class ListProductModelsQuery
     /** @var int */
     public $userId;
 
+    public string $withQualityScores = 'false';
+
     /**
      * Returns the parameter 'with_count' typed as a boolean
      *
@@ -57,5 +59,10 @@ class ListProductModelsQuery
     public function withCountAsBoolean(): bool
     {
         return $this->withCount === 'true';
+    }
+
+    public function withQualityScores(): bool
+    {
+        return $this->withQualityScores === 'true';
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductModelNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductModelNormalizer.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi;
 
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\DateTimeNormalizer;
@@ -54,6 +55,28 @@ final class ConnectorProductModelNormalizer
             $normalizedProductModel['metadata'] = $connectorProductModel->metadata();
         }
 
+        $qualityScores = $connectorProductModel->qualityScores();
+        if ($qualityScores !== null) {
+            $normalizedProductModel['quality_scores'] = $this->normalizeQualityScores($qualityScores);
+        }
+
         return $normalizedProductModel;
+    }
+
+    private function normalizeQualityScores(QualityScoreCollection $productModelScores): array
+    {
+        $qualityScores = [];
+
+        foreach ($productModelScores->qualityScores as $channel => $localeScores) {
+            foreach ($localeScores as $locale => $score) {
+                $qualityScores[] = [
+                    'scope' => $channel,
+                    'locale' => $locale,
+                    'data' => $score->getLetter(),
+                ];
+            }
+        }
+
+        return $qualityScores;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductList;
@@ -77,16 +77,16 @@ final class ConnectorProductNormalizer
         return $normalizedProduct;
     }
 
-    private function normalizeQualityScores(ChannelLocaleRateCollection $channelLocaleRates): array
+    private function normalizeQualityScores(QualityScoreCollection $qualityScoreCollection): array
     {
         $qualityScores = [];
 
-        foreach ($channelLocaleRates as $channel => $localeRates) {
-            foreach ($localeRates as $locale => $rate) {
+        foreach ($qualityScoreCollection->qualityScores as $channel => $localeScores) {
+            foreach ($localeScores as $locale => $score) {
                 $qualityScores[] = [
                     'scope' => $channel,
                     'locale' => $locale,
-                    'data' => $rate->toLetter(),
+                    'data' => $score->getLetter(),
                 ];
             }
         }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductModelsIntegration.php
@@ -79,7 +79,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                 ],
                 [],
                 [],
-                new ReadValueCollection([])
+                new ReadValueCollection([]),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataRootPm['id'],
@@ -140,7 +141,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                             'en_US'
                         ),
                     ]
-                )
+                ),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataSubPm['id'],
@@ -203,7 +205,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                         ),
                         ScalarValue::value('a_text', 'Lorem ipsum dolor sit amet'),
                     ]
-                )
+                ),
+                null
             ),
         ]);
 
@@ -265,7 +268,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                 ],
                 [],
                 [],
-                new ReadValueCollection([])
+                new ReadValueCollection([]),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataRootPm['id'],
@@ -319,7 +323,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                             'en_US'
                         ),
                     ]
-                )
+                ),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataSubPm['id'],
@@ -374,7 +379,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                             'en_US'
                         ),
                     ]
-                )
+                ),
+                null
             ),
         ]);
 
@@ -451,7 +457,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                         'en_US'
                     ),
                 ]
-            )
+            ),
+            null
         );
 
         $actualProductModel = $this->getQuery()->fromProductModelCode('sub_pm_A', $this->getUserIdFromUsername('admin'));
@@ -512,7 +519,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                 ],
                 [],
                 [],
-                new ReadValueCollection([])
+                new ReadValueCollection([]),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataRootPm['id'],
@@ -573,7 +581,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                             'en_US'
                         ),
                     ]
-                )
+                ),
+                null
             ),
             new ConnectorProductModel(
                 (int)$dataSubPm['id'],
@@ -636,7 +645,8 @@ class SqlGetConnectorProductModelsIntegration extends TestCase
                         ),
                         ScalarValue::value('a_text', 'Lorem ipsum dolor sit amet'),
                     ]
-                )
+                ),
+                null
             ),
         ]);
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductModelListSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductModelListSpec.php
@@ -46,7 +46,8 @@ final class ConnectorProductModelListSpec extends ObjectBehavior
                     ],
                 ],
                 ['category_code_1', 'category_code_2'],
-                new ReadValueCollection()
+                new ReadValueCollection(),
+                null
             )
         ]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductModelSpec.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel;
 
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScore;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
@@ -67,7 +69,8 @@ final class ConnectorProductModelSpec extends ObjectBehavior
                     ScalarValue::localizableValue('description', 'an English description', 'en_US'),
                     ScalarValue::localizableValue('description', 'une description en français', 'fr_FR'),
                 ]
-            )
+            ),
+            null
         );
     }
 
@@ -276,5 +279,18 @@ final class ConnectorProductModelSpec extends ObjectBehavior
                 'some_metadata' => ['key' => 'value'],
             ]
         );
+    }
+
+    function it_can_be_built_with_quality_scores(): void
+    {
+        $qualityScores = new QualityScoreCollection([
+            'ecommerce' => [
+                'en_US' => new QualityScore('A', 98),
+                'fr_FR' => new QualityScore('B', 87),
+            ]
+        ]);
+        $connectorProductModel = $this->buildWithQualityScores($qualityScores);
+
+        $connectorProductModel->qualityScores()->shouldReturn($qualityScores);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/GetProductModelsWithQualityScoresSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/GetProductModelsWithQualityScoresSpec.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase;
+
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScore;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+final class GetProductModelsWithQualityScoresSpec extends ObjectBehavior
+{
+    public function let(
+        GetProductModelScoresQueryInterface $getProductModelScoresQuery,
+        FeatureFlag $dataQualityInsightsFeature
+    ) {
+        $this->beConstructedWith($getProductModelScoresQuery, $dataQualityInsightsFeature);
+    }
+
+    public function it_returns_product_models_with_empty_quality_scores_if_dqi_feature_is_disabled($dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(false);
+
+        $productModel1 = $this->givenAProductModelWithoutQualityScores('pm_1');
+        $productModel2 = $this->givenAProductModelWithoutQualityScores('pm_2');
+
+        $this->fromConnectorProductModel($productModel1)->shouldBeLike(
+            $productModel1->buildWithQualityScores(new QualityScoreCollection([]))
+        );
+
+        $this->fromConnectorProductModelList(new ConnectorProductModelList(2, [$productModel1, $productModel2]))
+            ->shouldBeLike(new ConnectorProductModelList(2, [
+                $productModel1->buildWithQualityScores(new QualityScoreCollection([])),
+                $productModel2->buildWithQualityScores(new QualityScoreCollection([]))
+            ]));
+    }
+
+    public function it_returns_a_connector_product_model_with_quality_scores($getProductModelScoresQuery, $dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(true);
+
+        $productModel = $this->givenAProductModelWithoutQualityScores('pm_1');
+
+        $getProductModelScoresQuery->byProductModelCode('pm_1')->willReturn($this->givenQualityScoresSample1());
+
+        $this->fromConnectorProductModel($productModel)->shouldBeLike(
+            $productModel->buildWithQualityScores($this->givenQualityScoresSample1())
+        );
+    }
+
+    public function it_returns_a_list_of_connector_product_models_with_quality_scores_without_filters($getProductModelScoresQuery, $dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(true);
+
+        $productModel1 = $this->givenAProductModelWithoutQualityScores('pm_1');
+        $productModel2 = $this->givenAProductModelWithoutQualityScores('pm_2');
+        $productModelList = new ConnectorProductModelList(2, [$productModel1, $productModel2]);
+
+        $getProductModelScoresQuery->byProductModelCodes(['pm_1', 'pm_2'])->willReturn([
+            'pm_1' => $this->givenQualityScoresSample1(),
+            'pm_2' => $this->givenQualityScoresSample2(),
+        ]);
+
+        $this->fromConnectorProductModelList($productModelList, null, [])->shouldBeLike(new ConnectorProductModelList(2, [
+            $productModel1->buildWithQualityScores($this->givenQualityScoresSample1()),
+            $productModel2->buildWithQualityScores($this->givenQualityScoresSample2())
+        ]));
+    }
+
+    public function it_returns_a_list_of_connector_product_models_with_quality_scores_filtered_by_channel($getProductModelScoresQuery, $dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(true);
+
+        $productModel1 = $this->givenAProductModelWithoutQualityScores('pm_1');
+        $productModel2 = $this->givenAProductModelWithoutQualityScores('pm_2');
+        $productModelList = new ConnectorProductModelList(2, [$productModel1, $productModel2]);
+
+        $getProductModelScoresQuery->byProductModelCodes(['pm_1', 'pm_2'])->willReturn([
+            'pm_1' => $this->givenQualityScoresSample1(),
+            'pm_2' => $this->givenQualityScoresSample2(),
+        ]);
+
+        $expectedProductModelsList = new ConnectorProductModelList(2, [
+            $productModel1->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'en_US' => new QualityScore('C', 75),
+                    'fr_FR' => new QualityScore('E', 35),
+                ],
+            ])),
+            $productModel2->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'en_US' => new QualityScore('D', 65),
+                    'fr_FR' => new QualityScore('B', 85),
+                ],
+            ]))
+        ]);
+
+        $this->fromConnectorProductModelList($productModelList, 'ecommerce', [])->shouldBeLike($expectedProductModelsList);
+    }
+
+    public function it_returns_a_list_of_connector_product_models_with_quality_scores_filtered_by_locales($getProductModelScoresQuery, $dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(true);
+
+        $productModel1 = $this->givenAProductModelWithoutQualityScores('pm_1');
+        $productModel2 = $this->givenAProductModelWithoutQualityScores('pm_2');
+        $productModelList = new ConnectorProductModelList(2, [$productModel1, $productModel2]);
+
+        $getProductModelScoresQuery->byProductModelCodes(['pm_1', 'pm_2'])->willReturn([
+            'pm_1' => $this->givenQualityScoresSample1(),
+            'pm_2' => $this->givenQualityScoresSample2(),
+        ]);
+
+        $expectedProductModelsList = new ConnectorProductModelList(2, [
+            $productModel1->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'fr_FR' => new QualityScore('E', 35),
+                ],
+                'print' => [
+                    'fr_FR' => new QualityScore('E', 41),
+                ],
+            ])),
+            $productModel2->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'fr_FR' => new QualityScore('B', 85),
+                ],
+                'print' => [
+                    'fr_FR' => new QualityScore('C', 72),
+                ],
+            ]))
+        ]);
+
+        $this->fromConnectorProductModelList($productModelList, null, ['fr_FR'])->shouldBeLike($expectedProductModelsList);
+    }
+
+    public function it_returns_a_list_of_connector_product_models_with_quality_scores_filtered_by_channel_an_locales($getProductModelScoresQuery, $dataQualityInsightsFeature)
+    {
+        $dataQualityInsightsFeature->isEnabled()->willReturn(true);
+
+        $productModel1 = $this->givenAProductModelWithoutQualityScores('pm_1');
+        $productModel2 = $this->givenAProductModelWithoutQualityScores('pm_2');
+        $productModelList = new ConnectorProductModelList(2, [$productModel1, $productModel2]);
+
+        $getProductModelScoresQuery->byProductModelCodes(['pm_1', 'pm_2'])->willReturn([
+            'pm_1' => $this->givenQualityScoresSample1(),
+            'pm_2' => $this->givenQualityScoresSample2(),
+        ]);
+
+        $expectedProductModelsList = new ConnectorProductModelList(2, [
+            $productModel1->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'fr_FR' => new QualityScore('E', 35),
+                ],
+            ])),
+            $productModel2->buildWithQualityScores(new QualityScoreCollection([
+                'ecommerce' => [
+                    'fr_FR' => new QualityScore('B', 85),
+                ],
+            ]))
+        ]);
+
+        $this->fromConnectorProductModelList($productModelList, 'ecommerce', ['fr_FR'])->shouldBeLike($expectedProductModelsList);
+    }
+
+    private function givenAProductModelWithoutQualityScores(string $code): ConnectorProductModel
+    {
+        return new ConnectorProductModel(
+            1234,
+            $code,
+            new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
+            new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
+            'my_parent',
+            'my_family',
+            'my_family_variant',
+            ['workflow_status' => 'working_copy'],
+            [],
+            [],
+            ['category_code_1'],
+            new ReadValueCollection(),
+            null
+        );
+    }
+
+    private function givenQualityScoresSample1(): QualityScoreCollection
+    {
+        return new QualityScoreCollection([
+            'ecommerce' => [
+                'en_US' => new QualityScore('C', 75),
+                'fr_FR' => new QualityScore('E', 35),
+            ],
+            'print' => [
+                'en_US' => new QualityScore('A', 91),
+                'fr_FR' => new QualityScore('E', 41),
+            ],
+        ]);
+    }
+
+    private function givenQualityScoresSample2(): QualityScoreCollection
+    {
+        return new QualityScoreCollection([
+            'ecommerce' => [
+                'en_US' => new QualityScore('D', 65),
+                'fr_FR' => new QualityScore('B', 85),
+            ],
+            'print' => [
+                'en_US' => new QualityScore('B', 82),
+                'fr_FR' => new QualityScore('C', 72),
+            ],
+        ]);
+    }
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ListProductModelsQueryHandlerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/UseCase/ListProductModelsQueryHandlerSpec.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase;
 
 use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScore;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Category\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ApplyProductSearchQueryParametersToPQB;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\GetProductModelsWithQualityScoresInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductModelsQuery;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Query\GetConnectorProductModels;
@@ -28,7 +31,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $fromSizePqbFactory,
         ProductQueryBuilderFactoryInterface $searchAfterPqbFactory,
         GetConnectorProductModels $getConnectorProductModels,
-        FindId $findProductModelId
+        FindId $findProductModelId,
+        GetProductModelsWithQualityScoresInterface $getProductModelsWithQualityScores
     ) {
         $this->beConstructedWith(
             new ApplyProductSearchQueryParametersToPQB($channelRepository->getWrappedObject()),
@@ -36,7 +40,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
             $searchAfterPqbFactory,
             $getConnectorProductModels,
             $channelRepository,
-            $findProductModelId
+            $findProductModelId,
+            $getProductModelsWithQualityScores
         );
     }
 
@@ -74,7 +79,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
             [],
             [],
             ['category_code_1'],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            null
         );
 
         $connectorProductModel2 = new ConnectorProductModel(
@@ -89,7 +95,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
             [],
             [],
             ['category_code_4'],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            null
         );
 
 
@@ -136,7 +143,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
             [],
             [],
             ['category_code_1'],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            null
         );
 
         $connectorProductModel2 = new ConnectorProductModel(
@@ -151,7 +159,8 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
             [],
             [],
             ['category_code_4'],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            null
         );
 
 
@@ -257,5 +266,67 @@ final class ListProductModelsQueryHandlerSpec extends ObjectBehavior
         $fromSizePqbFactory->create(Argument::cetera())->shouldNotBeCalled();
 
         $this->handle($query)->shouldBeLike(new ConnectorProductModelList(0, []));
+    }
+
+    public function it_add_quality_scores_to_products_if_option_is_activated(
+        ProductQueryBuilderFactoryInterface $fromSizePqbFactory,
+        ProductQueryBuilderFactoryInterface $searchAfterPqbFactory,
+        ProductQueryBuilderInterface $pqb,
+        GetConnectorProductModels $getConnectorProductModels,
+        GetProductModelsWithQualityScoresInterface $getProductModelsWithQualityScores
+    ) {
+        $query = new ListProductModelsQuery();
+        $query->paginationType = PaginationTypes::OFFSET;
+        $query->limit = 42;
+        $query->page = 69;
+        $query->channelCode = 'tablet';
+        $query->localeCodes = ['en_US'];
+        $query->attributeCodes = ['name'];
+        $query->userId = 42;
+        $query->withQualityScores = 'true';
+
+        $fromSizePqbFactory->create([
+            'limit' => 42,
+            'from' => 2856
+        ])->shouldBeCalled()->willReturn($pqb);
+
+        $pqb->addSorter('identifier', Directions::ASCENDING)->shouldBeCalled();
+
+        $connectorProductModel1 = new ConnectorProductModel(
+            1234,
+            'code_1',
+            new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
+            new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
+            'my_parent',
+            'my_family',
+            'my_family_variant',
+            ['workflow_status' => 'working_copy'],
+            [],
+            [],
+            ['category_code_1'],
+            new ReadValueCollection(),
+            null
+        );
+
+        $connectorProductModelList = new ConnectorProductModelList(1, [$connectorProductModel1]);
+        $getConnectorProductModels
+            ->fromProductQueryBuilder($pqb, 42, ['name'], 'tablet', ['en_US'])
+            ->willReturn(new ConnectorProductModelList(1, [$connectorProductModel1]));
+
+        $connectorProductModelListWithQualityScores = new ConnectorProductModelList(1, [
+            $connectorProductModel1->buildWithQualityScores(new QualityScoreCollection([
+                'tablet' => [
+                    'en_US' => new QualityScore('C', 76),
+                ]
+            ]))
+        ]);
+
+        $getProductModelsWithQualityScores
+            ->fromConnectorProductModelList($connectorProductModelList, 'tablet', ['en_US'])
+            ->willReturn($connectorProductModelListWithQualityScores);
+
+        $searchAfterPqbFactory->create(Argument::cetera())->shouldNotBeCalled();
+
+        $this->handle($query)->shouldBeLike($connectorProductModelListWithQualityScores);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductModelNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductModelNormalizerSpec.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi;
 
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScore;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModel;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductModelList;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
@@ -12,7 +14,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ValuesNormali
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\DateTimeNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Routing\RouterInterface;
@@ -78,7 +79,13 @@ class ConnectorProductModelNormalizerSpec extends ObjectBehavior
                 ],
             ],
             ['category_code_1', 'category_code_2'],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            new QualityScoreCollection([
+                'ecommerce' => [
+                    'en_US' => new QualityScore('A', 98),
+                    'fr_FR' => new QualityScore('B', 87),
+                ]
+            ])
         );
 
         $connector2 = new ConnectorProductModel(
@@ -93,7 +100,8 @@ class ConnectorProductModelNormalizerSpec extends ObjectBehavior
             [],
             [],
             [],
-            new ReadValueCollection()
+            new ReadValueCollection(),
+            null
         );
 
         $this->normalizeConnectorProductModelList(new ConnectorProductModelList(1, [$connector1, $connector2]))
@@ -137,6 +145,10 @@ class ConnectorProductModelNormalizerSpec extends ObjectBehavior
                              ],
                          ],
                          'metadata' => ['a_metadata_key' => 'a_metadata_value'],
+                         'quality_scores' => [
+                             ['scope' => 'ecommerce', 'locale' => 'en_US', 'data' => 'A'],
+                             ['scope' => 'ecommerce', 'locale' => 'fr_FR', 'data' => 'B'],
+                         ]
                      ],
                      [
                          'code' => 'code_2',
@@ -198,7 +210,8 @@ class ConnectorProductModelNormalizerSpec extends ObjectBehavior
                 ],
             ],
             ['sportswear', 'men'],
-            new ReadValueCollection([$scalarValue])
+            new ReadValueCollection([$scalarValue]),
+            null
         );
 
         $this->normalizeConnectorProductModel($connectorProductModel)->shouldReturn(

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScore;
+use Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model\QualityScoreCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompleteness;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
@@ -76,9 +74,12 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
             ],
             [],
             new ReadValueCollection(),
-            (new ChannelLocaleRateCollection())
-                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(81))
-                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(73)),
+            new QualityScoreCollection([
+                'ecommerce' => [
+                    'en_US' => new QualityScore('B', 81),
+                    'fr_FR' => new QualityScore('C', 73),
+                ],
+            ]),
             new ProductCompletenessCollection(
                 1,
                 [


### PR DESCRIPTION
Rework to avoid coupling on `Akeneo\Pim\Automation\DataQualityInsights\Domain` in `Enrichment` 
We use `Akeneo\Pim\Automation\DataQualityInsights`PublicApi` instead, when DQI is needed in another BC