### PR TITLE
CPM-610 remove code to avoid deleting temporary indexes…

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillForeignUuid.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidFillForeignUuid.php
@@ -86,23 +86,6 @@ class MigrateToUuidFillForeignUuid implements MigrateToUuidStep
             }
         }
 
-        // TODO CPM-610: Keep this indexes
-        foreach (['pim_versioning_version', 'pim_comment_comment'] as $tableName) {
-            if ($this->indexExists($tableName, 'migrate_to_uuid_temp_index_to_delete')) {
-                $this->connection->executeQuery(
-                    <<<SQL
-                    ALTER TABLE {tableName}
-                    DROP INDEX migrate_to_uuid_temp_index_to_delete;
-                    SQL,
-                    ['{tableName}' => $tableName]
-                );
-                $this->logger->notice(
-                    "Temporary index dropped on table $tableName",
-                    $logContext->toArray()
-                );
-            }
-        }
-
         return true;
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Removed code to avoid deleting temporary indexes during the migration (in case the migration must be re-executed)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
