### PR TITLE
CXP-1145: App's user is not in the "All" default group

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/CreateConnectedAppWithAuthorizationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/CreateConnectedAppWithAuthorizationHandler.php
@@ -8,7 +8,7 @@ use Akeneo\Connectivity\Connection\Application\Apps\AppAuthorizationSessionInter
 use Akeneo\Connectivity\Connection\Application\Apps\AppRoleWithScopesFactoryInterface;
 use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnectedAppInterface;
 use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnectionInterface;
-use Akeneo\Connectivity\Connection\Application\Settings\Service\CreateUserInterface;
+use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateUserInterface;
 use Akeneo\Connectivity\Connection\Application\User\CreateUserGroupInterface;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequestException;
 use Akeneo\Connectivity\Connection\Domain\Marketplace\GetAppQueryInterface;
@@ -71,10 +71,9 @@ class CreateConnectedAppWithAuthorizationHandler
             throw new \LogicException('The user role should have a role code, like ROLE_*, got null.');
         }
 
-        $user = $this->createUser->execute(
+        $userId = $this->createUser->execute(
             $randomCode,
             $marketplaceApp->getName(),
-            ' ',
             [$group->getName()],
             [$role->getRole()]
         );
@@ -84,7 +83,7 @@ class CreateConnectedAppWithAuthorizationHandler
             $marketplaceApp->getName(),
             FlowType::OTHER,
             $client->getId(),
-            $user->id(),
+            $userId,
         );
 
         $this->createConnectedApp->execute(

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/CreateUserInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/CreateUserInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Apps\Service;
+
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\User;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface CreateUserInterface
+{
+    /**
+     * @param string[] $groups
+     * @param string[] $roles
+     * @return int user id
+     */
+    public function execute(string $username, string $name, array $groups, array $roles): int;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\EventSubscriber;
+
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Akeneo\UserManagement\Component\Model\Group;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [StorageEvents::PRE_SAVE => 'removeGroupAllFromUsersUsedByApps'];
+    }
+
+    public function removeGroupAllFromUsersUsedByApps(GenericEvent $event)
+    {
+        $subject = $event->getSubject();
+
+        if (!$subject instanceof UserInterface) {
+            return;
+        }
+
+        if (!$subject->isApiUser()) {
+            return;
+        }
+
+        if (!$this->hasGroupOfTypeApp($subject)) {
+            return;
+        }
+
+        $this->removeGroupAllFromUser($subject);
+    }
+
+    private function hasGroupOfTypeApp(UserInterface $user): bool
+    {
+        /** @var Group $group */
+        foreach ($user->getGroups() as $group) {
+            if ($group->getType() === 'app') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function removeGroupAllFromUser(UserInterface $user): void
+    {
+        /** @var Group $group */
+        foreach ($user->getGroups() as $group) {
+            if ($group->getName() === 'All') {
+                $user->removeGroup($group);
+                break;
+            }
+        }
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/User/CreateUser.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/User/CreateUser.php
@@ -8,7 +8,6 @@ use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateUserInterface;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
-use Akeneo\UserManagement\Component\Model\GroupInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -45,8 +44,6 @@ class CreateUser implements CreateUserInterface
         $user->defineAsApiUser();
         $this->userUpdater->update($user, $userPayload);
 
-        $this->removeDefaultGroupImposedByTheFactory($user, $groups);
-
         $errors = $this->validator->validate($user);
         if (0 < \count($errors)) {
             $errorMessages = [];
@@ -60,16 +57,6 @@ class CreateUser implements CreateUserInterface
         $this->userSaver->save($user);
 
         return $user->getId();
-    }
-
-    private function removeDefaultGroupImposedByTheFactory(UserInterface $user, array $groups): void
-    {
-        /** @var GroupInterface $group */
-        foreach ($user->getGroups() as $group) {
-            if (!\in_array($group->getName(), $groups)) {
-                $user->getGroups()->removeElement($group);
-            }
-        }
     }
 
     private function generatePassword(): string

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/User/CreateUser.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/User/CreateUser.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\User;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateUserInterface;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Akeneo\UserManagement\Component\Model\GroupInterface;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CreateUser implements CreateUserInterface
+{
+    public function __construct(
+        private SimpleFactoryInterface $userFactory,
+        private ObjectUpdaterInterface $userUpdater,
+        private ValidatorInterface $validator,
+        private SaverInterface $userSaver
+    ) {
+    }
+
+    public function execute(string $username, string $name, array $groups, array $roles): int
+    {
+        $password = $this->generatePassword();
+
+        $userPayload = [
+            'username' => $username,
+            'password' => $password,
+            'first_name' => $name,
+            'last_name' => ' ',
+            'email' => \sprintf('%s@example.com', $username),
+            'groups' => $groups,
+            'roles' => $roles,
+        ];
+
+        /** @var UserInterface $user */
+        $user = $this->userFactory->create();
+        $user->defineAsApiUser();
+        $this->userUpdater->update($user, $userPayload);
+
+        $this->removeDefaultGroupImposedByTheFactory($user, $groups);
+
+        $errors = $this->validator->validate($user);
+        if (0 < \count($errors)) {
+            $errorMessages = [];
+            foreach ($errors as $error) {
+                $errorMessages[] = $error->getPropertyPath() . ': ' . $error->getMessage();
+            }
+
+            throw new \LogicException("The user creation failed :\n" . \implode("\n", $errorMessages));
+        }
+
+        $this->userSaver->save($user);
+
+        return $user->getId();
+    }
+
+    private function removeDefaultGroupImposedByTheFactory(UserInterface $user, array $groups): void
+    {
+        /** @var GroupInterface $group */
+        foreach ($user->getGroups() as $group) {
+            if (!\in_array($group->getName(), $groups)) {
+                $user->getGroups()->removeElement($group);
+            }
+        }
+    }
+
+    private function generatePassword(): string
+    {
+        return \str_shuffle(\ucfirst(\substr(\uniqid(), 0, 9)));
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/event_subscribers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/event_subscribers.yml
@@ -11,3 +11,7 @@ services:
             - '@akeneo_connectivity.connection.app_developer_mode.feature'
         tags:
             - { name: kernel.event_subscriber }
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\EventSubscriber\GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
@@ -4,7 +4,7 @@ services:
             - '@validator'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Marketplace\Persistence\GetAppQuery'
-            - '@Akeneo\Connectivity\Connection\Infrastructure\Service\User\CreateUser'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup'
             - '@Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnection'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\AppRoleWithScopesFactory'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
@@ -54,3 +54,10 @@ services:
             - '@pim_user.repository.role'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry'
             - '@pim_user.saver.role_with_permissions'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser:
+        arguments:
+            - '@pim_user.factory.user'
+            - '@pim_user.updater.user'
+            - '@validator'
+            - '@pim_user.saver.user'

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -168,6 +168,7 @@ $rules = [
 
             'Akeneo\Connectivity\Connection\Domain\ClockInterface',
 
+            'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\User',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType',

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/ConfirmAuthenticationEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/ConfirmAuthenticationEndToEnd.php
@@ -14,9 +14,9 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\CreateConnectedAppQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup;
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApi;
-use Akeneo\Connectivity\Connection\Infrastructure\Service\User\CreateUser;
 use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeFeatureFlag;
 use Akeneo\Connectivity\Connection\Tests\Integration\Mock\FakeWebMarketplaceApi;
 use Akeneo\Test\Integration\Configuration;
@@ -113,11 +113,11 @@ class ConfirmAuthenticationEndToEnd extends WebTestCase
     {
         $group = $this->createUserGroup->execute('userGroup_'.$appPublicId);
 
-        $user = $this->createUser->execute(
+        $userId = $this->createUser->execute(
             'username_'.$appPublicId,
             'firstname_'.$appPublicId,
-            'lastname_'.$appPublicId,
-            [$group->getName()]
+            [$group->getName()],
+            ['ROLE_USER'],
         );
 
         $client = $this->clientProvider->findOrCreateClient(
@@ -138,7 +138,7 @@ class ConfirmAuthenticationEndToEnd extends WebTestCase
             'Connector_'.$appPublicId,
             FlowType::OTHER,
             $client->getId(),
-            $user->id()
+            $userId,
         );
 
         $this->createConnectedAppQuery->execute(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/ConsentAppAuthenticationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/ConsentAppAuthenticationHandlerIntegration.php
@@ -18,8 +18,8 @@ use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\CreateConnectedAppQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetUserConsentedAuthenticationScopesQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup;
-use Akeneo\Connectivity\Connection\Infrastructure\Service\User\CreateUser;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use FOS\OAuthServerBundle\Model\ClientInterface;
@@ -188,11 +188,11 @@ class ConsentAppAuthenticationHandlerIntegration extends TestCase
     {
         $group = $this->createUserGroup->execute('userGroup_'.$appPublicId);
 
-        $user = $this->createUser->execute(
+        $userId = $this->createUser->execute(
             'username_'.$appPublicId,
             'firstname_'.$appPublicId,
-            'lastname_'.$appPublicId,
-            [$group->getName()]
+            [$group->getName()],
+            ['ROLE_USER'],
         );
 
         $client = $this->clientProvider->findOrCreateClient(
@@ -213,7 +213,7 @@ class ConsentAppAuthenticationHandlerIntegration extends TestCase
             'Connector_'.$appPublicId,
             FlowType::OTHER,
             $client->getId(),
-            $user->id()
+            $userId,
         );
 
         $this->createConnectedAppQuery->execute(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateConnectedAppWithAuthorizationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateConnectedAppWithAuthorizationHandlerIntegration.php
@@ -198,10 +198,7 @@ class CreateConnectedAppWithAuthorizationHandlerIntegration extends TestCase
 
         /** @var Collection $userGroups */
         $userGroups = $foundUser->getGroups();
-        Assert::assertEquals(2, $userGroups->count(), 'User do not belong to exactly 2 groups');
-        Assert::assertTrue($userGroups->exists(function (int $index, Group $group) {
-            return $group->getName() === User::GROUP_DEFAULT;
-        }), 'User do not have default user group');
+        Assert::assertEquals(1, $userGroups->count(), 'User do not belong to exactly 1 group');
         Assert::assertTrue($userGroups->exists(function (int $index, Group $group) {
             return $group->getType() === 'app' && $group->getName() !== User::GROUP_DEFAULT;
         }), 'The user group created is not of type "app"');

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetAppConfirmationQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetAppConfirmationQueryIntegration.php
@@ -12,8 +12,8 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProvider;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\CreateConnectedAppQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetAppConfirmationQuery;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser;
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup;
-use Akeneo\Connectivity\Connection\Infrastructure\Service\User\CreateUser;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 
@@ -51,11 +51,11 @@ class GetAppConfirmationQueryIntegration extends TestCase
     {
         $group = $this->createUserGroup->execute('userGroup_' . $appPublicId);
 
-        $user = $this->createUser->execute(
+        $userId = $this->createUser->execute(
             'username_' . $appPublicId,
             'firstname_' . $appPublicId,
-            'lastname_' . $appPublicId,
-            [$group->getName()]
+            [$group->getName()],
+            ['ROLE_USER'],
         );
 
         $client = $this->clientProvider->findOrCreateClient(
@@ -76,7 +76,7 @@ class GetAppConfirmationQueryIntegration extends TestCase
             'Connector_' . $appPublicId,
             FlowType::OTHER,
             $client->getId(),
-            $user->id()
+            $userId,
         );
 
         $this->createConnectedAppQuery->execute(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/User/CreateUserIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/User/CreateUserIntegration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\User;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CreateUserIntegration extends TestCase
+{
+    private ?CreateUser $createUser;
+    private ?UserRepositoryInterface $userRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createUser = $this->get(CreateUser::class);
+        $this->userRepository = $this->get('pim_user.repository.user');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function test_it_creates_a_user(): void
+    {
+        $userId = $this->createUser->execute('x57L54a93CXq', 'magento', ['Manager'], ['ROLE_USER']);
+
+        /** @var UserInterface|null $user */
+        $user = $this->userRepository->find($userId);
+
+        Assert::assertNotNull($user);
+        Assert::assertSame('x57L54a93CXq', $user->getUserIdentifier());
+        Assert::assertSame('magento', $user->getFullName());
+        Assert::assertTrue($user->isApiUser());
+        Assert::assertSame(['Manager'], $user->getGroupNames());
+        Assert::assertSame(['ROLE_USER'], $user->getRoles());
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/User/CreateUserIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/User/CreateUserIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\User;
 
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUser;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\User\CreateUserGroup;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -18,6 +19,7 @@ use PHPUnit\Framework\Assert;
 class CreateUserIntegration extends TestCase
 {
     private ?CreateUser $createUser;
+    private ?CreateUserGroup $createUserGroup;
     private ?UserRepositoryInterface $userRepository;
 
     public function setUp(): void
@@ -25,6 +27,7 @@ class CreateUserIntegration extends TestCase
         parent::setUp();
 
         $this->createUser = $this->get(CreateUser::class);
+        $this->createUserGroup = $this->get(CreateUserGroup::class);
         $this->userRepository = $this->get('pim_user.repository.user');
     }
 
@@ -35,7 +38,8 @@ class CreateUserIntegration extends TestCase
 
     public function test_it_creates_a_user(): void
     {
-        $userId = $this->createUser->execute('x57L54a93CXq', 'magento', ['Manager'], ['ROLE_USER']);
+        $this->createUserGroup->execute('magento_ug');
+        $userId = $this->createUser->execute('x57L54a93CXq', 'magento', ['magento_ug'], ['ROLE_USER']);
 
         /** @var UserInterface|null $user */
         $user = $this->userRepository->find($userId);
@@ -44,7 +48,7 @@ class CreateUserIntegration extends TestCase
         Assert::assertSame('x57L54a93CXq', $user->getUserIdentifier());
         Assert::assertSame('magento', $user->getFullName());
         Assert::assertTrue($user->isApiUser());
-        Assert::assertSame(['Manager'], $user->getGroupNames());
+        Assert::assertSame(['magento_ug'], $user->getGroupNames());
         Assert::assertSame(['ROLE_USER'], $user->getRoles());
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/CreateConnectedAppWithAuthorizationHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/CreateConnectedAppWithAuthorizationHandlerSpec.php
@@ -10,7 +10,7 @@ use Akeneo\Connectivity\Connection\Application\Apps\Command\CreateConnectedAppWi
 use Akeneo\Connectivity\Connection\Application\Apps\Command\CreateConnectedAppWithAuthorizationHandler;
 use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnectedAppInterface;
 use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateConnectionInterface;
-use Akeneo\Connectivity\Connection\Application\Settings\Service\CreateUserInterface;
+use Akeneo\Connectivity\Connection\Application\Apps\Service\CreateUserInterface;
 use Akeneo\Connectivity\Connection\Application\User\CreateUserGroupInterface;
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AppAuthorization;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequestException;
@@ -236,11 +236,10 @@ class CreateConnectedAppWithAuthorizationHandlerSpec extends ObjectBehavior
         $userGroup->getName()->willReturn('a_group');
         $appRoleWithScopesFactory->createRole('an_app_id', ['a_scope'])->willReturn($role);
         $role->getRole()->willReturn('ROLE_APP');
-        $createUser->execute(Argument::any(), Argument::any(), Argument::any(), ['a_group'], ['ROLE_APP'])->willReturn($user);
+        $createUser->execute(Argument::any(), Argument::any(), ['a_group'], ['ROLE_APP'])->willReturn(43);
 
         $client->getId()->willReturn(42);
         $app->getName()->willReturn('My App');
-        $user->id()->willReturn(43);
         $createConnection->execute(Argument::any(), 'My App', 'other', 42, 43)->willReturn($connection);
         $connection->code()->willReturn('random_connection_code');
 

--- a/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
+++ b/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle\Manager;
 
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\User;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -16,33 +17,12 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 class UserManager implements UserProviderInterface
 {
-    /**
-     * @var string
-     */
-    protected $class;
-
-    /**
-     * @var ObjectManager
-     */
-    protected $om;
-
-    /**
-     * @var EncoderFactoryInterface
-     */
-    protected $encoderFactory;
-
-    /**
-     * Constructor
-     *
-     * @param string                  $class          Entity name
-     * @param ObjectManager           $om             Object manager
-     * @param EncoderFactoryInterface $encoderFactory
-     */
-    public function __construct($class, ObjectManager $om, EncoderFactoryInterface $encoderFactory)
-    {
-        $this->class = $class;
-        $this->om = $om;
-        $this->encoderFactory = $encoderFactory;
+    public function __construct(
+        protected string $class,
+        protected ObjectManager $om,
+        protected EncoderFactoryInterface $encoderFactory,
+        private SaverInterface $saver
+    ) {
     }
 
     /**
@@ -68,11 +48,7 @@ class UserManager implements UserProviderInterface
             $user->addRole($role);
         }
 
-        $this->getStorageManager()->persist($user);
-
-        if ($flush) {
-            $this->getStorageManager()->flush();
-        }
+        $this->saver->save($user);
     }
 
     /**

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
@@ -5,7 +5,11 @@ parameters:
 services:
     pim_user.manager:
         class: 'Akeneo\UserManagement\Bundle\Manager\UserManager'
-        arguments: ['%pim_user.entity.user.class%', "@doctrine.orm.entity_manager", "@security.encoder_factory"]
+        arguments:
+            - '%pim_user.entity.user.class%'
+            - "@doctrine.orm.entity_manager"
+            - "@security.encoder_factory"
+            - "@pim_user.saver.user"
 
     pim_user.security.login:
         class: 'Akeneo\UserManagement\Bundle\EventListener\LoginSubscriber'

--- a/upgrades/schema/Version_7_0_20220405000000_remove_group_all_from_apps.php
+++ b/upgrades/schema/Version_7_0_20220405000000_remove_group_all_from_apps.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_7_0_20220405000000_remove_group_all_from_apps extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            <<<SQL
+DELETE FROM oro_user_access_group
+WHERE user_id IN (
+    SELECT oro_user.id
+    FROM oro_user
+    JOIN akeneo_connectivity_connection on oro_user.id = akeneo_connectivity_connection.user_id
+    WHERE akeneo_connectivity_connection.type = 'app'
+)
+AND group_id = (
+    SELECT oro_access_group.id
+    FROM oro_access_group
+    WHERE oro_access_group.name = 'All'
+    LIMIT 1
+)
+SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    public function getDescription(): string
+    {
+        return 'Remove the UserGroup ALL from connected Apps';
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220405000000_remove_group_all_from_apps_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220405000000_remove_group_all_from_apps_Integration.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionType;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+class Version_7_0_20220405000000_remove_group_all_from_apps_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220405000000_remove_group_all_from_apps';
+
+    private ?Connection $connection;
+    private ?ConnectedAppLoader $connectedAppLoader;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = $this->get('database_connection');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function testTheGroupAllIsRemovedFromApps(): void
+    {
+        $this->insertUser('john');
+        $this->insertConnection('magento', ConnectionType::DEFAULT_TYPE);
+        $this->insertConnection('app_1t1n5nczm36ss00kws0cgckgw', ConnectionType::APP_TYPE);
+
+        $this->assertUserHasGroups('john', ['All', 'Manager']);
+        $this->assertUserHasGroups('magento', ['All', 'Manager']);
+        $this->assertUserHasGroups('app_1t1n5nczm36ss00kws0cgckgw', ['All', 'Manager']);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertUserHasGroups('john', ['All', 'Manager']);
+        $this->assertUserHasGroups('magento', ['All', 'Manager']);
+        $this->assertUserHasGroups('app_1t1n5nczm36ss00kws0cgckgw', ['Manager']);
+    }
+
+    private function assertUserHasGroups(string $username, array $expectedGroups): void
+    {
+        $query = <<<SQL
+SELECT oro_access_group.name
+FROM oro_access_group
+JOIN oro_user_access_group on oro_access_group.id = oro_user_access_group.group_id
+JOIN oro_user on oro_user_access_group.user_id = oro_user.id
+WHERE oro_user.username = :username
+SQL;
+        $groups = $this->connection->fetchFirstColumn($query, [
+            'username' => $username,
+        ]);
+
+        sort($expectedGroups);
+        sort($groups);
+
+        Assert::assertSame($expectedGroups, $groups);
+    }
+
+    private function insertConnection(string $code, string $type): void
+    {
+        $oauthClientId = $this->insertOAuthClient();
+        $userId = $this->insertUser($code);
+
+        $query = <<<SQL
+INSERT INTO akeneo_connectivity_connection (client_id, user_id, code, type, label)
+VALUES (:client, :user, :code, :type, '')
+SQL;
+
+        $this->connection->executeQuery($query, [
+            'client' => $oauthClientId,
+            'user' => $userId,
+            'code' => $code,
+            'type' => $type,
+        ]);
+    }
+
+    private function insertUser(string $username): int
+    {
+        $query = <<<SQL
+INSERT INTO oro_user (ui_locale_id, username, email, salt, password, createdAt, updatedAt, timezone, properties)
+VALUES ((SELECT id FROM pim_catalog_locale WHERE code = 'en_US'), :username, :username, '', '', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'UTC', '{}')
+SQL;
+
+        $this->connection->executeQuery($query, [
+            'username' => $username,
+        ]);
+
+        $uid = (int) $this->connection->lastInsertId();
+
+        $this->addUserToGroups($uid, ['All', 'Manager']);
+
+        return $uid;
+    }
+
+    private function addUserToGroups(int $uid, array $groups): void
+    {
+        $query = <<<SQL
+INSERT INTO oro_user_access_group (user_id, group_id)
+VALUES (:user, (SELECT id FROM oro_access_group WHERE name = :group))
+SQL;
+
+        foreach ($groups as $group) {
+            $this->connection->executeQuery($query, [
+                'user' => $uid,
+                'group' => $group,
+            ]);
+        }
+    }
+
+    private function insertOAuthClient(): int
+    {
+        $query = <<<SQL
+INSERT INTO pim_api_client (random_id, redirect_uris, secret, allowed_grant_types)
+VALUES (:random, 'a:0:{}', :random, 'a:0:{}')
+SQL;
+
+        $this->connection->executeQuery($query, [
+            'random' => $this->random(),
+        ]);
+
+        return (int) $this->connection->lastInsertId();
+    }
+
+    private function random(int $maxLength = 30): string
+    {
+        return \substr(\base_convert(\bin2hex(\random_bytes(16)), 16, 36), 0, $maxLength);
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When an App is connected, we create a hidden user for the Connection.
By default, this user had the group "All" which was provoking inconsistencies with the permissions configured in the App settings.

In this PR, I stopped using the service `CreateUser` for Connections, to use a new one dedicated to Apps.
In this new `CreateUser` service, I remove the group "All".

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
