### PR TITLE
Implement InMemoryProductRepository's findOneBy

### DIFF
--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -12,6 +12,8 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Ramsey\Uuid\UuidInterface;
+use Webmozart\Assert\Assert;
 
 class InMemoryProductRepository implements
     IdentifiableObjectRepositoryInterface,
@@ -86,7 +88,24 @@ class InMemoryProductRepository implements
 
     public function findOneBy(array $criteria)
     {
-        throw new NotImplementedException(__METHOD__);
+        Assert::count($criteria, 1);
+        $criteriaKey = \current(\array_keys($criteria));
+        $criteriaValue = \current($criteria);
+        if ($criteriaValue instanceof UuidInterface) {
+            $criteriaValue = $criteriaValue->toString();
+        }
+
+        foreach ($this->products as $product) {
+            $productValue = 'uuid' === $criteriaKey ? $product->getUuid() : $product->getId();
+            if ($productValue instanceof UuidInterface) {
+                $productValue = $productValue->toString();
+            }
+            if ($productValue === $criteriaValue) {
+                return $product;
+            }
+        }
+
+        return null;
     }
 
     public function getClassName()

--- a/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
+++ b/tests/back/Acceptance/spec/Product/InMemoryProductRepositorySpec.php
@@ -12,6 +12,7 @@ use Akeneo\Test\Acceptance\Product\InMemoryProductRepository;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 class InMemoryProductRepositorySpec extends ObjectBehavior
 {
@@ -105,7 +106,6 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
 
     function it_asserts_that_the_other_methods_are_not_implemented_yet()
     {
-        $this->shouldThrow(NotImplementedException::class)->during('findOneBy', [[]]);
         $this->shouldThrow(NotImplementedException::class)->during('getClassName', []);
         $this->shouldThrow(NotImplementedException::class)->during('getAvailableAttributeIdsToExport', [[]]);
         $this->shouldThrow(NotImplementedException::class)->during('getProductsByGroup', [new Group(), 10]);
@@ -162,5 +162,20 @@ class InMemoryProductRepositorySpec extends ObjectBehavior
         $products->shouldBeArray();
         $products->shouldHaveCount(1);
         $products->shouldHaveKeyWithValue('A', $productA);
+    }
+
+    function it_finds_one_product_by_criteria()
+    {
+        $productA = new Product();
+        $productA->setIdentifier('A');
+        $this->save($productA);
+
+        $productB = new Product();
+        $productA->setIdentifier('B');
+        $this->save($productB);
+
+        $this->findOneBy(['uuid' => $productA->getUuid()])->shouldBe($productA);
+        $this->findOneBy(['uuid' => $productB->getUuid()])->shouldBe($productB);
+        $this->findOneBy(['uuid' => Uuid::uuid4()])->shouldBeNull();
     }
 }


### PR DESCRIPTION
The CI of the CE is red because it is not configured to change the pim-onboarder dependency (still ^7.0).  

Instead please check the CI of the EE that can run tests with the `migration-adr-uuid` branch of pim-onboarder: https://app.circleci.com/pipelines/github/akeneo/pim-enterprise-dev?branch=migration-adr-uuid&filter=all