### PR TITLE
PLG-831: Adapt key indicators for GE in EE

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ComputeProductsKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ComputeProductsKeyIndicators.php
@@ -51,7 +51,7 @@ class ComputeProductsKeyIndicators
         foreach ($this->keyIndicatorQueries as $keyIndicatorQuery) {
             $keyIndicatorResult = $keyIndicatorQuery->compute($productIdCollection);
             if (!empty($keyIndicatorResult)) {
-                $keyIndicatorsResults[$keyIndicatorQuery->getName()] = $keyIndicatorResult;
+                $keyIndicatorsResults[(string)$keyIndicatorQuery->getCode()] = $keyIndicatorResult;
             }
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ComputeProductsKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ComputeProductsKeyIndicators.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicators.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicators.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicators.php
@@ -25,9 +25,9 @@ final class GetKeyIndicators implements GetKeyIndicatorsInterface
     public function __construct(
         private GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery,
         private GetProductKeyIndicatorsQueryInterface $getProductModelKeyIndicatorsQuery,
-        string ...$keyIndicators
+        ProductKeyIndicatorsByFeatureRegistry $productKeyIndicatorsRegistry
     ) {
-        $this->keyIndicatorCodes = array_map(static fn ($keyIndicator) => new KeyIndicatorCode($keyIndicator), $keyIndicators);
+        $this->keyIndicatorCodes = $productKeyIndicatorsRegistry->getCodes();
     }
 
     public function all(ChannelCode $channelCode, LocaleCode $localeCode): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicatorsInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/GetKeyIndicatorsInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Pim\Automation\DataQualityInsights\Application;
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ProductKeyIndicatorsByFeatureRegistry.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/KeyIndicator/ProductKeyIndicatorsByFeatureRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductKeyIndicatorsByFeatureRegistry
+{
+    private array $allKeyIndicatorCodes = [];
+    private array $partialKeyIndicatorCodes = [];
+
+    public function __construct(
+        private FeatureFlag $allCriteriaFeature,
+    ) {
+    }
+
+    public function register(ComputeProductsKeyIndicator $computeKeyIndicator, ?string $feature): void
+    {
+        $this->allKeyIndicatorCodes[] = $computeKeyIndicator->getCode();
+
+        if ('data_quality_insights_all_criteria' !== $feature) {
+            $this->partialKeyIndicatorCodes[] = $computeKeyIndicator->getCode();
+        }
+    }
+
+    /**
+     * @return array<KeyIndicatorCode>
+     */
+    public function getCodes(): array
+    {
+        return $this->allCriteriaFeature->isEnabled()
+            ? $this->allKeyIndicatorCodes
+            : $this->partialKeyIndicatorCodes;
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/Dashboard/ComputeProductsKeyIndicator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdCollection;
 
 /**
@@ -12,7 +13,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityId
  */
 interface ComputeProductsKeyIndicator
 {
-    public function getName(): string;
+    public function getCode(): KeyIndicatorCode;
 
     /**
      * @return array<string, array<string, array<string, bool>>> Enrichment status by product/product-model channel and locale

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndex.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndex.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdCollection;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductModelIdsFromProductModelCodesQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdsFromProductIdentifiersQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQuery.php
@@ -12,6 +12,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProd
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdCollection;
 
 /**
@@ -28,9 +29,9 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     ) {
     }
 
-    public function getName(): string
+    public function getCode(): KeyIndicatorCode
     {
-        return ProductsWithGoodEnrichment::CODE;
+        return new KeyIndicatorCode(ProductsWithGoodEnrichment::CODE);
     }
 
     /**
@@ -68,8 +69,8 @@ final class ComputeProductsEnrichmentStatusQuery implements ComputeProductsKeyIn
     private function computeEnrichmentStatus(
         ?CriterionEvaluationResult $nonRequiredAttributesEvaluationResult,
         ?CriterionEvaluationResult $requiredAttributesEvaluationResult,
-        string                     $channel,
-        string                     $locale
+        string $channel,
+        string $locale
     ): ?bool {
         $nonRequiredAttributesEvaluation = null !== $nonRequiredAttributesEvaluationResult ? $nonRequiredAttributesEvaluationResult->getData() : [];
         $requiredAttributesEvaluationData = null !== $requiredAttributesEvaluationResult ? $requiredAttributesEvaluationResult->getData() : [];

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsWithImageQuery.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\Products
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdCollection;
 
 /**
@@ -22,9 +23,9 @@ final class ComputeProductsWithImageQuery implements ComputeProductsKeyIndicator
     ) {
     }
 
-    public function getName(): string
+    public function getCode(): KeyIndicatorCode
     {
-        return ProductsWithImage::CODE;
+        return new KeyIndicatorCode(ProductsWithImage::CODE);
     }
 
     public function compute(ProductEntityIdCollection $productIdCollection): array

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/RegisterKeyIndicatorFilter.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/ProductGrid/RegisterKeyIndicatorFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\ProductGrid;
 
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use Oro\Bundle\DataGridBundle\Datagrid\Common\DatagridConfiguration;
 use Oro\Bundle\DataGridBundle\Event\BuildBefore;
 use Oro\Bundle\FilterBundle\Grid\Extension\Configuration;
@@ -17,17 +18,13 @@ class RegisterKeyIndicatorFilter
 {
     public const PRODUCT_DATAGRID_NAME = 'product-grid';
 
-    private FeatureFlag $featureFlag;
-
-    private string $filterName;
-
-    private string $filterLabel;
-
-    public function __construct(FeatureFlag $featureFlag, string $filterName, string $filterLabel)
-    {
-        $this->featureFlag = $featureFlag;
-        $this->filterName = $filterName;
-        $this->filterLabel = $filterLabel;
+    public function __construct(
+        private FeatureFlag $dqiFeature,
+        private FeatureFlags $featureFlags,
+        private string $filterName,
+        private string $filterLabel,
+        private ?string $featureName,
+    ) {
     }
 
     // TIP-1555: to remove later on with AddDraftStatusFilterToProductGridListener also
@@ -39,7 +36,11 @@ class RegisterKeyIndicatorFilter
             return;
         }
 
-        if (!$this->featureFlag->isEnabled()) {
+        if (!$this->dqiFeature->isEnabled()) {
+            return;
+        }
+
+        if (null !== $this->featureName && !$this->featureFlags->isEnabled($this->featureName)) {
             return;
         }
 

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/AkeneoDataQualityInsightsBundle.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/AkeneoDataQualityInsightsBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\DependencyInjection\Compiler\CriteriaByFeatureRegistryPass;
+use Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\DependencyInjection\Compiler\ProductKeyIndicatorsByFeatureRegistryPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -20,5 +21,6 @@ final class AkeneoDataQualityInsightsBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new CriteriaByFeatureRegistryPass());
+        $container->addCompilerPass(new ProductKeyIndicatorsByFeatureRegistryPass());
     }
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/Dashboard/DashboardKeyIndicatorsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller\Dashboard;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicatorsInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\GetKeyIndicatorsInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\FamilyCode;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/DependencyInjection/Compiler/ProductKeyIndicatorsByFeatureRegistryPass.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/DependencyInjection/Compiler/ProductKeyIndicatorsByFeatureRegistryPass.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\DependencyInjection\Compiler;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ProductKeyIndicatorsByFeatureRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductKeyIndicatorsByFeatureRegistryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $registryDefinition = $container->findDefinition(ProductKeyIndicatorsByFeatureRegistry::class);
+        $keyIndicatorServiceIds = $container->findTaggedServiceIds('akeneo.pim.automation.data_quality_insights.compute_product_key_indicator');
+
+        foreach ($keyIndicatorServiceIds as $serviceId => $tags) {
+            foreach ($tags as $tag) {
+                $registryDefinition->addMethodCall('register', [new Reference($serviceId), $tag['feature'] ?? null]);
+            }
+        }
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/queries.yml
@@ -210,7 +210,7 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductsAndCriterionQuery'
         tags:
-            - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query}
+            - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator}
 
     akeneo.pim.automation.data_quality_insights.query.compute_product_models_enrichment_status_query:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsEnrichmentStatusQuery
@@ -218,21 +218,21 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationResultsByProductModelsAndCriterionQuery'
         tags:
-            - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query }
+            - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator }
 
     akeneo.pim.automation.data_quality_insights.query.compute_products_with_image_query:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsWithImageQuery
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationRatesByProductsAndCriterionQuery'
         tags:
-            - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query}
+            - { name:  akeneo.pim.automation.data_quality_insights.compute_product_key_indicator}
 
     akeneo.pim.automation.data_quality_insights.query.compute_product_models_with_image_query:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\KeyIndicator\ComputeProductsWithImageQuery
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEvaluation\GetEvaluationRatesByProductModelsAndCriterionQuery'
         tags:
-            - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query }
+            - { name: akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator }
 
     akeneo.pim.automation.data_quality_insights.query.product.get_enrichment_images_masks:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Completeness\GetAttributeTypesMasksQuery

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -212,19 +212,19 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\SynchronousCriterionEvaluationsFilter
 
     akeneo.pim.automation.data_quality_insights.compute_products_key_indicators:
-        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - !tagged akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query
 
     akeneo.pim.automation.data_quality_insights.compute_product_models_key_indicators:
-        class: Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
             - !tagged akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query
 
     akeneo.pim.automation.data_quality_insights.get_key_indicators:
-        class: Akeneo\Pim\Automation\DataQualityInsights\Application\GetKeyIndicators
+        class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\GetKeyIndicators
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.infrastructure.elasticsearch.query.get_product_key_indicators_query'
             - '@akeneo.pim.automation.data_quality_insights.infrastructure.elasticsearch.query.get_product_model_key_indicators_query'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -215,21 +215,20 @@ services:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - !tagged akeneo.pim.automation.data_quality_insights.compute_product_key_indicator_query
+            - !tagged akeneo.pim.automation.data_quality_insights.compute_product_key_indicator
 
     akeneo.pim.automation.data_quality_insights.compute_product_models_key_indicators:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\Structure\CachedGetLocalesByChannelQuery'
-            - !tagged akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator_query
+            - !tagged akeneo.pim.automation.data_quality_insights.compute_product_model_key_indicator
 
     akeneo.pim.automation.data_quality_insights.get_key_indicators:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\GetKeyIndicators
         arguments:
             - '@akeneo.pim.automation.data_quality_insights.infrastructure.elasticsearch.query.get_product_key_indicators_query'
             - '@akeneo.pim.automation.data_quality_insights.infrastructure.elasticsearch.query.get_product_model_key_indicators_query'
-            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithGoodEnrichment::CODE
-            - !php/const Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\KeyIndicator\ProductsWithImage::CODE
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ProductKeyIndicatorsByFeatureRegistry'
 
     akeneo.pim.automation.data_quality_insights.product.complete_evaluation_with_improvable_attributes:
         class: Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CompleteEvaluationWithImprovableAttributes
@@ -280,5 +279,9 @@ services:
             - '@akeneo.pim.automation.data_quality_insights.product_model_criteria_by_feature_registry'
 
     Akeneo\Pim\Automation\DataQualityInsights\Application\GetScoresByCriteriaStrategy:
+        arguments:
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ProductKeyIndicatorsByFeatureRegistry:
         arguments:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\FeatureFlag\AllCriteriaFeature'

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ComputeProductsKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ComputeProductsKeyIndicatorsSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ComputeProductsKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ComputeProductsKeyIndicatorsSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\Ke
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Structure\GetLocalesByChannelQueryInterface;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
 use PhpSpec\ObjectBehavior;
 
@@ -76,8 +77,8 @@ final class ComputeProductsKeyIndicatorsSpec extends ObjectBehavior
             ],
         ];
 
-        $goodEnrichment->getName()->willReturn('good_enrichment');
-        $hasImage->getName()->willReturn('has_image');
+        $goodEnrichment->getCode()->willReturn(new KeyIndicatorCode('good_enrichment'));
+        $hasImage->getCode()->willReturn(new KeyIndicatorCode('has_image'));
 
         $goodEnrichment->compute($productIds)->willReturn([
             13 => [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/GetKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/GetKeyIndicatorsSpec.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application;
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/GetKeyIndicatorsSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/GetKeyIndicatorsSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
 
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ProductKeyIndicatorsByFeatureRegistry;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read\KeyIndicator;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\GetProductKeyIndicatorsQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CategoryCode;
@@ -19,9 +20,16 @@ use PhpSpec\ObjectBehavior;
  */
 final class GetKeyIndicatorsSpec extends ObjectBehavior
 {
-    public function let(GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery, GetProductKeyIndicatorsQueryInterface $getProductModelKeyIndicatorsQuery)
-    {
-        $this->beConstructedWith($getProductKeyIndicatorsQuery, $getProductModelKeyIndicatorsQuery, 'good_enrichment', 'has_image');
+    public function let(
+        GetProductKeyIndicatorsQueryInterface $getProductKeyIndicatorsQuery,
+        GetProductKeyIndicatorsQueryInterface $getProductModelKeyIndicatorsQuery,
+        ProductKeyIndicatorsByFeatureRegistry $productKeyIndicatorsRegistry
+    ) {
+        $productKeyIndicatorsRegistry->getCodes()->WillReturn([
+            new KeyIndicatorCode('good_enrichment'),
+            new KeyIndicatorCode('has_image'),
+        ]);
+        $this->beConstructedWith($getProductKeyIndicatorsQuery, $getProductModelKeyIndicatorsQuery, $productKeyIndicatorsRegistry);
     }
 
     public function it_gives_key_indicators_for_all_products_and_product_models($getProductKeyIndicatorsQuery, $getProductModelKeyIndicatorsQuery)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ProductKeyIndicatorsByFeatureRegistrySpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/KeyIndicator/ProductKeyIndicatorsByFeatureRegistrySpec.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\Dashboard\ComputeProductsKeyIndicator;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\KeyIndicatorCode;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
+use PhpSpec\ObjectBehavior;
+
+final class ProductKeyIndicatorsByFeatureRegistrySpec extends ObjectBehavior
+{
+    public function let(
+        FeatureFlag $allCriteriaFeature,
+        ComputeProductsKeyIndicator $keyIndicatorA,
+        ComputeProductsKeyIndicator $keyIndicatorB,
+        ComputeProductsKeyIndicator $allCriteriaOnlyKeyIndicatorB,
+    ) {
+        $this->beConstructedWith($allCriteriaFeature);
+
+        $keyIndicatorA->getCode()->willReturn(new KeyIndicatorCode('ki_A'));
+        $keyIndicatorB->getCode()->willReturn(new KeyIndicatorCode('ki_B'));
+        $allCriteriaOnlyKeyIndicatorB->getCode()->willReturn(new KeyIndicatorCode('all_criteria_only_ki'));
+        
+        $this->register($keyIndicatorA, null);
+        $this->register($keyIndicatorB, 'whatever_feature');
+        $this->register($allCriteriaOnlyKeyIndicatorB, 'data_quality_insights_all_criteria');
+    }
+
+    public function it_gets_all_key_indicators_when_all_criteria_feature_is_enabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(true);
+
+        $this->getCodes()->shouldBeLike([
+            new KeyIndicatorCode('ki_A'),
+            new KeyIndicatorCode('ki_B'),
+            new KeyIndicatorCode('all_criteria_only_ki'),
+        ]);
+    }
+
+    public function it_gets_partial_key_indicators_when_all_criteria_feature_is_disabled($allCriteriaFeature)
+    {
+        $allCriteriaFeature->isEnabled()->willReturn(false);
+
+        $this->getCodes()->shouldBeLike([
+            new KeyIndicatorCode('ki_A'),
+            new KeyIndicatorCode('ki_B'),
+        ]);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndexSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/BulkUpdateProductQualityScoresIndexSpec.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductModelScoresQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetProductScoresQueryInterface;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductModelProjectionSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Elasticsearch/GetDataQualityInsightsPropertiesForProductProjectionSpec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch;
 
-use Akeneo\Pim\Automation\DataQualityInsights\Application\ComputeProductsKeyIndicators;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\KeyIndicator\ComputeProductsKeyIndicators;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\ChannelLocaleRateCollection;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Read;


### PR DESCRIPTION
The key-indicators specific to the EE were declared directly from Symfony DI by passing their code. This PR add a registry that allows to provide the key-indicators according to the enabled feature.

See EE PR: https://github.com/akeneo/pim-enterprise-dev/pull/13607