### PR TITLE
PIM-10413: patch connections routing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PIM-10389: Export channel currencies for a non-scopable price attribute instead of all enabled currencies
 - PIM-10398: Fix category validator to prevent break-lines
 - PIM-10409: Allow creating a measurement value with case insensitive unit code
+- PIM-10413: Patch connections routes order
 
 ## Improvements
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/routing.yml
@@ -13,8 +13,9 @@ akeneo_connectivity_connection_error_management:
 akeneo_connectivity_connection_marketplace:
     resource: ./Marketplace/routing.yml
 
-akeneo_connectivity_connection_settings:
-    resource: ./Settings/routing.yml
-
 akeneo_connectivity_connection_webhook:
     resource: ./Webhook/routing.yml
+
+# connection_settings must be imported at the end because of the order of the front routes is important
+akeneo_connectivity_connection_settings:
+    resource: ./Settings/routing.yml


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
patch connections routing order : 
this front route must be at the end, always.
```
akeneo_connectivity_connection_settings_any:
    path: '/connect/connection-settings/{any}'
    requirements:
        any: .*
```

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
