### PR TITLE
fix-onboarder-ci: Pass default GRPC transport to rest in PubSubClientFactory from MessengerBundle

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Transport/GooglePubSub/PubSubClientFactory.php
@@ -27,7 +27,8 @@ class PubSubClientFactory
     public function createPubSubClient(array $config): PubSubClient
     {
         return new PubSubClient(array_merge([
-            'keyFilePath' => $this->keyFilePath
+            'keyFilePath' => $this->keyFilePath,
+            'transport' => 'rest',
         ], $config));
     }
 }


### PR DESCRIPTION
Backport of a fix done on master branch https://github.com/akeneo/pim-community-dev/pull/16308

We need to backport this fix because we run 6.0 PIM with PubSub on the pim-onboarder bundle CI

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
