### PR TITLE
PIM-10420: Handle status computed by health check time on process tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PIM-10421: Add missing translation key for delete button
 - PIM-10418: Simple and multi select values not showing if not imported with the correct letter case
 - PIM-10426: Fix empty array should be normalized as empty JSON object in Measurement Family API
+- PIM-10420: Handle status resolving when job crashes due to external issue (mysql crashes for example)
 - PIM-10416: Fix letter case issue when importing families
 - PIM-10427: Fix display of boolean value in variant axis
 

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/Model/JobExecutionHealthCheck.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/Model/JobExecutionHealthCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Akeneo\Platform\Job\Application\SearchJobExecution\Model;
+
+use Akeneo\Platform\Job\Domain\Model\Status;
+
+final class JobExecutionHealthCheck
+{
+    private const MAX_TIME_TO_UPDATE_HEALTH_CHECK = 5;
+    private const HEALTH_CHECK_INTERVAL = 5;
+
+    public function __construct(
+        private Status $currentStatus,
+        private ?\DateTimeImmutable $healthCheckedAt,
+        private \DateTimeImmutable $currentTime,
+    ) {
+    }
+
+    public function resolveStatus(): Status
+    {
+        if (null === $this->healthCheckedAt || !$this->hasRunningStatus()) {
+            return $this->currentStatus;
+        }
+
+        $diffInSeconds = $this->currentTime->getTimestamp() - $this->healthCheckedAt->getTimestamp();
+
+        if ($diffInSeconds > self::HEALTH_CHECK_INTERVAL + self::MAX_TIME_TO_UPDATE_HEALTH_CHECK) {
+            return Status::fromStatus(Status::FAILED);
+        }
+
+        return $this->currentStatus;
+    }
+
+    private function hasRunningStatus(): bool
+    {
+        return in_array($this->currentStatus->getStatus(), [Status::STARTING, Status::IN_PROGRESS, Status::STOPPING]);
+    }
+}

--- a/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/Model/JobExecutionRow.php
+++ b/src/Akeneo/Platform/Job/back/Application/SearchJobExecution/Model/JobExecutionRow.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Job\Application\SearchJobExecution\Model;
 
-use Akeneo\Platform\Job\Domain\Model\Status;
-
 /**
  * @author Pierre Jolly <pierre.jolly@akeneo.com>
  * @copyright 2021 Akeneo SAS (https://www.akeneo.com)
@@ -19,7 +17,7 @@ final class JobExecutionRow
         private string $type,
         private ?\DateTimeImmutable $startedAt,
         private ?string $username,
-        private Status $status,
+        private JobExecutionHealthCheck $jobExecutionHealthCheck,
         private bool $isStoppable,
         private JobExecutionTracking $tracking,
     ) {
@@ -33,7 +31,7 @@ final class JobExecutionRow
             'type' => $this->type,
             'started_at' => $this->startedAt?->format(DATE_ATOM),
             'username' => $this->username,
-            'status' => $this->status->getLabel(),
+            'status' => $this->jobExecutionHealthCheck->resolveStatus()->getLabel(),
             'warning_count' => $this->tracking->getWarningCount(),
             'has_error' => $this->tracking->hasError(),
             'tracking' => $this->tracking->normalize(),

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Clock/ClockInterface.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Clock/ClockInterface.php
@@ -6,5 +6,5 @@ namespace Akeneo\Platform\Job\Infrastructure\Clock;
 
 interface ClockInterface
 {
-    public function now(): \DateTimeInterface;
+    public function now(): \DateTimeImmutable;
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Clock/SystemClock.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Clock/SystemClock.php
@@ -6,8 +6,8 @@ namespace Akeneo\Platform\Job\Infrastructure\Clock;
 
 class SystemClock implements ClockInterface
 {
-    public function now(): \DateTimeInterface
+    public function now(): \DateTimeImmutable
     {
-        return new \DateTime('now', new \DateTimeZone('UTC'));
+        return new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
     }
 }

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Hydrator/JobExecutionHealthCheckHydrator.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Hydrator/JobExecutionHealthCheckHydrator.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Akeneo\Platform\Job\Infrastructure\Hydrator;
+
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
+use Akeneo\Platform\Job\Domain\Model\Status;
+use Akeneo\Platform\Job\Infrastructure\Clock\ClockInterface;
+
+class JobExecutionHealthCheckHydrator
+{
+    public function __construct(
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function hydrate(int $status, ?string $healthCheckTime): JobExecutionHealthCheck
+    {
+        $healthCheckedAt = null !== $healthCheckTime ?
+            \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $healthCheckTime, new \DateTimeZone('UTC'))
+            : null;
+
+        $currentTime = $this->clock->now();
+
+        return new JobExecutionHealthCheck(
+            Status::fromStatus($status),
+            $healthCheckedAt,
+            $currentTime,
+        );
+    }
+}

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Hydrator/JobExecutionRowHydrator.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Hydrator/JobExecutionRowHydrator.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Platform\Job\Infrastructure\Hydrator;
 
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
-use Akeneo\Platform\Job\Domain\Model\Status;
 
 /**
  * @author Grégoire Houssard <gregoire.houssard@akeneo.com>
@@ -16,6 +15,7 @@ class JobExecutionRowHydrator
 {
     public function __construct(
         private JobExecutionTrackingHydrator $jobExecutionTrackingHydrator,
+        private JobExecutionHealthCheckHydrator $jobExecutionRowHydrator,
     ) {
     }
 
@@ -31,13 +31,18 @@ class JobExecutionRowHydrator
             json_decode($jobExecution['steps'], true),
         );
 
+        $healthCheck = $this->jobExecutionRowHydrator->hydrate(
+            (int) $jobExecution['status'],
+            $jobExecution['health_check_time'],
+        );
+
         return new JobExecutionRow(
             (int) $jobExecution['id'],
             $jobExecution['label'],
             $jobExecution['type'],
             $startTime,
             $jobExecution['user'],
-            Status::fromStatus((int) $jobExecution['status']),
+            $healthCheck,
             (bool) $jobExecution['is_stoppable'],
             $tracking,
         );

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
@@ -68,7 +68,8 @@ SQL;
             job_execution.user,
             job_execution.status,
             job_execution.is_stoppable,
-            job_execution.step_count
+            job_execution.step_count,
+            job_execution.health_check_time
         FROM akeneo_batch_job_execution job_execution
         JOIN akeneo_batch_job_instance job_instance ON job_execution.job_instance_id = job_instance.id
         WHERE job_execution.is_visible = 1

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/hydrators.yml
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Symfony/Resources/config/hydrators.yml
@@ -2,11 +2,16 @@ services:
   Akeneo\Platform\Job\Infrastructure\Hydrator\JobExecutionRowHydrator:
     arguments:
       - '@Akeneo\Platform\Job\Infrastructure\Hydrator\JobExecutionTrackingHydrator'
+      - '@Akeneo\Platform\Job\Infrastructure\Hydrator\JobExecutionHealthCheckHydrator'
 
   Akeneo\Platform\Job\Infrastructure\Hydrator\JobExecutionTrackingHydrator:
     arguments:
       - '@Akeneo\Platform\Job\Infrastructure\Hydrator\StepExecutionTrackingHydrator'
 
   Akeneo\Platform\Job\Infrastructure\Hydrator\StepExecutionTrackingHydrator:
+    arguments:
+      - '@Akeneo\Platform\Job\Infrastructure\Clock\ClockInterface'
+
+  Akeneo\Platform\Job\Infrastructure\Hydrator\JobExecutionHealthCheckHydrator:
     arguments:
       - '@Akeneo\Platform\Job\Infrastructure\Clock\ClockInterface'

--- a/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Acceptance/Application/SearchJobExecution/SearchJobExecutionHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Job\Test\Acceptance\Application\SearchJobExecution;
 
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTable;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTracking;
@@ -49,7 +50,7 @@ class SearchJobExecutionHandlerTest extends AcceptanceTestCase
                 'export',
                 new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
                 'admin',
-                Status::fromLabel('COMPLETED'),
+                new JobExecutionHealthCheck(Status::fromLabel('COMPLETED'), new \DateTimeImmutable('2020-01-03T00:00:05+00:00'), new \DateTimeImmutable('2020-01-03T00:00:10+00:00')),
                 false,
                 new JobExecutionTracking(1, 2, []),
             ),
@@ -59,7 +60,7 @@ class SearchJobExecutionHandlerTest extends AcceptanceTestCase
                 'export',
                 new \DateTimeImmutable('2020-01-03T00:00:00+00:00'),
                 'admin',
-                Status::fromLabel('FAILED'),
+                new JobExecutionHealthCheck(Status::fromLabel('FAILED'), null, new \DateTimeImmutable('2020-01-03T00:00:05+00:00')),
                 true,
                 new JobExecutionTracking(1, 2, []),
             ),

--- a/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/Infrastructure/Query/SearchJobExecutionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Job\Test\Integration\Infrastructure\Query;
 
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTracking;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\StepExecutionTracking;
@@ -391,6 +392,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
             'user' => 'julia',
             'status' => Status::COMPLETED,
             'is_stoppable' => false,
+            'health_check_time' => '2020-01-02T01:00:05+01:00',
         ]);
 
         $this->jobExecutionIds[] = $this->fixturesJobHelper->createJobExecution([
@@ -471,7 +473,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                     'import',
                     new \DateTimeImmutable('2020-01-01T00:00:00+00:00'),
                     'julia',
-                    Status::fromLabel('COMPLETED'),
+                    new JobExecutionHealthCheck(Status::fromLabel('COMPLETED'), new \DateTimeImmutable('2020-01-02T00:00:05+00:00'), new \DateTimeImmutable('2020-01-02 01:00:00')),
                     false,
                     new JobExecutionTracking(3, 3, [
                         new StepExecutionTracking(
@@ -512,7 +514,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                     'import',
                     new \DateTimeImmutable('2020-01-02T00:00:00+00:00'),
                     'peter',
-                    Status::fromLabel('IN_PROGRESS'),
+                    new JobExecutionHealthCheck(Status::fromLabel('IN_PROGRESS'), null, new \DateTimeImmutable('2020-01-02 01:00:00')),
                     true,
                     new JobExecutionTracking(1, 3, [
                         new StepExecutionTracking(
@@ -533,7 +535,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                     'import',
                     null,
                     null,
-                    Status::fromLabel('STARTING'),
+                    new JobExecutionHealthCheck(Status::fromLabel('STARTING'), null, new \DateTimeImmutable('2020-01-02 01:00:00')),
                     true,
                     new JobExecutionTracking(0, 3, []),
                 ),
@@ -543,7 +545,7 @@ class SearchJobExecutionTest extends IntegrationTestCase
                     'export',
                     null,
                     null,
-                    Status::fromLabel('STARTING'),
+                    new JobExecutionHealthCheck(Status::fromLabel('STARTING'), null, new \DateTimeImmutable('2020-01-02 01:00:00')),
                     true,
                     new JobExecutionTracking(0, 3, []),
                 ),

--- a/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionHealthCheckSpec.php
+++ b/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionHealthCheckSpec.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Platform\Job\Application\SearchJobExecution\Model;
+
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTracking;
+use Akeneo\Platform\Job\Domain\Model\Status;
+use PhpSpec\ObjectBehavior;
+
+class JobExecutionHealthCheckSpec extends ObjectBehavior
+{
+    public function it_is_initializable(): void
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::COMPLETED),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->shouldBeAnInstanceOf(JobExecutionHealthCheck::class);
+    }
+
+    public function it_resolves_the_current_status_if_job_is_completed()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::COMPLETED),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::COMPLETED));
+    }
+
+    public function it_resolves_the_current_status_if_job_is_failed()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::FAILED),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::FAILED));
+    }
+
+    public function it_resolves_the_current_status_if_job_is_stopped()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::STOPPED),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::STOPPED));
+    }
+
+    public function it_resolves_the_current_status_if_job_is_abandoned()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::ABANDONED),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::ABANDONED));
+    }
+
+    public function it_resolves_the_current_status_if_job_is_unknown()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::UNKNOWN),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::UNKNOWN));
+    }
+
+
+    public function it_resolves_the_failed_status_if_job_is_starting_and_health_check_is_more_than_10_seconds_ago()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::STARTING),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::FAILED));
+    }
+
+    public function it_resolves_the_failed_status_if_job_is_in_progress_and_health_check_is_more_than_10_seconds_ago()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::IN_PROGRESS),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::FAILED));
+    }
+
+    public function it_resolves_the_failed_status_if_job_is_stopping_and_health_check_is_more_than_10_seconds_ago()
+    {
+        $this->beConstructedWith(
+            Status::fromStatus(Status::STOPPING),
+            new \DateTimeImmutable('2021-11-02T12:00:05+02:00'),
+            new \DateTimeImmutable('2021-11-02T12:00:20+02:00')
+        );
+
+        $this->resolveStatus()->shouldBeLike(Status::fromStatus(Status::FAILED));
+    }
+}

--- a/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionRowSpec.php
+++ b/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionRowSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Platform\Job\Application\SearchJobExecution\Model;
 
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTracking;
 use Akeneo\Platform\Job\Domain\Model\Status;
@@ -19,7 +20,7 @@ class JobExecutionRowSpec extends ObjectBehavior
             'export',
             new \DateTimeImmutable('2021-11-02T11:20:27+02:00'),
             'admin',
-            Status::fromLabel('COMPLETED'),
+            new JobExecutionHealthCheck(Status::fromLabel('COMPLETED'), null, new \DateTimeImmutable('2021-11-02T11:20:28+02:00')),
             true,
             new JobExecutionTracking(1, 3, [])
         );
@@ -58,7 +59,7 @@ class JobExecutionRowSpec extends ObjectBehavior
             'export',
             null,
             null,
-            Status::fromLabel('COMPLETED'),
+            new JobExecutionHealthCheck(Status::fromLabel('COMPLETED'), null, new \DateTimeImmutable('2021-11-02T11:20:28+02:00')),
             false,
             new JobExecutionTracking(1, 1, [])
         );

--- a/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionTableSpec.php
+++ b/src/Akeneo/Platform/Job/back/tests/Specification/Application/SearchJobExecution/Model/JobExecutionTableSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Platform\Job\Application\SearchJobExecution\Model;
 
+use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionHealthCheck;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionRow;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTable;
 use Akeneo\Platform\Job\Application\SearchJobExecution\Model\JobExecutionTracking;
@@ -28,7 +29,7 @@ class JobExecutionTableSpec extends ObjectBehavior
                     'export',
                     new \DateTimeImmutable('2021-11-02T11:20:27+02:00'),
                     'admin',
-                    Status::fromLabel('COMPLETED'),
+                    new JobExecutionHealthCheck(Status::fromLabel('COMPLETED'), null, new \DateTimeImmutable('2021-11-02T11:20:28+02:00')),
                     true,
                     new JobExecutionTracking(1, 2, []),
                 ),


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**What's going wrong ?**
We forgot to handle the recalculation of the status based on the health time check : this will cause some bugs when jobs fails due to external down like a mysql pod crash. Now, users can seen that their jobs are failed.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
