### PR TITLE
Fix unused requirements in php_cd

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -34,7 +34,6 @@ $rules = [
             'Akeneo\Connectivity\Connection\Application\Settings',
             'Akeneo\Connectivity\Connection\Application\User',
 
-            'Oro\Bundle\SecurityBundle\SecurityFacade',
             'Akeneo\UserManagement\Component\Model\RoleInterface',
             'Symfony\Component\Validator\Validator\ValidatorInterface',
 
@@ -98,7 +97,6 @@ $rules = [
             // Not ok
             'Akeneo\UserManagement\Component\Model\UserInterface',
             'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
-            'Doctrine\Persistence',
             'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface',
             'Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken',
             'Symfony\Component\Security\Core\User\UserInterface',
@@ -136,7 +134,6 @@ $rules = [
         'Akeneo\Platform\Component\EventQueue\Author',
         'Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface',
 
-        'Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval',
         'Akeneo\Connectivity\Connection\Domain\ValueObject\Url',
 
         'Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated',
@@ -162,9 +159,6 @@ $rules = [
             'FOS\OAuthServerBundle\Model\ClientManagerInterface',
             'FOS\OAuthServerBundle\Util\Random',
             'OAuth2\OAuth2',
-
-            // For acceptance tests purpose
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryConnectionRepository',
         ]
     )->in('Akeneo\Connectivity\Connection\Infrastructure\Client'),
 
@@ -182,10 +176,6 @@ $rules = [
             'Akeneo\UserManagement\Component\Model\User',
             'Akeneo\UserManagement\Component\Model\UserInterface',
             'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
-
-            // For acceptance tests purpose
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryConnectionRepository',
-            'Akeneo\Connectivity\Connection\Infrastructure\Persistence\InMemory\Repository\InMemoryUserPermissionsRepository',
 
             'Doctrine\DBAL\Driver\Connection',
 
@@ -219,46 +209,23 @@ $rules = [
         [
             'Akeneo\Connectivity\Connection\Application',
             'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\Connectivity\Connection\Infrastructure',
 
             // Dependency on HTTP foundation for Request/Response
             'Symfony\Component\HttpFoundation',
-            'Symfony\Component\HttpKernel\Exception',
             // Dependency on constraint violations to correctly display errors on frontend
             'Symfony\Component\Validator\ConstraintViolationListInterface',
             // ACL dependency
             'Symfony\Component\Security\Core\Exception\AccessDeniedException',
-            'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
             'Oro\Bundle\SecurityBundle\SecurityFacade',
-            // Dependency to retrieve the current User (and his timezone).
-            'Akeneo\UserManagement\Bundle\Context\UserContext',
-            // Feature flag dependency
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
-
-            'Psr\Log\LoggerInterface',
         ]
     )->in('Akeneo\Connectivity\Connection\Infrastructure\InternalApi'),
 
     $builder->only(
         [
             'Akeneo\Connectivity\Connection\Domain',
-            'Akeneo\UserManagement\Component\Model\User',
-
-            // Dependency for uuid generation
-            'Ramsey\Uuid\Uuid',
 
             // Dependency on Doctrine DBAL for persistence layer
             'Doctrine\DBAL',
-
-            // Dependency on Elasticsearch
-            'Akeneo\Tool\Bundle\ElasticsearchBundle\Client',
-
-            // Dependency on Encrypter
-            'Akeneo\Connectivity\Connection\Infrastructure\Service\Encrypter',
-
-            'Symfony\Component\OptionsResolver\OptionsResolver',
-
-            'Akeneo\Connectivity\Connection\Infrastructure\Connections\GetConnectionsNumberLimit',
         ]
     )->in('Akeneo\Connectivity\Connection\Infrastructure\Persistence'),
 
@@ -290,7 +257,6 @@ $rules = [
             'Akeneo\Connectivity\Connection\Domain\Marketplace',
             'Akeneo\Connectivity\Connection\Application\Marketplace',
 
-            'Akeneo\Connectivity\Connection\Domain\Apps',
             'Akeneo\Connectivity\Connection\Application\Apps\Command\DeleteAppCommand',
             'Akeneo\Connectivity\Connection\Application\Apps\Command\DeleteAppHandler',
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php
@@ -13,15 +13,11 @@ $builder = new RuleBuilder();
 $rules = [
     $builder->only(
         [
-            //Needed to access to the criteria codes. To remove after refactoring
-            'Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation',
-
             //External dependencies
             'Ramsey\Uuid\Uuid',
             'Akeneo\Pim\Structure\Component\AttributeTypes',
             'Symfony\Contracts\EventDispatcher\Event',
             'Webmozart\Assert\Assert',
-            'Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidArgumentException'
         ]
     )->in('Akeneo\Pim\Automation\DataQualityInsights\Domain'),
 
@@ -46,30 +42,18 @@ $rules = [
             //Enrichment computing
             'Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator',
 
-            //Consistency computing
-            'Akeneo\Pim\Structure\Component\AttributeTypes',
-
             //Bundle installation
             'Akeneo\Platform\Bundle\InstallerBundle\Event',
             'Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository',
-            'Akeneo\Tool\Bundle\BatchQueueBundle\Launcher\QueueJobLauncher',
-            'Akeneo\Tool\Component\Console\CommandLauncher',
-            'Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface',
-            'Akeneo\UserManagement\Bundle\Security\SystemUserToken',
             'Akeneo\UserManagement\Component\Model\UserInterface',
 
             //Subscribers for product updates
             'Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface',
             'Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface',
-            'Akeneo\Pim\Enrichment\Component\Product\Query\DescendantProductModelIdsQueryInterface',
             'Akeneo\Tool\Component\StorageUtils\StorageEvents',
             'Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface',
             'Akeneo\Tool\Component\Batch\Model\JobInstance',
             'Akeneo\Tool\Component\Batch\Job\JobInterface',
-
-            //Subscribers for attribute updates
-            'Akeneo\Pim\Structure\Component\Model\AttributeInterface',
-            'Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface',
 
             //Subscribers for attribute group updates
             'Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface',
@@ -105,10 +89,6 @@ $rules = [
             'Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration',
             'Oro\Bundle\DataGridBundle\Event\BuildBefore',
             'Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface',
-            'Oro\Bundle\DataGridBundle\Extension\Formatter\Configuration',
-            'Oro\Bundle\DataGridBundle\Datagrid\RequestParameters',
-            'Oro\Bundle\DataGridBundle\Extension\AbstractExtension',
-            'Oro\Bundle\DataGridBundle\Extension\Sorter\Configuration',
             'Oro\Bundle\PimDataGridBundle\Extension\Sorter\SorterInterface',
             'Oro\Bundle\FilterBundle\Grid\Extension\Configuration',
             'Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface',
@@ -122,7 +102,6 @@ $rules = [
             //Necessary for the particular command EvaluatePendingCriteriaCommand
             'Akeneo\Tool\Bundle\BatchQueueBundle\Manager\JobExecutionManager',
             'Akeneo\Tool\Component\Batch',
-            'Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessage',
             'Doctrine\ORM\EntityManager',
             'Symfony\Component\Process',
 
@@ -138,26 +117,17 @@ $rules = [
 
             //External dependencies
             'Doctrine\DBAL',
-            'Doctrine\Common\Persistence\ObjectRepository',
-            'Doctrine\ORM\Query\Expr',
             'Doctrine\Persistence\ObjectRepository',
             'Psr\Log\LoggerInterface',
             'Symfony\Component\Config\FileLocator',
             'Symfony\Component\Console',
             'Symfony\Component\DependencyInjection',
             'Symfony\Component\EventDispatcher',
-            'Symfony\Component\Filesystem',
-            'Symfony\Component\Finder',
             'Symfony\Component\HttpFoundation',
             'Symfony\Component\HttpKernel',
             'Symfony\Component\Security',
             'Symfony\Component\Validator\Constraints',
-            'Symfony\Contracts\EventDispatcher',
             'Symfony\Component\Form\FormFactoryInterface',
-            'GuzzleHttp\ClientInterface',
-            'GuzzleHttp\Exception',
-            'Mekras\Speller',
-            'League\Flysystem',
             'Webmozart\Assert\Assert',
 
             // Common Dependencies

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -58,11 +58,6 @@ $rules = [
         'Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface',
         'Akeneo\Pim\Structure\Component\Repository\AttributeOptionRepositoryInterface',
 
-        // TIP-918: PIM/Enrichment should not be linked to GroupType
-        'Akeneo\Pim\Structure\Component\Model\GroupTypeInterface',
-
-        'Akeneo\Pim\Structure\Component\Model\AssociationTypeInterface',
-
         // TIP-920: PIM/Enrichment should not be linked to Locale
         'Akeneo\Channel\Component\Model\LocaleInterface',
         'Akeneo\Channel\Component\Repository\LocaleRepositoryInterface',
@@ -70,9 +65,6 @@ $rules = [
         // TIP-921: PIM/Enrichment should not be linked to Channel
         'Akeneo\Channel\Component\Model\ChannelInterface',
         'Akeneo\Channel\Component\Repository\ChannelRepositoryInterface',
-
-        // TIP-922: PIM/Enrichment should not be linked to Currency
-        'Akeneo\Channel\Component\Repository\CurrencyRepositoryInterface',
 
         // TIP-923: PIM/Enrichment should not be linked to AttributeRequirement
         'Akeneo\Pim\Structure\Component\Repository\AttributeRequirementRepositoryInterface',
@@ -82,10 +74,6 @@ $rules = [
 
         // TIP-933: CategoryRepository should not depend on Gedmo
         'Gedmo\Tree\Entity\Repository\NestedTreeRepository',
-
-        // TIP-934: AttributeIsAFamilyVariantAxis is part of Structure
-        // TIP-935: AddBooleanValuesToNewProductSubscriber design problem
-        'Akeneo\Pim\Structure\Component\Model\VariantAttributeSetInterface',
 
         //TIP-936: PIM/Enrichment should not be linked to FamilyVariant
         'Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface',
@@ -120,12 +108,10 @@ $rules = [
 
         // TIP-1013: Rework Notification system
         'Akeneo\Platform\Bundle\DashboardBundle\Widget\WidgetInterface',
-        'Akeneo\Platform\Bundle\NotificationBundle\NotifierInterface',
 
         // TIP-1022: Drop LocaleResolver
         'Akeneo\Platform\Bundle\UIBundle\Resolver\LocaleResolver',
 
-        'Akeneo\Pim\Structure\Component\Query\InternalApi\GetAllBlacklistedAttributeCodesInterface',
         'Elasticsearch\Common\Exceptions\ElasticsearchException',
         'Akeneo\Pim\Structure\Bundle\Manager\AttributeCodeBlacklister',
 
@@ -158,10 +144,6 @@ $rules = [
         'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
         'Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query',
         'Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Model',
-
-        // TIP-915: PIM/Enrichment should not be linked to AttributeOption
-        // TIP-916: Do not check if entities exist in PQB filters or sorters
-        'Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface',
 
         // TIP-918: PIM/Enrichment should not be linked to GroupType
         'Akeneo\Pim\Structure\Component\Model\GroupTypeInterface',
@@ -232,9 +214,6 @@ $rules = [
         // TIP-1012: Create a Measure component
         'Akeneo\Tool\Bundle\MeasureBundle',
 
-        // TIP-1033: PIM/Enrichment should not depend on EntityRepository
-        'Doctrine\ORM\EntityRepository',
-
         // TIP-939: Remove filter system for permissions
         'Akeneo\Pim\Enrichment\Bundle\Filter\ObjectFilterInterface',
         'Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface',
@@ -260,9 +239,6 @@ $rules = [
 
         // TIP-1023: Drop CatalogContext
         'Akeneo\Pim\Enrichment\Bundle\Context\CatalogContext',
-
-        // TIP-1020: Move JobLauncherInterface
-        'Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface',
 
         'Akeneo\Platform\Bundle\NotificationBundle\NotifierInterface',
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
@@ -33,14 +33,12 @@ $rules = [
         // Legacy
         'Akeneo\Pim\Enrichment\Component',
         'Akeneo\Tool\Component\StorageUtils\Exception\PropertyException',
-        'Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException',
         'Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface',
         'Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface',
     ])->in('Akeneo\Pim\Enrichment\Product\Application'),
 
     $builder->only([
         'Akeneo\Pim\Enrichment\Product\API',
-        'Akeneo\Pim\Enrichment\Product\Application',
         'Akeneo\Pim\Enrichment\Product\Domain',
 
         // Public APIs

--- a/src/Akeneo/Pim/Structure/.php_cd.php
+++ b/src/Akeneo/Pim/Structure/.php_cd.php
@@ -43,12 +43,6 @@ $rules = [
         // TIP-939: Remove filter system for permissions
         'Akeneo\Platform\Bundle\UIBundle\Provider\TranslatedLabelsProviderInterface',
 
-        // TIP-1005: Clean UI form types
-        'Akeneo\Platform\Bundle\UIBundle\Form\Type\AsyncSelectType',
-        'Akeneo\Platform\Bundle\UIBundle\Form\Type\LightEntityType',
-        'Akeneo\Platform\Bundle\UIBundle\Form\Subscriber\DisableFieldSubscriber',
-        'Akeneo\Platform\Bundle\UIBundle\Form\Type\TranslatableFieldType',
-
         // TIP-939: Remove filter system for permissions
         'Akeneo\Pim\Enrichment\Bundle\Filter\CollectionFilterInterface',
         'Akeneo\Pim\Enrichment\Bundle\Filter\ObjectFilterInterface',

--- a/src/Akeneo/Platform/Job/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Job/back/tests/.php_cd.php
@@ -28,12 +28,8 @@ $rules = [
             'Akeneo\Platform\Job\Application',
             'Akeneo\Platform\Job\Domain',
             'Doctrine\DBAL\Connection',
-            'Doctrine\DBAL\Types',
-            'Oro\Bundle\SecurityBundle\Annotation\AclAncestor',
             'Oro\Bundle\SecurityBundle\SecurityFacade',
             'Symfony\Component',
-            'Symfony\Contracts',
-            'Webmozart\Assert\Assert',
         ],
     )->in('Akeneo\Platform\Job\Infrastructure'),
 ];

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -1,4 +1,4 @@
-Oro\Bundle\UserBundle\Exception\UserCannotBeDeletedException<?php
+<?php
 
 use Akeneo\CouplingDetector\Configuration\Configuration;
 use Akeneo\CouplingDetector\Configuration\DefaultFinder;

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -1,4 +1,4 @@
-<?php
+Oro\Bundle\UserBundle\Exception\UserCannotBeDeletedException<?php
 
 use Akeneo\CouplingDetector\Configuration\Configuration;
 use Akeneo\CouplingDetector\Configuration\DefaultFinder;
@@ -34,10 +34,7 @@ $rules = [
         'Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager',
         'Oro\Bundle\SecurityBundle\Acl\AccessLevel',
         'Oro\Bundle\SecurityBundle\Acl\Persistence\AclPrivilegeRepository',
-        'Oro\Bundle\SecurityBundle\Model\AclPrivilege',
         'Oro\Bundle\SecurityBundle\SecurityFacade',
-
-        'Oro\Bundle\UserBundle\Exception\UserCannotBeDeletedException',
 
         // TIP-947: UI Locale Provider should be part of UserManagement
         'Akeneo\Platform\Bundle\UIBundle\UiLocaleProvider'
@@ -53,9 +50,6 @@ $rules = [
         'Sensio\Bundle\FrameworkExtraBundle',
         'Symfony\Bundle\FrameworkBundle',
         'Symfony\Bundle\SecurityBundle',
-        'FOS\OAuthServerBundle\Entity\ClientManager', // used by API client controller
-        'OAuth2\OAuth2', // used by API client controller
-        'Swift_Mailer',
         'Twig\TwigFunction',
         'Oro\Bundle\DataGridBundle\Extension\Action\Actions\NavigateAction',
         'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags',
@@ -70,7 +64,6 @@ $rules = [
         'Akeneo\Channel\Component\Model\Locale',
         'Akeneo\Channel\Component\Repository\ChannelRepositoryInterface',
         'Akeneo\Channel\Component\Repository\LocaleRepositoryInterface',
-        'Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface',
 
         // TIP-1005: Clean UI form types
         'Akeneo\Platform\Bundle\UIBundle\Form\Type\EntityIdentifierType',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I removed all dependencies declared in the php_cd but not effective with the command `list-unused-requirements` of php coupling detector

**Why I do that ?**
In order to read more easily the php_cd file and have a graph dependency closer to reality.

**Why I didn't add the `list-unused-requirements` in all bounded context testing suite ?**
I should be the choice of each squad to check it at each time => can be annoying for people
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
