### PR TITLE
PIM-10374: Revert PIM-10333 + Fix category translations are not displayed in the category tree when locale is not xx_XX

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10374: Revert PIM-10333 + Fix category translations are not displayed in the category tree when locale is not xx_XX
+
 # 5.0.88 (2022-03-23)
 
 # 5.0.87 (2022-03-23)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/array_converter.yml
@@ -102,7 +102,6 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Category\Connector\ArrayConverter\FlatToStandard\Category'
         arguments:
             - '@pim_connector.array_convertor.checker.fields_requirement'
-            - '@pim_catalog.repository.locale'
 
     ### Extractors
     pim_connector.array_converter.flat_to_standard.product.attribute_column_info_extractor:

--- a/src/Akeneo/Pim/Enrichment/Component/Category/Model/Category.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Category/Model/Category.php
@@ -121,7 +121,7 @@ class Category extends BaseCategory implements CategoryInterface
             return null;
         }
         foreach ($this->getTranslations() as $translation) {
-            if ($translation->getLocale() === $locale) {
+            if (strtolower($translation->getLocale()) === strtolower($locale)) {
                 return $translation;
             }
         }

--- a/tests/back/Pim/Enrichment/Specification/Component/Category/Connector/ArrayConverter/FlatToStandard/CategorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Category/Connector/ArrayConverter/FlatToStandard/CategorySpec.php
@@ -2,27 +2,18 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Category\Connector\ArrayConverter\FlatToStandard;
 
-use Akeneo\Channel\Component\Model\Locale;
-use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
-use Akeneo\Tool\Component\Connector\Exception\StructureArrayConversionException;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Tool\Component\Connector\ArrayConverter\FieldsRequirementChecker;
 
 class CategorySpec extends ObjectBehavior
 {
-    function let(FieldsRequirementChecker $fieldChecker, LocaleRepositoryInterface $localeRepository)
+    function let(FieldsRequirementChecker $fieldChecker)
     {
-        $this->beConstructedWith($fieldChecker, $localeRepository);
+        $this->beConstructedWith($fieldChecker);
     }
 
-    function it_converts($localeRepository)
+    function it_converts()
     {
-        $us = new Locale();
-        $us->setCode('en_US');
-        $fr = new Locale();
-        $fr->setCode('fr_FR');
-        $localeRepository->findAll()->willReturn([$us, $fr]);
-
         $fields = [
             'code'        => 'mycode',
             'parent'      => 'master',
@@ -51,29 +42,6 @@ class CategorySpec extends ObjectBehavior
         $this
             ->shouldThrow(new \LogicException('Field "code" is expected, provided fields are "not_a_code"'))
             ->during('convert', [$item]);
-    }
-
-    function it_throws_an_exception_if_label_is_wrongly_written($localeRepository)
-    {
-        $us = new Locale();
-        $us->setCode('en_US');
-        $fr = new Locale();
-        $fr->setCode('fr_FR');
-        $localeRepository->findAll()->willReturn([$us, $fr]);
-
-        $this
-            ->shouldThrow(StructureArrayConversionException::class)
-            ->during(
-                'convert',
-                [
-                    [
-                        'code'        => 'mycode',
-                        'parent'      => 'master',
-                        'label-fr_Fr' => 'Ma superbe catégorie',
-                        'label-en_US' => 'My awesome category',
-                    ]
-                ]
-            );
     }
 
     function it_throws_an_exception_if_required_field_code_is_empty($fieldChecker)

--- a/tests/legacy/features/channel/edit_channel.feature
+++ b/tests/legacy/features/channel/edit_channel.feature
@@ -38,6 +38,7 @@ Feature: Edit a channel
     Then the grid should contain 1 elements
     And I should see locales "de_DE"
 
+  @skip
   Scenario: Successfully updates a channel conversion units
     Given I am logged in as "Peter"
     And I am on the "tablet" channel page

--- a/tests/legacy/features/channel/edit_channel.feature
+++ b/tests/legacy/features/channel/edit_channel.feature
@@ -38,7 +38,6 @@ Feature: Edit a channel
     Then the grid should contain 1 elements
     And I should see locales "de_DE"
 
-  @skip
   Scenario: Successfully updates a channel conversion units
     Given I am logged in as "Peter"
     And I am on the "tablet" channel page

--- a/tests/legacy/features/pim/enrichment/product-model/classify_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/classify_product_model.feature
@@ -7,7 +7,7 @@ Feature: Classify a product model
   Background:
     Given the "catalog_modeling" catalog configuration
     And the following categories:
-      | code         | label-en_US  | parent  |
+      | code         | label_en_US  | parent  |
       | long_sleeves | Long sleeves | tshirts |
       | seasons      | Seasons      | tshirts |
       | summer       | Summer       | seasons |

--- a/tests/legacy/features/pim/enrichment/product/export/export_products_by_categories.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/export_products_by_categories.feature
@@ -7,7 +7,7 @@ Feature: Export products from any given categories
   Background:
     Given a "default" catalog configuration
     And the following categories:
-      | code                   | label-en_US               | parent                 |
+      | code                   | label_en_US               | parent                 |
       | toys_games             | Toys & Games              | default                |
       | action_figures         | Action Figures            | toys_games             |
       | dolls                  | Dolls                     | toys_games             |

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/mass_edit_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/mass_edit_products_and_product_models.feature
@@ -8,7 +8,7 @@ Feature: Apply a mass action on products only (and not product models)
   Background:
     Given a "catalog_modeling" catalog configuration
     And the following categories:
-      | code         | label-en_US  | parent  |
+      | code         | label_en_US  | parent  |
       | long_sleeves | Long sleeves | tshirts |
       | seasons      | Seasons      | tshirts |
       | summer       | Summer       | seasons |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/jira/software/c/projects/PIM/boards/9?modal=detail&selectedIssue=PIM-10374

- Revert PIM-10333 changes
- Modify the locale comparison to be case insensitive for Category translation

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
