### PR TITLE
CXP-916: remove warning logs of live ACLs

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -170,8 +170,6 @@ class ProductController
 
     private GetProductsWithCompletenessesInterface $getProductsWithCompletenesses;
 
-    private LoggerInterface $apiProductAclLogger;
-
     private SecurityFacade $security;
 
     public function __construct(
@@ -208,7 +206,6 @@ class ProductController
         GetProductsWithQualityScoresInterface $getProductsWithQualityScores,
         RemoveParentInterface $removeParent,
         GetProductsWithCompletenessesInterface $getProductsWithCompletenesses,
-        LoggerInterface $apiProductAclLogger,
         SecurityFacade $security,
         private ValidatorInterface $validator
     ) {
@@ -245,7 +242,6 @@ class ProductController
         $this->getProductsWithQualityScores = $getProductsWithQualityScores;
         $this->removeParent = $removeParent;
         $this->getProductsWithCompletenesses = $getProductsWithCompletenesses;
-        $this->apiProductAclLogger = $apiProductAclLogger;
         $this->security = $security;
     }
 
@@ -911,16 +907,6 @@ class ProductController
     private function denyAccessUnlessAclIsGranted(string $acl): void
     {
         if (!$this->security->isGranted($acl)) {
-            $user = $this->tokenStorage->getToken()->getUser();
-            Assert::isInstanceOf($user, UserInterface::class);
-
-            $this->apiProductAclLogger->warning(sprintf(
-                'User "%s" with roles %s is not granted "%s"',
-                $user->getUsername(),
-                implode(',', $user->getRoles()),
-                $acl
-            ));
-
             throw new AccessDeniedHttpException($this->deniedAccessMessage($acl));
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductModelController.php
@@ -82,7 +82,6 @@ class ProductModelController
     private ApiAggregatorForProductModelPostSaveEventSubscriber $apiAggregatorForProductModelPostSave;
     private WarmupQueryCache $warmupQueryCache;
     private LoggerInterface $logger;
-    private LoggerInterface $apiProductAclLogger;
     private SecurityFacade $security;
     private RemoveProductModelHandler $removeProductModelHandler;
     private ValidatorInterface $validator;
@@ -112,7 +111,6 @@ class ProductModelController
         WarmupQueryCache $warmupQueryCache,
         LoggerInterface $logger,
         array $apiConfiguration,
-        LoggerInterface $apiProductAclLogger,
         SecurityFacade $security,
         RemoveProductModelHandler $removeProductModelHandler,
         ValidatorInterface $validator,
@@ -141,7 +139,6 @@ class ProductModelController
         $this->warmupQueryCache = $warmupQueryCache;
         $this->logger = $logger;
         $this->apiConfiguration = $apiConfiguration;
-        $this->apiProductAclLogger = $apiProductAclLogger;
         $this->security = $security;
         $this->removeProductModelHandler = $removeProductModelHandler;
         $this->validator = $validator;
@@ -571,16 +568,6 @@ class ProductModelController
     private function denyAccessUnlessAclIsGranted(string $acl): void
     {
         if (!$this->security->isGranted($acl)) {
-            $user = $this->tokenStorage->getToken()->getUser();
-            Assert::isInstanceOf($user, UserInterface::class);
-
-            $this->apiProductAclLogger->warning(sprintf(
-                'User "%s" with roles %s is not granted "%s"',
-                $user->getUsername(),
-                implode(',', $user->getRoles()),
-                $acl
-            ));
-
             throw new AccessDeniedHttpException($this->deniedAccessMessage($acl));
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -72,7 +72,6 @@ services:
             - '@akeneo.pim.enrichment.use_cases.get_products_with_quality_scores'
             - '@pim_catalog.entity_with_family_variant.remove_parent_from_product'
             - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
-            - '@monolog.logger.pim_api_acl'
             - '@oro_security.security_facade'
             - '@validator'
 
@@ -103,7 +102,6 @@ services:
             - '@pim_api.warmup_query_cache.dummy'
             - '@logger'
             - '%pim_api.configuration%'
-            - '@monolog.logger.pim_api_acl'
             - '@oro_security.security_facade'
             - '@Akeneo\Pim\Enrichment\Component\Product\Command\ProductModel\RemoveProductModelHandler'
             - '@validator'

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -1010,14 +1010,6 @@ JSON;
         $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductEndToEnd.php
@@ -65,14 +65,6 @@ class DeleteProductEndToEnd extends AbstractProductTestCase
         $client->request('DELETE', 'api/rest/v1/products/foo');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_remove"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -317,14 +317,6 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_list"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -975,14 +975,6 @@ JSON;
         $client->request('GET', 'api/rest/v1/products');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_list"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -327,14 +327,6 @@ JSON;
         $result = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
         $response = $result['http_response'];
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -1614,14 +1614,6 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/products/foo', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -972,14 +972,6 @@ JSON;
         $client->request('POST', 'api/rest/v1/product-models', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/GetProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/GetProductModelEndToEnd.php
@@ -108,14 +108,6 @@ class GetProductModelEndToEnd extends ApiTestCase
         $client->request('GET', 'api/rest/v1/product-models/model-biker-jacket-leather');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_list"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListOffsetProductModelEndToEnd.php
@@ -197,14 +197,6 @@ JSON;
         $client->request('GET', 'api/rest/v1/product-models');
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_list"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -341,14 +341,6 @@ JSON;
         $result = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);
         $response = $result['http_response'];
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -1326,14 +1326,6 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/product-models/sub_sweat', [], [], [], $data);
         $response = $client->getResponse();
 
-        $logger = self::$container->get('monolog.logger.pim_api_acl');
-        assert($logger instanceof TestLogger);
-
-        $this->assertTrue(
-            $logger->hasWarning('User "admin" with roles ROLE_ADMINISTRATOR is not granted "pim_api_product_edit"'),
-            'Expected warning not found in the logs.'
-        );
-
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 


### PR DESCRIPTION
<!-- <3 Peanut butter <3 -->

**Description (for Contributor and Core Developer)**

A long time ago, we were logging errors due to the introduced ACLs on this REST API endpoints.
We don't need those logs anymore.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
