### PR TITLE
Fix CI machine machine executor for 5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   checkout_ee:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -32,7 +32,7 @@ jobs:
 
   checkout_ce:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - persist_to_workspace:
@@ -49,7 +49,7 @@ jobs:
             type: string
             default: akeneo-design-system
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
             at: ~/
@@ -136,7 +136,7 @@ jobs:
 
   test_back_static_and_acceptance:
       machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
       steps:
           - attach_workspace:
                 at: ~/
@@ -173,7 +173,7 @@ jobs:
 
   test_back_phpunit:
       machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
       parallelism: 20
       steps:
           - attach_workspace:
@@ -205,7 +205,7 @@ jobs:
 
   test_back_behat_legacy:
     machine:
-        image: ubuntu-1604:201903-01
+        image: ubuntu-2004:202201-02
     parallelism: 40
     steps:
       - attach_workspace:
@@ -261,7 +261,7 @@ jobs:
 
   test_front_static_acceptance_and_integration:
       machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
       steps:
         - attach_workspace:
             at: ~/
@@ -283,7 +283,7 @@ jobs:
 
   test_back_performance:
     machine:
-        image: ubuntu-1604:201903-01
+        image: ubuntu-2004:202201-02
     steps:
       - attach_workspace:
           at: ~/
@@ -309,7 +309,7 @@ jobs:
 
   test_back_missing_structure_migrations:
       machine:
-        image: ubuntu-1604:201903-01
+        image: ubuntu-2004:202201-02
       steps:
         -   attach_workspace:
                 at: ~/
@@ -336,7 +336,7 @@ jobs:
 
   test_back_data_migrations:
       machine:
-          image: ubuntu-1604:201903-01
+          image: ubuntu-2004:202201-02
       steps:
           - attach_workspace:
                 at: ~/


### PR DESCRIPTION
Ubuntu 16.04 machine executor are deprecated

See https://circleci.com/blog/ubuntu-14-16-image-deprecation/