### PR TITLE
RAB-614: Retrieve all locales information (Query)

### DIFF
--- a/src/Akeneo/Channel/back/API/Query/FindLocales.php
+++ b/src/Akeneo/Channel/back/API/Query/FindLocales.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Akeneo\Channel\API\Query;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface FindLocales
+{
+    public function find(string $localeCode): ?Locale;
+
+    /**
+     * @return Locale[]
+     */
+    public function findAllActivated(): array;
+}

--- a/src/Akeneo/Channel/back/API/Query/Locale.php
+++ b/src/Akeneo/Channel/back/API/Query/Locale.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Akeneo\Channel\API\Query;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Locale
+{
+    public function __construct(
+        private string $code,
+        private bool $isActivated
+    ) {
+    }
+
+    public function getCode(): string
+    {
+        return $this->code;
+    }
+
+    public function isActivated(): bool
+    {
+        return $this->isActivated;
+    }
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
@@ -3,7 +3,6 @@
 
 namespace Akeneo\Channel\Infrastructure\Query\Sql;
 
-
 use Akeneo\Channel\API\Query\FindLocales;
 use Akeneo\Channel\API\Query\Locale;
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;

--- a/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
@@ -1,0 +1,88 @@
+<?php
+
+
+namespace Akeneo\Channel\Infrastructure\Query\Sql;
+
+
+use Akeneo\Channel\API\Query\FindLocales;
+use Akeneo\Channel\API\Query\Locale;
+use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class SqlFindLocales implements FindLocales, CachedQueryInterface
+{
+    private ?array $indexedCache = null;
+    private ?array $cache = null;
+
+    public function __construct(
+        private Connection $connection
+    ) {
+    }
+
+    public function find(string $localeCode): ?Locale
+    {
+        if (null === $this->indexedCache || !$this->isLocaleCached($localeCode)) {
+            $sql = <<<SQL
+                SELECT 
+                    l.code AS localeCode, 
+                    l.is_activated AS isActivated
+                FROM pim_catalog_locale l
+                WHERE l.code = :localeCode
+            SQL;
+
+            $result = $this->connection->executeQuery($sql, ['localeCode' => $localeCode])->fetchAssociative();
+            $this->indexedCache[$localeCode] = null;
+
+            if ($result) {
+                $this->indexedCache[$localeCode] = new Locale(
+                    $result['localeCode'],
+                    $result['isActivated']
+                );
+            }
+        }
+
+        return $this->indexedCache[$localeCode];
+    }
+
+    public function findAllActivated(): array
+    {
+        if (null === $this->cache) {
+            $sql = <<<SQL
+                SELECT 
+                    l.code AS localeCode, 
+                    l.is_activated AS isActivated
+                FROM pim_catalog_locale l
+                WHERE l.is_activated = 1
+            SQL;
+
+            $results = $this->connection->executeQuery($sql)->fetchAllAssociative();
+            $this->cache = [];
+
+            foreach ($results as $result) {
+                $locale = new Locale(
+                    $result['localeCode'],
+                    $result['isActivated']
+                );
+
+                $this->cache[] = $locale;
+            }
+        }
+
+        return $this->cache;
+    }
+
+    public function clearCache(): void
+    {
+        $this->indexedCache = null;
+        $this->cache = null;
+    }
+
+    private function isLocaleCached(string $localeCode): bool
+    {
+        return key_exists($localeCode, $this->indexedCache);
+    }
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindLocales.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Connection;
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class SqlFindLocales implements FindLocales, CachedQueryInterface
+final class SqlFindLocales implements FindLocales, CachedQueryInterface
 {
     private ?array $indexedCache = null;
     private ?array $cache = null;

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -43,3 +43,9 @@ services:
         arguments:
             - '@database_connection'
         tags: ['akeneo.pim.cached_query']
+
+    Akeneo\Channel\Infrastructure\Query\Sql\SqlFindLocales:
+        class: Akeneo\Channel\Infrastructure\Query\Sql\SqlFindLocales
+        arguments:
+            - '@database_connection'
+        tags: ['akeneo.pim.cached_query']

--- a/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindLocalesIntegration.php
+++ b/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindLocalesIntegration.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Akeneo\Test\Channel\Integration\Query\Sql;
+
+use Akeneo\Channel\API\Query\FindLocales;
+use Akeneo\Channel\API\Query\Locale;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+
+final class SqlFindLocalesIntegration extends TestCase
+{
+    private FindLocales $sqlFindLocales;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->sqlFindLocales = $this->get(
+            'Akeneo\Channel\Infrastructure\Query\Sql\SqlFindLocales'
+        );
+    }
+
+    public function test_it_finds_a_locale_by_its_code(): void
+    {
+        $activeLocale = $this->sqlFindLocales->find('en_US');
+        $this->assertInstanceOf(Locale::class, $activeLocale);
+        $this->assertEquals('en_US', $activeLocale->getCode());
+        $this->assertEquals(true, $activeLocale->isActivated());
+
+        $unactiveLocale = $this->sqlFindLocales->find('uk_UA');
+        $this->assertInstanceOf(Locale::class, $unactiveLocale);
+        $this->assertEquals('uk_UA', $unactiveLocale->getCode());
+        $this->assertEquals(false, $unactiveLocale->isActivated());
+
+        $unknownLocale = $this->sqlFindLocales->find('unknown');
+        $this->assertNull($unknownLocale);
+    }
+
+    public function test_it_finds_all_activated_locales(): void
+    {
+        $results = $this->sqlFindLocales->findAllActivated();
+
+        $this->assertIsArray($results);
+        $this->assertCount(3, $results);
+        $this->assertContainsOnlyInstancesOf(Locale::class, $results);
+
+        foreach ($results as $result) {
+            $this->assertEquals(true, $result->isActivated());
+        }
+
+        $enUSLocale = current(array_filter($results, fn (Locale $channel) => $channel->getCode() === 'en_US'));
+
+        $this->assertEquals('en_US', $enUSLocale->getCode());
+        $this->assertEquals(true, $enUSLocale->isActivated());
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+}

--- a/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindLocalesIntegration.php
+++ b/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindLocalesIntegration.php
@@ -23,14 +23,10 @@ final class SqlFindLocalesIntegration extends TestCase
     public function test_it_finds_a_locale_by_its_code(): void
     {
         $activeLocale = $this->sqlFindLocales->find('en_US');
-        $this->assertInstanceOf(Locale::class, $activeLocale);
-        $this->assertEquals('en_US', $activeLocale->getCode());
-        $this->assertEquals(true, $activeLocale->isActivated());
+        $this->assertEquals(new Locale('en_US', true), $activeLocale);
 
         $unactiveLocale = $this->sqlFindLocales->find('uk_UA');
-        $this->assertInstanceOf(Locale::class, $unactiveLocale);
-        $this->assertEquals('uk_UA', $unactiveLocale->getCode());
-        $this->assertEquals(false, $unactiveLocale->isActivated());
+        $this->assertEquals(new Locale('uk_UA', false), $unactiveLocale);
 
         $unknownLocale = $this->sqlFindLocales->find('unknown');
         $this->assertNull($unknownLocale);

--- a/src/Akeneo/Channel/back/tests/Specification/API/Query/LocaleSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/API/Query/LocaleSpec.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Specification\Akeneo\Channel\API\Query;
+
+use PhpSpec\ObjectBehavior;
+
+class LocaleSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beConstructedWith(
+            'fr_FR',
+            true
+        );
+    }
+
+    public function it_has_getters()
+    {
+        $this->getCode()->shouldReturn('fr_FR');
+        $this->isActivated()->shouldReturn(true);
+    }
+}

--- a/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Query/Sql/SqlFindLocalesSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Query/Sql/SqlFindLocalesSpec.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Specification\Akeneo\Channel\Infrastructure\Query\Sql;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class SqlFindLocalesSpec extends ObjectBehavior
+{
+    public function let(Connection $connection)
+    {
+        $this->beConstructedWith($connection);
+    }
+
+    public function it_finds_a_locale_by_its_code_and_caches_it(
+        Connection $connection,
+        Result $result
+    ) {
+        $connection
+            ->executeQuery(Argument::any(), Argument::any())
+            ->willReturn($result)
+            ->shouldBeCalledOnce()
+        ;
+
+        $result->fetchAssociative()->willReturn([
+            'localeCode' => 'en_US',
+            'isActivated' => true,
+        ]);
+
+        $this->find('en_US');
+        $this->find('en_US');
+        $this->find('en_US');
+    }
+
+    public function it_finds_all_activated_locales_and_caches_them(
+        Connection $connection,
+        Result $result
+    ) {
+        $connection
+            ->executeQuery(Argument::any())
+            ->willReturn($result)
+            ->shouldBeCalledOnce()
+        ;
+
+        $result->fetchAllAssociative()->willReturn(
+            [
+                [
+                    'localeCode' => 'en_US',
+                    'isActivated' => true,
+                ],
+                [
+                    'localeCode' => 'fr_FR',
+                    'isActivated' => true,
+                ],
+            ]
+        );
+
+        $this->findAllActivated();
+        $this->findAllActivated();
+        $this->findAllActivated();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
- Add a query in Channel's API to retrieve all activated locales & find a locale by its code
- Add related read model `Locale`
- Query is cached

**Definition Of Done (for Core Developer only)**
- [x] Tests
