### PR TITLE
CPM-600 and CPM-601: Add two-way associations integration tests for UpsertProduct Command

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UpsertProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UpsertProductCommand.php
@@ -29,7 +29,6 @@ final class UpsertProductCommand
     public function __construct(
         private int $userId,
         private string $productIdentifier,
-        private mixed $identifierUserIntent = null,
         private ?FamilyUserIntent $familyUserIntent = null,
         private ?CategoryUserIntent $categoryUserIntent = null,
         private ?ParentUserIntent $parentUserIntent = null,

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -221,17 +221,28 @@ abstract class EnrichmentProductTestCase extends TestCase
     /**
      * @return array<string>
      */
-    protected function getAssociatedProductIdentifiers(ProductInterface $product): array
+    protected function getAssociatedProductIdentifiers(ProductInterface $product, string $associationType = 'X_SELL'): array
     {
-        return $product->getAssociatedProducts('X_SELL')
+        return $product->getAssociatedProducts($associationType)
                 ?->map(fn (ProductInterface $product): string => $product->getIdentifier())
                 ?->toArray() ?? [];
     }
 
-    protected function getAssociatedProductModelIdentifiers(ProductInterface $product): array
+    protected function getAssociatedProductModelIdentifiers(ProductInterface $product, string $associationType = 'X_SELL'): array
     {
-        return $product->getAssociatedProductModels('X_SELL')
+        return $product->getAssociatedProductModels($associationType)
                 ?->map(fn (ProductModelInterface $productModel) => $productModel->getIdentifier())
                 ?->toArray() ?? [];
+    }
+
+    protected function createTwoWayAssociationType(string $code): void
+    {
+        $factory = $this->get('pim_catalog.factory.association_type');
+        $updater = $this->get('pim_catalog.updater.association_type');
+        $saver = $this->get('pim_catalog.saver.association_type');
+
+        $associationType = $factory->create();
+        $updater->update($associationType, ['code' => $code, 'is_two_way' => true]);
+        $saver->save($associationType);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
@@ -269,7 +269,38 @@ class UpsertProductAssociationsIntegration extends EnrichmentProductTestCase
         Assert::assertSame(['other_associated_group_code'], $this->getAssociatedGroupIdentifiers($updatedProduct));
     }
 
-    private function createGroup(string $groupCode): GroupInterface
+    /** @test */
+    public function it_associates_two_way_association_on_product(): void
+    {
+        $this->createTwoWayAssociationType('TWO_WAY');
+        $this->createProduct('my_product', []);
+        $this->createProduct('my_associated_product', []);
+        $this->createProductModel('product_model1', 'color_variant_accessories', []);
+        $this->createGroup('group1');
+
+        $command = UpsertProductCommand::createFromCollection($this->getUserId('peter'), 'my_product', [
+            new AssociateProducts('TWO_WAY', ['my_associated_product']),
+            new AssociateProductModels('TWO_WAY', ['product_model1']),
+            new AssociateGroups('TWO_WAY', ['group1'])
+        ]);
+        $this->messageBus->dispatch($command);
+
+        $myProduct = $this->productRepository->findOneByIdentifier('my_product');
+        $myAssociatedProduct = $this->productRepository->findOneByIdentifier('my_associated_product');
+        $myProductModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('product_model1');
+
+        Assert::assertEquals(['my_associated_product'], $this->getAssociatedProductIdentifiers($myProduct, 'TWO_WAY'));
+        Assert::assertEquals(['my_product'], $this->getAssociatedProductIdentifiers($myAssociatedProduct, 'TWO_WAY'));
+        Assert::assertEquals(['product_model1'], $this->getAssociatedProductModelIdentifiers($myProduct, 'TWO_WAY'));
+        Assert::assertEquals(['my_product'],
+            $myProductModel->getAssociatedProducts('TWO_WAY')
+                ?->map(fn (ProductInterface $product): string => $product->getIdentifier())
+                ?->toArray() ?? []
+        );
+        Assert::assertEquals(['group1'], $this->getAssociatedGroupIdentifiers($myProduct, 'TWO_WAY'));
+    }
+
+    private function createGroup(string $groupCode)
     {
         $group = $this->get('pim_catalog.factory.group')->createGroup('RELATED');
         $this->get('pim_catalog.updater.group')->update($group, [
@@ -282,16 +313,14 @@ class UpsertProductAssociationsIntegration extends EnrichmentProductTestCase
         }
 
         $this->get('pim_catalog.saver.group')->save($group);
-
-        return $group;
     }
 
     /**
      * @return array<string>
      */
-    private function getAssociatedGroupIdentifiers(ProductInterface $product): array
+    private function getAssociatedGroupIdentifiers(ProductInterface $product, string $associationType = 'X_SELL'): array
     {
-        return $product->getAssociatedGroups('X_SELL')
+        return $product->getAssociatedGroups($associationType)
                 ?->map(fn (GroupInterface $group): string => (string) $group->getCode())
                 ?->toArray() ?? [];
     }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
@@ -289,18 +289,19 @@ class UpsertProductAssociationsIntegration extends EnrichmentProductTestCase
         $myAssociatedProduct = $this->productRepository->findOneByIdentifier('my_associated_product');
         $myProductModel = $this->get('pim_catalog.repository.product_model')->findOneByIdentifier('product_model1');
 
-        Assert::assertEquals(['my_associated_product'], $this->getAssociatedProductIdentifiers($myProduct, 'TWO_WAY'));
-        Assert::assertEquals(['my_product'], $this->getAssociatedProductIdentifiers($myAssociatedProduct, 'TWO_WAY'));
-        Assert::assertEquals(['product_model1'], $this->getAssociatedProductModelIdentifiers($myProduct, 'TWO_WAY'));
-        Assert::assertEquals(['my_product'],
+        Assert::assertEqualsCanonicalizing(['my_associated_product'], $this->getAssociatedProductIdentifiers($myProduct, 'TWO_WAY'));
+        Assert::assertEqualsCanonicalizing(['my_product'], $this->getAssociatedProductIdentifiers($myAssociatedProduct, 'TWO_WAY'));
+        Assert::assertEqualsCanonicalizing(['product_model1'], $this->getAssociatedProductModelIdentifiers($myProduct, 'TWO_WAY'));
+        Assert::assertEqualsCanonicalizing(
+            ['my_product'],
             $myProductModel->getAssociatedProducts('TWO_WAY')
                 ?->map(fn (ProductInterface $product): string => $product->getIdentifier())
                 ?->toArray() ?? []
         );
-        Assert::assertEquals(['group1'], $this->getAssociatedGroupIdentifiers($myProduct, 'TWO_WAY'));
+        Assert::assertEqualsCanonicalizing(['group1'], $this->getAssociatedGroupIdentifiers($myProduct, 'TWO_WAY'));
     }
 
-    private function createGroup(string $groupCode)
+    private function createGroup(string $groupCode): void
     {
         $group = $this->get('pim_catalog.factory.group')->createGroup('RELATED');
         $this->get('pim_catalog.updater.group')->update($group, [

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UpsertProductCommandSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UpsertProductCommandSpec.php
@@ -39,7 +39,6 @@ class UpsertProductCommandSpec extends ObjectBehavior
             null,
             null,
             null,
-            null,
             []
         );
     }
@@ -71,7 +70,6 @@ class UpsertProductCommandSpec extends ObjectBehavior
             null,
             null,
             null,
-            null,
             $valueUserIntents
         );
         $this->userId()->shouldReturn(1);
@@ -90,7 +88,6 @@ class UpsertProductCommandSpec extends ObjectBehavior
             null,
             null,
             null,
-            null,
             [new \stdClass]
         );
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
@@ -103,7 +100,6 @@ class UpsertProductCommandSpec extends ObjectBehavior
         $this->beConstructedWith(
             1,
             'identifier1',
-            null,
             $familyUserIntent,
             $categoryUserIntent,
             null,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add two way association tests for the UpsertProductCommand

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
