### PR TITLE
PLG-830: Adapt double scores for exports and API

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresByCodesQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductModelScoresByCodesQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -12,10 +12,10 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateColl
  */
 interface GetProductModelScoresByCodesQueryInterface
 {
-    public function byProductModelCode(string $productModelCode): ChannelLocaleRateCollection;
+    public function byProductModelCode(string $productModelCode): Read\Scores;
 
     /**
-     * @return array<string, ChannelLocaleRateCollection>
+     * @return array<string, Read\Scores>
      */
     public function byProductModelCodes(array $productModelCodes): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresByIdentifiersQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEvaluation/GetProductScoresByIdentifiersQueryInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -17,9 +17,9 @@ interface GetProductScoresByIdentifiersQueryInterface
      *
      * @param string[] $productIdentifiers
      *
-     * @return ChannelLocaleRateCollection[]
+     * @return Read\Scores[]
      */
     public function byProductIdentifiers(array $productIdentifiers): array;
 
-    public function byProductIdentifier(string $identifier): ChannelLocaleRateCollection;
+    public function byProductIdentifier(string $identifier): Read\Scores;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreFilter.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rank;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -17,8 +17,9 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 class QualityScoreFilter extends AbstractFieldFilter implements FieldFilterInterface
 {
-    public function __construct()
-    {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty
+    ) {
         $this->supportedFields = ['data_quality_insights_score', 'quality_score'];
         $this->supportedOperators = ['IN'];
     }
@@ -56,7 +57,7 @@ class QualityScoreFilter extends AbstractFieldFilter implements FieldFilterInter
         $this->searchQueryBuilder->addFilter(
             [
                 'terms' => [
-                    sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values
+                    sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale) => $values
                 ]
             ]
         );

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -20,8 +21,9 @@ final class QualityScoreMultiLocalesFilter extends AbstractFieldFilter implement
     public const OPERATOR_IN_AT_LEAST_ONE_LOCALE = 'IN AT LEAST ONE LOCALE';
     public const OPERATOR_IN_ALL_LOCALES = 'IN ALL LOCALES';
 
-    public function __construct()
-    {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty
+    ) {
         $this->supportedFields = [self::FIELD];
         $this->supportedOperators = [
             self::OPERATOR_IN_ALL_LOCALES,
@@ -53,7 +55,7 @@ final class QualityScoreMultiLocalesFilter extends AbstractFieldFilter implement
         $terms = [];
         foreach ($locales as $locale) {
             $terms[] = [
-                'terms' => [sprintf('data_quality_insights.scores.%s.%s', $channel, $locale) => $values]
+                'terms' => [sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale) => $values]
             ];
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetScoresPropertyStrategy.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetScoresPropertyStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetScoresPropertyStrategy
+{
+    public function __construct(
+        private FeatureFlag $allCriteriaFeature
+    ) {
+    }
+
+    public function __invoke(): string
+    {
+        return $this->allCriteriaFeature->isEnabled() ? 'scores' : 'scores_partial_criteria';
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Sorter/QualityScoreSorter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/Sorter/QualityScoreSorter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Sorter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\BaseFieldSorter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
@@ -15,9 +16,16 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
  */
 final class QualityScoreSorter extends BaseFieldSorter
 {
+    public function __construct(
+        private GetScoresPropertyStrategy $getScoresProperty,
+        array $supportedFields = [],
+    ) {
+        parent::__construct($supportedFields);
+    }
+
     public function addFieldSorter($field, $direction, $locale = null, $channel = null): FieldSorterInterface
     {
-        $field = sprintf('data_quality_insights.scores.%s.%s', $channel, $locale);
+        $field = sprintf('data_quality_insights.%s.%s.%s', ($this->getScoresProperty)(), $channel, $locale);
 
         switch ($direction) {
             case Directions::ASCENDING:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/elasticsearch.yml
@@ -60,7 +60,13 @@ services:
             - 'Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreMultiLocalesFilter:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
         tags:
             - { name: pim_catalog.elasticsearch.query.product_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_and_product_model_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_model_filter, priority: 30 }
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
@@ -36,11 +36,14 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Sorter\QualityScoreSorter:
         arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
             - ['quality_score']
         tags:
             - { name: pim_catalog.elasticsearch.query.sorter, priority: 30 }
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreFilter:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
         tags:
             - { name: pim_catalog.elasticsearch.query.product_filter, priority: 30 }
             - { name: pim_catalog.elasticsearch.query.product_and_product_model_filter, priority: 30 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/public_api/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/public_api/queries.yml
@@ -2,7 +2,9 @@ services:
     Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductScoresQuery:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductScoresByIdentifiersQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\ProductEvaluation\GetProductModelScoresQuery:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetProductModelScoresByCodesQuery'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\GetEnabledScoresStrategy'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -50,10 +50,10 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Dashboard\GetRanksDistributionFromProductScoresQuery:
         arguments:
-            - '@database_connection'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery'
             - '@pim_channel.query.sql.get_channel_code_with_locale_codes'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
@@ -178,7 +178,8 @@ final class GetRanksDistributionFromProductScoresQueryIntegration extends TestCa
                     $consolidationDate,
                     (new ChannelLocaleRateCollection())
                         ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
-                    new ChannelLocaleRateCollection()
+                    (new ChannelLocaleRateCollection())
+                        ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
                 ),
             ]);
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresByCodesQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/ProductEvaluation/GetProductModelScoresByCodesQueryIntegration.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\tests\back\Integration\Infrastructure\Persistence\Query\ProductEvaluation;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\ProductScores;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
@@ -35,24 +36,28 @@ final class GetProductModelScoresByCodesQueryIntegration extends DataQualityInsi
         $this->resetProductModelsScores();
 
         $productModelsScores = [
-            'product_model_A_scores' => new ProductScores(
+            'product_model_A_scores' => new Write\ProductScores(
                 new ProductId($productModelA->getId()),
                 new \DateTimeImmutable('2020-01-07'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(76))
                     ->addRate($channelMobile, $localeFr, new Rate(67)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(57))
+                    ->addRate($channelMobile, $localeFr, new Rate(83)),
             ),
-            'product_model_B_scores' => new ProductScores(
+            'product_model_B_scores' => new Write\ProductScores(
                 new ProductId($productModelB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(98))
+                    ->addRate($channelMobile, $localeFr, new Rate(93)),
             ),
 
-            'other_product_model_scores' => new ProductScores(
+            'other_product_model_scores' => new Write\ProductScores(
                 new ProductId($productModelC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
@@ -65,8 +70,14 @@ final class GetProductModelScoresByCodesQueryIntegration extends DataQualityInsi
         $this->get(ProductModelScoreRepository::class)->saveAll(array_values($productModelsScores));
 
         $expectedProductModelsScores = [
-            $productModelA->getCode() => $productModelsScores['product_model_A_scores']->getScores(),
-            $productModelB->getCode() => $productModelsScores['product_model_B_scores']->getScores(),
+            $productModelA->getCode() => new Read\Scores(
+                $productModelsScores['product_model_A_scores']->getScores(),
+                $productModelsScores['product_model_A_scores']->getScoresPartialCriteria(),
+            ),
+            $productModelB->getCode() => new Read\Scores(
+                $productModelsScores['product_model_B_scores']->getScores(),
+                $productModelsScores['product_model_B_scores']->getScoresPartialCriteria(),
+            ),
         ];
 
         $productModelsScores = $this->get(GetProductModelScoresByCodesQuery::class)->byProductModelCodes([

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductModelScoresQueryIntegration.php
@@ -84,26 +84,32 @@ final class GetProductModelScoresQueryIntegration extends DataQualityInsightsTes
                 new ProductId($productModelA->getId()),
                 new \DateTimeImmutable('2020-01-07'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(86))
+                    ->addRate($channelMobile, $localeFr, new Rate(57)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(76))
                     ->addRate($channelMobile, $localeFr, new Rate(67)),
-                new ChannelLocaleRateCollection()
             ),
             'product_model_B_scores' => new ProductScores(
                 new ProductId($productModelB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
+                    ->addRate($channelMobile, $localeFr, new Rate(87)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
 
             'other_product_model_scores' => new ProductScores(
                 new ProductId($productModelC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(77))
+                    ->addRate($channelMobile, $localeFr, new Rate(95)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/PublicApi/Query/ProductEvaluation/GetProductScoresQueryIntegration.php
@@ -89,25 +89,31 @@ final class getProductScoresQueryIntegration extends DataQualityInsightsTestCase
                 new ProductId($productA->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(86))
+                    ->addRate($channelMobile, $localeFr, new Rate(56)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(96))
                     ->addRate($channelMobile, $localeFr, new Rate(36)),
-                new ChannelLocaleRateCollection()
             ),
             'product_B_scores' => new ProductScores(
                 new ProductId($productB->getId()),
                 new \DateTimeImmutable('2020-01-09'),
                 (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(100))
+                    ->addRate($channelMobile, $localeFr, new Rate(75)),
+                (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(100))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
             'other_product_scores' => new ProductScores(
                 new ProductId($productC->getId()),
                 new \DateTimeImmutable('2020-01-08'),
                 (new ChannelLocaleRateCollection())
+                    ->addRate($channelMobile, $localeEn, new Rate(67))
+                    ->addRate($channelMobile, $localeFr, new Rate(95)),
+                (new ChannelLocaleRateCollection())
                     ->addRate($channelMobile, $localeEn, new Rate(87))
                     ->addRate($channelMobile, $localeFr, new Rate(95)),
-                new ChannelLocaleRateCollection()
             ),
         ];
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreFilterSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -16,8 +17,11 @@ use PhpSpec\ObjectBehavior;
  */
 final class QualityScoreFilterSpec extends ObjectBehavior
 {
-    public function let(SearchQueryBuilder $queryBuilder)
+    public function let(SearchQueryBuilder $queryBuilder, GetScoresPropertyStrategy $getScoresPropertyStrategy)
     {
+        $getScoresPropertyStrategy->__invoke()->willReturn('scores');
+
+        $this->beConstructedWith($getScoresPropertyStrategy);
         $this->setQueryBuilder($queryBuilder);
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilterSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/Filter/QualityScoreMultiLocalesFilterSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Filter\QualityScoreMultiLocalesFilter;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -16,8 +17,11 @@ use PhpSpec\ObjectBehavior;
  */
 final class QualityScoreMultiLocalesFilterSpec extends ObjectBehavior
 {
-    public function let(SearchQueryBuilder $queryBuilder)
+    public function let(SearchQueryBuilder $queryBuilder, GetScoresPropertyStrategy $getScoresPropertyStrategy)
     {
+        $getScoresPropertyStrategy->__invoke()->willReturn('scores');
+
+        $this->beConstructedWith($getScoresPropertyStrategy);
         $this->setQueryBuilder($queryBuilder);
     }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetScoresPropertyStrategySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetScoresPropertyStrategySpec.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
+
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+final class GetScoresPropertyStrategySpec extends ObjectBehavior
+{
+    public function let(FeatureFlag $allCriteriaFeature)
+    {
+        $this->beConstructedWith($allCriteriaFeature);
+    }
+
+    public function it_gets_the_scores_property_when_the_feature_all_criteria_is_enabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(true);
+
+        $this->__invoke()->shouldReturn('scores');
+    }
+
+    public function it_gets_the_scores_property_when_the_feature_all_criteria_is_disabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(false);
+
+        $this->__invoke()->shouldReturn('scores_partial_criteria');
+    }
+}


### PR DESCRIPTION
- Adapt MySQL queries used for the exports and the API
- Adapt ES queries to filter and sort on the scores according to the feature flag