### PR TITLE
PIM-10364: Fix broken permissions on Associations with Quantity

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - CPM-562 Fix product grid loading when attribute as image has a numeric code
+- PIM-10364: Fix broken permissions on Associations with Quantity
 
 # 5.0.86 (2022-03-17)
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
@@ -136,7 +136,7 @@ const QuantifiedAssociationRow = ({
       ...row,
       quantifiedLink: {...row.quantifiedLink, quantity: limitedValue},
     });
-  }
+  };
 
   return (
     <>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, {ChangeEvent} from 'react';
 import styled, {css} from 'styled-components';
-import {useTranslate, useRoute} from '@akeneo-pim-community/legacy-bridge';
+import {useTranslate, useRoute, useSecurity} from '@akeneo-pim-community/legacy-bridge';
 import {filterErrors, InputErrors} from '@akeneo-pim-community/shared';
 import {BrokenLinkIcon, EditIcon, CloseIcon, useTheme} from 'akeneo-design-system';
 import {ProductType, Row, QuantifiedLink, MAX_QUANTITY} from '../models';
@@ -118,10 +118,25 @@ const QuantifiedAssociationRow = ({
   onRemove,
 }: QuantifiedAssociationRowProps) => {
   const translate = useTranslate();
+  const {isGranted} = useSecurity();
   const isProductModel = ProductType.ProductModel === row.productType;
   const productEditUrl = useRoute(`pim_enrich_${row.productType}_edit`, {id: row.product?.id.toString() || ''});
   const thumbnailUrl = useProductThumbnail(row.product);
   const blueColor = useTheme().color.blue100;
+  const canRemoveAssociation = isGranted('pim_enrich_associations_remove') && undefined === parentQuantifiedLink;
+  const canUpdateQuantity = isGranted('pim_enrich_associations_edit') && isGranted('pim_enrich_associations_remove');
+
+  const handleQuantityChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!canUpdateQuantity) return;
+
+    const numberValue = Number(event.currentTarget.value) || 1;
+    const limitedValue = numberValue > MAX_QUANTITY ? row.quantifiedLink.quantity : numberValue;
+
+    onChange({
+      ...row,
+      quantifiedLink: {...row.quantifiedLink, quantity: limitedValue},
+    });
+  }
 
   return (
     <>
@@ -189,15 +204,8 @@ const QuantifiedAssociationRow = ({
               max={MAX_QUANTITY}
               value={row.quantifiedLink.quantity}
               isInvalid={0 < filterErrors(row.errors, 'quantity').length}
-              onChange={event => {
-                const numberValue = Number(event.currentTarget.value) || 1;
-                const limitedValue = numberValue > MAX_QUANTITY ? row.quantifiedLink.quantity : numberValue;
-
-                onChange({
-                  ...row,
-                  quantifiedLink: {...row.quantifiedLink, quantity: limitedValue},
-                });
-              }}
+              disabled={!canUpdateQuantity}
+              onChange={handleQuantityChange}
             />
           </InputCellContainer>
           <InputErrors errors={row.errors} />
@@ -220,7 +228,7 @@ const QuantifiedAssociationRow = ({
                     </a>
                   </RowAction>
                 )}
-                {undefined === parentQuantifiedLink && (
+                {canRemoveAssociation && (
                   <RowAction onClick={() => onRemove(row)}>
                     <CloseIcon title={translate('pim_enrich.entity.product.module.associations.remove')} size={20} />
                   </RowAction>
@@ -232,7 +240,7 @@ const QuantifiedAssociationRow = ({
           <Cell>
             <ActionCellContainer>
               <RowActions>
-                {undefined === parentQuantifiedLink && (
+                {canRemoveAssociation && (
                   <RowAction onClick={() => onRemove(row)}>
                     <CloseIcon title={translate('pim_enrich.entity.product.module.associations.remove')} size={20} />
                   </RowAction>

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
@@ -1,6 +1,6 @@
 import React, {useState, useEffect, useCallback} from 'react';
 import styled from 'styled-components';
-import {useTranslate, useNotify, NotificationLevel} from '@akeneo-pim-community/legacy-bridge';
+import {useTranslate, useNotify, useSecurity, NotificationLevel} from '@akeneo-pim-community/legacy-bridge';
 import {BrokenLinkIcon, AssociationTypesIllustration, Helper, Button} from 'akeneo-design-system';
 import {
   SearchBar,
@@ -79,6 +79,7 @@ const QuantifiedAssociations = ({
 }: QuantifiedAssociationsProps) => {
   const translate = useTranslate();
   const notify = useNotify();
+  const {isGranted} = useSecurity();
   const [rowCollection, setRowCollection] = useState<Row[]>(
     quantifiedAssociationToRowCollection(quantifiedAssociations, errors)
   );
@@ -94,7 +95,7 @@ const QuantifiedAssociations = ({
     rowCollectionToQuantifiedAssociation(rowCollection)
   );
   const filteredCollectionWithProducts = collectionWithProducts.filter(filterOnLabelOrIdentifier(searchValue));
-
+  const canAddAssociation = isGranted('pim_enrich_associations_edit');
   useEffect(() => {
     formatParameters(getErrorsForPath(errors, '')).forEach(error =>
       notify(NotificationLevel.ERROR, translate(error.messageTemplate, error.parameters, error.plural))
@@ -156,7 +157,7 @@ const QuantifiedAssociations = ({
         searchValue={searchValue}
         onSearchChange={setSearchValue}
       />
-      {!isCompact && (
+      {!isCompact && canAddAssociation && (
         <Buttons>
           <Button level="secondary" onClick={handleAdd}>
             {translate('pim_enrich.entity.product.module.associations.add_associations')}

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {fireEvent} from '@testing-library/react';
+import {screen, fireEvent} from '@testing-library/react';
 import {QuantifiedAssociationRow} from '../../../../Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow';
 import {Product, ProductType} from '../../../../Resources/public/js/product/form/quantified-associations/models';
 import {renderWithProviders} from '@akeneo-pim-community/shared/tests/front/unit/utils';
@@ -26,6 +26,17 @@ const productModel: Product = {
     totalChildren: 2,
   },
 };
+
+let mockedGrantedAcl: string[] = [];
+jest.mock('@akeneo-pim-community/legacy-bridge/src/hooks/useSecurity', () => ({
+  useSecurity: () => ({
+    isGranted: (acl: string) => mockedGrantedAcl.includes(acl),
+  }),
+}));
+
+beforeEach(() => {
+  mockedGrantedAcl = ['pim_enrich_associations_remove', 'pim_enrich_associations_edit'];
+});
 
 test('It displays a quantified association row for a product', () => {
   const onChange = jest.fn();
@@ -200,4 +211,59 @@ test('It triggers the onRemove event when the remove button is clicked in compac
 
   expect(onChange).not.toBeCalled();
   expect(onRemove).toBeCalled();
+});
+
+test('It cannot remove an association when user did not have the ACL', () => {
+  mockedGrantedAcl = ['pim_enrich_associations_edit'];
+
+  renderWithProviders(
+    <table>
+      <tbody>
+      <QuantifiedAssociationRow
+        row={{
+          productType: ProductType.ProductModel,
+          quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+          product: productModel,
+          errors: [],
+        }}
+        isCompact={true}
+        parentQuantifiedLink={undefined}
+        onChange={jest.fn()}
+        onRemove={jest.fn()}
+      />
+      </tbody>
+    </table>
+  );
+
+  const removeButton = screen.queryByTitle('pim_enrich.entity.product.module.associations.remove');
+  expect(removeButton).not.toBeInTheDocument();
+});
+
+test('It cannot update the quantity of an association when user did not have the ACL', () => {
+  mockedGrantedAcl = [];
+  const handleChange = jest.fn();
+
+  renderWithProviders(
+    <table>
+      <tbody>
+      <QuantifiedAssociationRow
+        row={{
+          productType: ProductType.ProductModel,
+          quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+          product: productModel,
+          errors: [],
+        }}
+        isCompact={true}
+        parentQuantifiedLink={undefined}
+        onChange={handleChange}
+        onRemove={jest.fn()}
+      />
+      </tbody>
+    </table>
+  );
+
+  const quantityInput = screen.getByTitle('pim_enrich.entity.product.module.associations.quantified.quantity');
+  fireEvent.change(quantityInput, {target: {value: '16'}});
+
+  expect(handleChange).not.toBeCalled();
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
@@ -219,18 +219,18 @@ test('It cannot remove an association when user did not have the ACL', () => {
   renderWithProviders(
     <table>
       <tbody>
-      <QuantifiedAssociationRow
-        row={{
-          productType: ProductType.ProductModel,
-          quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
-          product: productModel,
-          errors: [],
-        }}
-        isCompact={true}
-        parentQuantifiedLink={undefined}
-        onChange={jest.fn()}
-        onRemove={jest.fn()}
-      />
+        <QuantifiedAssociationRow
+          row={{
+            productType: ProductType.ProductModel,
+            quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+            product: productModel,
+            errors: [],
+          }}
+          isCompact={true}
+          parentQuantifiedLink={undefined}
+          onChange={jest.fn()}
+          onRemove={jest.fn()}
+        />
       </tbody>
     </table>
   );
@@ -246,18 +246,18 @@ test('It cannot update the quantity of an association when user did not have the
   renderWithProviders(
     <table>
       <tbody>
-      <QuantifiedAssociationRow
-        row={{
-          productType: ProductType.ProductModel,
-          quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
-          product: productModel,
-          errors: [],
-        }}
-        isCompact={true}
-        parentQuantifiedLink={undefined}
-        onChange={handleChange}
-        onRemove={jest.fn()}
-      />
+        <QuantifiedAssociationRow
+          row={{
+            productType: ProductType.ProductModel,
+            quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+            product: productModel,
+            errors: [],
+          }}
+          isCompact={true}
+          parentQuantifiedLink={undefined}
+          onChange={handleChange}
+          onRemove={jest.fn()}
+        />
       </tbody>
     </table>
   );


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Now permission are take into account when user cannot add or remove an association
![Screenshot from 2022-03-21 18-04-24](https://user-images.githubusercontent.com/7239572/159325945-2f101a59-6f56-4648-9cb1-99096fa0fe57.png)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
