### PR TITLE
CXP-1174: Faster CXP CI

### DIFF
--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -107,10 +107,105 @@ jobs:
             - run:
                   name: Remove MySQL port translation (see BH-664)
                   command: yq delete --inplace docker-compose.yml services.mysql.ports
+            - run:
+                  name: Copy docker-compose.override.yml.dist
+                  command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
+            -   run:
+                    name: Setup tests results folder and log folder
+                    command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.composer
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Change permissions on project dir
+                    command: sudo chmod -R 777 ../project
             - persist_to_workspace:
                   root: ~/
                   paths:
                       - project
+
+    install_ce_back_dependencies:
+        machine:
+            image: *executor-machine
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Creating cache key for back dependencies
+                    command: cat composer.json > ~/back-dependency.hash && date +%F >> ~/back-dependency.hash
+            -   restore_cache:
+                    name: Restore cache - back dependencies
+                    keys:
+                        - backend-dependency-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/back-dependency.hash" }}
+            -   run:
+                    name: Pull docker image for php
+                    command: docker-compose pull php
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Change permissions on project dir
+                    command: sudo chmod -R 777 ../project
+            -   run:
+                    name: Install back dependencies
+                    command: make vendor
+            -   persist_to_workspace:
+                    root: ~/
+                    paths:
+                        - project/vendor
+
+    install_ce_front_dependencies:
+        parameters:
+            path_to_front_packages:
+                type: string
+                default: front-packages
+        machine:
+            image: *executor-machine
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Creating cache key for front dependencies
+                    command: cat yarn.lock > ~/front-dependency.hash && date +%F >> ~/front-dependency.hash
+            -   restore_cache:
+                    name: Restore cache - front dependencies
+                    keys:
+                        - frontend-dependency-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/front-dependency.hash" }}
+            -   run:
+                    name: Create hash for front packages
+                    command: |
+                        find << parameters.path_to_front_packages >>/akeneo-design-system -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/akeneo-design-system.hash
+                        find << parameters.path_to_front_packages >>/shared -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum > ~/shared.hash
+                        echo "$(date +%F) << parameters.path_to_front_packages >>" | tee -a ~/akeneo-design-system.hash
+            -   restore_cache:
+                    name: Restore cache - front library DSM
+                    key: front-packages-dsm-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/akeneo-design-system.hash" }}
+            -   restore_cache:
+                    name: Restore cache - front library Shared
+                    key: front-packages-shared-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/shared.hash" }}
+            -   run:
+                    name: Pull docker image for node
+                    command: docker-compose pull node
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Change permissions on project dir
+                    command: sudo chmod -R 777 ../project
+            -   run:
+                    name: Install front dependencies
+                    command: make node_modules
+            -   run:
+                    name: Build front libraries
+                    command: |
+                        docker-compose run -u node --rm node yarn dsm:build
+                        docker-compose run -u node --rm node yarn shared:build
+            -   persist_to_workspace:
+                    root: ~/
+                    paths:
+                        - project/node_modules
+                        - project/front-packages/akeneo-design-system/lib
+                        - project/front-packages/shared/lib
 
     build_dev:
         parameters:

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -107,18 +107,9 @@ jobs:
             - run:
                   name: Remove MySQL port translation (see BH-664)
                   command: yq delete --inplace docker-compose.yml services.mysql.ports
-            - run:
-                  name: Copy docker-compose.override.yml.dist
-                  command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
             -   run:
-                    name: Setup tests results folder and log folder
+                    name: Setup missing directories
                     command: mkdir -p var/tests/phpspec var/tests/csfixer var/logs var/tests/screenshots ~/.composer
-            -   run:
-                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
-                    command: sudo chown -R 1000:1000 ../project
-            -   run:
-                    name: Change permissions on project dir
-                    command: sudo chmod -R 777 ../project
             - persist_to_workspace:
                   root: ~/
                   paths:
@@ -131,6 +122,12 @@ jobs:
             -   attach_workspace:
                     at: ~/
             -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Change permissions on project dir
+                    command: sudo chmod -R 777 ../project
+            -   run:
                     name: Creating cache key for back dependencies
                     command: cat composer.json > ~/back-dependency.hash && date +%F >> ~/back-dependency.hash
             -   restore_cache:
@@ -140,12 +137,6 @@ jobs:
             -   run:
                     name: Pull docker image for php
                     command: docker-compose pull php
-            -   run:
-                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
-                    command: sudo chown -R 1000:1000 ../project
-            -   run:
-                    name: Change permissions on project dir
-                    command: sudo chmod -R 777 ../project
             -   run:
                     name: Install back dependencies
                     command: make vendor
@@ -164,6 +155,12 @@ jobs:
         steps:
             -   attach_workspace:
                     at: ~/
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Change permissions on project dir
+                    command: sudo chmod -R 777 ../project
             -   run:
                     name: Creating cache key for front dependencies
                     command: cat yarn.lock > ~/front-dependency.hash && date +%F >> ~/front-dependency.hash
@@ -186,12 +183,6 @@ jobs:
             -   run:
                     name: Pull docker image for node
                     command: docker-compose pull node
-            -   run:
-                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
-                    command: sudo chown -R 1000:1000 ../project
-            -   run:
-                    name: Change permissions on project dir
-                    command: sudo chmod -R 777 ../project
             -   run:
                     name: Install front dependencies
                     command: make node_modules

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -1,7 +1,7 @@
 executor-machine: &executor-machine 'ubuntu-2004:202111-02'
 
 jobs:
-    test_front_connectivity:
+    test_front_lint_connectivity:
         machine:
             image: *executor-machine
             docker_layer_caching: true
@@ -20,14 +20,28 @@ jobs:
             -   run:
                     name: Lint front
                     command: make connectivity-connection-lint-front
+
+    test_front_unit_connectivity:
+        machine:
+            image: *executor-machine
+            docker_layer_caching: true
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Create yarn cache folder
+                    command: mkdir -p  ~/.cache/yarn
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
+            -   run:
+                    name: Pull docker image for node
+                    command: docker-compose pull node
             -   run:
                     name: Unit front
                     command: make connectivity-connection-unit-front
-            -   run:
-                    name: Type checking front
-                    command: make javascript-dev-strict
 
-    test_back_connectivity:
+    test_back_unit_connectivity:
         machine:
             image: *executor-machine
             docker_layer_caching: true
@@ -49,9 +63,20 @@ jobs:
             -   run:
                     name: Unit back
                     command: make connectivity-connection-unit-back
+
+    test_back_integration_connectivity:
+        machine:
+            image: *executor-machine
+            docker_layer_caching: true
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker images
-                    command: docker-compose pull fpm mysql elasticsearch object-storage pubsub-emulator
+                    command: docker-compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
             -   run:
                     name: Start containers
                     command: |
@@ -59,17 +84,41 @@ jobs:
                         docker/wait_docker_up.sh
             -   run:
                     name: Install database
-                    command: APP_ENV=test make database
+                    command: APP_ENV=test O="--withoutFixtures" make database
             -   run:
                     name: Integration back
                     command: CI=false make connectivity-connection-integration-back
+            -   store_test_results:
+                    path: var/tests/phpunit
+
+    test_back_e2e_connectivity:
+        machine:
+            image: *executor-machine
+            docker_layer_caching: true
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project
+            -   run:
+                    name: Pull docker images
+                    command: docker-compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
+            -   run:
+                    name: Start containers
+                    command: |
+                        APP_ENV=test C='fpm mysql elasticsearch object-storage pubsub-emulator' make up
+                        docker/wait_docker_up.sh
+            -   run:
+                    name: Install database
+                    command: APP_ENV=test O="--withoutFixtures" make database
             -   run:
                     name: End to end back
                     command: CI=false make connectivity-connection-e2e-back
             -   store_test_results:
                     path: var/tests/phpunit
 
-    test_marketplace_activate_e2e:
+    test_back_behat_connectivity:
         machine:
             image: *executor-machine
         steps:

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -72,6 +72,9 @@ jobs:
             -   attach_workspace:
                     at: ~/
             -   run:
+                    name: Copy docker-compose.override.yml.dist
+                    command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
+            -   run:
                     name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                     command: sudo chown -R 1000:1000 ../project
             -   run:
@@ -99,6 +102,9 @@ jobs:
             -   attach_workspace:
                     at: ~/
             -   run:
+                    name: Copy docker-compose.override.yml.dist
+                    command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
+            -   run:
                     name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
                     command: sudo chown -R 1000:1000 ../project
             -   run:
@@ -124,6 +130,9 @@ jobs:
         steps:
             -   attach_workspace:
                     at: ~/
+            -   run:
+                    name: Copy docker-compose.override.yml.dist
+                    command: cp .circleci/docker-compose.override.yml.dist docker-compose.override.yml
             -   run:
                     name: Change owner on project dir in order to archive the project into the workspace
                     command: sudo chown -R 1000:1000 ../project

--- a/.circleci/workflows/squads/octopus.yml
+++ b/.circleci/workflows/squads/octopus.yml
@@ -12,28 +12,57 @@ workflows:
                 equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         jobs:
             - checkout_ce:
+                  name: checkout
                   filters:
                       branches:
                           only:
                               - /^(CXP|OCT)-.*/
+            - install_ce_front_dependencies:
+                  name: install_front_dependencies
+                  requires:
+                      - checkout
+            - install_ce_back_dependencies:
+                  name: install_back_dependencies
+                  requires:
+                      - checkout
             - build_dev:
-                  name: build_dev_ce
+                  name: build
                   is_ee_built: false
                   requires:
-                      - checkout_ce
-            - test_front_connectivity:
+                      - install_back_dependencies
+                      - install_front_dependencies
+            - test_front_unit_connectivity:
+                  name: test_front_unit
                   requires:
-                      - build_dev_ce
-            - test_back_connectivity:
+                      - install_front_dependencies
+            - test_front_lint_connectivity:
+                  name: test_front_lint
                   requires:
-                      - build_dev_ce
-            - test_marketplace_activate_e2e:
+                      - install_front_dependencies
+            - test_back_unit_connectivity:
+                  name: test_back_unit
                   requires:
-                      - build_dev_ce
+                      - install_back_dependencies
+            - test_back_integration_connectivity:
+                  name: test_back_integration
+                  requires:
+                      - install_back_dependencies
+            - test_back_e2e_connectivity:
+                  name: test_back_e2e
+                  requires:
+                      - install_back_dependencies
+            - test_back_behat_connectivity:
+                  name: test_back_behat
+                  requires:
+                      - build
             - pull_request_success:
                   requires:
-                      - test_front_connectivity
-                      - test_back_connectivity
+                      - test_front_lint
+                      - test_front_unit
+                      - test_back_unit
+                      - test_back_integration
+                      - test_back_e2e
+                      - test_back_behat
 
     octopus_weekly_code_quality:
         when:

--- a/make-file/connectivity-connection.mk
+++ b/make-file/connectivity-connection.mk
@@ -61,8 +61,10 @@ connectivity-connection-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php src/Akeneo/Connectivity/Connection/back
 
 connectivity-connection-lint-back:
+ifneq ($(CI),true)
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
 	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
+endif
 	$(PHP_RUN) vendor/bin/php-cs-fixer fix --diff --dry-run --config=src/Akeneo/Connectivity/Connection/back/tests/.php_cs.php
 	$(PHP_RUN) vendor/bin/phpstan analyse \
 		--level=8 \
@@ -121,8 +123,10 @@ connectivity-connection-unit-front:
 connectivity-connection-lint-front:
 	$(_CONNECTIVITY_CONNECTION_YARN_RUN) eslint
 	$(_CONNECTIVITY_CONNECTION_YARN_RUN) prettier --check
+	$(_CONNECTIVITY_CONNECTION_YARN_RUN) tsc --noEmit --strict
 	$(_PERMISSION_FORM_YARN_RUN) eslint
 	$(_PERMISSION_FORM_YARN_RUN) prettier --check
+	$(_PERMISSION_FORM_YARN_RUN) tsc --noEmit --strict
 
 # Development
 

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -27,7 +27,6 @@ lint-back:
 	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
 	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
 	$(DOCKER_COMPOSE) run -u www-data --rm php php -d memory_limit=1G vendor/bin/phpstan analyse src/Akeneo/Pim --level 2
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
 	${PHP_RUN} vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
 	$(MAKE) connectivity-connection-lint-back
 	$(MAKE) communication-channel-lint-back
@@ -35,6 +34,8 @@ lint-back:
 	$(MAKE) data-quality-insights-phpstan
 	$(MAKE) job-lint-back
 	$(MAKE) enrichment-product-lint-back
+	# Cache was created with debug enabled, removing it allows a faster one to be created for upcoming tests
+	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
 
 .PHONY: lint-front
 lint-front:

--- a/src/Akeneo/Connectivity/Connection/front/tsconfig.json
+++ b/src/Akeneo/Connectivity/Connection/front/tsconfig.json
@@ -5,6 +5,10 @@
         "noEmit": true,
         "esModuleInterop": true,
         "lib": ["dom", "es2015", "es2016", "es2017","es2018", "es2019"],
+        "skipLibCheck": true,
+        "paths": {
+            "@src/*": ["./src/*"]
+        }
     },
     "include": ["src", "tests", "types.d.ts"]
 }

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/tsconfig.json
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/tsconfig.json
@@ -4,6 +4,7 @@
         "jsx": "react",
         "noEmit": true,
         "esModuleInterop": true,
+        "skipLibCheck": true,
         "lib": ["dom", "es2015", "es2016", "es2017","es2018", "es2019"]
     },
     "include": ["src", "tests/types.d.ts"]


### PR DESCRIPTION
**Before**
![Screenshot_2022-04-28_15-03-53](https://user-images.githubusercontent.com/1421130/165758380-6652bc01-5756-43a5-9928-3343e97bb150.png)

_From start to finish: 16-17min_

**After**
![Screenshot_2022-04-28_14-26-16](https://user-images.githubusercontent.com/1421130/165751636-bc8c6858-9c32-45bd-b3bf-80b76a844a3e.png)

_From start to finish: 9-10min_

---

**The trick**

By installing the dependencies before building the PIM, we can already execute a lot of tests (unit, integration) while compiling the JS for example.
The `build_ce` is still the same and still tries to install the dependencies, but since they are already there or were cached, it has no impact.

**What about persistence of the files?**

Persisting the same workspace in parallelized jobs is possible.
https://circleci.com/blog/deep-diving-into-circleci-workspaces/
Thanks @ahocquard for the tips

By persisting only subdirectories when installing the dependencies:
```
-   persist_to_workspace:
        root: ~/
        paths:
            - project/vendor
```
```
-   persist_to_workspace:
        root: ~/
        paths:
            - project/node_modules
            - project/front-packages/akeneo-design-system/lib
            - project/front-packages/shared/lib
```

Circle CI is able to merge the layers at no cost
![Screenshot_2022-04-28_14-27-54](https://user-images.githubusercontent.com/1421130/165752283-55c79807-78be-44dd-b390-1f5ae648046b.png)

**Faster CI, early feedback**

The CI, while still running the same amount of tests, is obviously faster without having to rely on heavy parallelization. 
And this way, we have feedback earlier, for example, PHP unit tests are termined 2min after the CI starts. (before, it was around 8-10min after the CI started)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
