### PR TITLE
RAC-1234: Fix SQLSTATE[22032]: <<Unknown error>>: 3158 JSON documents may not contain NULL member names.

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -7,14 +7,13 @@ use Doctrine\DBAL\Connection;
 
 class SqlGetAttributeTranslations implements GetAttributeTranslations
 {
-    /** @var Connection */
-    private $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
+    /**
+     * @inerhitDoc
+     */
     public function byAttributeCodesAndLocale(array $attributeCodes, string $locale): array
     {
         if (empty($attributeCodes)) {
@@ -24,7 +23,7 @@ class SqlGetAttributeTranslations implements GetAttributeTranslations
         $query = <<<SQL
 SELECT code, label
 FROM pim_catalog_attribute a
-LEFT JOIN pim_catalog_attribute_translation at ON a.id = at.foreign_key
+INNER JOIN pim_catalog_attribute_translation at ON a.id = at.foreign_key
 WHERE locale = :locale
 AND code IN (:attributeCodes);
 SQL;
@@ -49,7 +48,7 @@ SQL;
     }
 
     /**
-     * @return array<array{locale: string, label: string}>
+     * @inerhitDoc
      */
     public function byAttributeCodes(array $attributeCodes): array
     {
@@ -62,7 +61,7 @@ SQL;
                 code,
                 JSON_OBJECTAGG(attribute_translation.locale, attribute_translation.label) as labels
             FROM pim_catalog_attribute attribute
-                LEFT JOIN pim_catalog_attribute_translation attribute_translation ON attribute.id = attribute_translation.foreign_key
+            INNER JOIN pim_catalog_attribute_translation attribute_translation ON attribute.id = attribute_translation.foreign_key
             WHERE attribute.code IN (:attributeCodes)
             GROUP BY attribute.code;
         SQL;

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Attribute/Sql/SqlGetAttributeTranslations.php
@@ -22,8 +22,8 @@ class SqlGetAttributeTranslations implements GetAttributeTranslations
 
         $query = <<<SQL
 SELECT code, label
-FROM pim_catalog_attribute a
-INNER JOIN pim_catalog_attribute_translation at ON a.id = at.foreign_key
+FROM pim_catalog_attribute_translation at
+LEFT JOIN pim_catalog_attribute a ON a.id = at.foreign_key
 WHERE locale = :locale
 AND code IN (:attributeCodes);
 SQL;
@@ -60,8 +60,8 @@ SQL;
             SELECT
                 code,
                 JSON_OBJECTAGG(attribute_translation.locale, attribute_translation.label) as labels
-            FROM pim_catalog_attribute attribute
-            INNER JOIN pim_catalog_attribute_translation attribute_translation ON attribute.id = attribute_translation.foreign_key
+            FROM pim_catalog_attribute_translation attribute_translation
+            LEFT JOIN pim_catalog_attribute attribute ON attribute.id = attribute_translation.foreign_key
             WHERE attribute.code IN (:attributeCodes)
             GROUP BY attribute.code;
         SQL;

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
@@ -6,6 +6,13 @@ namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute;
 
 interface GetAttributeTranslations
 {
+    /**
+     * @return array<string: attributeCode, string: label>
+     */
     public function byAttributeCodesAndLocale(array $attributeCodes, string $locale): array;
+
+    /**
+     * @return array<string: attributeCode, array<string: locale, string: label>>
+     */
     public function byAttributeCodes(array $attributeCodes): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Attribute/GetAttributeTranslations.php
@@ -7,12 +7,12 @@ namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Attribute;
 interface GetAttributeTranslations
 {
     /**
-     * @return array<string: attributeCode, string: label>
+     * @return array<string, string>
      */
     public function byAttributeCodesAndLocale(array $attributeCodes, string $locale): array;
 
     /**
-     * @return array<string: attributeCode, array<string: locale, string: label>>
+     * @return array<string , array<string, string>>
      */
     public function byAttributeCodes(array $attributeCodes): array;
 }

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributeTranslationsIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributeTranslationsIntegration.php
@@ -12,73 +12,25 @@ use Webmozart\Assert\Assert;
 
 final class SqlGetAttributeTranslationsIntegration extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loadFixture();
+    }
+
     public function test_it_gets_attribute_translations_by_giving_attribute_codes_and_locale_code(): void
     {
-        $query = $this->getQuery();
-
-        $this->givenAttributes([
-            [
-                'code' => 'a_boolean',
-                'type' => AttributeTypes::BOOLEAN,
-                'localizable' => false,
-                'scopable' => false,
-                'group' => 'other',
-                'labels' => [
-                    'en_US' => 'a boolean',
-                    'fr_FR' => 'un booléen'
-                ]
-            ],
-            [
-                'code' => 'a_textarea',
-                'type' => AttributeTypes::TEXTAREA,
-                'localizable' => false,
-                'scopable' => false,
-                'group' => 'other',
-                'labels' => [
-                    'en_US' => 'a textarea',
-                    'fr_FR' => 'une zone de texte'
-                ]
-            ]
-        ]);
-
         $expected = [
             'a_textarea' => 'une zone de texte',
             'a_boolean' => 'un booléen',
         ];
-        $actual = $query->byAttributeCodesAndLocale(['a_boolean', 'a_textarea'], 'fr_FR');
+        $actual = $this->getQuery()->byAttributeCodesAndLocale(['a_boolean', 'a_textarea'], 'fr_FR');
 
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
     public function test_it_gets_attribute_translations_by_giving_attribute_codes(): void
     {
-        $query = $this->getQuery();
-
-        $this->givenAttributes([
-            [
-                'code' => 'a_boolean',
-                'type' => AttributeTypes::BOOLEAN,
-                'localizable' => false,
-                'scopable' => false,
-                'group' => 'other',
-                'labels' => [
-                    'en_US' => 'a boolean',
-                    'fr_FR' => 'un booléen'
-                ]
-            ],
-            [
-                'code' => 'a_textarea',
-                'type' => AttributeTypes::TEXTAREA,
-                'localizable' => false,
-                'scopable' => false,
-                'group' => 'other',
-                'labels' => [
-                    'en_US' => 'a textarea',
-                    'fr_FR' => 'une zone de texte'
-                ]
-            ]
-        ]);
-
         $expected = [
             'a_textarea' => [
                 'en_US' => 'a textarea',
@@ -89,7 +41,31 @@ final class SqlGetAttributeTranslationsIntegration extends TestCase
                 'fr_FR' => 'un booléen'
             ],
         ];
-        $actual = $query->byAttributeCodes(['a_boolean', 'a_textarea']);
+        $actual = $this->getQuery()->byAttributeCodes(['a_boolean', 'a_textarea']);
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function test_it_returns_nothing_when_searching_on_a_specific_locale_and_attribute_does_not_have_translations(): void
+    {
+        $expected = [];
+        $actual = $this->getQuery()->byAttributeCodesAndLocale(['an_attribute_without_translations'], 'fr_FR');
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function test_it_returns_nothing_when_attribute_does_not_have_translation_on_a_given_locale(): void
+    {
+        $expected = [];
+        $actual = $this->getQuery()->byAttributeCodesAndLocale(['a_textarea'], 'br_FR');
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function test_it_returns_nothing_when_attribute_does_not_have_translations(): void
+    {
+        $expected = [];
+        $actual = $this->getQuery()->byAttributeCodes(['an_attribute_without_translations']);
 
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
@@ -117,5 +93,41 @@ final class SqlGetAttributeTranslationsIntegration extends TestCase
         }, $attributes);
 
         $this->get('pim_catalog.saver.attribute')->saveAll($attributes);
+    }
+
+    private function loadFixture()
+    {
+        $this->givenAttributes([
+            [
+                'code' => 'a_boolean',
+                'type' => AttributeTypes::BOOLEAN,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other',
+                'labels' => [
+                    'en_US' => 'a boolean',
+                    'fr_FR' => 'un booléen'
+                ]
+            ],
+            [
+                'code' => 'a_textarea',
+                'type' => AttributeTypes::TEXTAREA,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other',
+                'labels' => [
+                    'en_US' => 'a textarea',
+                    'fr_FR' => 'une zone de texte'
+                ]
+            ],
+            [
+                'code' => 'an_attribute_without_translations',
+                'type' => AttributeTypes::TEXTAREA,
+                'localizable' => false,
+                'scopable' => false,
+                'group' => 'other',
+                'labels' => []
+            ]
+        ]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
I fixed the following error in datadog : 

```
An exception occurred while executing '    SELECT
        code,
        JSON_OBJECTAGG(attribute_translation.locale, attribute_translation.label) as labels
    FROM pim_catalog_attribute attribute
        LEFT JOIN pim_catalog_attribute_translation attribute_translation ON attribute.id = attribute_translation.foreign_key
    WHERE attribute.code IN (?)
    GROUP BY attribute.code;' with params ["images"]:
```

> We cannot use result from left join as JSON_OBJECTAGG key. Solution is to do not left join anymore => we didn't care about there is not translation and there is no attribute in this query

![Screenshot from 2022-04-26 09-45-37](https://user-images.githubusercontent.com/7239572/165249599-79c74d12-8e6c-42b3-b848-70b8ac70b52c.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
