### PR TITLE
Fix duplicated PRE_REMOVE event

### DIFF
--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/Doctrine/Common/Remover/BaseRemover.php
@@ -81,12 +81,6 @@ class BaseRemover implements RemoverInterface, BulkRemoverInterface
             $this->eventDispatcher->dispatch(new RemoveEvent($object, $object->getId(), $options), StorageEvents::PRE_REMOVE);
         }
 
-        foreach ($objects as $object) {
-            $this->validateObject($object);
-
-            $this->eventDispatcher->dispatch(new RemoveEvent($object, $object->getId(), $options), StorageEvents::PRE_REMOVE);
-        }
-
         $removedObjects = [];
         foreach ($objects as $object) {
             $removedObjects[$object->getId()] = $object;


### PR DESCRIPTION
Due to conflict in a pull-up, we sent the PRE_REMOVE twice in the base remover.  
The bad commit is [here](https://github.com/akeneo/pim-community-dev/commit/c7d614472b1067f4b28ed0c848d0506204233f54#diff-d22771992fec043d501faf9cf4eddd75183214dc1d6eb66895d125e51cb43abbR84)