### PR TITLE
PLG-825: Adaptations to persist double scores in ES

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetEnabledScoresStrategy.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetEnabledScoresStrategy.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetEnabledScoresStrategy
+{
+    public function __construct(
+        private FeatureFlag $allCriteriaFeature,
+    ) {
+    }
+
+    /**
+     * Determines the scores to use, according to the current enabled features
+     */
+    public function __invoke(Read\Scores $scores): ChannelLocaleRateCollection
+    {
+        return $this->allCriteriaFeature->isEnabled() ? $scores->allCriteria() : $scores->partialCriteria();
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductModelScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductModelScores.php
@@ -16,7 +16,8 @@ class GetProductModelScores
 {
     public function __construct(
         private GetProductModelScoresQueryInterface $getProductModelScoresQuery,
-        private GetLocalesByChannelQueryInterface  $getLocalesByChannelQuery
+        private GetLocalesByChannelQueryInterface  $getLocalesByChannelQuery,
+        private GetEnabledScoresStrategy $getEnabledScores,
     ) {
     }
 
@@ -26,7 +27,7 @@ class GetProductModelScores
      */
     public function get(ProductId $productId): array
     {
-        $productScores = $this->getProductModelScoresQuery->byProductModelId($productId);
+        $productScores = ($this->getEnabledScores)($this->getProductModelScoresQuery->byProductModelId($productId));
 
         if ($productScores->isEmpty()) {
             return ["evaluations_available" => false];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductScores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductScores.php
@@ -14,14 +14,11 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
  */
 final class GetProductScores
 {
-    private GetProductScoresQueryInterface $getProductScoresQuery;
-
-    private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery;
-
-    public function __construct(GetProductScoresQueryInterface $getProductScoresQuery, GetLocalesByChannelQueryInterface $getLocalesByChannelQuery)
-    {
-        $this->getProductScoresQuery = $getProductScoresQuery;
-        $this->getLocalesByChannelQuery = $getLocalesByChannelQuery;
+    public function __construct(
+        private GetProductScoresQueryInterface $getProductScoresQuery,
+        private GetLocalesByChannelQueryInterface $getLocalesByChannelQuery,
+        private GetEnabledScoresStrategy $getEnabledScores,
+    ) {
     }
 
     /**
@@ -30,7 +27,7 @@ final class GetProductScores
      */
     public function get(ProductId $productId): array
     {
-        $productScores = $this->getProductScoresQuery->byProductId($productId);
+        $productScores = ($this->getEnabledScores)($this->getProductScoresQuery->byProductId($productId));
 
         if ($productScores->isEmpty()) {
             return ["evaluations_available" => false];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/Scores.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Model/Read/Scores.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Scores
+{
+    public function __construct(
+        private ChannelLocaleRateCollection $scoresAllCriteria,
+        private ChannelLocaleRateCollection $scoresPartialCriteria,
+    ) {
+    }
+
+    public function allCriteria(): ChannelLocaleRateCollection
+    {
+        return $this->scoresAllCriteria;
+    }
+
+    public function partialCriteria(): ChannelLocaleRateCollection
+    {
+        return $this->scoresPartialCriteria;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresByCodesQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresByCodesQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -12,10 +12,10 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateColl
  */
 interface GetProductModelScoresByCodesQueryInterface
 {
-    public function byProductModelCode(string $productModelCode): ChannelLocaleRateCollection;
+    public function byProductModelCode(string $productModelCode): Read\Scores;
 
     /**
-     * @return array<string, ChannelLocaleRateCollection>
+     * @return array<string, Read\Scores>
      */
     public function byProductModelCodes(array $productModelCodes): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
 
@@ -14,10 +14,10 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollec
  */
 interface GetProductModelScoresQueryInterface
 {
-    public function byProductModelId(ProductId $productId): ChannelLocaleRateCollection;
+    public function byProductModelId(ProductId $productId): Read\Scores;
 
     /**
-     * @return array<ChannelLocaleRateCollection>
+     * @return array<Read\Scores>
      */
     public function byProductModelIds(ProductIdCollection $productModelIds): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresByIdentifiersQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresByIdentifiersQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -17,9 +17,9 @@ interface GetProductScoresByIdentifiersQueryInterface
      *
      * @param string[] $productIdentifiers
      *
-     * @return ChannelLocaleRateCollection[]
+     * @return Read\Scores[]
      */
     public function byProductIdentifiers(array $productIdentifiers): array;
 
-    public function byProductIdentifier(string $identifier): ChannelLocaleRateCollection;
+    public function byProductIdentifier(string $identifier): Read\Scores;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
 
@@ -14,10 +14,10 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollec
  */
 interface GetProductScoresQueryInterface
 {
-    public function byProductId(ProductId $productId): ChannelLocaleRateCollection;
+    public function byProductId(ProductId $productId): Read\Scores;
 
     /**
-     * @return ChannelLocaleRateCollection[]
+     * @return Read\Scores[]
      */
     public function byProductIds(ProductIdCollection $productIdCollection): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndex.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndex.php
@@ -60,7 +60,8 @@ class BulkUpdateProductQualityScoresIndex implements BulkUpdateProductQualitySco
                 'script' => [
                     'inline' => "ctx._source.data_quality_insights = params;",
                     'params' => [
-                        'scores' => $qualityScores->toArrayIntRank(),
+                        'scores' => $qualityScores->allCriteria()->toArrayIntRank(),
+                        'scores_partial_criteria' => $qualityScores->partialCriteria()->toArrayIntRank(),
                         'key_indicators' => $keyIndicators
                     ],
                 ]

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -17,8 +17,9 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class QualityScoreFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    public function __construct()
-    {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty
+    ) {
         $this->supportedFields = ['data_quality_insights_score', 'quality_score'];
         $this->supportedOperators = ['IN'];
     }
@@ -56,7 +57,7 @@ class QualityScoreFilter extends AbstractFieldFilter implements FieldFilterInter
         $this->searchQueryBuilder->addFilter(
             [
                 'terms' => [
-                    sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values
+                    sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale) => $values
                 ]
             ]
         );

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -20,8 +21,9 @@ final class QualityScoreMultiLocalesFilter extends AbstractFieldFilter implement
     public const OPERATOR_IN_AT_LEAST_ONE_LOCALE = 'IN AT LEAST ONE LOCALE';
     public const OPERATOR_IN_ALL_LOCALES = 'IN ALL LOCALES';
 
-    public function __construct()
-    {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty
+    ) {
         $this->supportedFields = [self::FIELD];
         $this->supportedOperators = [
             self::OPERATOR_IN_ALL_LOCALES,
@@ -53,7 +55,7 @@ final class QualityScoreMultiLocalesFilter extends AbstractFieldFilter implement
         $terms = [];
         foreach ($locales as $locale) {
             $terms[] = [
-                'terms' => [sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values]
+                'terms' => [sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale) => $values]
             ];
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjection.php
@@ -42,7 +42,8 @@ final class GetDataQualityInsightsPropertiesForProductModelProjection implements
             $productModelId = $productId->toInt();
             $additionalProperties[$productModelCode] = [
                 'data_quality_insights' => [
-                    'scores' => isset($productModelScores[$productModelId]) ? $productModelScores[$productModelId]->toArrayIntRank() : [],
+                    'scores' => isset($productModelScores[$productModelId]) ? $productModelScores[$productModelId]->allCriteria()->toArrayIntRank() : [],
+                    'scores_partial_criteria' => isset($productModelScores[$productModelId]) ? $productModelScores[$productModelId]->partialCriteria()->toArrayIntRank() : [],
                     'key_indicators' => isset($productModelKeyIndicators[$productModelId]) ? $productModelKeyIndicators[$productModelId] : []
                 ],
             ];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
@@ -16,20 +16,11 @@ use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetAdditionalPropertiesForProduct
  */
 final class GetDataQualityInsightsPropertiesForProductProjection implements GetAdditionalPropertiesForProductProjectionInterface
 {
-    private GetProductScoresQueryInterface $getProductScoresQuery;
-
-    private GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery;
-
-    private ComputeProductsKeyIndicators $getProductsKeyIndicators;
-
     public function __construct(
-        GetProductScoresQueryInterface                    $getProductScoresQuery,
-        GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery,
-        ComputeProductsKeyIndicators                      $getProductsKeyIndicators
+        private GetProductScoresQueryInterface $getProductScoresQuery,
+        private GetProductIdsFromProductIdentifiersQueryInterface $getProductIdsFromProductIdentifiersQuery,
+        private ComputeProductsKeyIndicators $getProductsKeyIndicators,
     ) {
-        $this->getProductScoresQuery = $getProductScoresQuery;
-        $this->getProductIdsFromProductIdentifiersQuery = $getProductIdsFromProductIdentifiersQuery;
-        $this->getProductsKeyIndicators = $getProductsKeyIndicators;
     }
 
     /**
@@ -51,7 +42,8 @@ final class GetDataQualityInsightsPropertiesForProductProjection implements GetA
             $productId = $productId->toInt();
             $additionalProperties[$productIdentifier] = [
                 'data_quality_insights' => [
-                    'scores' => isset($productScores[$productId]) ? $productScores[$productId]->toArrayIntRank() : [],
+                    'scores' => isset($productScores[$productId]) ? $productScores[$productId]->allCriteria()->toArrayIntRank() : [],
+                    'scores_partial_criteria' => isset($productScores[$productId]) ? $productScores[$productId]->partialCriteria()->toArrayIntRank() : [],
                     'key_indicators' => isset($productKeyIndicators[$productId]) ? $productKeyIndicators[$productId] : []
                 ],
             ];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetScoresPropertyStrategy.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetScoresPropertyStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetScoresPropertyStrategy
+{
+    public function __construct(
+        private FeatureFlag $allCriteriaFeature
+    ) {
+    }
+
+    public function __invoke(): string
+    {
+        return $this->allCriteriaFeature->isEnabled() ? 'scores' : 'scores_partial_criteria';
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Sorter/QualityScoreSorter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Sorter/QualityScoreSorter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Sorter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\BaseFieldSorter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
@@ -15,9 +16,16 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
  */
 final class QualityScoreSorter extends BaseFieldSorter
 {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty,
+        array $supportedFields = [],
+    ) {
+        parent::__construct($supportedFields);
+    }
+
     public function addFieldSorter($field, $direction, $locale = null, $channel = null): FieldSorterInterface
     {
-        $field = sprintf('data_quality_insights.scores.%s.%s', $channel, $locale);
+        $field = sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale);
 
         switch ($direction) {
             case Directions::ASCENDING:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductEvaluationQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductEvaluationQuery.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\ProductEvaluation;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetCriteriaEvaluationsByProductIdQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductEvaluationQueryInterface;
@@ -12,21 +13,16 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
 
 final class GetUpToDateProductEvaluationQuery implements GetProductEvaluationQueryInterface
 {
-    private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery;
-
-    private GetProductScoresQueryInterface $getProductScoresQuery;
-
     public function __construct(
-        GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
-        GetProductScoresQueryInterface $getProductScoresQuery
+        private GetCriteriaEvaluationsByProductIdQueryInterface $getCriteriaEvaluationsByProductIdQuery,
+        private GetProductScoresQueryInterface $getProductScoresQuery,
+        private GetEnabledScoresStrategy $getEnabledScores,
     ) {
-        $this->getCriteriaEvaluationsByProductIdQuery = $getCriteriaEvaluationsByProductIdQuery;
-        $this->getProductScoresQuery = $getProductScoresQuery;
     }
 
     public function execute(ProductId $productId): ProductEvaluation
     {
-        $productScores = $this->getProductScoresQuery->byProductId($productId);
+        $productScores = ($this->getEnabledScores)($this->getProductScoresQuery->byProductId($productId));
         $productCriteriaEvaluations = $this->getCriteriaEvaluationsByProductIdQuery->execute($productId);
 
         return new ProductEvaluation($productId, $productScores, $productCriteriaEvaluations);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductModelScoresQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductModelScoresQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -22,13 +23,13 @@ class GetUpToDateProductModelScoresQuery implements GetProductModelScoresQueryIn
     ) {
     }
 
-    public function byProductModelId(ProductId $productModelId): ChannelLocaleRateCollection
+    public function byProductModelId(ProductId $productModelId): Read\Scores
     {
         if ($this->hasUpToDateEvaluationQuery->forProductId($productModelId)) {
             return $this->getProductModelScoresQuery->byProductModelId($productModelId);
         }
 
-        return new ChannelLocaleRateCollection();
+        return new Read\Scores(new ChannelLocaleRateCollection(), new ChannelLocaleRateCollection());
     }
 
     public function byProductModelIds(ProductIdCollection $productIdCollection): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductScoresQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductScoresQuery.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -28,13 +29,13 @@ class GetUpToDateProductScoresQuery implements GetProductScoresQueryInterface
         $this->getProductScoresQuery = $getProductScoresQuery;
     }
 
-    public function byProductId(ProductId $productId): ChannelLocaleRateCollection
+    public function byProductId(ProductId $productId): Read\Scores
     {
         if ($this->hasUpToDateEvaluationQuery->forProductId($productId)) {
             return $this->getProductScoresQuery->byProductId($productId);
         }
 
-        return new ChannelLocaleRateCollection();
+        return new Read\Scores(new ChannelLocaleRateCollection(), new ChannelLocaleRateCollection());
     }
 
     public function byProductIds(ProductIdCollection $productIdCollection): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/GetQualityScoresFactory.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/GetQualityScoresFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\ProductGrid;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
@@ -16,19 +18,19 @@ class GetQualityScoresFactory
 {
     public function __construct(
         private GetProductScoresQueryInterface $getProductScoresQuery,
-        private GetProductModelScoresQueryInterface $getProductModelScoresQuery
+        private GetProductModelScoresQueryInterface $getProductModelScoresQuery,
+        private GetEnabledScoresStrategy $getEnabledScores,
     ) {
     }
 
     public function __invoke(ProductIdCollection $productIdCollection, string $type): array
     {
-        switch ($type) {
-            case 'product':
-                return $this->getProductScoresQuery->byProductIds($productIdCollection);
-            case 'product_model':
-                return $this->getProductModelScoresQuery->byProductModelIds($productIdCollection);
-            default:
-                throw new \InvalidArgumentException(sprintf('Invalid type %s', $type));
-        }
+        $scoresByIds = match ($type) {
+            'product' => $this->getProductScoresQuery->byProductIds($productIdCollection),
+            'product_model' => $this->getProductModelScoresQuery->byProductModelIds($productIdCollection),
+            default => throw new \InvalidArgumentException(sprintf('Invalid type %s', $type))
+        };
+
+        return array_map(fn (Read\Scores $scores) => ($this->getEnabledScores)($scores), $scoresByIds);
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -60,7 +60,13 @@ services:
             - 'Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreMultiLocalesFilter:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
         tags:
             - { name: pim_catalog.elasticsearch.query.product_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_and_product_model_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_model_filter, priority: 30 }
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
@@ -36,11 +36,14 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Sorter\QualityScoreSorter:
         arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
             - ['quality_score']
         tags:
             - { name: pim_catalog.elasticsearch.query.sorter, priority: 30 }
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreFilter:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
         tags:
             - { name: pim_catalog.elasticsearch.query.product_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_and_product_model_filter, priority: 30 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
@@ -27,6 +27,7 @@ services:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateProductScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'
 
     akeneo.pim.automation.data_quality_insights.product_grid.add_scores_to_product_and_product_model_rows:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\ProductGrid\AddScoresToProductAndProductModelRows

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/public_api/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/public_api/queries.yml
@@ -2,7 +2,9 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductScoresQuery:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductScoresByIdentifiersQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductModelScoresQuery:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresByCodesQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -50,10 +50,10 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Dashboard\GetRanksDistributionFromProductScoresQuery:
         arguments:
-            - '@database_connection'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery'
             - '@pim_channel.query.sql.get_channel_code_with_locale_codes'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -33,11 +33,13 @@ services:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateProductScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductModelScores:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetUpToDateProductModelScoresQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'
 
     akeneo.pim.automation.data_quality_insights.get_product_evaluation:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation
@@ -272,3 +274,7 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\FilterPartialCriteriaEvaluations
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
@@ -178,7 +178,8 @@ final class GetRanksDistributionFromProductScoresQueryIntegration extends TestCa
                     $consolidationDate,
                     (new ChannelLocaleRateCollection())
                         ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
-                    new ChannelLocaleRateCollection()
+                    (new ChannelLocaleRateCollection())
+                        ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
                 ),
             ]);
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresByCodesQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresByCodesQueryIntegration.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -35,24 +36,28 @@ final class GetProductModelScoresByCodesQueryIntegration extends DataQualityInsi
         $this->resetProductModelsScores();
 
         $productModelsScores = [
-            'product_model_A_scores' => new ProductScores(
+            'product_model_A_scores' => new Write\ProductScores(
                 new ProductId($productModelA->getId()),
                 new \DateTimeImmutable('2020-01-07'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(76))
                     ->addRate($channelMobile, $localeFr, new Rate(67)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(57))
+                    ->addRate($channelMobile, $localeFr, new Rate(83)),
             ),
-            'product_model_B_scores' => new ProductScores(
+            'product_model_B_scores' => new Write\ProductScores(
                 new ProductId($productModelB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(98))
+                    ->addRate($channelMobile, $localeFr, new Rate(93)),
             ),
 
-            'other_product_model_scores' => new ProductScores(
+            'other_product_model_scores' => new Write\ProductScores(
                 new ProductId($productModelC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
@@ -65,8 +70,14 @@ final class GetProductModelScoresByCodesQueryIntegration extends DataQualityInsi
         $this->get(ProductModelScoreRepository::class)->saveAll(array_values($productModelsScores));
 
         $expectedProductModelsScores = [
-            $productModelA->getCode() => $productModelsScores['product_model_A_scores']->getScores(),
-            $productModelB->getCode() => $productModelsScores['product_model_B_scores']->getScores(),
+            $productModelA->getCode() => new Read\Scores(
+                $productModelsScores['product_model_A_scores']->getScores(),
+                $productModelsScores['product_model_A_scores']->getScoresPartialCriteria(),
+            ),
+            $productModelB->getCode() => new Read\Scores(
+                $productModelsScores['product_model_B_scores']->getScores(),
+                $productModelsScores['product_model_B_scores']->getScoresPartialCriteria(),
+            ),
         ];
 
         $productModelsScores = $this->get(GetProductModelScoresByCodesQuery::class)->byProductModelCodes([

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -37,8 +38,14 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
         $scores = $this->provideScores($productModelIds);
 
         $expectedProductModelsScores = [
-            $productModelIds['idA'] => $scores['product_model_A_scores']->getScores(),
-            $productModelIds['idB'] => $scores['product_model_B_scores']->getScores(),
+            $productModelIds['idA'] => new Read\Scores(
+                $scores['product_model_A_scores']->getScores(),
+                $scores['product_model_A_scores']->getScoresPartialCriteria(),
+            ),
+            $productModelIds['idB'] => new Read\Scores(
+                $scores['product_model_B_scores']->getScores(),
+                $scores['product_model_B_scores']->getScoresPartialCriteria(),
+            ),
         ];
 
         $productAxesRates = $this->get(GetProductModelScoresQuery::class)
@@ -50,20 +57,28 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
     }
 
     /**
-     * @param ProductScores[] $scores
+     * @param Write\ProductScores[] $scores
      */
     private function assertEqualsScore(array $scores, int $productModelId)
     {
         $searchProductId = new ProductId($productModelId);
         $result = $this->get(GetProductModelScoresQuery::class)->byProductModelId($searchProductId);
-        $this->assertEquals($result, $scores['product_model_A_scores']->getScores());
+        $expectedScores = new Read\Scores(
+            $scores['product_model_A_scores']->getScores(),
+            $scores['product_model_A_scores']->getScoresPartialCriteria()
+        );
+
+        $this->assertEquals($expectedScores, $result);
     }
 
     private function assertEqualsNoScore()
     {
         $missingProductId = new ProductId(1590);
         $result = $this->get(GetProductModelScoresQuery::class)->byProductModelId($missingProductId);
-        $this->assertEquals($result, new ChannelLocaleRateCollection());
+        $this->assertEquals($result, new Read\Scores(
+            new ChannelLocaleRateCollection(),
+            new ChannelLocaleRateCollection()
+        ));
     }
 
     /**
@@ -81,7 +96,7 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
 
     /**
      * @param int[]
-     * @return ProductScores[]
+     * @return Write\ProductScores[]
      */
     private function provideScores(array $productModelIds): array
     {
@@ -92,29 +107,35 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
         $this->resetProductModelsScores();
 
         $productModelsScores = [
-            'product_model_A_scores' => new ProductScores(
+            'product_model_A_scores' => new Write\ProductScores(
                 new ProductId($productModelIds['idA']),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(96))
                     ->addRate($channelMobile, $localeFr, new Rate(36)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(86))
+                    ->addRate($channelMobile, $localeFr, new Rate(46)),
             ),
-            'product_model_B_scores' => new ProductScores(
+            'product_model_B_scores' => new Write\ProductScores(
                 new ProductId($productModelIds['idB']),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(97))
+                    ->addRate($channelMobile, $localeFr, new Rate(98)),
             ),
-            'other_product_model_scores' => new ProductScores(
+            'other_product_model_scores' => new Write\ProductScores(
                 new ProductId($productModelIds['idC']),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(78))
+                    ->addRate($channelMobile, $localeFr, new Rate(46)),
             )
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -19,7 +20,7 @@ use Akeneo\Test\Pim\Automation\DataQualityInsights\Integration\DataQualityInsigh
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class getProductScoresQueryIntegration extends DataQualityInsightsTestCase
+final class GetProductScoresQueryIntegration extends DataQualityInsightsTestCase
 {
     public function test_it_returns_the_latest_scores_by_product_ids()
     {
@@ -35,53 +36,69 @@ final class getProductScoresQueryIntegration extends DataQualityInsightsTestCase
         $this->resetProductsScores();
 
         $productsScores = [
-            'product_A_latest_scores' => new ProductScores(
+            'product_A_latest_scores' => new Write\ProductScores(
                 new ProductId($productIdA),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(96))
                     ->addRate($channelMobile, $localeFr, new Rate(36)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(89))
+                    ->addRate($channelMobile, $localeFr, new Rate(23))
             ),
-            'product_A_previous_scores' => new ProductScores(
+            'product_A_previous_scores' => new Write\ProductScores(
                 new ProductId($productIdA),
                 new \DateTimeImmutable('2020-01-07'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(76))
                     ->addRate($channelMobile, $localeFr, new Rate(67)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(87))
+                    ->addRate($channelMobile, $localeFr, new Rate(48)),
             ),
-            'product_B_latest_scores' => new ProductScores(
+            'product_B_latest_scores' => new Write\ProductScores(
                 new ProductId($productIdB),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(89))
+                    ->addRate($channelMobile, $localeFr, new Rate(98)),
             ),
-            'product_B_previous_scores' => new ProductScores(
+            'product_B_previous_scores' => new Write\ProductScores(
                 new ProductId($productIdB),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(81))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(85))
+                    ->addRate($channelMobile, $localeFr, new Rate(97)),
             ),
-            'other_product_scores' => new ProductScores(
+            'other_product_scores' => new Write\ProductScores(
                 new ProductId($productIdC),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(67))
+                    ->addRate($channelMobile, $localeFr, new Rate(81)),
             ),
         ];
 
         $this->get(ProductScoreRepository::class)->saveAll(array_values($productsScores));
 
         $expectedProductsScores = [
-            $productIdA => $productsScores['product_A_latest_scores']->getScores(),
-            $productIdB => $productsScores['product_B_latest_scores']->getScores(),
+            $productIdA => new Read\Scores(
+                $productsScores['product_A_latest_scores']->getScores(),
+                $productsScores['product_A_latest_scores']->getScoresPartialCriteria()
+            ),
+            $productIdB => new Read\Scores(
+                $productsScores['product_B_latest_scores']->getScores(),
+                $productsScores['product_B_latest_scores']->getScoresPartialCriteria()
+            ),
         ];
 
         $productAxesRates = $this->get(GetProductScoresQuery::class)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
@@ -84,26 +84,32 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
                 new ProductId($productModelA->getId()),
                 new \DateTimeImmutable('2020-01-07'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(86))
+                    ->addRate($channelMobile, $localeFr, new Rate(57)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(76))
                     ->addRate($channelMobile, $localeFr, new Rate(67)),
-                new ChannelLocaleRateCollection()
             ),
             'product_model_B_scores' => new ProductScores(
                 new ProductId($productModelB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
+                    ->addRate($channelMobile, $localeFr, new Rate(87)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
 
             'other_product_model_scores' => new ProductScores(
                 new ProductId($productModelC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(77))
+                    ->addRate($channelMobile, $localeFr, new Rate(95)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
@@ -89,25 +89,31 @@ final class getProductScoresQueryIntegration extends DataQualityInsightsTestCase
                 new ProductId($productA->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(86))
+                    ->addRate($channelMobile, $localeFr, new Rate(56)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(96))
                     ->addRate($channelMobile, $localeFr, new Rate(36)),
-                new ChannelLocaleRateCollection()
             ),
             'product_B_scores' => new ProductScores(
                 new ProductId($productB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
+                    ->addRate($channelMobile, $localeFr, new Rate(75)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
             'other_product_scores' => new ProductScores(
                 new ProductId($productC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(67))
+                    ->addRate($channelMobile, $localeFr, new Rate(95)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetEnabledScoresStrategySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/GetEnabledScoresStrategySpec.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+final class GetEnabledScoresStrategySpec extends ObjectBehavior
+{
+    public function let(FeatureFlag $allCriteriaFeature)
+    {
+        $this->beConstructedWith($allCriteriaFeature);
+    }
+
+    public function it_gets_scores_all_criteria_when_the_feature_dqi_all_criteria_is_enabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(true);
+
+        $scores = $this->givenScores();
+        $this->__invoke($scores)->shouldReturn($scores->allCriteria());
+    }
+
+    public function it_gets_scores_partial_criteria_when_the_feature_dqi_all_criteria_is_disabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(false);
+
+        $scores = $this->givenScores();
+        $this->__invoke($scores)->shouldReturn($scores->partialCriteria());
+    }
+
+    private function givenScores(): Read\Scores
+    {
+        $channel = new ChannelCode('ecommerce');
+        $locale = new LocaleCode('en_US');
+
+        return new Read\Scores(
+            (new ChannelLocaleRateCollection)->addRate($channel, $locale, new Rate(76)),
+            (new ChannelLocaleRateCollection)->addRate($channel, $locale, new Rate(65))
+        );
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndexSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndexSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
@@ -69,6 +70,7 @@ class BulkUpdateProductQualityScoresIndexSpec extends ObjectBehavior
                         'inline' => "ctx._source.data_quality_insights = params;",
                         'params' => [
                             'scores' => ['ecommerce' => ['en_US' => 5]],
+                            'scores_partial_criteria' => ['ecommerce' => ['en_US' => 4]],
                             'key_indicators' => $productsKeyIndicators[123]
                         ],
                     ]
@@ -78,6 +80,7 @@ class BulkUpdateProductQualityScoresIndexSpec extends ObjectBehavior
                         'inline' => "ctx._source.data_quality_insights = params;",
                         'params' => [
                             'scores' => ['ecommerce' => ['en_US' => 1]],
+                            'scores_partial_criteria' => ['ecommerce' => ['en_US' => 3]],
                             'key_indicators' => $productsKeyIndicators[456]
                         ],
                     ]
@@ -119,6 +122,7 @@ class BulkUpdateProductQualityScoresIndexSpec extends ObjectBehavior
                         'inline' => "ctx._source.data_quality_insights = params;",
                         'params' => [
                             'scores' => ['ecommerce' => ['en_US' => 5]],
+                            'scores_partial_criteria' => ['ecommerce' => ['en_US' => 4]],
                             'key_indicators' => $productModelsKeyIndicators[123]
                         ],
                     ]
@@ -128,6 +132,7 @@ class BulkUpdateProductQualityScoresIndexSpec extends ObjectBehavior
                         'inline' => "ctx._source.data_quality_insights = params;",
                         'params' => [
                             'scores' => ['ecommerce' => ['en_US' => 1]],
+                            'scores_partial_criteria' => ['ecommerce' => ['en_US' => 3]],
                             'key_indicators' => $productModelsKeyIndicators[456]
                         ],
                     ]
@@ -146,10 +151,18 @@ class BulkUpdateProductQualityScoresIndexSpec extends ObjectBehavior
 
         $productIdCollection = ProductIdCollection::fromProductIds([new ProductId(123), new ProductId(456), new ProductId(42)]);
         $scores = [
-            123 => (new ChannelLocaleRateCollection)
-                ->addRate($channel, $locale, new Rate(10)),
-            456 => (new ChannelLocaleRateCollection)
-                ->addRate($channel, $locale, new Rate(96)),
+            123 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channel, $locale, new Rate(10)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channel, $locale, new Rate(65)),
+            ),
+            456 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channel, $locale, new Rate(96)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channel, $locale, new Rate(78)),
+            ),
         ];
         $keyIndicators = [
             123 => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -16,8 +17,11 @@ use PhpSpec\ObjectBehavior;
  */
 final class QualityScoreFilterSpec extends ObjectBehavior
 {
-    public function let(SearchQueryBuilder $queryBuilder)
+    public function let(SearchQueryBuilder $queryBuilder, GetScoresPropertyStrategy $getScoresPropertyStrategy)
     {
+        $getScoresPropertyStrategy->__invoke()->willReturn('scores');
+
+        $this->beConstructedWith($getScoresPropertyStrategy);
         $this->setQueryBuilder($queryBuilder);
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilterSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreMultiLocalesFilter;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -16,8 +17,11 @@ use PhpSpec\ObjectBehavior;
  */
 final class QualityScoreMultiLocalesFilterSpec extends ObjectBehavior
 {
-    public function let(SearchQueryBuilder $queryBuilder)
+    public function let(SearchQueryBuilder $queryBuilder, GetScoresPropertyStrategy $getScoresPropertyStrategy)
     {
+        $getScoresPropertyStrategy->__invoke()->willReturn('scores');
+
+        $this->beConstructedWith($getScoresPropertyStrategy);
         $this->setQueryBuilder($queryBuilder);
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjectionSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductModelIdsFromProductModelCodesQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
@@ -50,12 +51,22 @@ final class GetDataQualityInsightsPropertiesForProductModelProjectionSpec extend
         $localeFr = new LocaleCode('fr_FR');
 
         $getProductModelScoresQuery->byProductModelIds(ProductIdCollection::fromProductIds([$productId42, $productId123, $productId456]))->willReturn([
-            42 => (new ChannelLocaleRateCollection)
-                ->addRate($channelMobile, $localeEn, new Rate(81))
-                ->addRate($channelMobile, $localeFr, new Rate(30))
-                ->addRate($channelEcommerce, $localeEn, new Rate(73)),
-            123 => (new ChannelLocaleRateCollection)
-                ->addRate($channelMobile, $localeEn, new Rate(66)),
+            42 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(81))
+                    ->addRate($channelMobile, $localeFr, new Rate(30))
+                    ->addRate($channelEcommerce, $localeEn, new Rate(73)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(78))
+                    ->addRate($channelMobile, $localeFr, new Rate(46))
+                    ->addRate($channelEcommerce, $localeEn, new Rate(81))
+            ),
+            123 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(66)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(74)),
+            )
         ]);
 
         $productModelsKeyIndicators = [
@@ -111,6 +122,15 @@ final class GetDataQualityInsightsPropertiesForProductModelProjectionSpec extend
                             'en_US' => 3,
                         ],
                     ],
+                    'scores_partial_criteria' => [
+                        'mobile' => [
+                            'en_US' => 3,
+                            'fr_FR' => 5,
+                        ],
+                        'ecommerce' => [
+                            'en_US' => 2,
+                        ],
+                    ],
                     'key_indicators' => $productModelsKeyIndicators[42]
                 ],
             ],
@@ -121,11 +141,16 @@ final class GetDataQualityInsightsPropertiesForProductModelProjectionSpec extend
                             'en_US' => 4,
                         ],
                     ],
+                    'scores_partial_criteria' => [
+                        'mobile' => [
+                            'en_US' => 3,
+                        ],
+                    ],
                     'key_indicators' => $productModelsKeyIndicators[123]
                 ],
             ],
             'product_model_without_rates' => [
-                'data_quality_insights' => ['scores' => [], 'key_indicators' => []],
+                'data_quality_insights' => ['scores' => [], 'scores_partial_criteria' => [], 'key_indicators' => []],
             ],
         ]);
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
@@ -50,12 +51,22 @@ final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends Obj
         $localeFr = new LocaleCode('fr_FR');
 
         $getProductScoresQuery->byProductIds(ProductIdCollection::fromProductIds([$productId42, $productId123, $productId456]))->willReturn([
-            42 => (new ChannelLocaleRateCollection)
-                ->addRate($channelMobile, $localeEn, new Rate(81))
-                ->addRate($channelMobile, $localeFr, new Rate(30))
-                ->addRate($channelEcommerce, $localeEn, new Rate(73)),
-            123 => (new ChannelLocaleRateCollection)
-                ->addRate($channelMobile, $localeEn, new Rate(66)),
+            42 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(81))
+                    ->addRate($channelMobile, $localeFr, new Rate(30))
+                    ->addRate($channelEcommerce, $localeEn, new Rate(73)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(78))
+                    ->addRate($channelMobile, $localeFr, new Rate(46))
+                    ->addRate($channelEcommerce, $localeEn, new Rate(81))
+            ),
+            123 => new Read\Scores(
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(66)),
+                (new ChannelLocaleRateCollection)
+                    ->addRate($channelMobile, $localeEn, new Rate(74)),
+            )
         ]);
 
         $productsKeyIndicators = [
@@ -111,6 +122,15 @@ final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends Obj
                             'en_US' => 3,
                         ],
                     ],
+                    'scores_partial_criteria' => [
+                        'mobile' => [
+                            'en_US' => 3,
+                            'fr_FR' => 5,
+                        ],
+                        'ecommerce' => [
+                            'en_US' => 2,
+                        ],
+                    ],
                     'key_indicators' => $productsKeyIndicators[42]
                 ],
             ],
@@ -121,11 +141,16 @@ final class GetDataQualityInsightsPropertiesForProductProjectionSpec extends Obj
                             'en_US' => 4,
                         ],
                     ],
+                    'scores_partial_criteria' => [
+                        'mobile' => [
+                            'en_US' => 3,
+                        ],
+                    ],
                     'key_indicators' => $productsKeyIndicators[123]
                 ],
             ],
             'product_without_rates' => [
-                'data_quality_insights' => ['scores' => [], 'key_indicators' => []],
+                'data_quality_insights' => ['scores' => [], 'scores_partial_criteria' => [], 'key_indicators' => []],
             ],
         ]);
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetScoresPropertyStrategySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetScoresPropertyStrategySpec.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+final class GetScoresPropertyStrategySpec extends ObjectBehavior
+{
+    public function let(FeatureFlag $allCriteriaFeature)
+    {
+        $this->beConstructedWith($allCriteriaFeature);
+    }
+
+    public function it_gets_the_scores_property_when_the_feature_all_criteria_is_enabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(true);
+
+        $this->__invoke()->shouldReturn('scores');
+    }
+
+    public function it_gets_the_scores_property_when_the_feature_all_criteria_is_disabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(false);
+
+        $this->__invoke()->shouldReturn('scores_partial_criteria');
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductModelScoresQuerySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductModelScoresQuerySpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
@@ -30,13 +31,17 @@ class GetUpToDateProductModelScoresQuerySpec extends ObjectBehavior
     public function it_returns_the_product_model_scores_if_evaluation_for_product_id_is_up_to_date(
         $hasUpToDateEvaluationQuery,
         $getProductModelScoresQuery
-    )
-    {
+    ) {
         $productModelId = new ProductId(42);
 
-        $scores = (new ChannelLocaleRateCollection())
-            ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100))
-            ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(80));
+        $scores = new Read\Scores(
+            (new ChannelLocaleRateCollection())
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100))
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(80)),
+            (new ChannelLocaleRateCollection())
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(98))
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(74))
+        );
 
         $hasUpToDateEvaluationQuery->forProductId($productModelId)->willReturn(true);
         $getProductModelScoresQuery->byProductModelId($productModelId)->willReturn($scores);
@@ -47,13 +52,12 @@ class GetUpToDateProductModelScoresQuerySpec extends ObjectBehavior
     public function it_returns_empty_scores_if_evaluation_for_product_id_is_outdated(
         $hasUpToDateEvaluationQuery,
         $getProductModelScoresQuery
-    )
-    {
+    ) {
         $productModelId = new ProductId(42);
 
         $hasUpToDateEvaluationQuery->forProductId($productModelId)->willReturn(false);
         $getProductModelScoresQuery->byProductModelId($productModelId)->shouldNotBeCalled();
 
-        $this->byProductModelId($productModelId)->shouldBeLike(new ChannelLocaleRateCollection());
+        $this->byProductModelId($productModelId)->shouldBeLike(new Read\Scores(new ChannelLocaleRateCollection(), new ChannelLocaleRateCollection()));
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductScoresQuerySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Persistence/Query/ProductEvaluation/GetUpToDateProductScoresQuerySpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
@@ -24,21 +25,24 @@ final class GetUpToDateProductScoresQuerySpec extends ObjectBehavior
     public function let(
         HasUpToDateEvaluationQueryInterface  $hasUpToDateEvaluationQuery,
         GetProductScoresQueryInterface $getProductScoresQuery
-    )
-    {
+    ) {
         $this->beConstructedWith($hasUpToDateEvaluationQuery, $getProductScoresQuery);
     }
 
     public function it_returns_the_product_scores_if_the_evaluation_of_the_product_is_up_to_date(
         $hasUpToDateEvaluationQuery,
         $getProductScoresQuery
-    )
-    {
+    ) {
         $productId = new ProductId(42);
 
-        $productScores = (new ChannelLocaleRateCollection())
-            ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100))
-            ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(80));
+        $productScores = new Read\Scores(
+            (new ChannelLocaleRateCollection())
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100))
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(80)),
+            (new ChannelLocaleRateCollection())
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(78))
+                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('fr_FR'), new Rate(67))
+        );
 
         $hasUpToDateEvaluationQuery->forProductId($productId)->willReturn(true);
         $getProductScoresQuery->byProductId($productId)->willReturn($productScores);
@@ -49,31 +53,37 @@ final class GetUpToDateProductScoresQuerySpec extends ObjectBehavior
     public function it_returns_empty_scores_if_the_evaluation_of_the_product_is_outdated(
         $hasUpToDateEvaluationQuery,
         $getProductScoresQuery
-    )
-    {
+    ) {
         $productId = new ProductId(42);
 
         $hasUpToDateEvaluationQuery->forProductId($productId)->willReturn(false);
         $getProductScoresQuery->byProductId($productId)->shouldNotBeCalled();
 
-        $this->byProductId($productId)->shouldBeLike(new ChannelLocaleRateCollection());
+        $this->byProductId($productId)->shouldBeLike(new Read\Scores(new ChannelLocaleRateCollection(), new ChannelLocaleRateCollection()));
     }
 
     public function it_returns_the_product_scores_only_for_up_to_date_products(
         $hasUpToDateEvaluationQuery,
         $getProductScoresQuery
-    )
-    {
+    ) {
         $productIdA = new ProductId(42);
         $productIdB = new ProductId(123);
         $productIdC = new ProductId(456);
         $productIdCollection = ProductIdCollection::fromProductIds([$productIdA, $productIdB, $productIdC]);
         $upToDateProductIdCollection = ProductIdCollection::fromProductIds([$productIdA, $productIdB]);
         $productsScores = [
-            42 => (new ChannelLocaleRateCollection())
-                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100)),
-            123 => (new ChannelLocaleRateCollection())
-                ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(45)),
+            42 => new Read\Scores(
+                (new ChannelLocaleRateCollection())
+                    ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(100)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(90)),
+            ),
+            123 => new Read\Scores(
+                (new ChannelLocaleRateCollection())
+                    ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(45)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), new Rate(67)),
+            )
         ];
 
         $hasUpToDateEvaluationQuery->forProductIdCollection($productIdCollection)->willReturn($upToDateProductIdCollection);
@@ -85,8 +95,7 @@ final class GetUpToDateProductScoresQuerySpec extends ObjectBehavior
     public function it_returns_empty_array_if_there_are_no_up_to_date_products(
         $hasUpToDateEvaluationQuery,
         $getProductScoresQuery
-    )
-    {
+    ) {
         $products = ProductIdCollection::fromInts([42, 123]);
 
         $hasUpToDateEvaluationQuery->forProductIdCollection($products)->willReturn(null);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/elasticsearch/product_mapping.yml
@@ -290,3 +290,8 @@ mappings:
                 path_match: 'data_quality_insights.scores.*'
                 mapping:
                     type: 'short'
+        -
+            data_quality_insights_scores_partial_criteria:
+                path_match: 'data_quality_insights.scores_partial_criteria.*'
+                mapping:
+                    type: 'short'


### PR DESCRIPTION
For ES indexation, we need both scores, but for displaying in the PEF and the product-grid we need the scores enabled according to the feature flag. Although they use the same MySQL queries.

As we need either the enabled score or both scores depending of the usage context, I changed the type of return of the MySQL queries that fetch scores. It will now return a read-model with both scores, and a dedicated service will be able to determine the enabled ones if needed.

