### PR TITLE
PLG-810: Fix publishing the data_quality_insights_recompute_product_scores job during migration

### DIFF
--- a/upgrades/schema/Version_6_0_20210531152335_dqi_launch_recompute_products_scores.php
+++ b/upgrades/schema/Version_6_0_20210531152335_dqi_launch_recompute_products_scores.php
@@ -3,17 +3,14 @@
 namespace Pim\Upgrade\Schema;
 
 use Akeneo\Tool\Component\Batch\Job;
-use Akeneo\Tool\Component\BatchQueue\Queue\DataMaintenanceJobExecutionMessage;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Webmozart\Assert\Assert;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 final class Version_6_0_20210531152335_dqi_launch_recompute_products_scores extends AbstractMigration implements ContainerAwareInterface
 {
-    private ContainerInterface $container;
+    use ContainerAwareTrait;
 
     public function up(Schema $schema) : void
     {
@@ -31,30 +28,9 @@ final class Version_6_0_20210531152335_dqi_launch_recompute_products_scores exte
 
     public function postUp(Schema $schema): void
     {
-        // Retrieve the job execution id
-        $statement = $this->container->get('database_connection')->executeQuery(<<<SQL
-            SELECT abje.id AS job_execution_id FROM akeneo_batch_job_execution abje
-            INNER JOIN akeneo_batch_job_instance abji ON abje.job_instance_id = abji.id
-            WHERE abji.code = 'data_quality_insights_recompute_products_scores';
-        SQL);
-
-        $jobExecutionId = $statement->fetchOne();
-
-        $this->abortIf($jobExecutionId === false, 'The `data_quality_insights_recompute_products_scores` job execution is not initialized');
-
-        // Add the job execution in the maintenance job queue
-        $jobExecutionMessage = DataMaintenanceJobExecutionMessage::createJobExecutionMessageFromNormalized([
-            'id' => Uuid::uuid4(),
-            'job_execution_id' => (int) $jobExecutionId,
-        ]);
-
-        $this->container->get('akeneo_batch_queue.queue.job_execution_queue')->publish($jobExecutionMessage);
-    }
-
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        Assert::notNull($container);
-        $this->container = $container;
+        $this->container->get('pim_catalog.command_launcher')->executeForeground(
+            'akeneo:batch:publish-job-to-queue data_quality_insights_recompute_products_scores'
+        );
     }
 
     public function down(Schema $schema) : void


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Publish the `data_quality_insights_recompute_product_scores` job to the queue using dedicated public cli command instead of using the internal service
Migrations are run in `prod` environment so the use of the `akeneo_batch_queue.queue.job_execution_queue` internal service is not possible

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
