### PR TITLE
PLG-834: Register criteria according to feature flag

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ComputeScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/Consolidation/ComputeScores.php
@@ -52,11 +52,11 @@ class ComputeScores
         $criteriaRates = [];
         $totalCoefficient = 0;
 
-        foreach ($this->criteriaEvaluationRegistry->getCriterionCodes() as $criterionCode) {
-            $criterionRates = $criteriaEvaluations->getCriterionRates($criterionCode);
-            $criterionRate = null !== $criterionRates ? $criterionRates->getByChannelAndLocale($channelCode, $localeCode) : null;
+        /** @var Read\CriterionEvaluation $criterionEvaluation */
+        foreach ($criteriaEvaluations as $criterionEvaluation) {
+            $criterionRate = $criterionEvaluation->getResult()?->getRates()?->getByChannelAndLocale($channelCode, $localeCode);
             if (null !== $criterionRate) {
-                $coefficient = $this->criteriaEvaluationRegistry->getCriterionCoefficient($criterionCode);
+                $coefficient = $this->criteriaEvaluationRegistry->getCriterionCoefficient($criterionEvaluation->getCriterionCode());
                 $totalCoefficient += $coefficient;
                 $criteriaRates[] = $criterionRate->toInt() * $coefficient;
             }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
@@ -42,7 +43,7 @@ class GetProductEvaluation
     public function __construct(
         private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
         private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        private CriteriaEvaluationRegistry $criteriaEvaluationRegistry,
+        private CriteriaByFeatureRegistry $criteriaRegistry,
         private CompleteEvaluationWithImprovableAttributes $completeEvaluationWithImprovableAttributes
     ) {
     }
@@ -69,7 +70,7 @@ class GetProductEvaluation
     {
         $criteriaRates = [];
 
-        foreach ($this->criteriaEvaluationRegistry->getCriterionCodes() as $criterionCode) {
+        foreach ($this->criteriaRegistry->getEnabledCriterionCodes() as $criterionCode) {
             $criterionEvaluation = $criteriaEvaluations->get($criterionCode);
             $criteriaRates[] = $this->formatCriterionEvaluation(
                 $criterionCode,

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CreateCriteriaEvaluations.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CreateCriteriaEvaluations.php
@@ -17,14 +17,14 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollec
 class CreateCriteriaEvaluations
 {
     public function __construct(
-        private CriteriaEvaluationRegistry $criteriaEvaluationRegistry,
+        private CriteriaByFeatureRegistry $criteriaRegistry,
         private CriterionEvaluationRepositoryInterface $criterionEvaluationRepository
     ) {
     }
 
     public function createAll(ProductIdCollection $productIdCollection): void
     {
-        $this->create($this->criteriaEvaluationRegistry->getCriterionCodes(), $productIdCollection);
+        $this->create($this->criteriaRegistry->getAllCriterionCodes(), $productIdCollection);
     }
 
     /**

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaByFeatureRegistry.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaByFeatureRegistry.php
@@ -15,12 +15,12 @@ use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
 class CriteriaByFeatureRegistry
 {
     /**
-     * @phpstan-type array<CriterionCode>
+     * @params array<CriterionCode>
      */
     private array $allCriteriaCodes = [];
 
     /**
-     * @phpstan-type array<CriterionCode>
+     * @params array<CriterionCode>
      */
     private array $partialCriteriaCodes = [];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaByFeatureRegistry.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaByFeatureRegistry.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CriteriaByFeatureRegistry
+{
+    /**
+     * @phpstan-type array<CriterionCode>
+     */
+    private array $allCriteriaCodes = [];
+
+    /**
+     * @phpstan-type array<CriterionCode>
+     */
+    private array $partialCriteriaCodes = [];
+
+    public function __construct(
+        private FeatureFlag $allCriteriaFeature,
+    ) {
+    }
+
+    public function register(EvaluateCriterionInterface $criterionEvaluationService, ?string $feature): void
+    {
+        $this->allCriteriaCodes[] = $criterionEvaluationService->getCode();
+
+        if (AllCriteriaFeature::NAME !== $feature) {
+            $this->partialCriteriaCodes[] = $criterionEvaluationService->getCode();
+        }
+    }
+
+    /**
+     * @return array<CriterionCode> List of the criteria according to enabled feature (via feature flag)
+     */
+    public function getEnabledCriterionCodes(): array
+    {
+        return $this->allCriteriaFeature->isEnabled()
+            ? $this->getAllCriterionCodes()
+            : $this->getPartialCriterionCodes();
+    }
+
+    /**
+     * @return array<CriterionCode> List of all criteria whatever the feature
+     */
+    public function getAllCriterionCodes(): array
+    {
+        return $this->allCriteriaCodes;
+    }
+
+    /**
+     * @return array<CriterionCode> List of the criteria that are not part of the "DQI all criteria" feature
+     */
+    public function getPartialCriterionCodes(): array
+    {
+        return $this->partialCriteriaCodes;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaEvaluationRegistry.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CriteriaEvaluationRegistry.php
@@ -34,17 +34,6 @@ class CriteriaEvaluationRegistry
         return $this->criterionEvaluationServices[strval($code)];
     }
 
-    /**
-     * @return CriterionCode[]
-     */
-    public function getCriterionCodes(): array
-    {
-        return array_values(array_map(
-            fn (EvaluateCriterionInterface $evaluateCriterion) => $evaluateCriterion->getCode(),
-            $this->criterionEvaluationServices
-        ));
-    }
-
     public function getCriterionCoefficient(CriterionCode $code): int
     {
         return $this->get($code)->getCoefficient();

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/AllCriteriaFeature.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/AllCriteriaFeature.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AllCriteriaFeature implements FeatureFlag
+{
+    public const NAME = 'data_quality_insights_all_criteria';
+
+    public function __construct(
+        private FeatureFlags $featureFlags
+    ) {
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->featureFlags->isEnabled(self::NAME);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/AkeneoDataQualityInsightsBundle.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/AkeneoDataQualityInsightsBundle.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony;
 
+use Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\DependencyInjection\Compiler\CriteriaByFeatureRegistryPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -12,4 +14,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 final class AkeneoDataQualityInsightsBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new CriteriaByFeatureRegistryPass());
+    }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/InitializeProductsEvaluationsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/InitializeProductsEvaluationsCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Command;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationStatus;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Command\Command;
@@ -24,20 +24,12 @@ final class InitializeProductsEvaluationsCommand extends Command
 
     private const BATCH_SIZE = 100;
 
-    private Connection $dbConnection;
-    private CriteriaEvaluationRegistry $productCriteriaRegistry;
-    private CriteriaEvaluationRegistry $productModelCriteriaRegistry;
-
     public function __construct(
-        Connection $dbConnection,
-        CriteriaEvaluationRegistry $productCriteriaRegistry,
-        CriteriaEvaluationRegistry $productModelCriteriaRegistry
+        private Connection $dbConnection,
+        private CriteriaByFeatureRegistry $productCriteriaRegistry,
+        private CriteriaByFeatureRegistry $productModelCriteriaRegistry
     ) {
         parent::__construct();
-
-        $this->dbConnection = $dbConnection;
-        $this->productCriteriaRegistry = $productCriteriaRegistry;
-        $this->productModelCriteriaRegistry = $productModelCriteriaRegistry;
     }
 
     protected function configure()
@@ -89,7 +81,7 @@ SQL
         $progressBar = new ProgressBar($io, $productCount);
         $progressBar->start();
 
-        $criteria = array_map(fn ($criterionCode) => strval($criterionCode), $this->productCriteriaRegistry->getCriterionCodes());
+        $criteria = array_map(fn ($criterionCode) => strval($criterionCode), $this->productCriteriaRegistry->getAllCriterionCodes());
         $statusPending = CriterionEvaluationStatus::PENDING;
 
         $lastProductId = 0;
@@ -131,7 +123,7 @@ SQL
         $progressBar = new ProgressBar($io, $productModelCount);
         $progressBar->start();
 
-        $criteria = array_map(fn ($criterionCode) => strval($criterionCode), $this->productModelCriteriaRegistry->getCriterionCodes());
+        $criteria = array_map(fn ($criterionCode) => strval($criterionCode), $this->productModelCriteriaRegistry->getAllCriterionCodes());
         $statusPending = CriterionEvaluationStatus::PENDING;
 
         $lastProductModelId = 0;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/DependencyInjection/Compiler/CriteriaByFeatureRegistryPass.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/DependencyInjection/Compiler/CriteriaByFeatureRegistryPass.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\back\Infrastructure\Symfony\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class CriteriaByFeatureRegistryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $this->processForProducts($container);
+        $this->processForProductModels($container);
+    }
+
+    private function processForProducts(ContainerBuilder $container): void
+    {
+        $registryDefinition = $container->findDefinition('akeneo.pim.automation.data_quality_insights.product_criteria_by_feature_registry');
+        $criterionServiceIds = $container->findTaggedServiceIds('akeneo.pim.automation.data_quality_insights.evaluate_product_criterion');
+
+        foreach ($criterionServiceIds as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $registryDefinition->addMethodCall('register', [new Reference($serviceId), $tag['feature'] ?? null]);
+            }
+        }
+    }
+
+    private function processForProductModels(ContainerBuilder $container): void
+    {
+        $registryDefinition = $container->findDefinition('akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry');
+        $criterionServiceIds = $container->findTaggedServiceIds('akeneo.pim.automation.data_quality_insights.evaluate_product_model_criterion');
+
+        foreach ($criterionServiceIds as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $registryDefinition->addMethodCall('register', [new Reference($serviceId), $tag['feature'] ?? null]);
+            }
+        }
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/commands.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/commands.yml
@@ -42,8 +42,8 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Command\InitializeProductsEvaluationsCommand:
         arguments:
             - '@database_connection'
-            - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
-            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_criteria_by_feature_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry'
         tags:
             - { name: 'console.command' }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/feature_flags.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/feature_flags.yml
@@ -7,3 +7,7 @@ services:
         arguments:
             - '%env(bool:FLAG_DATA_QUALITY_INSIGHTS_ENABLED)%'
         public: true
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature:
+        arguments:
+            - '@feature_flags'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -82,6 +82,16 @@ services:
         arguments:
             - !tagged akeneo.pim.automation.data_quality_insights.evaluate_product_model_criterion
 
+    akeneo.pim.automation.data_quality_insights.product_criteria_by_feature_registry:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'
+
+    akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'
+
     akeneo.pim.automation.data_quality_insights.evaluate_products_pending_criteria:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluatePendingCriteria
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -4,21 +4,28 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductScores:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_criteria_evaluations'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeScores'
+            - '@akeneo.pim.automation.data_quality_insights.compute_product_scores'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductScoreRepository'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateProductModelScores:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_product_model_criteria_evaluations'
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeScores'
+            - '@akeneo.pim.automation.data_quality_insights.compute_product_model_scores'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Repository\ProductModelScoreRepository'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Clock\SystemClock'
 
-    Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeScores:
+    akeneo.pim.automation.data_quality_insights.compute_product_scores:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeScores
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
+
+    akeneo.pim.automation.data_quality_insights.compute_product_model_scores:
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ComputeScores
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductScores:
         arguments:
@@ -35,7 +42,7 @@ services:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_criteria_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_criteria_by_feature_registry'
             - '@akeneo.pim.automation.data_quality_insights.product.complete_evaluation_with_improvable_attributes'
 
     akeneo.pim.automation.data_quality_insights.get_product_model_evaluation:
@@ -43,7 +50,7 @@ services:
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.query.get_up_to_date_product_model_criteria_evaluations'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry'
             - '@akeneo.pim.automation.data_quality_insights.product_model.complete_evaluation_with_improvable_attributes'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\Consolidation\ConsolidateDashboardRates:
@@ -62,14 +69,14 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations
         public: true
         arguments:
-            - '@akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_criteria_by_feature_registry'
             - '@akeneo.pim.automation.data_quality_insights.repository.product_criterion_evaluation'
 
     akeneo.pim.automation.data_quality_insights.create_product_models_criteria_evaluations:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations
         public: true
         arguments:
-            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_evaluation_registry'
+            - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry'
             - '@akeneo.pim.automation.data_quality_insights.repository.product_model_criterion_evaluation'
 
     akeneo.pim.automation.data_quality_insights.product_criteria_evaluation_registry:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/Consolidation/ComputeScoresSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/Consolidation/ComputeScoresSpec.php
@@ -87,7 +87,6 @@ final class ComputeScoresSpec extends ObjectBehavior
             ))
         ;
 
-        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([$criterionA, $criterionB, $criterionC]);
         $criteriaEvaluationRegistry->getCriterionCoefficient($criterionA)->willReturn(2);
         $criteriaEvaluationRegistry->getCriterionCoefficient($criterionB)->willReturn(1);
         $criteriaEvaluationRegistry->getCriterionCoefficient($criterionC)->willReturn(1);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductEvaluationSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetProductEvaluationSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfNonRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\EvaluateCompletenessOfRequiredAttributes;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes;
@@ -35,20 +35,20 @@ class GetProductEvaluationSpec extends ObjectBehavior
     public function let(
         GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
         GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
-        CriteriaEvaluationRegistry $criteriaEvaluationRegistry,
+        CriteriaByFeatureRegistry $criteriaRegistry,
         CompleteEvaluationWithImprovableAttributes $completeEvaluationWithImprovableAttributes
     ) {
         $this->beConstructedWith(
             $getCriteriaEvaluationsByProductIdQuery,
             $getLocalesByChannelQuery,
-            $criteriaEvaluationRegistry,
+            $criteriaRegistry,
             $completeEvaluationWithImprovableAttributes
         );
     }
 
     public function it_gives_the_evaluation_of_a_product(
         $getCriteriaEvaluationsByProductIdQuery,
-        $criteriaEvaluationRegistry,
+        $criteriaRegistry,
         $getLocalesByChannelQuery,
         $completeEvaluationWithImprovableAttributes
     ) {
@@ -59,7 +59,7 @@ class GetProductEvaluationSpec extends ObjectBehavior
             'mobile' => ['en_US']
         ]));
 
-        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([
+        $criteriaRegistry->getEnabledCriterionCodes()->willReturn([
             new CriterionCode('completeness_of_required_attributes'),
             new CriterionCode('completeness_of_non_required_attributes'),
             new CriterionCode('consistency_spelling'),
@@ -75,7 +75,7 @@ class GetProductEvaluationSpec extends ObjectBehavior
 
     public function it_handle_deprecated_improvable_attribute_structure(
         $getCriteriaEvaluationsByProductIdQuery,
-        $criteriaEvaluationRegistry,
+        $criteriaRegistry,
         $getLocalesByChannelQuery,
         $completeEvaluationWithImprovableAttributes
     ) {
@@ -83,7 +83,7 @@ class GetProductEvaluationSpec extends ObjectBehavior
             'ecommerce' => ['en_US'],
         ]));
 
-        $criteriaEvaluationRegistry->getCriterionCodes()->willReturn([
+        $criteriaRegistry->getEnabledCriterionCodes()->willReturn([
             new CriterionCode('consistency_spelling'),
             new CriterionCode('consistency_textarea_lowercase_words'),
         ]);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CreateCriteriaEvaluationsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CreateCriteriaEvaluationsSpec.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaEvaluationRegistry;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CriteriaByFeatureRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\CriterionEvaluationCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Repository\CriterionEvaluationRepositoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -20,14 +19,14 @@ use Prophecy\Argument;
 final class CreateCriteriaEvaluationsSpec extends ObjectBehavior
 {
     public function it_creates_all_criteria(
-        CriteriaEvaluationRegistry $criterionEvaluationRegistry,
+        CriteriaByFeatureRegistry $criteriaRegistry,
         CriterionEvaluationRepositoryInterface $criterionEvaluationRepository
     ) {
-        $this->beConstructedWith($criterionEvaluationRegistry, $criterionEvaluationRepository);
+        $this->beConstructedWith($criteriaRegistry, $criterionEvaluationRepository);
 
         $productId = ProductIdCollection::fromInt(42);
 
-        $criterionEvaluationRegistry->getCriterionCodes()->willReturn([new CriterionCode('criterion1'), new CriterionCode('criterion2')]);
+        $criteriaRegistry->getAllCriterionCodes()->willReturn([new CriterionCode('criterion1'), new CriterionCode('criterion2')]);
 
         $criterionEvaluationRepository->create(Argument::that(function (CriterionEvaluationCollection $collection) {
             return $collection->count() === 2;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaByFeatureRegistrySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaByFeatureRegistrySpec.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateCriterionInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+class CriteriaByFeatureRegistrySpec extends ObjectBehavior
+{
+    private ?CriterionCode $criterionCodeWithoutFeature;
+    private ?CriterionCode $criterionCodeWhateverFeature;
+    private ?CriterionCode $criterionCodeAllFeatureOnly;
+
+    public function let(
+        FeatureFlag $allCriteriaFeature,
+        EvaluateCriterionInterface $evaluateCriterionWithoutFeature,
+        EvaluateCriterionInterface $evaluateCriterionWhateverFeature,
+        EvaluateCriterionInterface $evaluateCriterionAllFeatureOnly,
+    ) {
+        $this->beConstructedWith($allCriteriaFeature);
+
+        $this->criterionCodeWithoutFeature = new CriterionCode('criterion_without_feature');
+        $this->criterionCodeWhateverFeature = new CriterionCode('criterion_whatever_feature');
+        $this->criterionCodeAllFeatureOnly = new CriterionCode('criterion_all_feature');
+
+        $evaluateCriterionWithoutFeature->getCode()->willReturn($this->criterionCodeWithoutFeature);
+        $evaluateCriterionWhateverFeature->getCode()->willReturn($this->criterionCodeWhateverFeature);
+        $evaluateCriterionAllFeatureOnly->getCode()->willReturn($this->criterionCodeAllFeatureOnly);
+
+        $this->register($evaluateCriterionWithoutFeature, null);
+        $this->register($evaluateCriterionWhateverFeature, 'whatever_feature');
+        $this->register($evaluateCriterionAllFeatureOnly, AllCriteriaFeature::NAME);
+    }
+
+    public function it_gets_criteria_codes_with_all_criteria_feature_enabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(true);
+
+        $this->getEnabledCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature, $this->criterionCodeAllFeatureOnly]);
+        $this->getAllCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature, $this->criterionCodeAllFeatureOnly]);
+        $this->getPartialCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature]);
+    }
+
+    public function it_gets_criteria_codes_with_all_criteria_feature_disabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(false);
+
+        $this->getEnabledCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature]);
+        $this->getAllCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature, $this->criterionCodeAllFeatureOnly]);
+        $this->getPartialCriterionCodes()->shouldReturn([$this->criterionCodeWithoutFeature, $this->criterionCodeWhateverFeature]);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaEvaluationRegistrySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/CriteriaEvaluationRegistrySpec.php
@@ -15,12 +15,6 @@ use PhpSpec\ObjectBehavior;
  */
 class CriteriaEvaluationRegistrySpec extends ObjectBehavior
 {
-    public function it_returns_no_criterion_codes_if_no_services_are_injected()
-    {
-        $this->beConstructedWith([]);
-        $this->getCriterionCodes()->shouldReturn([]);
-    }
-
     public function it_throws_an_exception_if_an_evaluation_service_does_not_exist()
     {
         $this->beConstructedWith([]);
@@ -31,7 +25,6 @@ class CriteriaEvaluationRegistrySpec extends ObjectBehavior
     {
         $this->beConstructedWith([$evaluateCriterion->getWrappedObject(), new \stdClass()]);
         $evaluateCriterion->getCode()->willReturn(new CriterionCode('my_code'));
-        $this->getCriterionCodes()->shouldBeLike([new CriterionCode('my_code')]);
         $this->get(new CriterionCode('my_code'))->shouldReturn($evaluateCriterion->getWrappedObject());
     }
 


### PR DESCRIPTION
- Add a registry that will have the responsibility to list criteria codes according to the feature.
- Remove the responsibility to list criteria codes from the historic registry

The new registry will be used to be able to compute the double scores.

I choose to have an instance for the products and another for the product-models to be consistent with how the criteria are declared (with two tags), even if in practice the criteria are the same (it could change in the future)
See criteria declaration in EE: https://github.com/akeneo/pim-enterprise-dev/pull/13477/files