### PR TITLE
CXP-1130 ACL Update

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Application\Apps\Command;
 
 use Akeneo\Connectivity\Connection\Application\Apps\AppAuthorizationSessionInterface;
+use Akeneo\Connectivity\Connection\Application\Apps\Service\UpdateConnectedAppRoleWithScopesInterface;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequestException;
 use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\UpdateConnectedAppScopesQueryInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -19,6 +20,7 @@ class UpdateConnectedAppScopesWithAuthorizationHandler
         private ValidatorInterface $validator,
         private AppAuthorizationSessionInterface $appAuthorizationSession,
         private UpdateConnectedAppScopesQueryInterface $updateConnectedAppScopesQuery,
+        private UpdateConnectedAppRoleWithScopesInterface $updateConnectedAppRoleWithScopes,
     ) {
     }
 
@@ -37,9 +39,10 @@ class UpdateConnectedAppScopesWithAuthorizationHandler
             throw new \LogicException('There is no active app authorization in session');
         }
 
-        $this->updateConnectedAppScopesQuery->execute(
-            $appAuthorization->getAuthorizationScopes()->getScopes(),
-            $appId,
-        );
+        $authorizationScopes = $appAuthorization->getAuthorizationScopes()->getScopes();
+
+        $this->updateConnectedAppScopesQuery->execute($authorizationScopes, $appId);
+
+        $this->updateConnectedAppRoleWithScopes->execute($appId, $authorizationScopes);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/UpdateConnectedAppRoleWithScopesInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/UpdateConnectedAppRoleWithScopesInterface.php
@@ -10,5 +10,8 @@ namespace Akeneo\Connectivity\Connection\Application\Apps\Service;
  */
 interface UpdateConnectedAppRoleWithScopesInterface
 {
+    /**
+     * @param string[] $scopes
+     */
     public function execute(string $appId, array $scopes): void;
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/UpdateConnectedAppRoleWithScopesInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Apps/Service/UpdateConnectedAppRoleWithScopesInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Application\Apps\Service;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface UpdateConnectedAppRoleWithScopesInterface
+{
+    public function execute(string $appId, array $scopes): void;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/GetConnectedAppRoleIdentifierQueryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Apps/Persistence/GetConnectedAppRoleIdentifierQueryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Domain\Apps\Persistence;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetConnectedAppRoleIdentifierQueryInterface
+{
+    public function execute(string $appId): ?string;
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/FindAllUsernamesWithAclQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/FindAllUsernamesWithAclQuery.php
@@ -51,6 +51,6 @@ class FindAllUsernamesWithAclQuery implements FindAllUsernamesWithAclQueryInterf
 
         $results = $this->connection->executeQuery($selectSQL, ['acl' => $acl])->fetchFirstColumn();
 
-        return $results ?? [];
+        return $results ?: [];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/GetConnectedAppRoleIdentifierQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/GetConnectedAppRoleIdentifierQuery.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\GetConnectedAppRoleIdentifierQueryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetConnectedAppRoleIdentifierQuery implements GetConnectedAppRoleIdentifierQueryInterface
+{
+    public function __construct(private Connection $connection)
+    {
+    }
+
+    public function execute(string $appId): ?string
+    {
+        $query = <<<SQL
+        SELECT role.role
+        FROM akeneo_connectivity_connected_app app
+        JOIN akeneo_connectivity_connection connection ON app.connection_code = connection.code
+        JOIN oro_user_access_role user_role ON connection.user_id = user_role.user_id
+        JOIN oro_access_role role ON role.id = user_role.role_id
+        WHERE app.id = :app_id;
+        SQL;
+
+        $roleIdentifier = $this->connection->fetchOne(
+            $query,
+            [
+                'app_id' => $appId,
+            ]
+        );
+
+        return $roleIdentifier ?: null;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopes.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopes.php
@@ -45,7 +45,7 @@ final class UpdateConnectedAppRoleWithScopes implements UpdateConnectedAppRoleWi
     {
         $appRoleIdentifier = $this->getConnectedAppRoleIdentifierQuery->execute($appId);
         if (null === $appRoleIdentifier) {
-            throw new \LogicException("Connected app $appRoleIdentifier should have a role");
+            throw new \LogicException("Connected app $appId should have a role");
         }
 
         $appRole = $this->roleRepository->findOneByIdentifier($appRoleIdentifier);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopes.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopes.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Service;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Security\ScopeMapperRegistryInterface;
+use Akeneo\Connectivity\Connection\Application\Apps\Service\UpdateConnectedAppRoleWithScopesInterface;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\GetConnectedAppRoleIdentifierQueryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\UserManagement\Component\Connector\RoleWithPermissions;
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class UpdateConnectedAppRoleWithScopes implements UpdateConnectedAppRoleWithScopesInterface
+{
+    public function __construct(
+        private GetConnectedAppRoleIdentifierQueryInterface $getConnectedAppRoleIdentifierQuery,
+        private RoleRepositoryInterface $roleRepository,
+        private ScopeMapperRegistryInterface $scopeMapperRegistry,
+        private BulkSaverInterface $roleWithPermissionsSaver,
+    ) {
+    }
+
+    public function execute(string $appId, array $scopes): void
+    {
+        $appRole = $this->getAppRole($appId);
+
+        $permissions = ['action:pim_api_overall_access' => true];
+
+        $acls = $this->scopeMapperRegistry->getAcls($scopes);
+        foreach ($acls as $acl) {
+            $permissions[\sprintf('action:%s', $acl)] = true;
+        }
+
+        $roleWithPermissions = RoleWithPermissions::createFromRoleAndPermissions($appRole, $permissions);
+        $this->roleWithPermissionsSaver->saveAll([$roleWithPermissions]);
+    }
+
+    private function getAppRole(string $appId): RoleInterface
+    {
+        $appRoleIdentifier = $this->getConnectedAppRoleIdentifierQuery->execute($appId);
+        if (null === $appRoleIdentifier) {
+            throw new \LogicException("Connected app $appRoleIdentifier should have a role");
+        }
+
+        $appRole = $this->roleRepository->findOneByIdentifier($appRoleIdentifier);
+        if (!$appRole instanceof RoleInterface) {
+            throw new \LogicException("Role entity not found for $appRoleIdentifier");
+        }
+
+        return $appRole;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/handlers.yml
@@ -16,6 +16,7 @@ services:
             - '@validator'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Session\AppAuthorizationSession'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\UpdateConnectedAppScopesQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Service\UpdateConnectedAppRoleWithScopes'
 
     Akeneo\Connectivity\Connection\Application\Apps\Command\ConsentAppAuthenticationHandler:
         arguments:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/queries.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/queries.yml
@@ -95,3 +95,7 @@ services:
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\UpdateConnectedAppDescriptionQuery:
         arguments:
             - '@database_connection'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetConnectedAppRoleIdentifierQuery:
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/services.yml
@@ -47,3 +47,10 @@ services:
         arguments:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindAllUsernamesWithAclQuery'
             - '@pim_notification.notifier'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Service\UpdateConnectedAppRoleWithScopes:
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetConnectedAppRoleIdentifierQuery'
+            - '@pim_user.repository.role'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry'
+            - '@pim_user.saver.role_with_permissions'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/FindAllUsernamesWithAclQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/FindAllUsernamesWithAclQueryIntegration.php
@@ -61,4 +61,21 @@ class FindAllUsernamesWithAclQueryIntegration extends TestCase
 
         self::assertEqualsCanonicalizing($expectedUsernames, $foundUsernames);
     }
+
+    public function test_it_returns_no_usernames_given_the_acl(): void
+    {
+        $this->createAdminUser();
+        $this->userLoader->createUser('userA', ['userGroupA'], ['ROLE_APP_A']);
+        $this->userLoader->createUser('userB', ['userGroupB'], ['ROLE_APP_A']);
+        $this->userLoader->createUser('userC', ['userGroupC'], ['ROLE_APP_B']);
+        $this->userLoader->createUser('userD', ['userGroupC'], ['ROLE_APP_B']);
+
+        $this->aclLoader->addAclToRoles('akeneo_connectivity_connection_manage_apps', [
+            'ROLE_USER',
+        ]);
+
+        $foundUsernames = $this->query->execute('akeneo_connectivity_connection_manage_apps');
+
+        self::assertEqualsCanonicalizing([], $foundUsernames);
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence;
 
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetConnectedAppRoleIdentifierQuery;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 
@@ -15,6 +16,7 @@ use Akeneo\Test\Integration\TestCase;
 class GetConnectedAppRoleIdentifierQueryIntegration extends TestCase
 {
     private GetConnectedAppRoleIdentifierQuery $query;
+    private ConnectedAppLoader $connectedAppLoader;
 
     protected function getConfiguration(): Configuration
     {
@@ -26,12 +28,7 @@ class GetConnectedAppRoleIdentifierQueryIntegration extends TestCase
         parent::setUp();
 
         $this->query = $this->get(GetConnectedAppRoleIdentifierQuery::class);
-        $connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
-
-        $connectedAppLoader->createConnectedAppWithUserAndTokens(
-            'connected_app_id',
-            'connection_code',
-        );
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
     }
 
     public function test_it_returns_null_on_unknown_app(): void
@@ -43,6 +40,8 @@ class GetConnectedAppRoleIdentifierQueryIntegration extends TestCase
 
     public function test_it_returns_role_identifier_for_a_connected_app(): void
     {
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens('connected_app_id',  'connection_code');
+
         $roleIdentifier = $this->query->execute('connected_app_id');
 
         self::assertEquals('ROLE_CONNECTION_CODE', $roleIdentifier, 'Should return connected app role');

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
@@ -40,7 +40,7 @@ class GetConnectedAppRoleIdentifierQueryIntegration extends TestCase
 
     public function test_it_returns_role_identifier_for_a_connected_app(): void
     {
-        $this->connectedAppLoader->createConnectedAppWithUserAndTokens('connected_app_id',  'connection_code');
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens('connected_app_id', 'connection_code');
 
         $roleIdentifier = $this->query->execute('connected_app_id');
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/GetConnectedAppRoleIdentifierQueryIntegration.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\GetConnectedAppRoleIdentifierQuery;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetConnectedAppRoleIdentifierQueryIntegration extends TestCase
+{
+    private GetConnectedAppRoleIdentifierQuery $query;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->query = $this->get(GetConnectedAppRoleIdentifierQuery::class);
+        $connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+
+        $connectedAppLoader->createConnectedAppWithUserAndTokens(
+            'connected_app_id',
+            'connection_code',
+        );
+    }
+
+    public function test_it_returns_null_on_unknown_app(): void
+    {
+        $roleIdentifier = $this->query->execute('some_app');
+
+        self::assertNull($roleIdentifier, 'Should return null on unknown app');
+    }
+
+    public function test_it_returns_role_identifier_for_a_connected_app(): void
+    {
+        $roleIdentifier = $this->query->execute('connected_app_id');
+
+        self::assertEquals('ROLE_CONNECTION_CODE', $roleIdentifier, 'Should return connected app role');
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandlerSpec.php
@@ -7,6 +7,7 @@ namespace spec\Akeneo\Connectivity\Connection\Application\Apps\Command;
 use Akeneo\Connectivity\Connection\Application\Apps\AppAuthorizationSessionInterface;
 use Akeneo\Connectivity\Connection\Application\Apps\Command\UpdateConnectedAppScopesWithAuthorizationCommand;
 use Akeneo\Connectivity\Connection\Application\Apps\Command\UpdateConnectedAppScopesWithAuthorizationHandler;
+use Akeneo\Connectivity\Connection\Application\Apps\Service\UpdateConnectedAppRoleWithScopesInterface;
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AppAuthorization;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\InvalidAppAuthorizationRequestException;
 use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\UpdateConnectedAppScopesQueryInterface;
@@ -26,11 +27,13 @@ class UpdateConnectedAppScopesWithAuthorizationHandlerSpec extends ObjectBehavio
         ValidatorInterface $validator,
         AppAuthorizationSessionInterface $appAuthorizationSession,
         UpdateConnectedAppScopesQueryInterface $updateConnectedAppScopesQuery,
+        UpdateConnectedAppRoleWithScopesInterface $updateConnectedAppRoleWithScopes,
     ): void {
         $this->beConstructedWith(
             $validator,
             $appAuthorizationSession,
             $updateConnectedAppScopesQuery,
+            $updateConnectedAppRoleWithScopes,
         );
     }
 
@@ -77,6 +80,7 @@ class UpdateConnectedAppScopesWithAuthorizationHandlerSpec extends ObjectBehavio
         ValidatorInterface $validator,
         AppAuthorizationSessionInterface $appAuthorizationSession,
         UpdateConnectedAppScopesQueryInterface $updateConnectedAppScopesQuery,
+        UpdateConnectedAppRoleWithScopesInterface $updateConnectedAppRoleWithScopes,
         AppAuthorization $appAuthorization,
     ): void {
         $command = new UpdateConnectedAppScopesWithAuthorizationCommand('an_app_id');
@@ -91,6 +95,10 @@ class UpdateConnectedAppScopesWithAuthorizationHandlerSpec extends ObjectBehavio
 
         $updateConnectedAppScopesQuery
             ->execute(['a_scope'], 'an_app_id')
+            ->shouldBeCalled();
+
+        $updateConnectedAppRoleWithScopes
+            ->execute('an_app_id', ['a_scope'])
             ->shouldBeCalled();
 
         $this->handle($command);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopesSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopesSpec.php
@@ -46,7 +46,6 @@ class UpdateConnectedAppRoleWithScopesSpec extends ObjectBehavior
         BulkSaverInterface $roleWithPermissionsSaver,
         RoleInterface $role
     ): void {
-
         $this->execute('connected_app_id', ['scopeA', 'scopeB', 'scopeC']);
 
         $roleWithPermissions = RoleWithPermissions::createFromRoleAndPermissions($role->getWrappedObject(), [

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopesSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Service/UpdateConnectedAppRoleWithScopesSpec.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Apps\Service;
+
+use Akeneo\Connectivity\Connection\Application\Apps\Security\ScopeMapperRegistryInterface;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\GetConnectedAppRoleIdentifierQueryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\UserManagement\Component\Connector\RoleWithPermissions;
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateConnectedAppRoleWithScopesSpec extends ObjectBehavior
+{
+    public function let(
+        GetConnectedAppRoleIdentifierQueryInterface $getConnectedAppRoleIdentifierQuery,
+        RoleRepositoryInterface $roleRepository,
+        ScopeMapperRegistryInterface $scopeMapperRegistry,
+        BulkSaverInterface $roleWithPermissionsSaver,
+        RoleInterface $role,
+    ): void {
+        $getConnectedAppRoleIdentifierQuery->execute('connected_app_id')->willReturn('ROLE_CONNECTED_APP');
+        $roleRepository->findOneByIdentifier('ROLE_CONNECTED_APP')->willReturn($role->getWrappedObject());
+
+        $scopeMapperRegistry->getAcls(['scopeA', 'scopeB', 'scopeC'])->willReturn([
+            'some_acl_1',
+            'some_acl_2',
+            'some_acl_3',
+        ]);
+
+        $this->beConstructedWith(
+            $getConnectedAppRoleIdentifierQuery,
+            $roleRepository,
+            $scopeMapperRegistry,
+            $roleWithPermissionsSaver,
+        );
+    }
+
+    public function it_updates_connected_app_role_with_new_acl_given_scopes(
+        BulkSaverInterface $roleWithPermissionsSaver,
+        RoleInterface $role
+    ): void {
+
+        $this->execute('connected_app_id', ['scopeA', 'scopeB', 'scopeC']);
+
+        $roleWithPermissions = RoleWithPermissions::createFromRoleAndPermissions($role->getWrappedObject(), [
+            'action:pim_api_overall_access' => true,
+            'action:some_acl_1' => true,
+            'action:some_acl_2' => true,
+            'action:some_acl_3' => true,
+        ]);
+        $roleWithPermissionsSaver->saveAll([$roleWithPermissions])->shouldHaveBeenCalled();
+    }
+
+    public function it_throws_an_exception_when_no_role_identifier_is_found(
+        GetConnectedAppRoleIdentifierQueryInterface $getConnectedAppRoleIdentifierQuery,
+    ): void {
+        $getConnectedAppRoleIdentifierQuery->execute('connected_app_id')->willReturn(null);
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('execute', ['connected_app_id', ['scopeA', 'scopeB', 'scopeC']]);
+    }
+
+    public function it_throws_an_exception_when_no_role_entity_is_found(
+        RoleRepositoryInterface $roleRepository,
+    ): void {
+        $roleRepository->findOneByIdentifier('ROLE_CONNECTED_APP')->willReturn(null);
+
+        $this
+            ->shouldThrow(\LogicException::class)
+            ->during('execute', ['connected_app_id', ['scopeA', 'scopeB', 'scopeC']]);
+    }
+}


### PR DESCRIPTION
When an app requests a different scopes list for an already connected app, its scope list is persisted. However, the role associated with the hidden user created for the said app remains unchanged. Meaning underlying ACLs are not updated with new scope changes
This PR creates a new service to update the connected app role ACLs based on provided scopes.
Much of its code is taken from [`AppRoleWithScopesFactory`](https://github.com/akeneo/pim-community-dev/blob/d826b9f3dbc465ec2b677f351e45b4803dafe7c6/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/AppRoleWithScopesFactory.php). I didn't feel the need in extracting (yet) this chunk of code even if it is repeated