### PR TITLE
CXP-fixunused-phpcd-rules: Removed unsused rules

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -249,7 +249,6 @@ $rules = [
 
     $builder->only(
         [
-            'Akeneo\Connectivity\Connection\Domain\User',
             'Akeneo\Connectivity\Connection\Application\User',
 
             // Exceptions
@@ -289,7 +288,6 @@ $rules = [
 
             'Psr\Log\LoggerInterface',
             'Psr\Http\Message\ResponseInterface',
-            'Akeneo\Platform\Bundle\UIBundle\Provider\ContentSecurityPolicy\ContentSecurityPolicyProviderInterface',
         ]
     )->in('Akeneo\Connectivity\Connection\Application\Webhook'),
 


### PR DESCRIPTION
The following rules have unused rules in our phpcd configuration file

Rule Akeneo\Connectivity\Connection\Application\User  have:
   `Akeneo\Connectivity\Connection\Domain\User`
Rule Akeneo\Connectivity\Connection\Application\Webhook have:
    `Akeneo\Platform\Bundle\UIBundle\Provider\ContentSecurityPolicy\ContentSecurityPolicyProviderInterface` 
