### PR TITLE
PIM-10345: Having a full numerical attribute code cause an error on product model import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PIM-10330: Fix wrong error message while importing boolean attribute value
 - PIM-10331: Fix error when using an association with quantities having an numeric code
 - PIM-10336: Fix product Export edition in error if no locale selected
+- PIM-10345: Fix issue when importing product model with an attribute constituted of only digits
 
 ## Improvements
 - PIM-10293: add batch-size option to pim:completness:calculate command

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModel.php
@@ -93,6 +93,7 @@ class ProductModel implements ArrayConverterInterface
             $isProductAssociationQuantityPattern = sprintf('/^\w+%s%s$/', AssociationColumnsResolver::PRODUCT_ASSOCIATION_SUFFIX, AssociationColumnsResolver::QUANTITY_SUFFIX);
             $isProductModelAssociationQuantityPattern = sprintf('/^\w+%s%s$/', AssociationColumnsResolver::PRODUCT_MODEL_ASSOCIATION_SUFFIX, AssociationColumnsResolver::QUANTITY_SUFFIX);
             foreach (array_keys($mappedItem) as $field) {
+                $field = is_int($field) ? strval($field) : $field;
                 $isGroup = (1 === preg_match($isGroupAssociationPattern, $field));
                 $isProduct = (1 === preg_match($isProductAssociationPattern, $field));
                 $isProductModel = (1 === preg_match($isProductModelAssociationPattern, $field));

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard;
 
+use Akeneo\Tool\Component\Connector\Exception\ArrayConversionException;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\FieldsRequirementChecker;
@@ -70,6 +71,7 @@ class ProductModelSpec extends ObjectBehavior
             'categories' => 'tshirt,pull',
             'name-en_US' => 'name',
             'description-en_US-ecommerce' => 'description',
+            123456 => "numerical code name field"
         ];
 
         $columnsMapper->map($flatProductModel, [
@@ -79,7 +81,7 @@ class ProductModelSpec extends ObjectBehavior
         $columnsMerger->merge($flatProductModel)->willReturn($flatProductModel);
 
         $fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code'])->shouldBeCalled();
-        $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name-en_US', 'description-en_US-ecommerce']);
+        $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name-en_US', 'description-en_US-ecommerce', '123456']);
 
         $fieldConverter->supportsColumn('code')->willreturn(true);
         $fieldConverter->convert('code', 'code')->willreturn($identifierConverter);
@@ -119,10 +121,11 @@ class ProductModelSpec extends ObjectBehavior
             ],
         ]);
 
+        $fieldConverter->supportsColumn('123456')->willreturn(false);
         $fieldConverter->supportsColumn('name-en_US')->willreturn(false);
         $fieldConverter->supportsColumn('description-en_US-ecommerce')->willreturn(false);
 
-        $productValueConverter->convert(["name-en_US" => "name", "description-en_US-ecommerce" => "description"])
+        $productValueConverter->convert(["name-en_US" => "name", "description-en_US-ecommerce" => "description", 123456 => "numerical code name field"])
             ->willReturn([
                     'name' => [
                         [
@@ -138,6 +141,13 @@ class ProductModelSpec extends ObjectBehavior
                             'data' => 'description',
                         ],
                     ],
+                    123456 => [
+                        [
+                            'locale' => null,
+                            'scope' => null,
+                            'data' => 'numerical code name field'
+                        ]
+                    ]
                 ]
             );
 
@@ -169,6 +179,13 @@ class ProductModelSpec extends ObjectBehavior
                         'data' => 'description',
                     ],
                 ],
+                123456 => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'numerical code name field'
+                    ]
+                ]
             ],
         ]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -70,7 +70,10 @@ class ProductModelSpec extends ObjectBehavior
             'categories' => 'tshirt,pull',
             'name-en_US' => 'name',
             'description-en_US-ecommerce' => 'description',
-            123456 => "numerical code name field"
+            123456 => 'numerical as field code',
+            '0123456' => 'numerical with trailing zero as field code',
+            '12.33' => 'string float as field code',
+            '1234567' => 'numerical as field code',
         ];
 
         $columnsMapper->map($flatProductModel, [
@@ -80,7 +83,7 @@ class ProductModelSpec extends ObjectBehavior
         $columnsMerger->merge($flatProductModel)->willReturn($flatProductModel);
 
         $fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code'])->shouldBeCalled();
-        $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name-en_US', 'description-en_US-ecommerce', '123456']);
+        $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name-en_US', 'description-en_US-ecommerce', '123456', '0123456', '12.33', '1234567']);
 
         $fieldConverter->supportsColumn('code')->willreturn(true);
         $fieldConverter->convert('code', 'code')->willreturn($identifierConverter);
@@ -121,34 +124,64 @@ class ProductModelSpec extends ObjectBehavior
         ]);
 
         $fieldConverter->supportsColumn('123456')->willreturn(false);
+        $fieldConverter->supportsColumn('0123456')->willreturn(false);
+        $fieldConverter->supportsColumn('12.33')->willreturn(false);
+        $fieldConverter->supportsColumn('1234567')->willreturn(false);
+
         $fieldConverter->supportsColumn('name-en_US')->willreturn(false);
         $fieldConverter->supportsColumn('description-en_US-ecommerce')->willreturn(false);
 
-        $productValueConverter->convert(["name-en_US" => "name", "description-en_US-ecommerce" => "description", 123456 => "numerical code name field"])
-            ->willReturn([
-                    'name' => [
-                        [
-                            'locale' => 'en_US',
-                            'scope' => null,
-                            'data' => 'name',
-                        ],
-                    ],
-                    'description' => [
-                        [
-                            'locale' => 'en_US',
-                            'scope' => 'ecommerce',
-                            'data' => 'description',
-                        ],
-                    ],
-                    123456 => [
-                        [
-                            'locale' => null,
-                            'scope' => null,
-                            'data' => 'numerical code name field'
-                        ]
-                    ]
-                ]
-            );
+        $productValueConverter->convert([
+            "name-en_US" => "name",
+            "description-en_US-ecommerce" => "description",
+            123456 => 'numerical as field code',
+            '0123456' => 'numerical with trailing zero as field code',
+            '12.33' => 'string float as field code',
+            '1234567' => 'numerical as field code',
+        ])->willReturn([
+            'name' => [
+                [
+                    'locale' => 'en_US',
+                    'scope' => null,
+                    'data' => 'name',
+                ],
+            ],
+            'description' => [
+                [
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                    'data' => 'description',
+                ],
+            ],
+            123456 => [
+                [
+                    'locale' => null,
+                    'scope' => null,
+                    'data' => 'numerical as field code',
+                ],
+            ],
+            '0123456' => [
+                [
+                    'locale' => null,
+                    'scope' => null,
+                    'data' => 'numerical with trailing zero as field code',
+                ],
+            ],
+            '12.33' => [
+                [
+                    'locale' => null,
+                    'scope' => null,
+                    'data' => 'string float as field code',
+                ],
+            ],
+            '1234567' => [
+                [
+                    'locale' => null,
+                    'scope' => null,
+                    'data' => 'numerical as field code',
+                ],
+            ],
+        ]);
 
         $this->convert($flatProductModel, [
             'mapping' => [
@@ -182,9 +215,30 @@ class ProductModelSpec extends ObjectBehavior
                     [
                         'locale' => null,
                         'scope' => null,
-                        'data' => 'numerical code name field'
-                    ]
-                ]
+                        'data' => 'numerical as field code',
+                    ],
+                ],
+                '0123456' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'numerical with trailing zero as field code',
+                    ],
+                ],
+                '12.33' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'string float as field code',
+                    ],
+                ],
+                '1234567' => [
+                    [
+                        'locale' => null,
+                        'scope' => null,
+                        'data' => 'numerical as field code',
+                    ],
+                ],
             ],
         ]);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -2,7 +2,6 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard;
 
-use Akeneo\Tool\Component\Connector\Exception\ArrayConversionException;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\ArrayConverter\FieldsRequirementChecker;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductSpec.php
@@ -78,7 +78,11 @@ class ProductSpec extends ObjectBehavior
             'PACK-products'          => 'sku-A,sku-B',
             'PACK-products-quantity' => '12|24',
             'PACK-product_models'    => 'sku-C',
-            'PACK-product_models-quantity' => '14'
+            'PACK-product_models-quantity' => '14',
+            123456 => 'numerical as field code',
+            '0123456' => 'numerical with trailing zero as field code',
+            '12.33' => 'string float as field code',
+            '1234567' => 'numerical as field code',
         ];
 
         $itemMerged = [
@@ -100,13 +104,29 @@ class ProductSpec extends ObjectBehavior
             'PACK-product_models'    => [
                 ['identifier' => 'sku-C', 'quantity' => '14']
             ],
+            123456 => 'numerical as field code',
+            '0123456' => 'numerical with trailing zero as field code',
+            '12.33' => 'string float as field code',
+            '1234567' => 'numerical as field code',
         ];
 
         $columnsMapper->map($item)->willReturn($item);
 
-        $attrColumnsResolver->resolveAttributeColumns()->willReturn(
-            ['sku', 'name', 'release_date-ecommerce', 'release_date-print', 7, 'price', 'price-EUR', 'price-USD']
-        );
+        $attrColumnsResolver->resolveAttributeColumns()->willReturn([
+            'sku',
+            'name',
+            'release_date-ecommerce',
+            'release_date-print',
+            7,
+            'price',
+            'price-EUR',
+            'price-USD',
+            123456,
+            '0123456',
+            '12.33',
+            '1234567'
+        ]);
+
         $assocColumnsResolver->resolveAssociationColumns()->willReturn(
             [
                 'X_SELL-groups',
@@ -134,6 +154,11 @@ class ProductSpec extends ObjectBehavior
         $fieldConverter->supportsColumn('release_date-ecommerce')->willReturn(false);
         $fieldConverter->supportsColumn('release_date-print')->willReturn(false);
         $fieldConverter->supportsColumn('7')->willReturn(false);
+        $fieldConverter->supportsColumn('price')->willReturn(false);
+        $fieldConverter->supportsColumn('123456')->willReturn(false);
+        $fieldConverter->supportsColumn('0123456')->willReturn(false);
+        $fieldConverter->supportsColumn('1234567')->willReturn(false);
+        $fieldConverter->supportsColumn('12.33')->willReturn(false);
         $fieldConverter->supportsColumn('price')->willReturn(false);
         $fieldConverter->supportsColumn('X_SELL-groups')->willReturn(true);
         $fieldConverter->supportsColumn('X_SELL-products')->willReturn(true);
@@ -297,7 +322,11 @@ class ProductSpec extends ObjectBehavior
             'name'                   => 'Sony SRS-BTV25',
             'release_date-ecommerce' => '2011-08-21',
             'release_date-print'     => '2011-07-15',
-            'price'                  => '15 EUR, 10 USD'
+            'price'                  => '15 EUR, 10 USD',
+            123456 => 'numerical as field code',
+            '0123456' => 'numerical with trailing zero as field code',
+            '12.33' => 'string float as field code',
+            '1234567' => 'numerical as field code',
         ];
 
         $standardProductValues = [


### PR DESCRIPTION
In this PR: 

I fixed the following error : When user import a product with a numeric only attribute name, we have a fatal error with the following message: `preg_match(): #2 ($subject) must be of type string, int given.`

**Why we didn't have this error message in product import ?** 
Because src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/Product.php doesn't have `declare(strict_types=1);` so the cast is automatically done by PHP.

Current PHPStan level is 2 on enrichment, only level 5 can catch this error. 

Instead of removing the `declare(strict_types=1);` i manually casted the variable