### PR TITLE
CPM-587: Fix ALGORITHM and LOCK on uuid columns migration

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/AddUuidColumnsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/Db/AddUuidColumnsSubscriber.php
@@ -55,10 +55,7 @@ class AddUuidColumnsSubscriber implements EventSubscriberInterface
     private function addUuidColumn(string $tableName, string $uuidColumName): void
     {
         $addUuidColumnSql = <<<SQL
-            ALTER TABLE `{table_name}`
-                ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL,
-                    ALGORITHM=INPLACE,
-                    LOCK=NONE;
+            ALTER TABLE `{table_name}` ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL;
         SQL;
 
         $addUuidColumnQuery = \strtr(

--- a/upgrades/schema/Version_7_0_20220404075823_add_uuid_columns.php
+++ b/upgrades/schema/Version_7_0_20220404075823_add_uuid_columns.php
@@ -52,10 +52,7 @@ final class Version_7_0_20220404075823_add_uuid_columns extends AbstractMigratio
     private function addUuidColumn(string $tableName, string $uuidColumName): void
     {
         $addUuidColumnSql = <<<SQL
-            ALTER TABLE `{table_name}`
-                ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL,
-                    ALGORITHM=INPLACE,
-                    LOCK=NONE;
+            ALTER TABLE `{table_name}` ADD `{uuid_column_name}` BINARY(16) DEFAULT NULL;
         SQL;
 
         $addUuidColumnQuery = \strtr(


### PR DESCRIPTION
The previous queries were too long and lead to a timeout (+20min)
This version should be a lot quicker, but will add a lock on the tables.