### PR TITLE
PLG-853: Fix fetching and launching product models evaluation

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/GetProductEvaluation.php
@@ -13,7 +13,7 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\CriterionEvaluationResultStatus;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -47,7 +47,7 @@ class GetProductEvaluation
     ) {
     }
 
-    public function get(ProductId $productId): array
+    public function get(ProductEntityIdInterface $productId): array
     {
         $criteriaEvaluations = $this->getCriteriaEvaluationsByProductIdQuery->execute($productId);
         $criteriaEvaluations = ($this->completeEvaluationWithImprovableAttributes)($criteriaEvaluations);

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/EvaluateOutdatedProductModel.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/EvaluateOutdatedProductModel.php
@@ -6,7 +6,7 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluatio
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelId;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
@@ -23,7 +23,7 @@ class EvaluateOutdatedProductModel
     ) {
     }
 
-    public function __invoke(ProductId $productModelId): void
+    public function __invoke(ProductModelId $productModelId): void
     {
         if (false === $this->hasUpToDateEvaluationQuery->forProductId($productModelId)) {
             ($this->evaluateProductModels)($this->factory->createCollection([(string) $productModelId]));

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/EvaluateProductModelController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/EvaluateProductModelController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateOutdatedProductModel;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelId;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -23,7 +23,7 @@ final class EvaluateProductModelController
     public function __invoke(string $productId): JsonResponse
     {
         try {
-            ($this->evaluateProductModel)(new ProductId(intval($productId)));
+            ($this->evaluateProductModel)(new ProductModelId(intval($productId)));
         } catch (\InvalidArgumentException $exception) {
             return new JsonResponse(['message' => $exception->getMessage()], Response::HTTP_BAD_REQUEST);
         }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/GetProductModelEvaluationController.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Controller/GetProductModelEvaluationController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Symfony\Controller;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\GetProductEvaluation;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelId;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,7 +27,7 @@ class GetProductModelEvaluationController
     {
         try {
             $evaluation = $this->getProductModelEvaluation->get(
-                new ProductId(intval($productId))
+                new ProductModelId(intval($productId))
             );
         } catch (\InvalidArgumentException $exception) {
             return new JsonResponse([

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/EvaluateOutdatedProductModelSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Application/ProductEvaluation/EvaluateOutdatedProductModelSpec.php
@@ -7,7 +7,7 @@ namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Application\Pr
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEntityIdFactoryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProductModels;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\HasUpToDateEvaluationQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelId;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelIdCollection;
 use PhpSpec\ObjectBehavior;
 
@@ -30,7 +30,7 @@ final class EvaluateOutdatedProductModelSpec extends ObjectBehavior
         $evaluateProductModels,
         $idFactory
     ) {
-        $productModelId = new ProductId(42);
+        $productModelId = new ProductModelId(42);
         $collection = ProductModelIdCollection::fromStrings(['42']);
 
         $hasUpToDateEvaluationQuery->forProductId($productModelId)->willReturn(false);
@@ -45,7 +45,7 @@ final class EvaluateOutdatedProductModelSpec extends ObjectBehavior
         $evaluateProductModels,
         $idFactory
     ) {
-        $productModelId = new ProductId(42);
+        $productModelId = new ProductModelId(42);
         $collection = ProductModelIdCollection::fromStrings(['42']);
 
         $hasUpToDateEvaluationQuery->forProductId($productModelId)->willReturn(true);


### PR DESCRIPTION
Fetching and launching evaluation of product models were broken because the dedicated controllers used `ProductId` instead of `ProductModelId` 