### PR TITLE
PLG-837: Adapt ranks distribution for double scores

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -50,10 +50,10 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Dashboard\GetRanksDistributionFromProductScoresQuery:
         arguments:
-            - '@database_connection'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery'
             - '@pim_channel.query.sql.get_channel_code_with_locale_codes'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\GetScoresPropertyStrategy'
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\GetCategoryChildrenCodesQuery:
         arguments:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/Dashboard/GetRanksDistributionFromProductScoresQueryIntegration.php
@@ -178,7 +178,8 @@ final class GetRanksDistributionFromProductScoresQueryIntegration extends TestCa
                     $consolidationDate,
                     (new ChannelLocaleRateCollection())
                         ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
-                    new ChannelLocaleRateCollection()
+                    (new ChannelLocaleRateCollection())
+                        ->addRate(new ChannelCode('ecommerce'), new LocaleCode('en_US'), $this->getRateFromRank($rank)),
                 ),
             ]);
         }


### PR DESCRIPTION
The data used in the Dashboard for evolution graphs and for the category/family widgets are computed from scores stored in ES.
So we just need to adapt the ES query to do the aggregations on the right scores property