### PR TITLE
PIM-10372 make sure labels are saved with know locale codes correctly spelled regarding letter cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@
 - PIM-10345: Fix issue when importing product model with an attribute constituted of only digits
 - PIM-10334: Fix error on the clean-removed-attributes
 - PIM-10362: Fix attribute type "number" gets modified in history when import with same value
+- PIM-10372: Fix letter case issue when importing channels
 
 ## Improvements
+
 - PIM-10293: add batch-size option to pim:completness:calculate command
 - PIM-10229: Enforce strict samesite policy for session cookies
 

--- a/src/Akeneo/Channel/Component/Updater/ChannelUpdater.php
+++ b/src/Akeneo/Channel/Component/Updater/ChannelUpdater.php
@@ -21,21 +21,6 @@ use Doctrine\Common\Util\ClassUtils;
  */
 class ChannelUpdater implements ObjectUpdaterInterface
 {
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $categoryRepository;
-
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $localeRepository;
-
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $currencyRepository;
-
-    /** @var IdentifiableObjectRepositoryInterface */
-    protected $attributeRepository;
-
-    /** @var TranslatableUpdater */
-    protected $translatableUpdater;
-
     /**
      * @param IdentifiableObjectRepositoryInterface $categoryRepository
      * @param IdentifiableObjectRepositoryInterface $localeRepository
@@ -44,17 +29,12 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param TranslatableUpdater                   $translatableUpdater
      */
     public function __construct(
-        IdentifiableObjectRepositoryInterface $categoryRepository,
-        IdentifiableObjectRepositoryInterface $localeRepository,
-        IdentifiableObjectRepositoryInterface $currencyRepository,
-        IdentifiableObjectRepositoryInterface $attributeRepository,
-        TranslatableUpdater $translatableUpdater
+        protected IdentifiableObjectRepositoryInterface $categoryRepository,
+        protected IdentifiableObjectRepositoryInterface $localeRepository,
+        protected IdentifiableObjectRepositoryInterface $currencyRepository,
+        protected IdentifiableObjectRepositoryInterface $attributeRepository,
+        protected TranslatableUpdater $translatableUpdater
     ) {
-        $this->categoryRepository = $categoryRepository;
-        $this->localeRepository = $localeRepository;
-        $this->currencyRepository = $currencyRepository;
-        $this->attributeRepository = $attributeRepository;
-        $this->translatableUpdater = $translatableUpdater;
     }
 
     /**
@@ -151,9 +131,29 @@ class ChannelUpdater implements ObjectUpdaterInterface
                 $channel->setConversionUnits($data);
                 break;
             case 'labels':
-                $this->translatableUpdater->update($channel, $data);
+                $this->setLabels($channel, $data);
                 break;
         }
+    }
+
+    /**
+     * set labels on a channel, ensuring correct case of locale codes.
+     * 
+     * @param ChannelInterface $channel
+     * @param array            $localizedLabels
+     */
+    private function setLabels($channel, $localizedLabels)
+    {
+        // using known locale code when found (modulo case-insensitive comparison)
+        // leaving unknown locale code as is for the moment (Jira PIM-10372)
+        $normalizedLocalizedLabels = [];
+        foreach ($localizedLabels as $localeCode => $label) {
+            $knownLocale = $this->localeRepository->findOneByIdentifier($localeCode);
+            $normalizedLocalCode = null === $knownLocale ? $localeCode : $knownLocale->getCode();
+            $normalizedLocalizedLabels[$normalizedLocalCode] = $label;
+        };
+
+        $this->translatableUpdater->update($channel, $normalizedLocalizedLabels);
     }
 
     /**

--- a/src/Akeneo/Channel/Component/Updater/ChannelUpdater.php
+++ b/src/Akeneo/Channel/Component/Updater/ChannelUpdater.php
@@ -138,7 +138,6 @@ class ChannelUpdater implements ObjectUpdaterInterface
 
     /**
      * set labels on a channel, ensuring correct case of locale codes.
-     * 
      * @param ChannelInterface $channel
      * @param array            $localizedLabels
      */

--- a/tests/back/Channel/Specification/Component/Updater/ChannelUpdaterSpec.php
+++ b/tests/back/Channel/Specification/Component/Updater/ChannelUpdaterSpec.php
@@ -5,7 +5,7 @@ namespace Specification\Akeneo\Channel\Component\Updater;
 use Akeneo\Channel\Component\Model\ChannelInterface;
 use Akeneo\Channel\Component\Model\ChannelTranslationInterface;
 use Akeneo\Channel\Component\Model\CurrencyInterface;
-use Akeneo\Channel\Component\Model\LocaleInterface;
+use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Channel\Component\Updater\ChannelUpdater;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\Localization\TranslatableUpdater;
@@ -19,8 +19,19 @@ use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
+
+function makeLocale(string $code): Locale
+{
+    $locale = new Locale();
+    $locale->setCode($code);
+    return $locale;
+}
 class ChannelUpdaterSpec extends ObjectBehavior
 {
+
+    private static Locale $enUS;
+    private static Locale $frFR;
+
     function let(
         IdentifiableObjectRepositoryInterface $categoryRepository,
         IdentifiableObjectRepositoryInterface $localeRepository,
@@ -28,6 +39,8 @@ class ChannelUpdaterSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $attributeRepository,
         TranslatableUpdater $translatableUpdater
     ) {
+        $this::$enUS = $this::$enUS ?? makeLocale('en_US');
+        $this::$frFR = $this::$frFR ?? makeLocale('fr_FR');
         $this->beConstructedWith(
             $categoryRepository,
             $localeRepository,
@@ -68,8 +81,6 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $translatableUpdater,
         ChannelInterface $channel,
         CategoryInterface $tree,
-        LocaleInterface $enUS,
-        LocaleInterface $frFR,
         CurrencyInterface $usd,
         CurrencyInterface $eur,
         AttributeInterface $maximumDiagonalAttribute,
@@ -95,9 +106,9 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('master_catalog')->willReturn($tree);
         $channel->setCategory($tree)->shouldBeCalled();
 
-        $localeRepository->findOneByIdentifier('en_US')->willReturn($enUS);
-        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frFR);
-        $channel->setLocales([$enUS, $frFR])->shouldBeCalled();
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($this::$enUS);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($this::$frFR);
+        $channel->setLocales([$this::$enUS, $this::$frFR])->shouldBeCalled();
 
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
         $currencyRepository->findOneByIdentifier('USD')->willReturn($usd);
@@ -127,8 +138,6 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $attributeRepository,
         ChannelInterface $channel,
         CategoryInterface $tree,
-        LocaleInterface $enUS,
-        LocaleInterface $frFR,
         CurrencyInterface $usd,
         CurrencyInterface $eur,
         ChannelTranslationInterface $channelTranslation,
@@ -152,9 +161,9 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $categoryRepository->findOneByIdentifier('master_catalog')->willReturn($tree);
         $channel->setCategory($tree)->shouldBeCalled();
 
-        $localeRepository->findOneByIdentifier('en_US')->willReturn($enUS);
-        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($frFR);
-        $channel->setLocales([$enUS, $frFR])->shouldBeCalled();
+        $localeRepository->findOneByIdentifier('en_US')->willReturn($this::$enUS);
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($this::$frFR);
+        $channel->setLocales([$this::$enUS, $this::$frFR])->shouldBeCalled();
 
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
         $currencyRepository->findOneByIdentifier('USD')->willReturn($usd);
@@ -173,6 +182,35 @@ class ChannelUpdaterSpec extends ObjectBehavior
         $channel->setConversionUnits([])->shouldBeCalled();
 
         $this->update($channel, $values, []);
+    }
+
+    function it_does_locale_code_normalization_when_updating_labels(
+        $localeRepository,
+        $translatableUpdater,
+        ChannelInterface $channel
+    ) {
+        $inputLabels = [
+            'fr_FR' => 'Tablette',
+            'EN_us' => 'Tablet',
+            'foo_bar' => 'Tablefoo'
+        ];
+        $normalizedLabels = [
+            'fr_FR' => 'Tablette',
+            'en_US' => 'Tablet',
+            'foo_bar' => 'Tablefoo'
+        ];
+        $values = [
+            'code' => 'ecommerce',
+            'labels' => $inputLabels,
+        ];
+
+        $localeRepository->findOneByIdentifier('EN_us')->willReturn($this::$enUS); // by case-insentive matching BDD-side
+        $localeRepository->findOneByIdentifier('fr_FR')->willReturn($this::$frFR);
+        $localeRepository->findOneByIdentifier('foo_bar')->willReturn(null); // unknown to PIM
+
+        $this->update($channel, $values, []);
+
+        $translatableUpdater->update($channel, $normalizedLabels)->shouldBeCalled();
     }
 
     function it_throws_an_exception_if_category_not_found(

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -60,7 +60,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return static::getContainer()->get($service);
     }
 
     /**
@@ -70,7 +70,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function getParameter(string $parameter)
     {
-        return self::$container->getParameter($parameter);
+        return static::getContainer()->getParameter($parameter);
     }
 
     /**
@@ -80,7 +80,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function hasParameter(string $parameter)
     {
-        return self::$container->hasParameter($parameter);
+        return static::getContainer()->hasParameter($parameter);
     }
 
     /**

--- a/upgrades/schema/Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case.php
+++ b/upgrades/schema/Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+
+final class Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enforces all locale codes in the pim_catalog_channel_translation to be correclty spelled regarding case (meaning same case as locale codes in table pim_catalog_locale)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // PIM-10372
+        // for each channel localized label search for the locale code into the locale table (case insensitive search)
+        // for spelling if found, leave untouched if not found
+        $this->addSql(
+            <<<SQL
+UPDATE pim_catalog_channel_translation as TRANSLATION
+    INNER JOIN (
+        SELECT code 
+        FROM pim_catalog_locale as p    
+    ) as LOCALE
+    ON TRANSLATION.locale = LOCALE.code
+SET TRANSLATION.locale = COALESCE (LOCALE.code, TRANSLATION.locale);
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case_integration.php
+++ b/upgrades/test_schema/Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case_integration.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+
+class Version_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220330095652_ensure_locale_codes_for_labels_in_channels_have_correct_case';
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function makeTestChannel()
+    {
+        $cnx = $this->get('database_connection');
+
+        $result = $cnx->fetchNumeric('SELECT id FROM pim_catalog_category WHERE code = ?', ['master']);
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $master_category_id = $result[0];
+
+
+        $result = $cnx->insert('pim_catalog_channel', [
+            'category_id' => $master_category_id,
+            'code' => 'test channel',
+            'conversionUnits' => 'a:0:{}'
+        ]);
+        $this->assertTrue($result === 1);
+        $channel_id = $cnx->lastInsertId();
+
+
+        $result = $cnx->insert('pim_catalog_channel_translation', [
+            'foreign_key' => $channel_id,
+            'label' => 'test channel fr_FR',
+            'locale' => 'fr_FR' // correspond to some locale in pim_catalog_locale, with same case
+        ]);
+        $this->assertTrue($result === 1);
+
+        $result = $cnx->insert('pim_catalog_channel_translation', [
+            'foreign_key' => $channel_id,
+            'label' => 'test channel en_US',
+            'locale' => 'EN_US' // correspond to some locale in pim_catalog_locale, but wrong case
+        ]);
+        $this->assertTrue($result === 1);
+
+        $result = $cnx->insert('pim_catalog_channel_translation', [
+            'foreign_key' => $channel_id,
+            'label' => 'test channel foo_bar',
+            'locale' => 'foo_bar' // does not correspond to some locale in pim_catalog_locale
+        ]);
+        $this->assertTrue($result === 1);
+
+        return $channel_id;
+    }
+
+    public function test_known_locale_codes_are_normalized_for_channel_labels(): void
+    {
+
+        $channel_id = $this->makeTestChannel();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $cnx = $this->get('database_connection');
+
+        $localeCodes = $cnx->fetchAllAssociative('SELECT locale FROM pim_catalog_channel_translation WHERE foreign_key=? ORDER BY locale ASC', [$channel_id]);
+
+        $this->assertEquals($localeCodes, [['locale' => 'en_US'], ['locale' => 'foo_bar'], ['locale' => 'fr_FR']]);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When Setting/Importing channels labels are localized using a [localeCode => label] map.
The locale codes must refer to locales known by the PIM, and case must be correct to prevent issue frontside.
The proposed modification ensures that when a locale is known, its case is correct in the channel data.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)

