### PR TITLE
PIM-10362: Fix attribute type "number" gets modified in history when import with same value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PIM-10336: Fix product Export edition in error if no locale selected
 - PIM-10345: Fix issue when importing product model with an attribute constituted of only digits
 - PIM-10334: Fix error on the clean-removed-attributes
+- PIM-10362: Fix attribute type "number" gets modified in history when import with same value
 
 ## Improvements
 - PIM-10293: add batch-size option to pim:completness:calculate command

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
@@ -77,9 +77,7 @@ class ValueNormalizer implements NormalizerInterface, NormalizerAwareInterface, 
             if ('metric' === $backendType) {
                 $result[$fieldName . '-unit'] = '';
             }
-        } elseif (is_int($data)) {
-            $result = [$fieldName => (string) $data];
-        } elseif (is_float($data) || 'decimal' === $attribute->getBackendType()) {
+        } elseif (is_int($data) || is_float($data) || 'decimal' === $attribute->getBackendType()) {
             $pattern = $attribute->isDecimalsAllowed() ? sprintf('%%.%sF', $this->precision) : '%d';
             $result = [$fieldName => sprintf($pattern, $data)];
         } elseif (is_string($data)) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Versioning/Product/ValueNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/Versioning/Product/ValueNormalizerSpec.php
@@ -66,7 +66,29 @@ class ValueNormalizerSpec extends ObjectBehavior
         $this->normalize($value, 'flat', [])->shouldReturn(['simple' => '']);
     }
 
-    function it_normalizes_a_value_with_a_integer_data(
+    function it_normalizes_a_value_with_a_integer_data_with_decimals_allowed(
+        NumberLocalizer $numberLocalizer,
+        ValueInterface $value,
+        AttributeInterface $simpleAttribute,
+        $attributeRepository
+    ) {
+        $simpleAttribute->getType()->willReturn(AttributeTypes::NUMBER);
+        $simpleAttribute->isDecimalsAllowed()->willReturn(true);
+        $context = ['decimal_separator' => '.'];
+        $numberLocalizer->localize('12', $context)->willReturn(12);
+
+        $value->getData()->willReturn(12);
+        $value->getAttributeCode()->willReturn('simple');
+        $value->isLocalizable()->willReturn(false);
+        $value->isScopable()->willReturn(false);
+
+        $attributeRepository->findOneByIdentifier('simple')->willReturn($simpleAttribute);
+        $simpleAttribute->isLocaleSpecific()->willReturn(false);
+        $simpleAttribute->getBackendType()->willReturn('decimal');
+        $this->normalize($value, 'flat', $context)->shouldReturn(['simple' => '12.0000']);
+    }
+
+    function it_normalizes_a_value_with_a_integer_data_with_decimals_not_allowed(
         NumberLocalizer $numberLocalizer,
         ValueInterface $value,
         AttributeInterface $simpleAttribute,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When importing a "number" attribute through XLS, it was cast to an int and we don't normalize it as a float because we never check the attribute configuration.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
