### PR TITLE
PLG-696: Add command to clean deprecated data in completeness results

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\Command\OneTimeTask;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CleanCompletenessEvaluationResultsCommand extends Command
+{
+    use OneTimeTaskCommandTrait;
+
+    protected static $defaultName = 'pim:data-quality-insights:clean-completeness-evaluation-results';
+    protected static $defaultDescription = 'Clean the results of the products completeness criteria to replace the list of attributes codes by their number.';
+
+    private const BULK_SIZE = 1000;
+
+    public function __construct(
+        private Connection $dbConnection
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->taskCanBeStarted(self::$defaultName)) {
+            $output->writeln('This task has already been performed or is in progress.', OutputInterface::VERBOSITY_VERBOSE);
+            return Command::SUCCESS;
+        }
+
+        $output->writeln('Start cleaning...');
+        $this->startTask(self::$defaultName);
+
+        try {
+            $this->cleanEvaluationResultsForProducts();
+            $this->cleanEvaluationResultsForProductModels();
+        } catch (\Throwable $exception) {
+            $this->deleteTask(self::$defaultName);
+            throw $exception;
+        }
+
+        $output->writeln('Cleaning done.');
+
+        $this->finishTask(self::$defaultName);
+
+        return Command::SUCCESS;
+    }
+
+    private function cleanEvaluationResultsForProducts(): void
+    {
+        foreach ($this->getBulksOfCriterionResultsToClean('pim_data_quality_insights_product_criteria_evaluation') as $resultsBulk) {
+            $cleanedResults = $this->cleanBulkOfCriterionResults($resultsBulk);
+            $this->saveBulkOfCleanedResults('pim_data_quality_insights_product_criteria_evaluation', $cleanedResults);
+        }
+    }
+
+    private function cleanEvaluationResultsForProductModels(): void
+    {
+        foreach ($this->getBulksOfCriterionResultsToClean('pim_data_quality_insights_product_model_criteria_evaluation') as $resultsBulk) {
+            $cleanedResults = $this->cleanBulkOfCriterionResults($resultsBulk);
+            $this->saveBulkOfCleanedResults('pim_data_quality_insights_product_model_criteria_evaluation', $cleanedResults);
+        }
+    }
+
+    private function getBulksOfCriterionResultsToClean(string $tableName): \Generator
+    {
+        $limit = self::BULK_SIZE;
+
+        $query = <<<SQL
+SELECT product_id, criterion_code, status ,result
+FROM $tableName
+WHERE product_id > :lastProductId
+    AND criterion_code IN (:criterionCodes)
+ORDER BY product_id ASC
+LIMIT $limit;
+SQL;
+
+        $lastProductId = 0;
+
+        do {
+            $results = $this->dbConnection->executeQuery(
+                $query,
+                [
+                    'lastProductId' => $lastProductId,
+                    'criterionCodes' => [
+                        EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+                        EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+                    ]
+                ],
+                [
+                    'lastProductId' => \PDO::PARAM_INT,
+                    'criterionCodes' => Connection::PARAM_STR_ARRAY,
+                ]
+            )->fetchAllAssociative();
+
+            if (!empty($results)) {
+                $lastProductId = end($results)['product_id'];
+                yield array_map(function (array $resultRow) {
+                    $resultRow['result'] = null !== $resultRow['result'] ? \json_decode($resultRow['result'], true) : [];
+                    return $resultRow;
+                }, $results);
+            }
+        } while (!empty($results));
+    }
+
+    private function cleanBulkOfCriterionResults(array $resultsBulk): array
+    {
+        $indexData = TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'];
+        $indexAttributesList = TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'];
+        $indexAttributesCount = TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'];
+
+        $cleanedResults = [];
+        foreach ($resultsBulk as $resultRow) {
+            if (isset($resultRow['result'][$indexData][$indexAttributesList])) {
+                $resultRow['result'][$indexData][$indexAttributesCount] = $this->countAttributesByChannelAndLocales($resultRow['result'][$indexData][$indexAttributesList]);
+                unset($resultRow['result'][$indexData][$indexAttributesList]);
+                $cleanedResults[] = $resultRow;
+            }
+        }
+
+        return $cleanedResults;
+    }
+
+    private function countAttributesByChannelAndLocales(array $attributesList): array
+    {
+        return array_map(
+            fn ($attributesByLocale) => array_map(
+                fn ($attributes) => count($attributes),
+                $attributesByLocale
+            ), $attributesList);
+    }
+
+    private function saveBulkOfCleanedResults(string $tableName, array $cleanedResults): void
+    {
+        if (empty($cleanedResults)) {
+            return;
+        }
+
+        $values = implode(', ', array_map(function (array $result) {
+            return sprintf(
+                "(%d, '%s', '%s', '%s')",
+                $result['product_id'],
+                $result['criterion_code'],
+                $result['status'],
+                \json_encode($result['result'])
+            );
+        }, $cleanedResults));
+
+        // To update data by bulk in a single query, it's easiest to do it with "INSERT INTO... ON DUPLICATE KEY UPDATE..."
+        $query = <<<SQL
+INSERT INTO $tableName (product_id, criterion_code, status, result) 
+VALUES $values AS cleaned_values
+ON DUPLICATE KEY UPDATE result = cleaned_values.result;
+SQL;
+
+        $this->dbConnection->executeQuery($query);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/OneTimeTaskCommandTrait.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/OneTimeTaskCommandTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\Command\OneTimeTask;
+
+use Doctrine\DBAL\Connection;
+
+trait OneTimeTaskCommandTrait
+{
+    private Connection $dbConnection;
+
+    private function startTask(string $taskCode): void
+    {
+        $query = <<<SQL
+INSERT IGNORE INTO pim_one_time_task (code, status, start_time) 
+VALUES (:code, 'started', NOW());
+SQL;
+
+        $this->dbConnection->executeQuery($query, ['code' => $taskCode]);
+    }
+
+    private function finishTask(string $taskCode): void
+    {
+        $query = <<<SQL
+UPDATE pim_one_time_task 
+SET status = 'done', end_time = NOW()
+WHERE code = :code;
+SQL;
+
+        $this->dbConnection->executeQuery($query, ['code' => $taskCode]);
+    }
+
+    private function deleteTask(string $taskCode): void
+    {
+        $query = <<<SQL
+DELETE FROM pim_one_time_task WHERE code = :code;
+SQL;
+        $this->dbConnection->executeQuery($query, ['code' => $taskCode]);
+    }
+
+    private function taskCanBeStarted(string $taskCode): bool
+    {
+        $query = <<<SQL
+SELECT 1 FROM pim_one_time_task WHERE code = :code;
+SQL;
+
+        return !(bool)$this->dbConnection->executeQuery($query, ['code' => $taskCode])->fetchOne();
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/commands.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/commands.yml
@@ -71,3 +71,9 @@ services:
             - '@akeneo.pim.automation.data_quality_insights.create_product_models_criteria_evaluations'
         tags:
             - { name: 'console.command' }
+
+    Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\Command\OneTimeTask\CleanCompletenessEvaluationResultsCommand:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'console.command' }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommandIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommandIntegration.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Symfony\Command\OneTimeTask;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
+use Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\Command\OneTimeTask\OneTimeTaskCommandTrait;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Transformation\TransformCriterionEvaluationResultCodes;
+use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsightsTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CleanCompletenessEvaluationResultsCommandIntegration extends DataQualityInsightsTestCase
+{
+    use OneTimeTaskCommandTrait;
+
+    private const COMMAND_NAME = 'pim:data-quality-insights:clean-completeness-evaluation-results';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->dbConnection = $this->get('database_connection');
+        $this->deleteTask(self::COMMAND_NAME);
+    }
+
+    public function test_it_cleans_completeness_evaluation_results(): void
+    {
+        $cleanProductId = $this->givenAProductWithCleanCompletenessResults();
+        $aDirtyProductId = $this->givenAProductWithDirtyCompletenessResults();
+        $anotherDirtyProductId = $this->givenAnotherProductWithDirtyCompletenessResults();
+        $aDirtyProductModelId = $this->givenAProductModelWithDirtyCompletenessResults();
+
+        $this->launchCleaning();
+
+        $this->assertDirtyProductHasBeenCleaned($aDirtyProductId);
+        $this->assertAnotherDirtyProductHasBeenCleaned($anotherDirtyProductId);
+        $this->assertCleanProductHasNoChanges($cleanProductId);
+        $this->assertDirtyProductModelHasBeenCleaned($aDirtyProductModelId);
+    }
+
+    private function launchCleaning(): void
+    {
+        $kernel = self::bootKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find(self::COMMAND_NAME);
+
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName()], ['capture_stderr_separately' => true]);
+
+        self::assertEquals(0, $commandTester->getStatusCode(), $commandTester->getErrorOutput());
+    }
+
+    private function givenAProductWithCleanCompletenessResults(): int
+    {
+        $productId = $this->createProduct('a_clean_product')->getId();
+
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+            $this->buildCleanResult(5)
+        );
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+            $this->buildCleanResult(1)
+        );
+
+        return $productId;
+    }
+
+    private function givenAProductWithDirtyCompletenessResults(): int
+    {
+        $productId = $this->createProduct('a_dirty_product')->getId();
+
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+            $this->buildDirtyResult([12, 45, 64])
+        );
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+            $this->buildDirtyResult([99, 57])
+        );
+
+        return $productId;
+    }
+
+    private function givenAnotherProductWithDirtyCompletenessResults(): int
+    {
+        $productId = $this->createProduct('another_dirty_product')->getId();
+
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+            $this->buildDirtyResult([89])
+        );
+        $this->updateProductCriterionResult(
+            $productId,
+            EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE,
+            $this->buildDirtyResult([])
+        );
+
+        return $productId;
+    }
+
+    private function assertDirtyProductHasBeenCleaned(int $productId): void
+    {
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(3), 'The completeness of non required attributes should have been cleaned for the dirty product');
+
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(2), 'The completeness of required attributes should have been cleaned for the dirty product');
+    }
+
+    private function assertAnotherDirtyProductHasBeenCleaned(int $productId): void
+    {
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(1), 'The completeness of non required attributes should have been cleaned for the another dirty product');
+
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(0), 'The completeness of required attributes should have been cleaned for the another dirty product');
+    }
+
+    private function assertCleanProductHasNoChanges(int $productId): void
+    {
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(5), 'The completeness of non required attributes should not have been changed for the clean product');
+
+        $result = $this->getProductCriterionResult($productId, EvaluateCompletenessOfRequiredAttributes::CRITERION_CODE);
+        $this->assertEquals($result, $this->buildCleanResult(1), 'The completeness of required attributes should not have been changed for the clean product');
+    }
+
+    private function buildDirtyResult(array $attributeList): array
+    {
+        return [
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [],
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['attributes_with_rates'] => [
+                    1 => [39 => $attributeList, 58 => $attributeList],
+                    2 => [39 => $attributeList],
+                ],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                    1 => [39 => 42, 58 => 42],
+                    2 => [39 => 42],
+                ],
+            ]
+        ];
+    }
+
+    private function buildCleanResult(int $numberOfAttributes): array
+    {
+        return [
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['rates'] => [],
+            TransformCriterionEvaluationResultCodes::PROPERTIES_ID['data'] => [
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['total_number_of_attributes'] => [
+                    1 => [39 => 42, 58 => 42],
+                    2 => [39 => 42],
+                ],
+                TransformCriterionEvaluationResultCodes::DATA_TYPES_ID['number_of_improvable_attributes'] => [
+                    1 => [39 => $numberOfAttributes, 58 => $numberOfAttributes],
+                    2 => [39 => $numberOfAttributes],
+                ],
+            ]
+        ];
+    }
+
+    private function updateProductCriterionResult(int $productId, string $criterionCode, array $result): void
+    {
+        $query = <<<SQL
+UPDATE pim_data_quality_insights_product_criteria_evaluation
+SET result = :result 
+WHERE product_id = :productId AND criterion_code = :criterionCode;
+SQL;
+
+        $this->dbConnection->executeQuery($query, [
+            'productId' => $productId,
+            'criterionCode' => $criterionCode,
+            'result' => \json_encode($result)
+        ]);
+    }
+
+    private function getProductCriterionResult(int $productId, string $criterionCode): ?array
+    {
+        $query = <<<SQL
+SELECT result FROM pim_data_quality_insights_product_criteria_evaluation
+WHERE product_id = :productId AND criterion_code = :criterionCode;
+SQL;
+
+        $result = $this->dbConnection->executeQuery($query, [
+            'productId' => $productId,
+            'criterionCode' => $criterionCode
+        ])->fetchOne();
+
+        return $result ? \json_decode($result, true) : null;
+    }
+
+    private function givenAProductModelWithDirtyCompletenessResults(): int
+    {
+        $this->createMinimalFamilyAndFamilyVariant('a_family', 'a_family_variant');
+        $productModelId = $this->createProductModel('a_dirty_product_model', 'a_family_variant')->getId();
+        $dirtyResult = $this->buildDirtyResult([34, 6, 76]);
+
+        $query = <<<SQL
+UPDATE pim_data_quality_insights_product_model_criteria_evaluation
+SET result = :result 
+WHERE product_id = :productModelId AND criterion_code = :criterionCode;
+SQL;
+
+        $this->dbConnection->executeQuery($query, [
+            'productModelId' => $productModelId,
+            'criterionCode' => EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE,
+            'result' => \json_encode($dirtyResult)
+        ]);
+
+        return $productModelId;
+    }
+
+    private function assertDirtyProductModelHasBeenCleaned(int $productModelId): void
+    {
+        $query = <<<SQL
+SELECT result FROM pim_data_quality_insights_product_model_criteria_evaluation
+WHERE product_id = :productModelId AND criterion_code = :criterionCode;
+SQL;
+
+        $result = $this->dbConnection->executeQuery($query, [
+            'productModelId' => $productModelId,
+            'criterionCode' => EvaluateCompletenessOfNonRequiredAttributes::CRITERION_CODE
+        ])->fetchOne();
+
+        $this->assertEquals(\json_decode($result, true), $this->buildCleanResult(3), 'The completeness results should have been cleaned for the dirty product model');
+    }
+}


### PR DESCRIPTION
Since PLG-468 we store the number of improvable attributes instead of the list of their id for the two completeness criteria. 

This command aims to clean the criteria results data where there are still this list of attributes id

In the process, we browses all the results of the completeness criteria. When a result has the deprecated format, it's replaced by the new one (counting the attributes). 
We could add a condition to fetch only the deprecated results, but it would generate slow queries on big catalogs