### PR TITLE
CXP-1124: Refresh the name & logo of a Connected App when different

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RefreshConnectedAppCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RefreshConnectedAppCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Apps\Command;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RefreshConnectedAppCommand
+{
+    private string $appId;
+
+    public function __construct(string $appId)
+    {
+        $this->appId = $appId;
+    }
+
+    public function getAppId(): string
+    {
+        return $this->appId;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RefreshConnectedAppHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/RefreshConnectedAppHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Apps\Command;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\FindOneConnectedAppByIdQueryInterface;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\UpdateConnectedAppDescriptionQueryInterface;
+use Akeneo\Connectivity\Connection\Domain\Marketplace\GetAppQueryInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RefreshConnectedAppHandler
+{
+    public function __construct(
+        private UpdateConnectedAppDescriptionQueryInterface $updateConnectedAppDescriptionQuery,
+        private FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+        private GetAppQueryInterface $getAppQuery
+    ) {
+    }
+
+    public function handle(RefreshConnectedAppCommand $command): void
+    {
+        $connectedApp = $this->findOneConnectedAppByIdQuery->execute($command->getAppId());
+        if (null === $connectedApp) {
+            throw new \LogicException('Cannot refresh a non-exisiting connected app');
+        }
+
+        $app = $this->getAppQuery->execute($command->getAppId());
+        if (null === $app) {
+            throw new \LogicException('Cannot refresh a non-exisiting app');
+        }
+
+        $updatedConnectedApp = $connectedApp->withUpdatedDescription(
+            $app->getName(),
+            $app->getLogo(),
+            $app->getAuthor(),
+            $app->getCategories(),
+            $app->isCertified(),
+            $app->getPartner(),
+        );
+
+        $this->updateConnectedAppDescriptionQuery->execute($updatedConnectedApp);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -132,14 +132,18 @@ final class ConnectedApp
         bool $certified = false,
         ?string $partner = null,
     ): self {
-        $self = clone $this;
-        $self->name = $name;
-        $self->logo = $logo;
-        $self->author = $author;
-        $self->categories = $categories;
-        $self->certified = $certified;
-        $self->partner = $partner;
-
-        return $self;
+        return new self(
+            $this->id,
+            $name,
+            $this->scopes,
+            $this->connectionCode,
+            $logo,
+            $author,
+            $this->userGroupName,
+            $categories,
+            $certified,
+            $partner,
+            $this->isTestApp,
+        );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -121,6 +121,9 @@ final class ConnectedApp
         ];
     }
 
+    /**
+     * @param array<string> $categories
+     */
     public function withUpdatedDescription(
         string $name,
         ?string $logo,

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Model/ConnectedApp.php
@@ -120,4 +120,23 @@ final class ConnectedApp
             'is_test_app' => $this->isTestApp,
         ];
     }
+
+    public function withUpdatedDescription(
+        string $name,
+        ?string $logo,
+        ?string $author,
+        array $categories = [],
+        bool $certified = false,
+        ?string $partner = null,
+    ): self {
+        $self = clone $this;
+        $self->name = $name;
+        $self->logo = $logo;
+        $self->author = $author;
+        $self->categories = $categories;
+        $self->certified = $certified;
+        $self->partner = $partner;
+
+        return $self;
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/UpdateConnectedAppDescriptionQueryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/UpdateConnectedAppDescriptionQueryInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Domain\Apps\Persistence;

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/UpdateConnectedAppDescriptionQueryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/UpdateConnectedAppDescriptionQueryInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Domain\Apps\Persistence;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Model\ConnectedApp;
+
+interface UpdateConnectedAppDescriptionQueryInterface
+{
+    public function execute(ConnectedApp $app): void;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/RefreshConnectedAppAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/RefreshConnectedAppAction.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Internal;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppHandler;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\FindOneConnectedAppByConnectionCodeQueryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RefreshConnectedAppAction
+{
+    public function __construct(
+        private FindOneConnectedAppByConnectionCodeQueryInterface $findOneConnectedAppByConnectionCodeQuery,
+        private RefreshConnectedAppHandler $refreshConnectedAppHandler,
+    ) {
+    }
+
+    public function __invoke(Request $request, string $connectionCode): Response
+    {
+        if (!$request->isXmlHttpRequest()) {
+            return new RedirectResponse('/');
+        }
+
+        $connectedApp = $this->findOneConnectedAppByConnectionCodeQuery->execute($connectionCode);
+
+        if (null === $connectedApp) {
+            throw new NotFoundHttpException("Connected app with connection code $connectionCode does not exist.");
+        }
+
+        $this->refreshConnectedAppHandler->handle(new RefreshConnectedAppCommand($connectedApp->getId()));
+
+        return new Response(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/UpdateConnectedAppDescriptionQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/UpdateConnectedAppDescriptionQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Model\ConnectedApp;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\UpdateConnectedAppDescriptionQueryInterface;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class UpdateConnectedAppDescriptionQuery implements UpdateConnectedAppDescriptionQueryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function execute(ConnectedApp $app): void
+    {
+        $query = <<<SQL
+        UPDATE akeneo_connectivity_connected_app
+        SET
+            name = :name,
+            logo = :logo,
+            author = :author,
+            categories = :categories,
+            certified = :certified,
+            partner = :partner
+        WHERE id = :id
+        SQL;
+
+        $this->connection->executeQuery(
+            $query,
+            [
+                'id' => $app->getId(),
+                'name' => $app->getName(),
+                'logo' => $app->getLogo(),
+                'author' => $app->getAuthor(),
+                'categories' => $app->getCategories(),
+                'certified' => $app->isCertified(),
+                'partner' => $app->getPartner(),
+            ],
+            [
+                'categories' => Types::JSON,
+                'certified' => Types::BOOLEAN,
+            ]
+        );
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/controllers.yml
@@ -92,6 +92,12 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry'
 
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Internal\RefreshConnectedAppAction:
+        public: true
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByConnectionCodeQuery'
+            - '@Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppHandler'
+
     ## PUBLIC
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public\AuthorizeAction:
         public: true

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
@@ -48,3 +48,9 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\User\Internal\DeleteUserGroup'
             - '@Akeneo\Connectivity\Connection\Infrastructure\User\Internal\DeleteUserRole'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\SaveRevokedAccessTokensOfDisconnectedAppQuery'
+
+    Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppHandler:
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\UpdateConnectedAppDescriptionQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByIdQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Marketplace\Persistence\GetAppQuery'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/queries.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/queries.yml
@@ -63,3 +63,7 @@ services:
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\IsAccessTokenRevokedQuery:
         arguments:
             - '@database_connection'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\UpdateConnectedAppDescriptionQuery:
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/routing.yml
@@ -47,3 +47,8 @@ akeneo_connectivity_connection_apps_rest_update_connected_app_monitoring_setting
     path: '/connected-apps/{connectionCode}/monitoring-settings'
     controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Internal\UpdateConnectedAppMonitoringSettingsAction
     methods: [POST]
+
+akeneo_connectivity_connection_apps_rest_refresh:
+    path: '/connected-apps/{connectionCode}/refresh'
+    controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Internal\RefreshConnectedAppAction
+    methods: [POST]

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/RefreshConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/RefreshConnectedAppActionEndToEnd.php
@@ -41,7 +41,7 @@ class RefreshConnectedAppActionEndToEnd extends WebTestCase
         return $this->catalog->useMinimalCatalog();
     }
 
-    public function test_it_refresh_a_connected_app(): void
+    public function test_it_refreshes_a_connected_app(): void
     {
         $this->featureFlagMarketplaceActivate->enable();
         $this->authenticateAsAdmin();

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/RefreshConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/RefreshConnectedAppActionEndToEnd.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\EndToEnd\Apps\Internal;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApi;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeWebMarketplaceApi;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RefreshConnectedAppActionEndToEnd extends WebTestCase
+{
+    private FakeFeatureFlag $featureFlagMarketplaceActivate;
+    private ConnectedAppLoader $connectedAppLoader;
+    private FakeWebMarketplaceApi $webMarketplaceApi;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->featureFlagMarketplaceActivate = $this->get(
+            'akeneo_connectivity.connection.marketplace_activate.feature'
+        );
+        $this->connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
+        $this->userGroupLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.user_group_loader');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+        $this->webMarketplaceApi = $this->get(WebMarketplaceApi::class);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_refresh_a_connected_app(): void
+    {
+        $this->featureFlagMarketplaceActivate->enable();
+        $this->authenticateAsAdmin();
+
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens(
+            '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+            'magento',
+        );
+
+        $this->webMarketplaceApi->setApps([
+            [
+                'id' => '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+                'name' => 'Akeneo Shopware 6 Connector by EIKONA Media',
+                'logo' => 'https://marketplace.akeneo.com/sites/default/files/styles/extension_logo_large/public/extension-logos/akeneo-to-shopware6-eimed_0.jpg?itok=InguS-1N',
+                'author' => 'EIKONA Media GmbH',
+                'partner' => 'Akeneo Preferred Partner',
+                'description' => 'With the new "Akeneo-Shopware-6-Connector" from EIKONA Media, you can smoothly export all your product data from Akeneo to Shopware. The connector uses the standard interfaces provided for data exchange. Benefit from up-to-date product data in all your e-commerce channels and be faster on the market.',
+                'url' => 'https://marketplace.akeneo.com/extension/akeneo-shopware-6-connector-eikona-media',
+                'categories' => [
+                    'E-commerce',
+                ],
+                'certified' => false,
+                'activate_url' => 'http://shopware.example.com/activate',
+                'callback_url' => 'http://shopware.example.com/callback',
+            ],
+        ]);
+
+        $this->client->request(
+            'POST',
+            '/rest/apps/connected-apps/magento/refresh',
+            [],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+                'CONTENT_TYPE' => 'application/json',
+            ]
+        );
+
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
@@ -41,7 +41,7 @@ class RefreshConnectedAppHandlerIntegration extends TestCase
         return $this->catalog->useMinimalCatalog();
     }
 
-    public function test_it_refresh_a_connected_app(): void
+    public function test_it_refreshes_a_connected_app(): void
     {
         $this->connectedAppLoader->createConnectedAppWithUserAndTokens(
             '2677e764-f852-4956-bf9b-1a1ec1b0d145',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Command;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\RefreshConnectedAppHandler;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByIdQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApi;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeWebMarketplaceApi;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RefreshConnectedAppHandlerIntegration extends TestCase
+{
+    private ConnectedAppLoader $connectedAppLoader;
+    private RefreshConnectedAppHandler $refreshConnectedAppHandler;
+    private FindOneConnectedAppByIdQuery $findOneConnectedAppByIdQuery;
+    private FakeWebMarketplaceApi $webMarketplaceApi;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->get('database_connection');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+        $this->refreshConnectedAppHandler = $this->get(RefreshConnectedAppHandler::class);
+        $this->findOneConnectedAppByIdQuery = $this->get(FindOneConnectedAppByIdQuery::class);
+        $this->webMarketplaceApi = $this->get(WebMarketplaceApi::class);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_refresh_a_connected_app(): void
+    {
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens(
+            '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+            'magento',
+        );
+        $this->webMarketplaceApi->setApps([
+            [
+                'id' => '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+                'name' => 'MAGENTO',
+                'logo' => 'http://example.com/LOGO.png',
+                'author' => 'AKENEO',
+                'partner' => 'AKENEO',
+                'description' => '',
+                'url' => '',
+                'categories' => [
+                    'ECOMMERCE',
+                ],
+                'certified' => true,
+                'activate_url' => 'http://example.com/activate',
+                'callback_url' => 'http://example.com/callback',
+            ],
+        ]);
+
+        $this->assertConnectedAppHasValues('2677e764-f852-4956-bf9b-1a1ec1b0d145', [
+            'name' => 'magento',
+            'logo' => 'http://example.com/logo.png',
+            'author' => 'Akeneo',
+            'categories' => ['ecommerce'],
+            'certified' => false,
+            'partner' => null,
+        ]);
+
+        $this->refreshConnectedApp('2677e764-f852-4956-bf9b-1a1ec1b0d145');
+
+        $this->assertConnectedAppHasValues('2677e764-f852-4956-bf9b-1a1ec1b0d145', [
+            'name' => 'MAGENTO',
+            'logo' => 'http://example.com/LOGO.png',
+            'author' => 'AKENEO',
+            'categories' => ['ECOMMERCE'],
+            'certified' => true,
+            'partner' => 'AKENEO',
+        ]);
+    }
+
+    private function refreshConnectedApp($id): void
+    {
+        $this->refreshConnectedAppHandler->handle(new RefreshConnectedAppCommand($id));
+    }
+
+    private function assertConnectedAppHasValues($id, array $expected): void
+    {
+        $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
+        $normalizedConnectedApp = $connectedApp->normalize();
+        $actual = array_combine(array_keys($expected), array_intersect_key($normalizedConnectedApp, $expected));
+
+        Assert::assertSame($expected, $actual);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/RefreshConnectedAppHandlerIntegration.php
@@ -95,7 +95,7 @@ class RefreshConnectedAppHandlerIntegration extends TestCase
     {
         $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
         $normalizedConnectedApp = $connectedApp->normalize();
-        $actual = array_combine(array_keys($expected), array_intersect_key($normalizedConnectedApp, $expected));
+        $actual = \array_combine(\array_keys($expected), \array_intersect_key($normalizedConnectedApp, $expected));
 
         Assert::assertSame($expected, $actual);
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/UpdateConnectedAppDescriptionQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/UpdateConnectedAppDescriptionQueryIntegration.php
@@ -90,7 +90,7 @@ class UpdateConnectedAppDescriptionQueryIntegration extends TestCase
     {
         $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
         $normalizedConnectedApp = $connectedApp->normalize();
-        $actual = array_combine(array_keys($expected), array_intersect_key($normalizedConnectedApp, $expected));
+        $actual = \array_combine(\array_keys($expected), \array_intersect_key($normalizedConnectedApp, $expected));
 
         Assert::assertSame($expected, $actual);
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/UpdateConnectedAppDescriptionQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/UpdateConnectedAppDescriptionQueryIntegration.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByIdQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\UpdateConnectedAppDescriptionQuery;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateConnectedAppDescriptionQueryIntegration extends TestCase
+{
+    private ConnectedAppLoader $connectedAppLoader;
+    private UpdateConnectedAppDescriptionQuery $query;
+    private FindOneConnectedAppByIdQuery $findOneConnectedAppByIdQuery;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+        $this->query = $this->get(UpdateConnectedAppDescriptionQuery::class);
+        $this->findOneConnectedAppByIdQuery = $this->get(FindOneConnectedAppByIdQuery::class);
+    }
+
+    public function test_it_updates_the_description_of_a_connected_app()
+    {
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens(
+            '2677e764-f852-4956-bf9b-1a1ec1b0d145',
+            'magento',
+        );
+
+        $this->assertConnectedAppHasValues('2677e764-f852-4956-bf9b-1a1ec1b0d145', [
+            'name' => 'magento',
+            'logo' => 'http://example.com/logo.png',
+            'author' => 'Akeneo',
+            'categories' => ['ecommerce'],
+            'certified' => false,
+            'partner' => null,
+        ]);
+
+        $this->updateConnectedAppDescription('2677e764-f852-4956-bf9b-1a1ec1b0d145', [
+            'name' => 'MAGENTO',
+            'logo' => 'http://example.com/LOGO.png',
+            'author' => 'AKENEO',
+            'categories' => ['ECOMMERCE'],
+            'certified' => true,
+            'partner' => 'AKENEO',
+        ]);
+
+        $this->assertConnectedAppHasValues('2677e764-f852-4956-bf9b-1a1ec1b0d145', [
+            'name' => 'MAGENTO',
+            'logo' => 'http://example.com/LOGO.png',
+            'author' => 'AKENEO',
+            'categories' => ['ECOMMERCE'],
+            'certified' => true,
+            'partner' => 'AKENEO',
+        ]);
+    }
+
+    private function updateConnectedAppDescription($id, $values): void
+    {
+        $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
+
+        $updatedConnectedApp = $connectedApp->withUpdatedDescription(
+            $values['name'],
+            $values['logo'],
+            $values['author'],
+            $values['categories'],
+            $values['certified'],
+            $values['partner'],
+        );
+
+        $this->query->execute($updatedConnectedApp);
+    }
+
+    private function assertConnectedAppHasValues($id, array $expected): void
+    {
+        $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
+        $normalizedConnectedApp = $connectedApp->normalize();
+        $actual = array_combine(array_keys($expected), array_intersect_key($normalizedConnectedApp, $expected));
+
+        Assert::assertSame($expected, $actual);
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
@@ -132,7 +132,7 @@ class ConnectedAppSpec extends ObjectBehavior
         ]);
     }
 
-    public function is_updates_description_properties(): void
+    public function it_updates_description_properties(): void
     {
         $updated = $this->withUpdatedDescription(
             'New Name',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Apps/Model/ConnectedAppSpec.php
@@ -131,4 +131,30 @@ class ConnectedAppSpec extends ObjectBehavior
             'is_test_app' => false,
         ]);
     }
+
+    public function is_updates_description_properties(): void
+    {
+        $updated = $this->withUpdatedDescription(
+            'New Name',
+            'http://example.com/new-logo.png',
+            'New Author',
+            ['new category'],
+            true,
+            'Akeneo Premium Partner',
+        );
+
+        $updated->normalize()->shouldBe([
+            'id' => '4028c158-d620-4903-9859-958b66a059e2',
+            'name' => 'New Name',
+            'scopes' => ['Scope1', 'Scope2'],
+            'connection_code' => 'someConnectionCode',
+            'logo' => 'http://example.com/new-logo.png',
+            'author' => 'New Author',
+            'user_group_name' => 'app_123456abcdef',
+            'categories' => ['new category'],
+            'certified' => true,
+            'partner' => 'Akeneo Premium Partner',
+            'is_test_app' => true,
+        ]);
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-connected-apps.ts
@@ -6,6 +6,23 @@ import {useFetchConnectedApps} from './use-fetch-connected-apps';
 import {useFetchApps} from './use-fetch-apps';
 import {useTranslate} from '../../shared/translate';
 import {useFetchTestApps} from './use-fetch-test-apps';
+import {App} from '../../model/app';
+import {useTriggerConnectedAppRefresh} from './use-trigger-connected-app-refresh';
+
+const hashAppSubset = ({name, logo, author, categories, certified, partner}: ConnectedApp | App): string => {
+    return JSON.stringify({
+        name,
+        logo,
+        author,
+        categories,
+        certified,
+        partner,
+    });
+};
+
+const isAppSubsetIdentical = (app: App, connectedApp: ConnectedApp): boolean => {
+    return hashAppSubset(app) === hashAppSubset(connectedApp);
+};
 
 export const useConnectedApps = (): ConnectedApp[] | null | false => {
     const featureFlag = useFeatureFlags();
@@ -14,6 +31,7 @@ export const useConnectedApps = (): ConnectedApp[] | null | false => {
     const fetchConnectedApps = useFetchConnectedApps();
     const fetchApps = useFetchApps();
     const fetchTestApps = useFetchTestApps();
+    const triggerConnectedAppRefresh = useTriggerConnectedAppRefresh();
     const [connectedApps, setConnectedApps] = useState<ConnectedApp[] | null | false>(null);
 
     useEffect(() => {
@@ -62,6 +80,16 @@ export const useConnectedApps = (): ConnectedApp[] | null | false => {
                             activate_url: app?.activate_url || undefined,
                         };
                     });
+                });
+
+                // trigger a refresh when there is an inconsistency between the data in a connected app and the data
+                // in the app store
+                connectedApps.forEach(connectedApp => {
+                    const app = apps.apps.find(app => app.id === connectedApp.id);
+
+                    if (undefined !== app && !isAppSubsetIdentical(app, connectedApp)) {
+                        triggerConnectedAppRefresh(connectedApp.connection_code);
+                    }
                 });
             } catch (e) {
                 return;

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-trigger-connected-app-refresh.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-trigger-connected-app-refresh.ts
@@ -1,0 +1,22 @@
+import {useCallback} from 'react';
+import {useRouter} from '../../shared/router/use-router';
+
+type Callback = (id: string) => Promise<boolean>;
+
+export const useTriggerConnectedAppRefresh = (): Callback => {
+    const router = useRouter();
+
+    return useCallback(
+        async (connectionCode: string): Promise<boolean> => {
+            const url = router('akeneo_connectivity_connection_apps_rest_refresh', {connectionCode: connectionCode});
+
+            const response = await fetch(url, {
+                method: 'POST',
+                headers: [['X-Requested-With', 'XMLHttpRequest']],
+            });
+
+            return response.ok;
+        },
+        [router]
+    );
+};

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
@@ -233,7 +233,7 @@ test('it fetches connected test apps', async () => {
     expect(result.current).toEqual([expectedApp]);
 });
 
-test('it trigger a connnected app update if there is inconsistency between it and the app store data', async () => {
+test('it triggers a connected app update if there is inconsistency between it and the app store data', async () => {
     (useFeatureFlags as jest.Mock).mockImplementation(() => ({
         isEnabled: (feature: string) => {
             switch (feature) {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
@@ -2,12 +2,13 @@ import {renderHook} from '@testing-library/react-hooks';
 import {mockFetchResponses} from '../../../test-utils';
 import {useConnectedApps} from '@src/connect/hooks/use-connected-apps';
 import {useFeatureFlags} from '@src/shared/feature-flags/use-feature-flags';
-import {useNotify} from '@src/shared/notify';
-import {NotificationLevel} from '@src/shared/notify';
+import {NotificationLevel, useNotify} from '@src/shared/notify';
 import {TestApp} from '@src/model/app';
+import {useTriggerConnectedAppRefresh} from '@src/connect/hooks/use-trigger-connected-app-refresh';
 
 jest.mock('@src/shared/feature-flags/use-feature-flags');
 jest.mock('@src/shared/notify');
+jest.mock('@src/connect/hooks/use-trigger-connected-app-refresh');
 
 const notify = jest.fn();
 
@@ -230,4 +231,88 @@ test('it fetches connected test apps', async () => {
     expect(result.current).toEqual(null);
     await waitForNextUpdate();
     expect(result.current).toEqual([expectedApp]);
+});
+
+test('it trigger a connnected app update if there is inconsistency between it and the app store data', async () => {
+    (useFeatureFlags as jest.Mock).mockImplementation(() => ({
+        isEnabled: (feature: string) => {
+            switch (feature) {
+                case 'marketplace_activate':
+                    return true;
+            }
+        },
+    }));
+
+    mockFetchResponses({
+        akeneo_connectivity_connection_apps_rest_get_all_connected_apps: {
+            json: [
+                {
+                    id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+                    name: 'App A',
+                    scopes: ['scope A1'],
+                    connection_code: 'connectionCodeA',
+                    logo: 'http://www.example.com/path/to/logo/a',
+                    author: 'author A',
+                    user_group_name: 'app_123456abcde',
+                    categories: ['E-commerce'],
+                    certified: false,
+                    partner: 'Akeneo Partner',
+                },
+                {
+                    id: '0dfce574-2238-4b13-b8cc-8d257ce7645c',
+                    name: 'App B',
+                    scopes: ['scope A1'],
+                    connection_code: 'connectionCodeB',
+                    logo: 'http://www.example.com/path/to/logo/a',
+                    author: 'author A',
+                    user_group_name: 'app_123456abcde',
+                    categories: ['E-commerce'],
+                    certified: false,
+                    partner: 'Akeneo Partner',
+                },
+            ],
+        },
+        akeneo_connectivity_connection_marketplace_rest_get_all_apps: {
+            json: {
+                total: 2,
+                apps: [
+                    {
+                        id: '0dfce574-2238-4b13-b8cc-8d257ce7645b',
+                        name: 'App A WITH NEW TITLE',
+                        logo: 'http://www.example.com/path/to/logo/a',
+                        author: 'author A',
+                        partner: 'Akeneo Partner',
+                        description: 'Our Akeneo Connector',
+                        url: 'https://marketplace.akeneo.com/extension/extension_1',
+                        categories: ['E-commerce'],
+                        certified: false,
+                        activate_url: 'https://example.com/activate',
+                        callback_url: 'https://example.com/oauth2',
+                    },
+                    {
+                        id: '0dfce574-2238-4b13-b8cc-8d257ce7645c',
+                        name: 'App B',
+                        logo: 'http://www.example.com/path/to/logo/a',
+                        author: 'author A',
+                        partner: 'Akeneo Partner',
+                        description: 'Our Akeneo Connector',
+                        url: 'https://marketplace.akeneo.com/extension/extension_1',
+                        categories: ['E-commerce'],
+                        certified: false,
+                        activate_url: 'https://example.com/activate',
+                        callback_url: 'https://example.com/oauth2',
+                    },
+                ],
+            },
+        },
+    });
+
+    const triggerConnectedAppRefresh = jest.fn();
+    (useTriggerConnectedAppRefresh as jest.Mock).mockImplementation(() => triggerConnectedAppRefresh);
+
+    const {result, waitForNextUpdate} = renderHook(() => useConnectedApps());
+    expect(result.current).toEqual(null);
+    await waitForNextUpdate();
+    expect(triggerConnectedAppRefresh).toHaveBeenCalledWith('connectionCodeA');
+    expect(triggerConnectedAppRefresh).not.toHaveBeenCalledWith('connectionCodeB');
 });


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When cached information from the App Store changes (name, logo), we need to update it in the ConnectedApp for consistency.

This is triggered when both versions are reconciled in the front.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
