### PR TITLE
PLG-832: Display DQI axis only if there are recommencations

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/AxisEvaluation.tsx
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/front/src/application/component/ProductEditForm/TabContent/DataQualityInsights/AxisEvaluation.tsx
@@ -38,30 +38,32 @@ const AxisEvaluation: FC<AxisEvaluationProps> = ({children, evaluation = evaluat
     return criteria.find(criterion => criterion.code === code);
   };
 
-  return (
+  const recommendations = Children.map(children, child => {
+    const element = child as ReactElement;
+    if (element.type === Criterion) {
+      const criterionEvaluation = getCriterionEvaluation(element.props.code);
+
+      if (!criterionEvaluation) {
+        return;
+      }
+
+      return React.cloneElement(element, {
+        axis,
+        evaluation,
+        criterionEvaluation,
+      });
+    }
+    return child;
+  });
+
+  return recommendations.length > 0 && (
     <div className="AknSubsection AxisEvaluationContainer">
       <AxisHeader evaluation={evaluation} axis={axis} />
 
       {axisHasError && <AxisError />}
       {axisGradingInProgress && !axisHasError && <AxisGradingInProgress />}
 
-      {Children.map(children, child => {
-        const element = child as ReactElement;
-        if (element.type === Criterion) {
-          const criterionEvaluation = getCriterionEvaluation(element.props.code);
-
-          if (!criterionEvaluation) {
-            return;
-          }
-
-          return React.cloneElement(element, {
-            axis,
-            evaluation,
-            criterionEvaluation,
-          });
-        }
-        return child;
-      })}
+      {recommendations}
     </div>
   );
 };


### PR DESCRIPTION
When GE will be merged in the EE code base, the criteria of the axis Consistency will be evaluated but must not be displayed. 

On a GE, the Backend will not return the Consistency recommendations, but the axis compenent (with its title) is still display.

We previously choose to let the Backend have the responsibility to decide what are the recommendations according to the feature flags. So the simplest way to fix the problem is to not display an axis if it has no recommendations.