### PR TITLE
OCT-37: Fix feature flag in App Activate behat tests

### DIFF
--- a/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
+++ b/src/Akeneo/Connectivity/Connection/tests/features/activate_an_app.feature
@@ -4,6 +4,7 @@ Feature: Activate an OAuth2 client application in the PIM
   As Julia
   I need to be able to go through the Authorization tunnel
 
+  @marketplace-activate-feature-enabled
   Scenario: julia is authorized to activate an App
     Given a "default" catalog configuration
     And the role "ROLE_CATALOG_MANAGER" has the ACL "Manage Apps"
@@ -26,6 +27,7 @@ Feature: Activate an OAuth2 client application in the PIM
       | pim_api_product_remove | true    |
     And it can exchange the authorization code for a token
 
+  @marketplace-activate-feature-enabled
   Scenario: Julia can activate and authenticate in an App
     Given a "default" catalog configuration
     And the role "ROLE_CATALOG_MANAGER" has the ACL "Manage Apps"


### PR DESCRIPTION
<!-- it's 22:22 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The changes related to the feature flags introduced by @ahocquard in https://github.com/akeneo/pim-community-dev/pull/16657 broke our 2 behat tests for the App Activation.
It's not his fault, these 2 tests are not executed in the complete CI, only ours.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
