### PR TITLE
RAC-1227: Handle index does not have alias when we migrate index mapping

### DIFF
--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigration.php
@@ -22,6 +22,11 @@ final class ClientMigration implements ClientMigrationInterface
         $this->client = $clientBuilder->setHosts($hosts)->build();
     }
 
+    public function aliasExist(string $indexAlias): bool
+    {
+        return $this->client->indices()->existsAlias(['name' => $indexAlias]);
+    }
+
     public function getIndexNameFromAlias(string $indexAlias): array
     {
         $aliases = $this->client->indices()->getAlias(['name' => $indexAlias]);
@@ -101,6 +106,48 @@ final class ClientMigration implements ClientMigrationInterface
                                 'alias' => $newIndexAlias,
                                 'index' => $newIndexName,
                             ]
+                        ],
+                    ]
+                ]
+            ])
+        );
+    }
+
+    public function createAlias(string $indexAlias, string $indexName): void
+    {
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->updateAliases([
+                'body' => [
+                    'actions' => [
+                        [
+                            'add' => [
+                                'alias' => $indexAlias,
+                                'index' => $indexName,
+                            ],
+                        ],
+                    ],
+                ]
+            ])
+        );
+    }
+
+    public function renameAlias(string $oldIndexAlias, string $newIndexAlias, string $indexName): void
+    {
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->updateAliases([
+                'body' => [
+                    'actions' => [
+                        [
+                            'add' => [
+                                'alias' => $newIndexAlias,
+                                'index' => $indexName,
+                            ],
+                        ],
+                        [
+                            'remove' => [
+                                'alias' => $oldIndexAlias,
+                                'index' => $indexName,
+                            ],
                         ],
                     ]
                 ]

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigrationInterface.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/ClientMigrationInterface.php
@@ -12,12 +12,15 @@ namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client;
 interface ClientMigrationInterface
 {
     public function getIndexNameFromAlias(string $indexAlias): array;
+    public function aliasExist(string $indexAlias): bool;
+    public function createAlias(string $indexAlias, string $indexName): void;
     public function reindex(string $sourceIndexAlias, string $targetIndexAlias, array $query);
     public function removeIndex(string $indexName): void;
     public function getIndexSettings(string $indexName): array;
     public function putIndexSetting(string $indexName, array $indexSettings);
     public function switchIndexAlias(string $oldIndexAlias, string $oldIndexName, string $newIndexAlias, string $newIndexName): void;
     public function createIndex(string $indexName, array $body): void;
+    public function renameAlias(string $oldIndexAlias, string $newIndexAlias, string $indexName): void;
 
     public function refreshIndex(string $indexName);
 }

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/UpdateIndexMappingWithoutDowntimeSpec.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/spec/IndexConfiguration/UpdateIndexMappingWithoutDowntimeSpec.php
@@ -63,6 +63,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
         ClientMigrationInterface $clientMigration,
         IndexConfiguration $indexConfiguration
     ) {
+        $clientMigration->aliasExist(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(true);
         $clientMigration->getIndexNameFromAlias(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(
             [self::INDEX_NAME_TO_MIGRATE],
             [self::MIGRATED_INDEX_NAME],
@@ -153,11 +154,115 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
         );
     }
 
+    public function it_handle_index_migration_without_alias(
+        ClockInterface $clock,
+        ClientMigrationInterface $clientMigration,
+        IndexConfiguration $indexConfiguration
+    ) {
+        $clientMigration->aliasExist(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(false);
+        $clientMigration->createAlias('index_alias_to_migrate_migration_alias', self::INDEX_ALIAS_TO_MIGRATE);
+        $clientMigration->getIndexNameFromAlias('index_alias_to_migrate_migration_alias')->willReturn(
+            [self::INDEX_ALIAS_TO_MIGRATE],
+            [self::MIGRATED_INDEX_NAME],
+        );
+
+        $clientMigration->getIndexSettings(self::INDEX_ALIAS_TO_MIGRATE)->willReturn([
+            'refresh_interval' => 5,
+            'number_of_replicas' => 2,
+        ]);
+
+        $clientMigration->createIndex(self::MIGRATED_INDEX_NAME, [
+            'settings' => [
+                'index' => [
+                    'number_of_shards' => 3,
+                    'number_of_replicas' => 0,
+                    'refresh_interval' => -1,
+                ],
+            ],
+            'mappings' => [
+                'properties' => [
+                    'name' => [
+                        'properties' => [
+                            'last' => [
+                                'type' => 'text',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'aliases' => [self::TEMPORARY_INDEX_ALIAS => new \stdClass()]
+        ])->shouldBeCalledOnce();
+
+        $firstDatetime = new \DateTimeImmutable('@0');
+        $datetimeAfterFirstIndexation = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2021-08-04T01:53:22-0700');
+        $datetimeAfterSwitch = \DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2021-08-04T01:53:25-0700');
+        $clock->now()->willReturn($firstDatetime, $datetimeAfterFirstIndexation, $datetimeAfterSwitch);
+
+        $clientMigration->reindex(
+            'index_alias_to_migrate_migration_alias',
+            self::TEMPORARY_INDEX_ALIAS,
+            [
+                'range' => [
+                    'updated_at' => ['gt' => $firstDatetime->getTimestamp()],
+                ]
+            ],
+        )->shouldBeCalledOnce()->willReturn(10);
+
+        $clientMigration->reindex(
+            'index_alias_to_migrate_migration_alias',
+            self::TEMPORARY_INDEX_ALIAS,
+            [
+                'range' => [
+                    'updated_at' => ['gt' => $datetimeAfterFirstIndexation->modify('- 1second')->getTimestamp()],
+                ],
+            ],
+        )->shouldBeCalledOnce()->willReturn(0);
+
+        $clientMigration
+            ->putIndexSetting(self::MIGRATED_INDEX_NAME, ['refresh_interval' => 5, 'number_of_replicas' => 2])
+            ->shouldBeCalledTimes(1);
+
+        $clientMigration->refreshIndex(self::MIGRATED_INDEX_NAME)->shouldBeCalledOnce();
+
+        $clientMigration->switchIndexAlias(
+            'index_alias_to_migrate_migration_alias',
+            self::INDEX_ALIAS_TO_MIGRATE,
+            self::TEMPORARY_INDEX_ALIAS,
+            self::MIGRATED_INDEX_NAME
+        )->shouldBeCalledOnce();
+
+        $clientMigration->reindex(
+            self::TEMPORARY_INDEX_ALIAS,
+            'index_alias_to_migrate_migration_alias',
+            [
+                'range' => [
+                    'updated_at' => ['gt' => $datetimeAfterSwitch->modify('- 1second')->getTimestamp()],
+                ],
+            ]
+        )->shouldBeCalledOnce()->willReturn(0);
+
+        $clientMigration->removeIndex(self::INDEX_ALIAS_TO_MIGRATE)->shouldBeCalledOnce();
+        $clientMigration->renameAlias('index_alias_to_migrate_migration_alias', self::INDEX_ALIAS_TO_MIGRATE, self::MIGRATED_INDEX_NAME)->shouldBeCalledOnce();
+
+        $this->execute(
+            self::INDEX_ALIAS_TO_MIGRATE,
+            self::TEMPORARY_INDEX_ALIAS,
+            self::MIGRATED_INDEX_NAME,
+            $indexConfiguration,
+            fn (\DateTimeImmutable $referenceDatetime) => [
+                'range' => [
+                    'updated_at' => ['gt' => $referenceDatetime->getTimestamp()]
+                ],
+            ]
+        );
+    }
+
     public function it_reindex_records_updated_during_the_indexation(
         ClockInterface $clock,
         ClientMigrationInterface $clientMigration,
         IndexConfiguration $indexConfiguration
     ) {
+        $clientMigration->aliasExist(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(true);
         $clientMigration->getIndexNameFromAlias(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(
             [self::INDEX_NAME_TO_MIGRATE],
             [self::MIGRATED_INDEX_NAME]
@@ -269,6 +374,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
         ClientMigrationInterface $clientMigration,
         IndexConfiguration $indexConfiguration
     ) {
+        $clientMigration->aliasExist(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(true);
         $clientMigration->getIndexNameFromAlias(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(
             [self::INDEX_NAME_TO_MIGRATE],
             [self::MIGRATED_INDEX_NAME],
@@ -368,6 +474,7 @@ class UpdateIndexMappingWithoutDowntimeSpec extends ObjectBehavior
         ClientMigrationInterface $clientMigration,
         IndexConfiguration $indexConfiguration
     ) {
+        $clientMigration->aliasExist(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(true);
         $clientMigration->getIndexNameFromAlias(self::INDEX_ALIAS_TO_MIGRATE)->willReturn(
             [self::INDEX_NAME_TO_MIGRATE],
             [self::MIGRATED_INDEX_NAME],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**In this PR:** 
I handle the fact that index to migrate is not an alias. 
Some client have directly the index instead of having the alias that pointing to index, this lead to an error in production when we tried to reindex.

Another solution have been tested here : https://github.com/akeneo/pim-enterprise-dev/pull/13587. Problem is that the migration have an downtime, it's not what we wanted. Some impacted client (listed in Jira) have more than 250000 documents to reindex it could take time. Another problem is that we have not guaranty about that the problem will not exist anymore. So best choice is to handle it directly on the handler 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
