### PR TITLE
RAC-1208: Hide "reference data" attributes from SaaS users

### DIFF
--- a/config/packages/akeneo_feature_flag.yml
+++ b/config/packages/akeneo_feature_flag.yml
@@ -7,3 +7,4 @@ akeneo_feature_flag:
         - { feature: 'connect_app_with_permissions', service: 'akeneo_connectivity.connection.connect_app_with_permissions.feature' }
         - { feature: 'communication_channel', service: 'akeneo_communication_channel.feature' }
         - { feature: 'app_developer_mode', service: 'akeneo_connectivity.connection.app_developer_mode.feature' }
+        - { feature: 'reference_data', service: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature' }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFlexibilityOnPremiseFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFlexibilityOnPremiseFeatureFlag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\FeatureFlagBundle\Configuration;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+class OnlyFlexibilityOnPremiseFeatureFlag implements FeatureFlag
+{
+    private const SAAS_EDITIONS = [
+        'SERENITY_EDITION',
+        'GROWTH_EDITION',
+        'TRIAL_EDITION',
+    ];
+
+    public function __construct(
+        private string $edition
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return !in_array($this->edition, self::SAAS_EDITIONS);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/services.yml
@@ -31,3 +31,9 @@ services:
         arguments:
             - '%env(string:PIM_EDITION)%'
         public: true
+
+    akeneo.feature_flag.service.only_flexibility_on_premise_feature:
+        class: Akeneo\Platform\Bundle\FeatureFlagBundle\Configuration\OnlyFlexibilityOnPremiseFeatureFlag
+        arguments:
+            - '%env(string:PIM_EDITION)%'
+        public: true

--- a/tests/legacy/features/pim/enrichment/reference-data/attribute/add_attribute.feature
+++ b/tests/legacy/features/pim/enrichment/reference-data/attribute/add_attribute.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @reference-data-feature-enabled
 Feature: Add attribute options
   In order to define choices for a choice attribute
   As a product manager

--- a/tests/legacy/features/pim/enrichment/reference-data/attribute/display_attribute_history.feature
+++ b/tests/legacy/features/pim/enrichment/reference-data/attribute/display_attribute_history.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @reference-data-feature-enabled
 Feature: Display the attribute history
   In order to know who, when and what changes has been made to an attribute
   As a product manager


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, I introduced a new feature flag configuration `OnlyFlexibilityOnPremiseFeatureFlag`. Its purpose is to have the possibility to enabled some feature only on Flexibility and OnPremise environment. It will be very useful to hide any feature from SaaS.
Also I added a reference_data feature and I added a check into the SelectAttributeType.tsx to remove reference data attribute type from the create options. That will hide reference data creation from the SaaS UI.

**/!\ This PR just hides reference data, don't disable it.**
I created a card to completly disable it. At this time, it is a quickwin to just hide it and it is ok for our PM.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
