### PR TITLE
CPM-587: Add uuid columns

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/AddUuidColumnsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/AddUuidColumnsSubscriber.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Db;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AddUuidColumnsSubscriber implements EventSubscriberInterface
+{
+    private const TABLES = [
+        'pim_catalog_product' => 'uuid',
+        'pim_catalog_association' => 'owner_uuid',
+        'pim_catalog_association_product' => 'product_uuid',
+        'pim_catalog_association_product_model_to_product' => 'product_uuid',
+        'pim_catalog_category_product' => 'product_uuid',
+        'pim_catalog_group_product' => 'product_uuid',
+        'pim_catalog_product_unique_data' => 'product_uuid',
+        'pim_catalog_completeness' => 'product_uuid',
+        'pim_data_quality_insights_product_criteria_evaluation' => 'product_uuid',
+        'pim_data_quality_insights_product_score' => 'product_uuid',
+        'pimee_teamwork_assistant_completeness_per_attribute_group' => 'product_uuid',
+        'pimee_teamwork_assistant_project_product' => 'product_uuid',
+        'pimee_workflow_product_draft' => 'product_uuid',
+        'pimee_workflow_published_product' => 'original_product_uuid',
+        'pim_versioning_version' => 'resource_uuid',
+    ];
+
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            InstallerEvents::POST_DB_CREATE => ['addUuidColumns', -50],
+        ];
+    }
+
+    public function addUuidColumns(InstallerEvent $event): void
+    {
+        foreach (self::TABLES as $tableName => $columnName) {
+            if ($this->tableExists($tableName) && !$this->columnExists($tableName, $columnName)) {
+                $this->addUuidColumn(
+                    $tableName,
+                    $columnName
+                );
+            }
+        }
+    }
+
+    private function addUuidColumn(string $tableName, string $uuidColumName): void
+    {
+        $addUuidColumnSql = <<<SQL
+            ALTER TABLE `{table_name}`
+                ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL,
+                    ALGORITHM=INPLACE,
+                    LOCK=NONE;
+        SQL;
+
+        $addUuidColumnQuery = \strtr(
+            $addUuidColumnSql,
+            [
+                '{table_name}' => $tableName,
+                '{uuid_column_name}' => $uuidColumName,
+            ]
+        );
+
+        $this->connection->executeQuery($addUuidColumnQuery);
+    }
+
+    private function tableExists(string $tableName): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+                SHOW TABLES LIKE :tableName
+            SQL,
+            ['tableName' => $tableName]
+        );
+
+        return count($rows) >= 1;
+    }
+
+    private function columnExists(string $tableName, string $columnName): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            \strtr(
+                <<<SQL
+                    SHOW COLUMNS FROM {table_name} LIKE :columnName
+                SQL,
+                ['{table_name}' => $tableName]
+            ),
+            ['columnName' => $columnName]
+        );
+
+        return count($rows) >= 1;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -134,6 +134,12 @@ services:
         tags:
             - { name: 'kernel.event_subscriber' }
 
+    Akeneo\Pim\Enrichment\Bundle\EventSubscriber\Db\AddUuidColumnsSubscriber:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'kernel.event_subscriber' }
+
     pim_catalog.event_subscriber.attribute_option_set_sort_order:
         class: 'Akeneo\Pim\Enrichment\Bundle\EventSubscriber\AttributeOption\SetAttributeOptionSortOrderSubscriber'
         arguments:

--- a/tests/back/Integration/catalog/technical_sql/200_products.sql
+++ b/tests/back/Integration/catalog/technical_sql/200_products.sql
@@ -20,7 +20,7 @@
 --
 
 /*!40000 ALTER TABLE `pim_catalog_association` DISABLE KEYS */;
-INSERT INTO `pim_catalog_association` VALUES (9,865,49),(8,866,49),(7,868,49),(6,867,49);
+INSERT INTO `pim_catalog_association` (`id`, `association_type_id`, `owner_id`) VALUES (9,865,49),(8,866,49),(7,868,49),(6,867,49);
 /*!40000 ALTER TABLE `pim_catalog_association` ENABLE KEYS */;
 
 --
@@ -28,7 +28,7 @@ INSERT INTO `pim_catalog_association` VALUES (9,865,49),(8,866,49),(7,868,49),(6
 --
 
 /*!40000 ALTER TABLE `pim_catalog_association_group` DISABLE KEYS */;
-INSERT INTO `pim_catalog_association_group` VALUES (8,240),(9,241);
+INSERT INTO `pim_catalog_association_group` (`association_id`, `group_id`) VALUES (8,240),(9,241);
 /*!40000 ALTER TABLE `pim_catalog_association_group` ENABLE KEYS */;
 
 
@@ -37,7 +37,7 @@ INSERT INTO `pim_catalog_association_group` VALUES (8,240),(9,241);
 --
 
 /*!40000 ALTER TABLE `pim_catalog_association_product` DISABLE KEYS */;
-INSERT INTO `pim_catalog_association_product` VALUES (7,47),(7,48),(9,47);
+INSERT INTO `pim_catalog_association_product` (`association_id`, `product_id`) VALUES (7,47),(7,48),(9,47);
 /*!40000 ALTER TABLE `pim_catalog_association_product` ENABLE KEYS */;
 
 
@@ -46,7 +46,7 @@ INSERT INTO `pim_catalog_association_product` VALUES (7,47),(7,48),(9,47);
 --
 
 /*!40000 ALTER TABLE `pim_catalog_completeness` DISABLE KEYS */;
-INSERT INTO `pim_catalog_completeness` VALUES (773,21058,209,49,0,19),(774,21039,210,49,2,19),(775,21058,210,49,0,19),(776,21090,210,49,0,19);
+INSERT INTO `pim_catalog_completeness` (`id`, `locale_id`, `channel_id`, `product_id`, `missing_count`, `required_count`) VALUES (773,21058,209,49,0,19),(774,21039,210,49,2,19),(775,21058,210,49,0,19),(776,21090,210,49,0,19);
 /*!40000 ALTER TABLE `pim_catalog_completeness` ENABLE KEYS */;
 
 
@@ -55,7 +55,7 @@ INSERT INTO `pim_catalog_completeness` VALUES (773,21058,209,49,0,19),(774,21039
 --
 
 /*!40000 ALTER TABLE `pim_catalog_group_product` DISABLE KEYS */;
-INSERT INTO `pim_catalog_group_product` VALUES (49,239),(49,240),(49,241);
+INSERT INTO `pim_catalog_group_product` (`product_id`, `group_id`) VALUES (49,239),(49,240),(49,241);
 /*!40000 ALTER TABLE `pim_catalog_group_product` ENABLE KEYS */;
 
 --
@@ -84,11 +84,11 @@ INSERT INTO `pim_catalog_product` (`id`, `identifier`, `family_id`, `family_vari
 /*!40000 ALTER TABLE `pim_catalog_product` ENABLE KEYS */;
 
 /*!40000 ALTER TABLE `pim_catalog_category_product_model` DISABLE KEYS */;
-INSERT INTO `pim_catalog_category_product_model` VALUES (150,896),(151,899),(151,897);
+INSERT INTO `pim_catalog_category_product_model` (`product_model_id`, `category_id`) VALUES (150,896),(151,899),(151,897);
 /*!40000 ALTER TABLE `pim_catalog_category_product_model` ENABLE KEYS */;
 
 /*!40000 ALTER TABLE `pim_catalog_category_product` DISABLE KEYS */;
-INSERT INTO `pim_catalog_category_product` VALUES (49,897),(49,899),(50,898);
+INSERT INTO `pim_catalog_category_product` (`product_id`, `category_id`) VALUES (49,897),(49,899),(50,898);
 /*!40000 ALTER TABLE `pim_catalog_category_product` ENABLE KEYS */;
 
 

--- a/upgrades/schema/Version_7_0_20220404075823_add_uuid_columns.php
+++ b/upgrades/schema/Version_7_0_20220404075823_add_uuid_columns.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_7_0_20220404075823_add_uuid_columns extends AbstractMigration
+{
+    private const TABLES = [
+        'pim_catalog_product' => 'uuid',
+        'pim_catalog_association' => 'owner_uuid',
+        'pim_catalog_association_product' => 'product_uuid',
+        'pim_catalog_association_product_model_to_product' => 'product_uuid',
+        'pim_catalog_category_product' => 'product_uuid',
+        'pim_catalog_group_product' => 'product_uuid',
+        'pim_catalog_product_unique_data' => 'product_uuid',
+        'pim_catalog_completeness' => 'product_uuid',
+        'pim_data_quality_insights_product_criteria_evaluation' => 'product_uuid',
+        'pim_data_quality_insights_product_score' => 'product_uuid',
+        'pimee_teamwork_assistant_completeness_per_attribute_group' => 'product_uuid',
+        'pimee_teamwork_assistant_project_product' => 'product_uuid',
+        'pimee_workflow_product_draft' => 'product_uuid',
+        'pimee_workflow_published_product' => 'original_product_uuid',
+        'pim_versioning_version' => 'resource_uuid',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Add uuid columns for product table and every foreign table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::TABLES as $tableName => $columnName) {
+            if ($this->tableExists($tableName) && !$this->columnExists($tableName, $columnName)) {
+                $this->addUuidColumn(
+                    $tableName,
+                    $columnName
+                );
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function addUuidColumn(string $tableName, string $uuidColumName): void
+    {
+        $addUuidColumnSql = <<<SQL
+            ALTER TABLE `{table_name}`
+                ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL,
+                    ALGORITHM=INPLACE,
+                    LOCK=NONE;
+        SQL;
+
+        $addUuidColumnQuery = \strtr(
+            $addUuidColumnSql,
+            [
+                '{table_name}' => $tableName,
+                '{uuid_column_name}' => $uuidColumName,
+            ]
+        );
+
+        $this->addSql($addUuidColumnQuery);
+    }
+
+    private function tableExists(string $tableName): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+                SHOW TABLES LIKE :tableName
+            SQL,
+            ['tableName' => $tableName]
+        );
+
+        return count($rows) >= 1;
+    }
+
+    private function columnExists(string $tableName, string $columnName): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            \strtr(
+                <<<SQL
+                    SHOW COLUMNS FROM {table_name} LIKE :columnName
+                SQL,
+                ['{table_name}' => $tableName]
+            ),
+            ['columnName' => $columnName]
+        );
+
+        return count($rows) >= 1;
+    }
+}


### PR DESCRIPTION
This PR prepares the migration from product id to product uuid
The first step is to add columns for product table and for every foreign table.
This can be done in a simple Symfony migration
We tested this migration on a real environment with tens of millions of lines and it takes less than 1 second per table.