### PR TITLE
PIM-10372: Fix letter case issue when importing channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - PIM-10346: Fix spellcheck badge not displayed on attribute options
 - PIM-10336: Fix product Export edition in error if no locale selected
 - PIM-10345: Fix issue when importing product model with an attribute constituted of only digits
+- PIM-10372: Fix letter case issue when importing channels
 - PIM-10334: Fix error on the clean-removed-attributes
 
 ## Improvements

--- a/src/Akeneo/Channel/Bundle/Resources/config/array_converters.yml
+++ b/src/Akeneo/Channel/Bundle/Resources/config/array_converters.yml
@@ -13,6 +13,7 @@ services:
         class: 'Akeneo\Channel\Component\ArrayConverter\FlatToStandard\Channel'
         arguments:
             - '@pim_connector.array_convertor.checker.fields_requirement'
+            - '@pim_catalog.repository.cached_locale'
 
     pim_connector.array_converter.standard_to_flat.channel:
         class: 'Akeneo\Channel\Component\ArrayConverter\StandardToFlat\Channel'

--- a/src/Akeneo/Channel/Component/Model/Channel.php
+++ b/src/Akeneo/Channel/Component/Model/Channel.php
@@ -115,7 +115,7 @@ class Channel implements ChannelInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() === $locale) {
+            if (\strtolower($translation->getLocale()) === \strtolower($locale)) {
                 return $translation;
             }
         }

--- a/tests/back/Channel/Specification/Component/ArrayConverter/FlatToStandard/ChannelSpec.php
+++ b/tests/back/Channel/Specification/Component/ArrayConverter/FlatToStandard/ChannelSpec.php
@@ -2,15 +2,17 @@
 
 namespace Specification\Akeneo\Channel\Component\ArrayConverter\FlatToStandard;
 
+use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Tool\Component\Connector\ArrayConverter\FieldsRequirementChecker;
 
 class ChannelSpec extends ObjectBehavior
 {
-    function let(FieldsRequirementChecker $fieldChecker)
+    function let(FieldsRequirementChecker $fieldChecker, IdentifiableObjectRepositoryInterface $localeRepository)
     {
-        $this->beConstructedWith($fieldChecker);
+        $this->beConstructedWith($fieldChecker, $localeRepository);
     }
 
     function it_is_a_standard_array_converter()
@@ -20,8 +22,14 @@ class ChannelSpec extends ObjectBehavior
         );
     }
 
-    function it_converts_an_item_to_standard_format()
+    function it_converts_an_item_to_standard_format($localeRepository)
     {
+        $localeEn = (new Locale())->setCode('en_US');
+        $localeFr = (new Locale())->setCode('fr_FR');
+        
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($localeEn);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($localeFr);
+        
         $item = [
             'code'        => 'ecommerce',
             'label-fr_FR' => 'Ecommerce',
@@ -50,6 +58,36 @@ class ChannelSpec extends ObjectBehavior
         ];
 
         $this->convert($item)->shouldReturn($result);
+    }
+
+    public function it_converts_labels_with_the_right_locale_code_letter_case($localeRepository): void
+    {
+        $localeEn = (new Locale())->setCode('en_US');
+
+        $localeRepository->findOneByIdentifier('en_uS')->willReturn($localeEn);
+        $localeRepository->findOneByIdentifier('xx_XX')->willReturn(null);
+
+        $item = [
+            'code'        => 'ecommerce',
+            'label-en_uS' => 'Ecommerce',
+            'label-xx_XX' => 'Unknown locale',
+            'locales'     => 'en_US',
+            'currencies'  => 'USD',
+            'tree'        => 'master_catalog',
+        ];
+
+        $expectedResult = [
+            'labels'           => [
+                'en_US' => 'Ecommerce',
+                'xx_XX' => 'Unknown locale',
+            ],
+            'code'             => 'ecommerce',
+            'locales'          => ['en_US'],
+            'currencies'       => ['USD'],
+            'category_tree'    => 'master_catalog',
+        ];
+
+        $this->convert($item)->shouldReturn($expectedResult);
     }
 
     function it_converts_empty_conversion_units()


### PR DESCRIPTION
Locale codes of channel labels translations could be persisted with a different letter case that the (good) one persisted in the locales table.

This fix prevent that problem by replacing the locale code with the locale entity one during the data conversion from flat to standard.
 