### PR TITLE
PIM-10426: Fix empty array should be normalized as empty JSON object in Measurement Family API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - PIM-10377: Change Elastic Search field Limit for everyone
 - PIM-10251: Fix locale on API call
 - PIM-10418: Simple and multi select values not showing if not imported with the correct letter case
+- PIM-10426: Fix empty array should be normalized as empty JSON object in Measurement Family API
 - PIM-10416: Fix letter case issue when importing families
 
 ## Improvements

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/GetMeasurementFamiliesAction.php
@@ -7,6 +7,7 @@ namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
 use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @author    Samir Boulil <samir.boulil@akeneo.com>
@@ -15,17 +16,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class GetMeasurementFamiliesAction
 {
-    private MeasurementFamilyRepositoryInterface $measurementFamilyRepository;
-
-    public function __construct(MeasurementFamilyRepositoryInterface $measurementFamilyRepository)
-    {
-        $this->measurementFamilyRepository = $measurementFamilyRepository;
+    public function __construct(
+        private MeasurementFamilyRepositoryInterface $measurementFamilyRepository,
+        private NormalizerInterface $normalizer,
+    ) {
     }
 
     public function __invoke(): JsonResponse
     {
         $measurementFamilies = $this->measurementFamilyRepository->all();
-        $normalizedMeasurementFamilies = array_map(static fn (MeasurementFamily $measurementFamily) => $measurementFamily->normalizeWithIndexedUnits(), $measurementFamilies);
+        $normalizedMeasurementFamilies = array_map(fn (MeasurementFamily $measurementFamily) => $this->normalizer->normalize($measurementFamily), $measurementFamilies);
 
         return new JsonResponse($normalizedMeasurementFamilies);
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Normalizer/ExternalMeasurementFamilyNormalizer.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Normalizer/ExternalMeasurementFamilyNormalizer.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\MeasureBundle\Normalizer;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ */
+final class ExternalMeasurementFamilyNormalizer implements NormalizerInterface
+{
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        /** @var MeasurementFamily $object */
+        $normalizedMeasurementFamily = $object->normalizeWithIndexedUnits();
+
+        if ([] === $normalizedMeasurementFamily['labels']) {
+            $normalizedMeasurementFamily['labels'] = new \ArrayObject();
+        }
+
+        $normalizedMeasurementFamily['units'] = array_map(function (array $normalizedUnit) {
+            if ([] === $normalizedUnit['labels']) {
+                $normalizedUnit['labels'] = new \ArrayObject();
+            }
+
+            return $normalizedUnit;
+        }, $normalizedMeasurementFamily['units']);
+
+        return $normalizedMeasurementFamily;
+    }
+
+    public function supportsNormalization($data, string $format = null)
+    {
+        return $data instanceof MeasurementFamily;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/api.yml
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Resources/config/api.yml
@@ -25,6 +25,7 @@ services:
         public: true
         arguments:
             - '@akeneo_measure.persistence.measurement_family_repository'
+            - '@akeneo_measure.normalizer.external_measurement_family'
 
     pim_api.controller.create_update_measurement_families:
         class: Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\SaveMeasurementFamiliesAction
@@ -48,3 +49,7 @@ services:
 
     pim_api.controller.external_api.json_schema.measurement_family_validator:
         class: Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema\MeasurementFamilyValidator
+
+    # Normalizers
+    akeneo_measure.normalizer.external_measurement_family:
+        class: Akeneo\Tool\Bundle\MeasureBundle\Normalizer\ExternalMeasurementFamilyNormalizer

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Normalizer/ExternalMeasurementFamilyNormalizerSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Normalizer/ExternalMeasurementFamilyNormalizerSpec.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Normalizer;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Normalizer\ExternalMeasurementFamilyNormalizer;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @author    Valentin Dijkstra <valentin.dijkstra@akeneo.com>
+ * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
+ */
+class ExternalMeasurementFamilyNormalizerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ExternalMeasurementFamilyNormalizer::class);
+    }
+
+    public function it_normalizes_a_measurement_family_and_replaces_empty_arrays_by_empty_objects() {
+        $aMeasurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('Area'),
+            LabelCollection::fromArray([]),
+            UnitCode::fromString('SQUARE_MILLIMETER'),
+            [
+                Unit::create(
+                    UnitCode::fromString('SQUARE_MILLIMETER'),
+                    LabelCollection::fromArray([]),
+                    [Operation::create('mul', '1')],
+                    'mm²',
+                ),
+                Unit::create(
+                    UnitCode::fromString('SQUARE_CENTIMETER'),
+                    LabelCollection::fromArray(['en_US' => 'Square centimeter', 'fr_FR' => 'Centimètre carré']),
+                    [Operation::create('mul', '0.0001')],
+                    'cm²',
+                )
+            ]
+        );
+
+        $this->normalize($aMeasurementFamily)->shouldBeLike([
+            'code' => 'Area',
+            'labels' => new \ArrayObject(),
+            'standard_unit_code' => 'SQUARE_MILLIMETER',
+            'units' => [
+                'SQUARE_MILLIMETER' => [
+                    'code' => 'SQUARE_MILLIMETER',
+                    'labels' => new \ArrayObject(),
+                    'convert_from_standard' => [
+                        [
+                            'operator' => 'mul',
+                            'value' => '1'
+                        ]
+                    ],
+                    'symbol' => 'mm²'
+                ],
+                'SQUARE_CENTIMETER' => [
+                    'code' => 'SQUARE_CENTIMETER',
+                    'labels' => [
+                        'en_US' => 'Square centimeter',
+                        'fr_FR' => 'Centimètre carré'
+                    ],
+                    'convert_from_standard' => [
+                        [
+                            'operator' => 'mul',
+                            'value' => '0.0001'
+                        ]
+                    ],
+                    'symbol' => 'cm²'
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/GetMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/GetMeasurementFamiliesActionEndToEnd.php
@@ -3,15 +3,33 @@
 namespace Akeneo\Tool\Bundle\MeasureBundle\tests\EndToEnd\ExternalApi;
 
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamilyCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
+use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
+use Akeneo\Tool\Bundle\MeasureBundle\Persistence\MeasurementFamilyRepositoryInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class GetMeasurementFamiliesActionEndToEnd extends ApiTestCase
 {
+    private ?MeasurementFamilyRepositoryInterface $measurementFamilyRepository = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->measurementFamilyRepository = $this->get('akeneo_measure.persistence.measurement_family_repository');
+    }
+
     /**
      * @test
      */
     public function it_returns_the_list_of_measurement_families()
     {
+        $this->insertMeasurementFamilyWithEmptyLabels();
+
         $client = $this->createAuthenticatedClient();
         $client->request('GET', 'api/rest/v1/measurement-families');
 
@@ -28,6 +46,25 @@ class GetMeasurementFamiliesActionEndToEnd extends ApiTestCase
     protected function getConfiguration()
     {
         return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function insertMeasurementFamilyWithEmptyLabels()
+    {
+        $measurementFamily = MeasurementFamily::create(
+            MeasurementFamilyCode::fromString('Bitcoin'),
+            LabelCollection::fromArray([]),
+            UnitCode::fromString('SATOSHI'),
+            [
+                Unit::create(
+                    UnitCode::fromString('SATOSHI'),
+                    LabelCollection::fromArray([]),
+                    [Operation::create('mul', '1')],
+                    'satoshi'
+                ),
+            ]
+        );
+
+        $this->measurementFamilyRepository->save($measurementFamily);
     }
 
     private function getExpectedJSON(string $expected)

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Responses/measurement-families.json
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Responses/measurement-families.json
@@ -861,6 +861,24 @@
         }
     },
     {
+        "code": "Bitcoin",
+        "labels": {},
+        "standard_unit_code": "SATOSHI",
+        "units": {
+            "SATOSHI": {
+                "code": "SATOSHI",
+                "labels": {},
+                "convert_from_standard": [
+                    {
+                        "operator": "mul",
+                        "value": "1"
+                    }
+                ],
+                "symbol": "satoshi"
+            }
+        }
+    },
+    {
         "code": "Brightness",
         "labels": {
             "de_DE": "Helligkeit",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Fixes https://akeneo.atlassian.net/browse/PIM-10426?atlOrigin=eyJpIjoiMGRiN2JkY2U2NjUwNGZlMzllMjAyZWQwNzA3NTEyZDIiLCJwIjoiaiJ9

If we want to have a empty JSON object, we need to pass an empty ArrayObject to JsonResponse as the Symfony JSON Encoder will encode empty array into JSON empty array and empty object into JSON empty object.

cf https://github.com/symfony/symfony/issues/23019

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
