### PR TITLE
Add new FindUnit query in the public API of MeasurementBundle

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/FindUnit.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/FindUnit.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi;
+
+/**
+ * @author Adrien Pétremann <adrien.petremann@getakeneo.com>
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+interface FindUnit
+{
+    public function byMeasurementFamilyCodeAndUnitCode(string $measurementFamilyCode, string $unitCode): ?Unit;
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/SqlFindUnit.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/SqlFindUnit.php
@@ -41,7 +41,9 @@ SQL;
             ]
         )->fetchAssociative();
 
-        if (!$result) return null;
+        if (!$result) {
+            return null;
+        }
 
         $unit = new Unit();
         $unit->code = $result['code'];

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/SqlFindUnit.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/PublicApi/SqlFindUnit.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\PublicApi;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @author Adrien Pétremann <adrien.petremann@getakeneo.com>
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SqlFindUnit implements FindUnit
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function byMeasurementFamilyCodeAndUnitCode(string $measurementFamilyCode, string $unitCode): ?Unit
+    {
+        $sql = <<<SQL
+SELECT unit.*
+FROM akeneo_measurement measurement, JSON_TABLE(measurement.units,
+    '$[*]' COLUMNS(
+        code VARCHAR(100) PATH '$.code',
+        labels JSON PATH '$.labels',
+        symbol VARCHAR(100) PATH '$.symbol',
+        convert_from_standard JSON PATH '$.convert_from_standard'
+    )
+) AS unit
+WHERE measurement.code = :measurementFamilyCode
+AND unit.code = :unitCode;
+SQL;
+
+        $result = $this->connection->executeQuery(
+            $sql,
+            [
+                'unitCode' => $unitCode,
+                'measurementFamilyCode' => $measurementFamilyCode
+            ]
+        )->fetchAssociative();
+
+        if (!$result) return null;
+
+        $unit = new Unit();
+        $unit->code = $result['code'];
+        $unit->labels = json_decode($result['labels'], true);
+        $unit->symbol = $result['symbol'];
+        $unit->convertFromStandard = json_decode($result['convert_from_standard'], true);
+
+        return $unit;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/public_api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/public_api.yml
@@ -9,6 +9,11 @@ services:
         arguments:
             - '@database_connection'
 
+    akeneo_measurement.public_api.find_unit:
+      class: 'Akeneo\Tool\Bundle\MeasureBundle\PublicApi\SqlFindUnit'
+      arguments:
+        - '@database_connection'
+
     akeneo_measurement.public_api.onboarder.find_all_measurement_families:
         class: 'Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Onboarder\FindAllMeasurementFamilies'
         arguments:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/SqlFindUnitIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/SqlFindUnitIntegration.php
@@ -6,7 +6,7 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Integration\PublicApi;
 
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Akeneo\Tool\Bundle\MeasureBundle\PublicApi\SqlGetUnit;
+use Akeneo\Tool\Bundle\MeasureBundle\PublicApi\SqlFindUnit;
 use Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Unit;
 
 final class SqlFindUnitIntegration extends TestCase
@@ -48,8 +48,8 @@ final class SqlFindUnitIntegration extends TestCase
         return $this->catalog->useMinimalCatalog();
     }
 
-    private function getQuery(): SqlGetUnit
+    private function getQuery(): SqlFindUnit
     {
-        return $this->get('akeneo_measurement.public_api.get_unit');
+        return $this->get('akeneo_measurement.public_api.find_unit');
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/SqlFindUnitIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/PublicApi/SqlFindUnitIntegration.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\tests\Integration\PublicApi;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\MeasureBundle\PublicApi\SqlGetUnit;
+use Akeneo\Tool\Bundle\MeasureBundle\PublicApi\Unit;
+
+final class SqlFindUnitIntegration extends TestCase
+{
+    public function test_it_finds_unit_by_measurement_family_code_and_unit_code(): void
+    {
+        $query = $this->getQuery();
+
+        $expectedUnit = new Unit();
+        $expectedUnit->code = 'MICROGRAM';
+        $expectedUnit->labels = [
+            'en_US' => 'Microgram',
+            'fr_FR' => 'Microgramme',
+        ];
+        $expectedUnit->symbol = 'μg';
+        $expectedUnit->convertFromStandard = [
+            [
+                'value' => '0.000000001',
+                'operator' => 'mul',
+            ]
+        ];
+
+        $this->assertEqualsCanonicalizing(
+            $expectedUnit,
+            $query->byMeasurementFamilyCodeAndUnitCode('Weight', 'MICROGRAM')
+        );
+    }
+
+    public function test_it_returns_null_when_unit_is_not_found(): void
+    {
+        $this->assertEquals(
+            null,
+            $this->getQuery()->byMeasurementFamilyCodeAndUnitCode('Foo', 'BAR')
+        );
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getQuery(): SqlGetUnit
+    {
+        return $this->get('akeneo_measurement.public_api.get_unit');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the measurement bundle: 
- adds a new `\Akeneo\Tool\Bundle\MeasureBundle\PublicApi\FindUnit` query in the public api to allow **finding** unit instead of **getting** it (returns `null` instead of throwing exception)
- this PR keeps the the existing `\Akeneo\Tool\Bundle\MeasureBundle\PublicApi\GetUnit`

**Definition Of Done (for Core Developer only)**

- [x] Tests
