### PR TITLE
PIM-10346: Fix spellcheck badge not displayed on attribute options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PIM-10295: Fixed product categories disappearing on adjacent tab locale switch
 - PIM-10330: Fix wrong error message while importing boolean attribute value
 - PIM-10331: Fix error when using an association with quantities having an numeric code
+- PIM-10346: Fix spellcheck badge not displayed on attribute options
 - PIM-10336: Fix product Export edition in error if no locale selected
 
 ## Improvements

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/AttributeOptionsContextProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/public/js/attribute-option/contexts/AttributeOptionsContextProvider.tsx
@@ -50,7 +50,7 @@ const mergeAttributeOptionsEvaluation = (
 
   Object.entries(evaluation.options).forEach(([optionCode, optionEvaluation]) => {
     const optionIndex = attributeOptions.findIndex(
-      (attributeOption: AttributeOption) => attributeOption.code === optionCode
+      (attributeOption: AttributeOption) => attributeOption.code.toLowerCase() === optionCode.toLowerCase()
     );
     const attributeOptionToUpdate: AttributeOption | null = attributeOptions[optionIndex] ?? null;
     if (attributeOptionToUpdate) {


### PR DESCRIPTION
In a previous bug, labels of attribute options have been persisted in the spellcheck evaluations instead of their code. This bug has been fixed since, but the spellcheck evaluations have not been well cleaned. It remains some codes with different sensitive case.

This will be fixed by a new cleaning (command launched from CRON in EE) https://github.com/akeneo/pim-enterprise-dev/pull/13255

I didn't find any test on `AttributeOptionsContextProvider.tsx` and I think that it would be too complex and heavy to do it for a SLA