### PR TITLE
CPM-488: create product and product model identifier PQB factory

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
@@ -13,7 +13,7 @@ services:
             - '%akeneo_elasticsearch.cursor.cursor.class%'
             - '%pim_job_product_batch_size%'
 
-    pim_catalog.factory.product_identifier_cursor:
+    pim_catalog.factory.product_and_product_model_identifier_cursor:
         class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierCursorFactory'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -50,7 +50,7 @@ services:
     pim_enrich.doctrine.query.count_impacted_products:
         class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductGrid\CountImpactedProducts'
         arguments:
-            - '@pim_catalog.query.product_and_product_model_query_builder_factory'
+            - '@pim_catalog.query.product_and_product_model_identifier_query_builder_factory'
 
     pim_catalog.query.find_activated_currencies:
         class: Akeneo\Channel\Bundle\Doctrine\Query\FindActivatedCurrencies

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -76,7 +76,7 @@ services:
             - '@pim_catalog.repository.attribute'
             - '@pim_catalog.query.filter.product_registry'
             - '@pim_catalog.query.sorter.registry'
-            - '@pim_catalog.factory.product_identifier_cursor'
+            - '@pim_catalog.factory.product_and_product_model_identifier_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
     pim_catalog.query.product_query_builder_search_after_size_factory:
@@ -177,6 +177,16 @@ services:
             - '@pim_catalog.query.filter.product_and_product_model_registry'
             - '@pim_catalog.query.sorter.registry'
             - '@pim_catalog.factory.product_and_product_model_cursor'
+            - '@pim_catalog.query.product_query_builder_resolver'
+
+    pim_catalog.query.product_and_product_model_identifier_query_builder_factory:
+        class: '%pim_catalog.query.elasticsearch.product_and_model_query_builder_factory.class%'
+        arguments:
+            - '%pim_catalog.query.product_and_product_model_query_builder.class%'
+            - '@pim_catalog.repository.attribute'
+            - '@pim_catalog.query.filter.product_and_product_model_registry'
+            - '@pim_catalog.query.sorter.registry'
+            - '@pim_catalog.factory.product_and_product_model_identifier_cursor'
             - '@pim_catalog.query.product_query_builder_resolver'
 
     pim_catalog.factory.product_and_product_model_cursor:


### PR DESCRIPTION
and use it in counter

**Description (for Contributor and Core Developer)**

CountImpactedProducts used the product and product model factory PQB. So to have a count, the PQB hydrated the first 100 products/product models. It was useless because we just want the count of the query result.

Now this class uses the product and product model *identifier* PQB => **no more hydration!**

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
