### PR TITLE
PIM-10411: Fix non numeric metric value in imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PIM-10389: Export channel currencies for a non-scopable price attribute instead of all enabled currencies
 - PIM-10398: Fix category validator to prevent break-lines
 - PIM-10409: Allow creating a measurement value with case insensitive unit code
+- PIM-10411: Fix non numeric metric value in imports
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractMetric.php
@@ -97,6 +97,10 @@ abstract class AbstractMetric implements MetricInterface
             return $metric->getData() === $this->data;
         }
 
+        if (!\is_numeric($metric->getData()) || !\is_numeric($this->data)) {
+            return false;
+        }
+
         return 0 === bccomp($metric->getData(), $this->data, 50);
     }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -105,14 +105,14 @@ class MeasureConverter
      */
     protected function applyOperation($value, $operator, $operand)
     {
+        if (!is_numeric($value)) {
+            return '0';
+        }
+
         if (is_float($value)) {
             $processedValue = \number_format($value, static::SCALE, '.', '');
         } else {
             $processedValue = (string) $value;
-        }
-
-        if (!is_numeric($processedValue)) {
-            return '0';
         }
 
         switch ($operator) {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
@@ -96,6 +96,15 @@ YAML;
         )->shouldReturn('0.000100000000');
     }
 
+    public function it_returns_zero_when_value_is_not_numeric()
+    {
+        $this->setFamily('Weight');
+        $this->convertBaseToStandard(
+            'KILOGRAM',
+            '1.900.000'
+        )->shouldReturn('0');
+    }
+
     public function it_converts_a_standard_value_to_a_final_unit()
     {
         $this->setFamily('Weight');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Model/MetricSpec.php
@@ -159,4 +159,21 @@ class MetricSpec extends ObjectBehavior
 
         $this->isEqual($anotherMetric)->shouldReturn(false);
     }
+
+    function it_is_not_equal_to_another_metric_with_non_numeric_data(
+        MetricInterface $anotherMetric
+    ) {
+        $this->beConstructedWith(
+            'length_family',
+            'centimeter',
+            '9.000.000',
+            'meter',
+            6.6611
+        );
+
+        $anotherMetric->getData()->willReturn('9000000');
+        $anotherMetric->getUnit()->willReturn('centimeter');
+
+        $this->isEqual($anotherMetric)->shouldReturn(false);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
When importing "1.900.000" as metric value, there is an error on bcomp

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
