### PR TITLE
TIP-1558: use persisted feature flag implementation as API tests use …

### DIFF
--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/test_services.yml
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/test_services.yml
@@ -1,6 +1,7 @@
 services:
     feature_flags:
         public: true
-        class: 'Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\InMemoryFeatureFlags'
+        class: 'Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\FilePersistedFeatureFlags'
         arguments:
             - '@akeneo.feature_flag.service.registry'
+            - '%kernel.cache_dir%/'

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -7,6 +7,7 @@ use Akeneo\Connectivity\Connection\Application\Settings\Command\CreateConnection
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials;
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Pim\Enrichment\Component\FileStorage;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\FilePersistedFeatureFlags;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
@@ -60,6 +61,10 @@ abstract class ApiTestCase extends WebTestCase
         $authenticator->createSystemUser();
 
         $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        /** @var FilePersistedFeatureFlags $featureFlags*/
+        $featureFlags = $this->get('feature_flags');
+        $featureFlags->deleteFile();
     }
 
     /**

--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -6,6 +6,7 @@ namespace Akeneo\Test\Integration;
 
 use Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface;
 use Akeneo\Pim\Enrichment\Component\FileStorage;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\FilePersistedFeatureFlags;
 use Akeneo\Test\IntegrationTestsBundle\Configuration\CatalogInterface;
 use Akeneo\UserManagement\Component\Model\User;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -51,6 +52,10 @@ abstract class TestCase extends KernelTestCase
 
         // Some messages can be in the queue after a failing test. To prevent error we remove then before each tests.
         $this->get('akeneo_integration_tests.launcher.job_launcher')->flushJobQueue();
+
+        /** @var FilePersistedFeatureFlags $featureFlags*/
+        $featureFlags = $this->get('feature_flags');
+        $featureFlags->deleteFile();
     }
 
     /**


### PR DESCRIPTION
…a different container

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
I could not use in memory feature flag registry for integration tests.
Indeed, when testing the API, Symfony testing helper creates a new container to perform a request (web test cases).

So, as for behat, we persist the state of the feature flags on disk.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
