### PR TITLE
Fix invalid JSON Path Expression

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -332,7 +332,7 @@ SQL;
                     a_image.code AS attribute_code,
                     a_image.is_localizable,
                     a_image.is_scopable,
-                    JSON_EXTRACT(product_child.raw_values, CONCAT('$.', a_image.code)) AS image_values,
+                    JSON_EXTRACT(product_child.raw_values, CONCAT('$."', a_image.code, '"')) AS image_values,
                     JSON_EXTRACT(
                         product_child.raw_values,
                         CONCAT('$."', a_image.code, '".', IF(is_scopable = 1, '":channel_code"', '"<all_channels>"'), '.', IF(is_localizable = 1, '":locale_code"', '"<all_locales>"'))


### PR DESCRIPTION
A JSON Path Expression in the form `$.memberName` is only valid if
`memberName` is a field name that does not contain spaces, dots and/or
other characters or starts with a number!
So if there is an AttributeCode that starts with a number, e.g.
`1ws_thumbnail`, this leads to an invalid JSON Path Expression.
This can be avoided with this notation `$."memberName"`.

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
