### PR TITLE
PIM-10410: Do not count the total number of products/models when doing a full reindex

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
@@ -88,7 +88,7 @@ class IndexProductCommand extends Command
 
         if (true === $input->getOption('all')) {
             $chunkedProductIdentifiers = $this->getAllProductIdentifiers($batchSize);
-            $productCount = $this->getTotalNumberOfProducts();
+            $productCount = 0;
         } elseif (!empty($input->getArgument('identifiers'))) {
             $requestedIdentifiers = $input->getArgument('identifiers');
             $existingIdentifiers = $this->getExistingProductIdentifiers($requestedIdentifiers);
@@ -164,11 +164,6 @@ SQL;
             $formerId = (int)end($rows)['id'];
             yield array_column($rows, 'identifier');
         }
-    }
-
-    private function getTotalNumberOfProducts(): int
-    {
-        return (int)$this->connection->executeQuery('SELECT COUNT(0) FROM pim_catalog_product')->fetchOne();
     }
 
     private function getExistingProductIdentifiers(array $identifiers): array

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
@@ -99,7 +99,7 @@ class IndexProductModelCommand extends Command
 
         if (true === $input->getOption('all')) {
             $chunkedProductModelCodes = $this->getAllRootProductModelCodes($batchSize);
-            $productModelCount = $this->getTotalNumberOfRootProductModels();
+            $productModelCount = 0;
         } elseif (!empty($input->getArgument('codes'))) {
             $requestedCodes = $input->getArgument('codes');
             $existingroductModelCodes = $this->getExistingProductModelCodes($requestedCodes);
@@ -207,13 +207,6 @@ SQL;
                 'codes' => Connection::PARAM_STR_ARRAY,
             ]
         )->fetchFirstColumn();
-    }
-
-    private function getTotalNumberOfRootProductModels(): int
-    {
-        return (int)$this->connection->executeQuery(
-            'SELECT COUNT(0) FROM pim_catalog_product_model WHERE parent_id IS NULL'
-        )->fetchOne();
     }
 
     /**


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The count(*) query can be very long and quite ineffective for big tables, and was only used to init the ProgressBar

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
