### PR TITLE
PIM-10335: Fix locale not saved for localizable attribute in product exports

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10335: Fix locale not saved for localizable attribute in product exports
+
 # 5.0.85 (2022-03-17)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/attribute/attribute.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/filter/attribute/attribute.js
@@ -225,6 +225,7 @@ define([
         scopeEvent.scopeCode = this.getScope();
       } else {
         this.setScope(scopeEvent.scopeCode, {silent: true});
+        this.trigger('pim_enrich:form:entity:post_update');
       }
     },
 
@@ -240,6 +241,7 @@ define([
         localeEvent.localeCode = this.getLocale();
       } else {
         this.setLocale(localeEvent.localeCode, {silent: true});
+        this.trigger('pim_enrich:form:entity:post_update');
       }
     },
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When adding a localizable boolean attribute as a product export filter, the locale was not correctly initialized in the state.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
