### PR TITLE
PIM-10409: Allow creating a measurement value with case insensitive unit code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PIM-10372: Fix letter case issue when importing channels
 - PIM-10389: Export channel currencies for a non-scopable price attribute instead of all enabled currencies
 - PIM-10398: Fix category validator to prevent break-lines
+- PIM-10409: Allow creating a measurement value with case insensitive unit code
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Manager/MeasureManager.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Manager/MeasureManager.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Manager;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider;
 
 /**
@@ -107,14 +108,14 @@ class MeasureManager
      *
      * @param string $family
      *
-     * @throws \InvalidArgumentException
+     * @throws MeasurementFamilyNotFoundException
      * @return array
      */
     protected function getFamilyConfig($family)
     {
         $families = $this->legacyMeasurementProvider->getMeasurementFamilies();
         if (!isset($families[$family])) {
-            throw new \InvalidArgumentException(
+            throw new MeasurementFamilyNotFoundException(
                 sprintf('Undefined measure family "%s"', $family)
             );
         }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Manager/MeasureManagerSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Manager/MeasureManagerSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Manager;
 
+use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Yaml\Yaml;
@@ -51,13 +52,13 @@ YAML;
     {
         $this
             ->shouldThrow(
-                new \InvalidArgumentException('Undefined measure family "foo"')
+                new MeasurementFamilyNotFoundException('Undefined measure family "foo"')
             )
             ->during('getUnitSymbolsForFamily', ['foo']);
 
         $this
             ->shouldThrow(
-                new \InvalidArgumentException('Undefined measure family "foo"')
+                new MeasurementFamilyNotFoundException('Undefined measure family "foo"')
             )
             ->during('getUnitCodesForFamily', ['foo']);
     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -279,7 +279,7 @@ JSON;
                 "scope": null,
                 "data": {
                     "amount": "987654321987.1234",
-                    "unit": "KILOWATT"
+                    "unit": "Kilowatt"
                 }
             }],
             "a_metric_without_decimal": [{
@@ -287,7 +287,7 @@ JSON;
                 "scope": null,
                 "data": {
                     "amount": 98,
-                    "unit": "CENTIMETER"
+                    "unit": "CentiMeter"
                 }
             }],
             "a_metric_without_decimal_negative": [{


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When trying to create a metric with a unit code which does not match the measurement family's unit code case (e.g: Gram instead of GRAM), the [ValidMetricValidator](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Structure/Component/Validator/Constraints/ValidMetricValidator.php) would create a violation stating that the unit code is invalid
I could have simply fixed the validator, but this would cause an entry to be wrongly created in the product's history if e.g, updating a value from "200 GRAM" to "200 gram". Instead, the metric factory now gets the right unit code (with the right case) when creating a metric

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
