### PR TITLE
CXP-1062: open app button must reset outdated scopes flag when clicking on it

### DIFF
--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApps/ConnectedAppCard.tsx
@@ -73,7 +73,10 @@ const ConnectedAppCard: FC<Props> = ({item}) => {
     const translate = useTranslate();
     const security = useSecurity();
     const generateUrl = useRouter();
-    const connectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_edit', {
+    const manageConnectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_edit', {
+        connectionCode: item.connection_code,
+    })}`;
+    const openConnectedAppUrl = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_open', {
         connectionCode: item.connection_code,
     })}`;
     const logo = item.logo ? <Logo src={item.logo} alt={item.name} /> : <AppIllustration width={100} height={100} />;
@@ -94,12 +97,12 @@ const ConnectedAppCard: FC<Props> = ({item}) => {
                 <ConnectedAppCardDescription connectedApp={item} />
             </TextInformation>
             <Actions>
-                <Button ghost level='tertiary' href={connectedAppUrl} disabled={!canManageApp}>
+                <Button ghost level='tertiary' href={manageConnectedAppUrl} disabled={!canManageApp}>
                     {translate('akeneo_connectivity.connection.connect.connected_apps.list.card.manage_app')}
                 </Button>
                 <Button
                     level={item.is_pending || item.has_outdated_scopes ? 'warning' : 'secondary'}
-                    href={item.activate_url}
+                    href={openConnectedAppUrl}
                     disabled={!item.activate_url || !canOpenApp}
                     target='_blank'
                 >

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/Settings/Authentication.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/Settings/Authentication.test.tsx
@@ -31,6 +31,7 @@ const connectedApp = {
     partner: null,
     is_test_app: false,
     is_pending: false,
+    has_outdated_scopes: false,
 };
 
 beforeEach(() => {

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppCard.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApps/ConnectedAppCard.test.tsx
@@ -178,7 +178,10 @@ test('The Open App and Manage App buttons are enabled for test app when the user
     const openAppButton = expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.open_app')
     );
-    openAppButton.toHaveAttribute('href', 'http://www.example.com/activate');
+    openAppButton.toHaveAttribute(
+        'href',
+        '#akeneo_connectivity_connection_connect_connected_apps_open?connectionCode=connectionCodeA'
+    );
     openAppButton.not.toHaveAttribute('disabled');
     openAppButton.not.toHaveAttribute('aria-disabled', 'true');
 
@@ -318,7 +321,10 @@ test('The pending App card renders', async () => {
     const openAppButton = expect(
         screen.queryByText('akeneo_connectivity.connection.connect.connected_apps.list.card.open_app')
     );
-    openAppButton.toHaveAttribute('href', 'http://www.example.com/activate');
+    openAppButton.toHaveAttribute(
+        'href',
+        '#akeneo_connectivity_connection_connect_connected_apps_open?connectionCode=connectionCodeA'
+    );
     openAppButton.not.toHaveAttribute('disabled');
     openAppButton.not.toHaveAttribute('aria-disabled', 'true');
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an app has outdated scopes, the open app button displays in yellow. When clicking on this button, the outdated scopes flag must be removed and the button must come back to its default color.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
