### PR TITLE
PLG-822 fix (Data quality insights) Key indicator component must be ready when key product_models is missing.

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetKeyIndicators.php
@@ -25,7 +25,7 @@ final class GetKeyIndicators implements GetKeyIndicatorsInterface
     public function __construct(
         private GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery,
         private GetProductKeyIndicatorsQueryInterface $getProductModelKeyIndicatorsQuery,
-        string... $keyIndicators
+        string ...$keyIndicators
     ) {
         $this->keyIndicatorCodes = array_map(static fn ($keyIndicator) => new KeyIndicatorCode($keyIndicator), $keyIndicators);
     }
@@ -54,6 +54,13 @@ final class GetKeyIndicators implements GetKeyIndicatorsInterface
     private function formatKeyIndicators(array $productKeyIndicators, array $productModelKeyIndicators): array
     {
         $formattedKeyIndicators = [];
+        foreach ($this->keyIndicatorCodes as $code) {
+            $formattedKeyIndicators[(string)$code] = [
+                'products' => ['totalGood' => 0, 'totalToImprove' => 0],
+                'product_models' => ['totalGood' => 0, 'totalToImprove' => 0]
+            ];
+        };
+
         foreach ($productKeyIndicators as $productKeyIndicator) {
             Assert::isInstanceOf($productKeyIndicator, KeyIndicator::class);
             $formattedKeyIndicators[(string)$productKeyIndicator->getCode()]['products'] = [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/KeyIndicator.php
@@ -56,8 +56,8 @@ final class KeyIndicator
     public function toArray(): array
     {
         return [
-            'totalGood' => $this->totalGood,
-            'totalToImprove' => $this->totalToImprove,
+            'totalGood' => $this->totalGood ?? 0,
+            'totalToImprove' => $this->totalToImprove ?? 0,
             'extraData' => $this->extraData,
         ];
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/KeyIndicators/KeyIndicatorAboutProducts.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/KeyIndicators/KeyIndicatorAboutProducts.tsx
@@ -10,7 +10,8 @@ import {
   computePercent,
   IntegerPercent,
   KeyIndicatorProducts,
-} from '../../../../domain';
+  makeCounts,
+} from '@akeneo-pim-community/data-quality-insights/src/domain';
 import {useGetKeyIndicatorTips} from '../../../../infrastructure/hooks/Dashboard/UseKeyIndicatorTips';
 import {useDashboardContext} from '../../../context/DashboardContext';
 import {ProductsKeyIndicatorLinkCallback} from '../../../user-actions';
@@ -19,6 +20,8 @@ import {ProductMessageBuilder} from './ProductMessageBuilder';
 import {KeyIndicatorNoData} from './KeyIndicatorNoData';
 import {TextWithLink, Text} from './styled';
 import {KeyIndicatorBase} from './KeyIndicatorBase';
+
+const defaultCounts = makeCounts();
 
 type Props = {
   type: KeyIndicatorProducts;
@@ -62,7 +65,9 @@ export const KeyIndicatorAboutProducts: FC<Props> = ({children, type, counts, ti
   let percentOK: IntegerPercent;
   let entitiesToWorkOn: JSX.Element;
 
-  percentOK = computePercent(counts.products.totalGood, counts.products.totalToImprove);
+  const {products: {totalGood, totalToImprove} = defaultCounts} = counts;
+
+  percentOK = computePercent(totalGood, totalToImprove);
 
   entitiesToWorkOn = (
     <ProductMessageBuilder

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/KeyIndicators/ProductMessageBuilder.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/KeyIndicators/ProductMessageBuilder.tsx
@@ -3,6 +3,9 @@ import {useTranslate} from '@akeneo-pim-community/shared';
 import {CountsByProductType} from '../../../../domain';
 import {roughCount} from '../../../helper/Dashboard/KeyIndicator';
 import {MarkersMapping, messageBuilder} from './messageBuilder';
+import {makeCounts} from '@akeneo-pim-community/data-quality-insights/src/domain';
+
+const defaultCounts = makeCounts();
 
 interface Props {
   counts: CountsByProductType;
@@ -16,8 +19,8 @@ export const ProductMessageBuilder = (props: Props) => {
   const translate = useTranslate();
 
   const {
-    products: {totalToImprove: nbProductsKO},
-    product_models: {totalToImprove: nbProductModelsKO},
+    products: {totalToImprove: nbProductsKO} = defaultCounts,
+    product_models: {totalToImprove: nbProductModelsKO} = defaultCounts,
   } = counts;
 
   if (nbProductsKO === 0 && nbProductModelsKO === 0) {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/QualityScoreEvolutionSection/QualityScoreEvolutionSection.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/Dashboard/QualityScoreEvolutionSection/QualityScoreEvolutionSection.tsx
@@ -29,7 +29,7 @@ const QualityScoreEvolutionSection: FC<Props> = ({categoryCode, familyCode, chan
   const [chart, setChart] = useState<ReactElement | null>(null);
 
   useEffect(() => {
-    if (dataset === null) {
+    if (dataset === null || Object.keys(dataset.data).length === 0) {
       return;
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/domain/KeyIndicator.ts
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/domain/KeyIndicator.ts
@@ -10,7 +10,7 @@ export const makeCounts = (): Counts => ({
 });
 
 export type CountsByProductType = {
-  [entitityKind in 'products' | 'product_models']: Counts;
+  [entitityKind in 'products' | 'product_models']?: Counts;
 };
 
 export const makeCountsByProductType = (): CountsByProductType => ({
@@ -18,10 +18,11 @@ export const makeCountsByProductType = (): CountsByProductType => ({
   product_models: makeCounts(),
 });
 
-export const areCountsZero = ({totalGood, totalToImprove}: Counts): boolean => totalGood === 0 && totalToImprove === 0;
+export const areCountsZero = (counts?: Counts): boolean =>
+  !!counts && counts.totalGood === 0 && counts.totalToImprove === 0;
 
 export const isCountsByProductType = (c: CountsByProductType | Counts): c is CountsByProductType => {
-  return c.hasOwnProperty('products') && c.hasOwnProperty('product_models');
+  return c.hasOwnProperty('products') || c.hasOwnProperty('product_models');
 };
 
 export const areAllCountsZero = (c: CountsByProductType | Counts): boolean => {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetKeyIndicatorsSpec.php
@@ -50,10 +50,10 @@ final class GetKeyIndicatorsSpec extends ObjectBehavior
                     'totalToImprove' => 60,
                 ],
                 'product_models' =>
-                    [
-                        'totalGood' => 23,
-                        'totalToImprove' => 52,
-                    ]
+                [
+                    'totalGood' => 23,
+                    'totalToImprove' => 52,
+                ]
             ],
             'has_image' => [
                 'products' => [
@@ -61,10 +61,10 @@ final class GetKeyIndicatorsSpec extends ObjectBehavior
                     'totalToImprove' => 26,
                 ],
                 'product_models' =>
-                    [
-                        'totalGood' => 24,
-                        'totalToImprove' => 89,
-                    ]
+                [
+                    'totalGood' => 24,
+                    'totalToImprove' => 89,
+                ]
             ]
         ]);
     }
@@ -94,11 +94,22 @@ final class GetKeyIndicatorsSpec extends ObjectBehavior
                     'totalToImprove' => 60,
                 ],
                 'product_models' =>
-                    [
-                        'totalGood' => 30,
-                        'totalToImprove' => 40,
-                    ]
+                [
+                    'totalGood' => 30,
+                    'totalToImprove' => 40,
+                ]
             ],
+            'has_image' => [
+                'products' => [
+                    'totalGood' => 0,
+                    'totalToImprove' => 0,
+                ],
+                'product_models' =>
+                [
+                    'totalGood' => 0,
+                    'totalToImprove' => 0,
+                ]
+            ]
         ]);
     }
 
@@ -129,10 +140,10 @@ final class GetKeyIndicatorsSpec extends ObjectBehavior
                     'totalToImprove' => 60,
                 ],
                 'product_models' =>
-                    [
-                        'totalGood' => 45,
-                        'totalToImprove' => 65,
-                    ]
+                [
+                    'totalGood' => 45,
+                    'totalToImprove' => 65,
+                ]
             ],
             'has_image' => [
                 'products' => [
@@ -140,10 +151,10 @@ final class GetKeyIndicatorsSpec extends ObjectBehavior
                     'totalToImprove' => 0,
                 ],
                 'product_models' =>
-                    [
-                        'totalGood' => 0,
-                        'totalToImprove' => 0,
-                    ]
+                [
+                    'totalGood' => 0,
+                    'totalToImprove' => 0,
+                ]
             ]
         ]);
     }


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

Key indicator component crashed when backend service missed product_models key in the response (meaning nothing was returned by ES query).
Front is now ready for this.

**Definition Of Done (for Core Developer only)**

- [ ] PM Validation (Story)

