### PR TITLE
PIM-10398: Fix category validator on import to prevent break-lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - PIM-10334: Fix error on the clean-removed-attributes
 - PIM-10362: Fix attribute type "number" gets modified in history when import with same value
 - PIM-10372: Fix letter case issue when importing channels
+- PIM-10398: Fix category validator to prevent break-lines
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/category.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/category.yml
@@ -10,6 +10,9 @@ Akeneo\Pim\Enrichment\Component\Category\Model\Category:
             - Regex:
                 pattern: /^[a-zA-Z0-9_]+$/
                 message: Category code may contain only letters, numbers and underscores
+            - Regex:
+                pattern: /^[^\n]+$/D
+                message: Category code may not contain line-feed characters
             - Length:
                 max: 100
         translations:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fix category validator on import to prevent break-lines

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
