### PR TITLE
CPM-603: Use UpsertProductCommand in test

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
@@ -275,9 +275,8 @@ final class UpsertProductIntegration extends TestCase
     {
         // create product with values from every type of attribute
         $this->createProduct('complex_product', 'familyA', [
-            new SetDateValue('a_date', null, null, '2010-10-10'),
-            // TODO : use SetFileValue when ready
-            new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))),
+            new SetDateValue('a_date', null, null, new \DateTime('2010-10-10')),
+            new SetFileValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))),
             new SetMeasurementValue('a_metric', null, null, 1, 'WATT'),
             new SetMultiSelectValue('a_multi_select', null,null, ['optionA']),
             new SetNumberValue('a_number_float', null,null, '3.14'),
@@ -289,8 +288,7 @@ final class UpsertProductIntegration extends TestCase
             new SetTextValue('a_text', null,null, 'foo'),
             new SetTextareaValue('a_text_area', null,null, self::TEXT_AREA_VALUE),
             new SetBooleanValue('a_yes_no', null,null, true),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null,null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('an_image', null,null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
 
         $product = $this->productRepository->findOneByIdentifier('complex_product');

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
@@ -275,20 +275,22 @@ final class UpsertProductIntegration extends TestCase
     {
         // create product with values from every type of attribute
         $this->createProduct('complex_product', 'familyA', [
-            'a_date' => [['locale' => null, 'scope' => null, 'data' => '2010-10-10']],
-            'a_file' => [['locale' => null, 'scope' => null, 'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))]],
-            'a_metric' => [['locale' => null, 'scope' => null, 'data' => ['amount' => 1, 'unit' => 'WATT']]],
-            'a_multi_select' => [['locale' => null, 'scope' => null, 'data' => ['optionA']]],
-            'a_number_float' => [['locale' => null, 'scope' => null, 'data' => 3.14]],
-            'a_number_float_negative' => [['locale' => null, 'scope' => null, 'data' => -3.14]],
-            'a_number_integer' => [['locale' => null, 'scope' => null, 'data' => 42]],
-            'a_ref_data_multi_select' => [['locale' => null, 'scope' => null, 'data' => ['brilliantine', 'tapestry', 'zibeline']]],
-            'a_ref_data_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'bright-pink']],
-            'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionA']],
-            'a_text' => [['locale' => null, 'scope' => null, 'data' => 'foo']],
-            'a_text_area' => [['locale' => null, 'scope' => null, 'data' => self::TEXT_AREA_VALUE]],
-            'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
-            'an_image' => [['locale' => null, 'scope' => null, 'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))]],
+            new SetDateValue('a_date', null, null, '2010-10-10'),
+            // TODO : use SetFileValue when ready
+            new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))),
+            new SetMeasurementValue('a_metric', null, null, 1, 'WATT'),
+            new SetMultiSelectValue('a_multi_select', null,null, ['optionA']),
+            new SetNumberValue('a_number_float', null,null, '3.14'),
+            new SetNumberValue('a_number_float_negative', null,null, '-3.14'),
+            new SetNumberValue('a_number_integer', null,null, '42'),
+            new SetMultiReferenceEntityValue('a_ref_data_multi_select', null,null, ['brilliantine', 'tapestry', 'zibeline']),
+            new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null,null, 'bright-pink'),
+            new SetSimpleSelectValue('a_simple_select', null,null, 'optionA'),
+            new SetTextValue('a_text', null,null, 'foo'),
+            new SetTextareaValue('a_text_area', null,null, self::TEXT_AREA_VALUE),
+            new SetBooleanValue('a_yes_no', null,null, true),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null,null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
 
         $product = $this->productRepository->findOneByIdentifier('complex_product');
@@ -345,7 +347,7 @@ final class UpsertProductIntegration extends TestCase
         $this->createProduct(
             'product_with_asset',
             'other',
-            ['packshot_attr' => [['scope' => null, 'locale' => null, 'data' => ['packshot1']]]]
+            [new SetAssetValue('packshot_attr', null, null, ['packshot1'])]
         );
         $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset(); // Needed to update the product
 
@@ -393,8 +395,8 @@ final class UpsertProductIntegration extends TestCase
             'product_with_ref_entities',
             'other',
             [
-                'a_reference_entity_attribute' => [['scope' => null, 'locale' => null, 'data' => 'Akeneo']],
-                'a_reference_entity_collection_attribute' => [['scope' => null, 'locale' => null, 'data' => ['Akeneo', 'Other']]]
+                new SetSimpleReferenceEntityValue('a_reference_entity_attribute', null, null, 'Akeneo'),
+                new SetMultiReferenceEntityValue('a_reference_entity_collection_attribute', null, null, ['Akeneo', 'Other'])
             ]
         );
         $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset(); // Needed to update the product
@@ -964,7 +966,7 @@ final class UpsertProductIntegration extends TestCase
         $this->createProduct(
             'identifier',
             'other',
-            ['packshot_attr' => [['scope' => null, 'locale' => null, 'data' => ['packshot1', 'packshot2', 'packshot3']]]]
+            [new SetAssetValue('packshot_attr' , null, null, ['packshot1', 'packshot2', 'packshot3'])]
         );
         $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset(); // Needed to update the product
 
@@ -1198,15 +1200,20 @@ final class UpsertProductIntegration extends TestCase
         $this->clearDoctrineUoW();
     }
 
-    private function createProduct(string $identifier, ?string $familyCode, array $values): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProduct(string $identifier, ?string $familyCode, array $userIntents): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $familyCode);
-        $this->get('pim_catalog.updater.product')->update($product, ['values' => $values]);
-        $errors = $this->get('pim_catalog.validator.product')->validate($product);
-        if (0 !== $errors->count()) {
-            throw new \Exception(sprintf('Impossible to setup test in %s: %s', static::class, $errors->get(0)->getMessage()));
-        }
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->clearDoctrineUoW();
     }
 
     protected function getFileInfoKey(string $path): string

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdCollection;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use PHPUnit\Framework\Assert;
@@ -20,14 +27,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
     public function test_it_gets_a_product_with_attribute_options_simple_select()
     {
         $this->createProduct('product', [
-            'family' => 'familyA',
-            'categories' => [],
-            'groups' => [],
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'optionA', 'locale' => null, 'scope' => null]
-                ],
-            ],
+            new SetFamily('familyA'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -76,14 +77,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
     public function test_it_gets_a_product_with_attribute_options_multi_select()
     {
         $this->createProduct('product', [
-            'family' => 'familyA',
-            'categories' => [],
-            'groups' => [],
-            'values' => [
-                'a_multi_select' => [
-                    ['data' => ['optionA', 'optionB'], 'locale' => null, 'scope' => null]
-                ],
-            ],
+            new SetFamily('familyA'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'optionB'])
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -144,15 +139,11 @@ class GetProductEndToEnd extends AbstractProductTestCase
     public function test_it_gets_a_product()
     {
         $this->createProduct('product', [
-            'family' => 'familyA1',
-            'enabled' => true,
-            'categories' => ['categoryA', 'master', 'master_china'],
-            'groups' => ['groupA', 'groupB'],
-            'values' => [
-                'a_date' => [
-                    ['data' => '2016-06-28', 'locale' => null, 'scope' => null]
-                ],
-            ],
+            new SetFamily('familyA1'),
+            new SetEnabled(true),
+            new SetCategories(['categoryA', 'master', 'master_china']),
+            new SetGroups(['groupA', 'groupB']),
+            new SetDateValue('a_date', null, null, new \DateTime('2016-06-28'))
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -202,12 +193,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function test_it_gets_a_product_with_quality_scores()
     {
-        $product = $this->createProduct('product', [
-            'family' => 'familyA',
-            'categories' => [],
-            'groups' => [],
-            'values' => [],
-        ]);
+        $product = $this->createProduct('product', [new SetFamily('familyA')]);
 
         ($this->get('Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts'))(
             ProductIdCollection::fromInt($product->getId())
@@ -252,14 +238,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
     public function test_it_gets_a_product_with_completenesses()
     {
         $this->createProduct('product', [
-            'family' => 'familyA',
-            'categories' => [],
-            'groups' => [],
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'optionA', 'locale' => null, 'scope' => null]
-                ],
-            ],
+            new SetFamily('familyA'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
 
         $client = $this->createAuthenticatedClient();
@@ -308,9 +288,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function testAccessDeniedWhenRetrievingProductWithoutTheAcl()
     {
-        $this->createProduct('product', [
-            'family' => 'familyA',
-        ]);
+        $this->createProduct('product', [new SetFamily('familyA')]);
         $client = $this->createAuthenticatedClient();
         $this->removeAclFromRole('action:pim_api_product_list');
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListProducts;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
 use Doctrine\Common\Collections\Collection;
@@ -25,44 +31,39 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
 
         // product complete, whatever the scope
         $this->createProduct('product_complete', [
-            'family'     => 'familyA2',
-            'categories' => ['categoryA', 'categoryB', 'master'],
-            'values'     => [
-                'a_metric' => [
-                    ['data' => ['amount' => 1, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]
-                ],
-                'a_number_float' => [
-                    ['data' => '12.05', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('familyA2'),
+            new SetCategories(['categoryA', 'categoryB', 'master']),
+            new SetMeasurementValue('a_metric', null, null, 1, 'WATT'),
+            new SetNumberValue('a_number_float', null, null, '12.05')
         ]);
 
         // product complete only on en_US-tablet & en-US-ecommerce
         $this->createProduct('product_complete_en_locale', [
-            'family'     => 'familyA1',
-            'categories' => ['categoryA', 'master', 'master_china'],
-            'values'     => [
-                'a_localizable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
-                ],
-                'a_date' => [
-                    ['data' => '2016-06-28', 'locale' => null, 'scope' => null]
-                ],
-                'a_file' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'locale' => null, 'scope' => null],
-                ]
-            ]
+            new SetFamily('familyA1'),
+            new SetCategories(['categoryA', 'master', 'master_china']),
+            // TODO use SetImageValue when ready
+            new SetTextValue(
+                'a_localizable_image',
+                null,
+                null,
+                $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))
+            ),
+            new SetDateValue('a_date', null, null, new \DateTime('2016-06-28')),
+            // TODO: use SetFileValue when ready
+            new SetTextValue(
+                'a_file',
+                null,
+                null,
+                $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))
+            )
         ]);
 
         // product incomplete
         $this->createProduct('product_incomplete', [
-            'family'     => 'familyA',
-            'categories' => ['categoryA', 'master', 'master_china'],
-            'values'     => [
-                'a_file' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'locale' => null, 'scope' => null],
-                ]
-            ]
+            new SetFamily('familyA'),
+            new SetCategories(['categoryA', 'master', 'master_china']),
+            // TODO: use SetFileValue when ready
+            new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt')))
         ]);
 
         $this->products = $this->get('pim_catalog.repository.product')->findAll();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
@@ -7,9 +7,10 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListPro
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFileValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
 use Doctrine\Common\Collections\Collection;
@@ -41,16 +42,14 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         $this->createProduct('product_complete_en_locale', [
             new SetFamily('familyA1'),
             new SetCategories(['categoryA', 'master', 'master_china']),
-            // TODO use SetImageValue when ready
-            new SetTextValue(
+            new SetImageValue(
                 'a_localizable_image',
                 null,
                 null,
                 $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))
             ),
             new SetDateValue('a_date', null, null, new \DateTime('2016-06-28')),
-            // TODO: use SetFileValue when ready
-            new SetTextValue(
+            new SetFileValue(
                 'a_file',
                 null,
                 null,
@@ -62,8 +61,12 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         $this->createProduct('product_incomplete', [
             new SetFamily('familyA'),
             new SetCategories(['categoryA', 'master', 'master_china']),
-            // TODO: use SetFileValue when ready
-            new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt')))
+            new SetFileValue(
+                'a_file',
+                null,
+                null,
+                $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))
+            )
         ]);
 
         $this->products = $this->get('pim_catalog.repository.product')->findAll();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -10,8 +10,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -40,10 +40,9 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         $path = $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'));
         $this->createProduct('localizable', [
             new SetCategories(['categoryB']),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('a_localizable_image', null, 'en_US', $path),
-            new SetTextValue('a_localizable_image', null, 'fr_FR', $path),
-            new SetTextValue('a_localizable_image', null, 'zh_CN', $path),
+            new SetImageValue('a_localizable_image', null, 'en_US', $path),
+            new SetImageValue('a_localizable_image', null, 'fr_FR', $path),
+            new SetImageValue('a_localizable_image', null, 'zh_CN', $path),
         ]);
 
         // scopable, categorized in 1 tree (master)

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
@@ -3,6 +3,11 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListProducts;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -253,25 +258,20 @@ JSON;
     {
         parent::setUp();
         $this->createProduct('product1', [
-            'categories' => ['master'],
-            'values'     => [
-                'a_metric' => [
-                    ['data' => ['amount' => 10, 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                ],
-                'a_text' => [
-                    ['data' => 'Text', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetCategories(['master']),
+            new SetMeasurementValue('a_metric', null, null, 10, 'KILOWATT'),
+            new SetTextValue('a_text', null, null, 'Text')
         ]);
         $this->createProduct('product2', [
-            'categories' => ['categoryB'],
-            'values'     => [
+            new SetCategories(['categoryB']),
+            // TODO : use SetImageValue when ready
+            /**'values'     => [
                 'a_localizable_image' => [
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'fr_FR', 'scope' => null],
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'zh_CN', 'scope' => null]
                 ]
-            ]
+            ]*/
         ]);
         $this->createProductModel(
             [
@@ -314,45 +314,21 @@ JSON;
         );
 
         $this->createVariantProduct('apollon_optionb_false', [
-            'categories' => ['master'],
-            'parent' => 'prod_mod_optB',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => false,
-                    ]
-                ]
-            ]
+            new SetCategories(['master']),
+            new ChangeParent('prod_mod_optB'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
 
         $this->createVariantProduct('apollon_optionb_true', [
-            'categories' => ['master'],
-            'parent' => 'prod_mod_optB',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => true,
-                    ]
-                ]
-            ]
+            new SetCategories(['master']),
+            new ChangeParent('prod_mod_optB'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $this->createVariantProduct('apollon_optiona_true', [
-            'categories' => ['master'],
-            'parent' => 'prod_mod_optA',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => true,
-                    ]
-                ]
-            ]
+            new SetCategories(['master']),
+            new ChangeParent('prod_mod_optA'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListVariantProductDeltaEndToEnd.php
@@ -6,6 +6,7 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListPro
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
@@ -264,14 +265,9 @@ JSON;
         ]);
         $this->createProduct('product2', [
             new SetCategories(['categoryB']),
-            // TODO : use SetImageValue when ready
-            /**'values'     => [
-                'a_localizable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'fr_FR', 'scope' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'zh_CN', 'scope' => null]
-                ]
-            ]*/
+            new SetImageValue('a_localizable_image', null, 'en_US',  $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_image', null, 'fr_FR',  $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_image', null, 'zh_CN',  $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
         $this->createProductModel(
             [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -5,6 +5,14 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateGroups;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use Psr\Log\Test\TestLogger;
@@ -22,56 +30,41 @@ class PartialUpdateProductEndToEnd extends AbstractProductTestCase
         parent::setUp();
 
         $this->createProduct('product_family', [
-            'family' => 'familyA2',
+            new SetFamily('familyA2')
         ]);
 
         $this->createProduct('product_groups', [
-            'groups' => ['groupA'],
+            new SetGroups(['groupA'])
         ]);
 
         $this->createProduct('product_categories', [
-            'categories' => ['master'],
+            new SetCategories(['master'])
         ]);
 
         $this->createProduct('product_associations', [
-            'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories'], 'product_models' => []],
-            ],
+            new AssociateProducts('X_SELL', ['product_categories']),
+            new AssociateGroups('X_SELL', ['groupA'])
         ]);
 
         $this->createProduct('localizable', [
-            'values'     => [
+            // TODO : use SetImageValue when ready
+            /**'values'     => [
                 'a_localizable_image' => [
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
                     ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'fr_FR', 'scope' => null],
                 ]
-            ]
+            ]*/
         ]);
 
         $this->createProduct('complete', [
-            'family'        => 'familyA2',
-            'groups'        => ['groupA'],
-            'categories'    => ['master'],
-            'values'        => [
-                'a_metric' => [
-                    ['data' => ['amount' => '10.0000', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null],
-                ],
-                'a_date'   => [
-                    ['data' => '2016-06-13T00:00:00+02:00', 'locale' => null, 'scope' => null],
-                ],
-                'a_simple_select' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'optionB'],
-                ],
-            ],
-            'associations'  => [
-                'PACK'         => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'SUBSTITUTION' => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
-                'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories'], 'product_models' => []],
-            ],
+            new SetFamily('familyA2'),
+            new SetGroups(['groupA']),
+            new SetCategories(['master']),
+            new SetMeasurementValue('a_metric', null, null, '10.0000', 'KILOWATT'),
+            new SetDateValue('a_date', null, null, new \DateTime('2016-06-13T00:00:00+02:00')),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionB'),
+            new AssociateProducts('X_SELL', ['product_categories']),
+            new AssociateGroups('X_SELL', ['groupA'])
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -11,6 +11,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
@@ -47,13 +48,8 @@ class PartialUpdateProductEndToEnd extends AbstractProductTestCase
         ]);
 
         $this->createProduct('localizable', [
-            // TODO : use SetImageValue when ready
-            /**'values'     => [
-                'a_localizable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]*/
+            new SetImageValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
 
         $this->createProduct('complete', [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetAssetValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\Application\Applier\SetSingleValueApplier;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\InternalApiTestCase;
 use PHPUnit\Framework\Assert;
@@ -32,15 +35,11 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
             'simple',
             'familyA',
             [
-                'values' => [
-                    'an_image' => [
-                        [
-                            'locale' => null,
-                            'scope' => null,
-                            'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')),
-                        ],
-                    ],
-                ],
+                new SetTextValue(
+                    'an_image',
+                    null,
+                    null,
+                    $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')))
             ]
         );
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetAssetValue;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
-use Akeneo\Pim\Enrichment\Product\Application\Applier\SetSingleValueApplier;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\InternalApiTestCase;
 use PHPUnit\Framework\Assert;
@@ -35,7 +32,7 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
             'simple',
             'familyA',
             [
-                new SetTextValue(
+                new SetImageValue(
                     'an_image',
                     null,
                     null,

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
@@ -49,10 +49,11 @@ abstract class AbstractProductWithQuantifiedAssociationsTestCase extends Abstrac
         return array_merge_recursive($data, $changes);
     }
 
-    protected function getProductSaver(): SaverInterface
+    // TODO : is it used?
+    /*protected function getProductSaver(): SaverInterface
     {
         return self::$container->get('pim_catalog.saver.product');
-    }
+    }*/
 
     protected function getProductUpdater(): ObjectUpdaterInterface
     {

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
@@ -49,12 +49,6 @@ abstract class AbstractProductWithQuantifiedAssociationsTestCase extends Abstrac
         return array_merge_recursive($data, $changes);
     }
 
-    // TODO : is it used?
-    /*protected function getProductSaver(): SaverInterface
-    {
-        return self::$container->get('pim_catalog.saver.product');
-    }*/
-
     protected function getProductUpdater(): ObjectUpdaterInterface
     {
         return self::$container->get('pim_catalog.updater.product');

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Symfony\Component\HttpFoundation\Response;
 
 class AddQuantifiedAssociationsToProductEndToEnd extends AbstractProductWithQuantifiedAssociationsTestCase
@@ -15,15 +16,7 @@ class AddQuantifiedAssociationsToProductEndToEnd extends AbstractProductWithQuan
             'yellow_chair',
             null,
             [
-                'values' => [
-                    'sku' => [
-                        [
-                            'scope' => null,
-                            'locale' => null,
-                            'data' => 'yellow_chair',
-                        ],
-                    ],
-                ],
+                new SetTextValue('sku', null, null, 'yellow_chair')
             ]);
         $normalizedProduct = $this->getProductFromInternalApi($product->getId());
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/RemoveQuantifiedAssociationsFromProductEndToEnd.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Symfony\Component\HttpFoundation\Response;
 
 class RemoveQuantifiedAssociationsFromProductEndToEnd extends AbstractProductWithQuantifiedAssociationsTestCase
@@ -15,15 +16,7 @@ class RemoveQuantifiedAssociationsFromProductEndToEnd extends AbstractProductWit
             'yellow_chair',
             null,
             [
-                'values' => [
-                    'sku' => [
-                        [
-                            'scope' => null,
-                            'locale' => null,
-                            'data' => 'yellow_chair',
-                        ],
-                    ],
-                ],
+                new SetTextValue('sku', null, null, 'yellow_chair')
             ]
         );
         $normalizedProduct = $this->getProductFromInternalApi($product->getId());

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/ValidateQuantifiedAssociationsInProductEndToEnd.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\InternalApi\QuantifiedAssociations;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Symfony\Component\HttpFoundation\Response;
 
 class ValidateQuantifiedAssociationsInProductEndToEnd extends AbstractProductWithQuantifiedAssociationsTestCase
@@ -14,16 +15,9 @@ class ValidateQuantifiedAssociationsInProductEndToEnd extends AbstractProductWit
         $product = $this->createProduct(
             'yellow_chair',
             'shoes',[
-            'values' => [
-                'sku' => [
-                    [
-                        'scope' => null,
-                        'locale' => null,
-                        'data' => 'yellow_chair',
-                    ],
-                ],
+                new SetTextValue('sku', null, null, 'yellow_chair')
             ],
-        ]);
+        );
         $normalizedProduct = $this->getProductFromInternalApi($product->getId());
 
         $quantifiedAssociations = [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/CreateProductModelEndToEnd.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelCreated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Psr\Log\Test\TestLogger;
@@ -781,7 +782,7 @@ JSON;
             'values'  => [],
         ]);
 
-        $this->createProduct('simple', ['enabled' => false]);
+        $this->createProduct('simple', [new SetEnabled(false)]);
 
         $client = $this->createAuthenticatedClient();
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListProductModelWithCompletenessEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/ListProductModelWithCompletenessEndToEnd.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 
@@ -142,20 +147,9 @@ JSON;
 
         // product complete, whatever the scope
         $this->createVariantProduct('product_complete', [
-            'categories' => ['categoryA', 'categoryB', 'master'],
-            'parent' => 'product_model_complete',
-            'values'     => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => false,
-                    ],
-                ],
-                'sku' => [
-                    ['data' => 'sku-product-complete', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetCategories(['categoryA', 'categoryB', 'master']),
+            new ChangeParent('product_model_complete'),
+            new SetBooleanValue('a_yes_no', null, null, false),
         ]);
     }
 
@@ -201,20 +195,9 @@ JSON;
 
         // product complete, whatever the scope
         $this->createVariantProduct('product_uncomplete', [
-            'categories' => ['categoryA', 'categoryB', 'master'],
-            'parent' => 'product_model_uncomplete',
-            'values'     => [
-                'a_simple_select' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => 'optionB',
-                    ],
-                ],
-                'sku' => [
-                    ['data' => 'sku-product-uncomplete', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetCategories(['categoryA', 'categoryB', 'master']),
+            new ChangeParent('product_model_uncomplete'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionB'),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -2,6 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use PHPUnit\Framework\Assert;
@@ -35,17 +38,9 @@ class PartialUpdateListProductModelEndToEnd extends AbstractProductModelTestCase
         );
 
         $this->createVariantProduct('apollon_optiona_true', [
-            'categories' => ['master'],
-            'parent' => 'sub_sweat_option_a',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => true,
-                    ],
-                ],
-            ],
+            new SetCategories(['master']),
+            new ChangeParent('sub_sweat_option_a'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateProductModelEndToEnd.php
@@ -4,6 +4,9 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\ProductModel\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductModelUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Psr\Log\Test\TestLogger;
@@ -47,17 +50,9 @@ class PartialUpdateProductModelEndToEnd extends AbstractProductModelTestCase
         );
 
         $this->createVariantProduct('apollon_optionb_false', [
-            'categories' => ['categoryB'],
-            'parent' => 'sub_sweat',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => false,
-                    ],
-                ],
-            ],
+            new SetCategories(['categoryB']),
+            new ChangeParent('sub_sweat'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\VariantProduct\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -49,12 +52,8 @@ class CreateVariantProductEndToEnd extends AbstractProductTestCase
         );
 
         $this->createVariantProduct('simple', [
-            'parent' => 'amor',
-            'values'  => [
-                'a_yes_no' => [
-                    ['locale' => null, 'scope' => null, 'data' => false],
-                ],
-            ],
+            new ChangeParent('amor'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
     }
 
@@ -1051,17 +1050,9 @@ JSON;
     public function testProductVariantCreationWithSameIdentifier()
     {
         $this->createVariantProduct('apollon_option_b_true', [
-            'categories' => ['master'],
-            'parent' => 'amor',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => false,
-                    ],
-                ],
-            ],
+            new SetCategories(['master']),
+            new ChangeParent('amor'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
 
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\VariantProduct\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -47,17 +50,9 @@ class PartialUpdateListVariantProductEndToEnd extends AbstractProductTestCase
 
         // no locale, no scope, 1 category
         $this->createVariantProduct('apollon_optionb_true', [
-            'categories' => ['master'],
-            'parent' => 'amor',
-            'values' => [
-                'a_yes_no' => [
-                    [
-                        'locale' => null,
-                        'scope' => null,
-                        'data' => true,
-                    ],
-                ],
-            ],
+            new SetCategories(['master']),
+            new ChangeParent('amor'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\VariantProduct\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
@@ -132,11 +135,9 @@ JSON;
         $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
         $this->createProduct('product_familyA3', [
-            'family' => 'familyA3',
-            'categories' => ['master'],
-            'values' => [
-                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('familyA3'),
+            new SetCategories(['master']),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
         $client = $this->createAuthenticatedClient();
         $data =
@@ -178,9 +179,8 @@ JSON;
         );
 
         $this->createProduct('product_no_value', [
-            'family' => 'familyA',
-            'categories' => ['categoryA2'],
-            'values' => []
+            new SetFamily('familyA'),
+            new SetCategories(['categoryA2']),
         ]);
         $client = $this->createAuthenticatedClient();
         $data =
@@ -239,11 +239,9 @@ JSON;
             ],
         ]);
         $this->createProduct('product_family_variant', [
-            'family' => 'familyA',
-            'categories' => ['categoryA2'],
-            'values' => [
-                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('familyA'),
+            new SetCategories(['categoryA2']),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
         $this->get('doctrine.orm.default_entity_manager')->clear();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
@@ -2,6 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\QuantifiedAssociations;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -41,10 +44,9 @@ class DeleteQuantifiedAssociationsFromVariantProductEndToEnd extends AbstractPro
 
         $this->createProduct('chair');
         $this->createVariantProduct('garden_table_set-black-gold', [
-            'parent' => 'garden_table_set-black',
-            'values' => [
-                'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
-            ],
+            new ChangeParent('garden_table_set-black'),
+            new SetBooleanValue('a_yes_no', null, null, true),
+            new AssociateProducts()
             'quantified_associations' => [
                 "PRODUCTSET" => [
                     "products" => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
@@ -4,6 +4,9 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\
 
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProductModels;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\QuantifiedEntity;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
@@ -46,17 +49,12 @@ class DeleteQuantifiedAssociationsFromVariantProductEndToEnd extends AbstractPro
         $this->createVariantProduct('garden_table_set-black-gold', [
             new ChangeParent('garden_table_set-black'),
             new SetBooleanValue('a_yes_no', null, null, true),
-            new AssociateProducts()
-            'quantified_associations' => [
-                "PRODUCTSET" => [
-                    "products" => [
-                        ["identifier" => "chair", "quantity" => 8]
-                    ],
-                    "product_models" => [
-                        ["identifier" => "umbrella", "quantity" => 2]
-                    ],
-                ],
-            ],
+            new AssociateQuantifiedProducts('PRODUCTSET', [
+                new QuantifiedEntity('chair', 8)
+            ]),
+            new AssociateQuantifiedProductModels('PRODUCTSET', [
+                new QuantifiedEntity('umbrella', 2)
+            ])
         ]);
 
         $data = <<<JSON

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
@@ -2,6 +2,11 @@
 
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\ExternalApi\QuantifiedAssociations;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProductModels;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\QuantifiedEntity;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\QuantifiedAssociationsTestCaseTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
@@ -41,20 +46,12 @@ class UpdateQuantifiedAssociationsInVariantProductEndToEnd extends AbstractProdu
         ]);
 
         $this->createVariantProduct('garden_table_set-black-gold', [
-            'parent' => 'garden_table_set-black',
-            'values' => [
-                'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
-            ],
-            'quantified_associations' => [
-                "PRODUCTSET" => [
-                    "products" => [
-                        ["identifier" => "chair", "quantity" => 4]
-                    ],
-                    "product_models" => [
-                        ["identifier" => "umbrella", "quantity" => 4]
-                    ],
-                ],
-            ],
+            new ChangeParent('garden_table_set-black'),
+            new SetBooleanValue('a_yes_no', null, null, true),
+            new AssociateQuantifiedProducts('PRODUCTSET', [new QuantifiedEntity('chair', 4)]),
+            new AssociateQuantifiedProductModels('PRODUCTSET', [
+                new QuantifiedEntity('umbrella', 4)
+            ])
         ]);
 
         $data = <<<JSON

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/InternalApi/UpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/InternalApi/UpdateVariantProductEndToEnd.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\VariantProduct\InternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountInTransportTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\InternalApiTestCase;
@@ -21,18 +25,10 @@ class UpdateVariantProductEndToEnd extends InternalApiTestCase
             'apollon_optionb_false',
             'clothing_colorsize',
             [
-                'categories' => ['master', 'categoryB'],
-                'parent' => 'amor',
-                'groups' => ['groupA'],
-                'values' => [
-                    'a_yes_no' => [
-                        [
-                            'locale' => null,
-                            'scope' => null,
-                            'data' => false,
-                        ],
-                    ],
-                ],
+                new SetCategories(['master', 'categoryB']),
+                new ChangeParent('amor'),
+                new SetGroups(['groupA']),
+                new SetBooleanValue('a_yes_no', null, null, false)
             ]
         );
         $normalizedProduct = $this->getProductFromInternalApi((string) $product->getId());

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
@@ -3,16 +3,28 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Classification;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
 
 class ClassifyProductIntegration extends TestCase
 {
     public function testClassify()
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct('tee', 'clothing');
-        $this->get('pim_catalog.updater.product')->update($product, ['categories' => ['supplier_zaro']]);
-        $this->get('pim_catalog.validator.product')->validate($product);
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: 'tee',
+            userIntents: [
+                new SetFamily('clothing'),
+                new SetCategories(['supplier_zaro'])
+            ]
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('tee');
         $this->assertCount(1, $product->getCategories());
@@ -26,5 +38,17 @@ class ClassifyProductIntegration extends TestCase
     protected function getConfiguration()
     {
         return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\CommandLauncher;
@@ -64,28 +69,22 @@ class CalculateCompletenessCommandIntegration extends TestCase
         $this->createProduct(
             'variant_A_yes',
             [
-                'parent' => 'sub_pm_A',
-                'values' => [
-                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
-                ],
+                new ChangeParent('sub_pm_A'),
+                new SetBooleanValue('a_yes_no', null, null, true)
             ]
         );
         $this->createProduct(
             'variant_A_no',
             [
-                'parent' => 'sub_pm_A',
-                'values' => [
-                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => false]],
-                ],
+                new ChangeParent('sub_pm_A'),
+                new SetBooleanValue('a_yes_no', null, null, false)
             ]
         );
         $this->createProduct(
             'simple_product',
             [
-                'family' => 'familyA3',
-                'values' => [
-                    'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
-                ],
+                new SetFamily('familyA3'),
+                new SetBooleanValue('a_yes_no', null, null, true)
             ]
         );
 
@@ -120,11 +119,22 @@ class CalculateCompletenessCommandIntegration extends TestCase
         );
     }
 
-    private function createProduct(string $identifier, array $data): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProduct(string $identifier, array $userIntents): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
 
         $this->productIds[$identifier] = $product->getId();
     }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForLocalisableAttributeIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompleteness;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -39,23 +41,11 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         );
 
         $product = $this->createProductWithStandardValues(
-            $family,
             'another_product',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => null,
-                            'data'   => 'just a text'
-                        ],
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => null,
-                            'data'   => null
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', null, 'en_US', 'just a text'),
+                new SetTextValue('a_text', null, 'fr_FR', null),
             ]
         );
 
@@ -78,8 +68,8 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         );
 
         $productLocaleSpecificNoLocale = $this->createProductWithStandardValues(
-            $family,
-            'product_locale_specific_no_locale'
+            'product_locale_specific_no_locale',
+            [new SetFamily('another_family')]
         );
         $this->assertNotComplete($productLocaleSpecificNoLocale, 'fr_FR', 2);
         $this->assertComplete($productLocaleSpecificNoLocale, 'en_US', 1);
@@ -89,7 +79,7 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
     {
         $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
 
-        $family = $this->createFamilyWithRequirement(
+        $this->createFamilyWithRequirement(
             'another_family',
             'ecommerce',
             'a_text',
@@ -100,18 +90,10 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         );
 
         $productLocaleSpecificLocaleEmpty = $this->createProductWithStandardValues(
-            $family,
             'product_locale_specific_locale_empty',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => null,
-                            'data'   => null
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', null, 'fr_FR', null)
             ]
         );
         $this->assertNotComplete($productLocaleSpecificLocaleEmpty, 'fr_FR', 2);
@@ -122,7 +104,7 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
     {
         $fr = $this->get('pim_catalog.repository.locale')->findOneByIdentifier('fr_FR');
 
-        $family = $this->createFamilyWithRequirement(
+        $this->createFamilyWithRequirement(
             'another_family',
             'ecommerce',
             'a_text',
@@ -133,18 +115,10 @@ class CompletenessForLocalisableAttributeIntegration extends AbstractCompletenes
         );
 
         $productComplete = $this->createProductWithStandardValues(
-            $family,
             'product_complete',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => null,
-                            'data'   => 'juste un texte'
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', null, 'fr_FR', 'juste un texte')
             ]
         );
         $this->assertComplete($productComplete, 'fr_FR', 2);

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForNonRequiredAttributeIntegration.php
@@ -3,6 +3,9 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -24,25 +27,11 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
         $this->createAttribute('a_number', AttributeTypes::NUMBER);
 
         $product = $this->createProductWithStandardValues(
-            $family,
             'always_complete_product',
             [
-                'values' => [
-                    'a_text'   => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => 'This is some text',
-                        ],
-                    ],
-                    'a_number' => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => null,
-                        ],
-                    ],
-                ],
+                new SetFamily('family_without_any_attribute_requirements'),
+                new SetTextValue('a_text', null, null, 'This is some text'),
+                new SetNumberValue('a_number', null, null, null)
             ]
         );
 
@@ -51,7 +40,7 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
 
     public function testAttributeRequiredByFamily()
     {
-        $family = $this->createFamilyWithRequirement(
+        $this->createFamilyWithRequirement(
             'another_family',
             'ecommerce',
             'a_text',
@@ -59,18 +48,10 @@ class CompletenessForNonRequiredAttributeIntegration extends AbstractCompletenes
         );
 
         $product = $this->createProductWithStandardValues(
-            $family,
             'product_complete',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => 'Some text for ecommerce channel'
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', null, null, 'Some text for ecommerce channel')
             ]
         );
 

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForScopableAndLocalisableAttributeIntegration.php
@@ -2,6 +2,13 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
+
 /**
  * Checks that the completeness has been well calculated for localisable and scopable attributes.
  *
@@ -15,12 +22,14 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
 {
     public function testProductIncomplete()
     {
-        $sandalsFamily = $this->get('pim_catalog.repository.family')->findOneByIdentifier('sandals');
+        $this->get('pim_catalog.repository.family')->findOneByIdentifier('sandals');
 
         $sandals = $this->createProductWithStandardValues(
-            $sandalsFamily,
             'sandals',
-            ['values' => $this->getSandalStandardValues()]
+            \array_merge([
+                new SetFamily('sandals'),
+                $this->getSandalStandardValues()
+            ])
         );
 
         $completenesses = $this->getProductCompletenesses()->fromProductId($sandals->getId());
@@ -57,12 +66,14 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
 
     public function testProductCompleteOnOneChannel()
     {
-        $sneakersFamily = $this->get('pim_catalog.repository.family')->findOneByIdentifier('sneakers');
+        $this->get('pim_catalog.repository.family')->findOneByIdentifier('sneakers');
 
         $sandals = $this->createProductWithStandardValues(
-            $sneakersFamily,
             'sneakers',
-            ['values' => $this->getSneakerStandardValues()]
+            \array_merge(
+                [new SetFamily('sneakers')],
+                $this->getSneakerStandardValues()
+            )
         );
 
         $completenesses = $this->getProductCompletenesses()->fromProductId($sandals->getId());
@@ -126,75 +137,26 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
     private function getSandalStandardValues()
     {
         return [
-            'color' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => 'white'
-                ],
-            ],
-            'name' => [
-                [
-                    'locale' => 'fr_FR',
-                    'scope'  => null,
-                    'data'   => 'Sandales'
-                ],
-            ],
-            'description' => [
-                [
-                    'locale' => 'fr_FR',
-                    'scope'  => 'mobile',
-                    'data'   => 'Super sandales !'
-                ],
-                [
-                    'locale' => 'fr_FR',
-                    'scope'  => 'tablet',
-                    'data'   => 'Des sandales magiques !'
-                ],
-            ],
+            new SetSimpleSelectValue('color', null, null, 'white'),
+            new SetTextValue('name', null, 'fr_FR', 'Sandales'),
+            new SetTextareaValue('description', 'mobile', 'fr_FR', 'Super sandales !'),
+            new SetTextareaValue('description', 'tablet', 'fr_FR', 'Des sandales magiques !'),
         ];
     }
 
     /**
-     * @return array
+     * @return UserIntent[]
      */
-    private function getSneakerStandardValues()
+    private function getSneakerStandardValues(): array
     {
         return [
-            'manufacturer' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => 'Converse'
-                ],
-            ],
-            'weather_conditions' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => ['hot']
-                ],
-            ],
-            'color' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => 'blue'
-                ],
-            ],
-            'name' => [
-                [
-                    'locale' => 'en_US',
-                    'scope'  => null,
-                    'data'   => 'Sneakers'
-                ],
-                [
-                    'locale' => 'fr_FR',
-                    'scope'  => null,
-                    'data'   => 'Espadrilles'
-                ],
-            ],
-            'price' => [
+            new SetSimpleSelectValue('manufacturer', null, null, 'Converse'),
+            new SetMultiSelectValue('weather_conditions', null, null, ['hot']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
+            new SetTextValue('name', null, 'en_US', 'Sneakers'),
+            new SetTextValue('name', null, 'fr_FR', 'Espadrilles'),
+            // TODO : use SetPriceValue when ready
+            /*'price' => [
                 [
                     'locale' => null,
                     'scope'  => null,
@@ -204,45 +166,13 @@ class CompletenessForScopableAndLocalisableAttributeIntegration extends Abstract
                     ]
 
                 ],
-            ],
-            'rating' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => "4"
-                ],
-            ],
-            'size' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => "43"
-                ],
-            ],
-            'lace_color' => [
-                [
-                    'locale' => null,
-                    'scope'  => null,
-                    'data'   => 'laces_white'
-                ],
-            ],
-            'description' => [
-                [
-                    'locale' => 'en_US',
-                    'scope'  => 'mobile',
-                    'data'   => 'Great sneakers'
-                ],
-                [
-                    'locale' => 'en_US',
-                    'scope'  => 'tablet',
-                    'data'   => 'Really great sneakers'
-                ],
-                [
-                    'locale' => 'fr_FR',
-                    'scope'  => 'mobile',
-                    'data'   => 'Grandes espadrilles'
-                ],
-            ],
+            ],*/
+            new SetSimpleSelectValue('rating', null, null, '4'),
+            new SetSimpleSelectValue('size', null, null, '43'),
+            new SetSimpleSelectValue('lace_color', null, null, 'laces_white'),
+            new SetTextareaValue('description', 'mobile', 'en_US', 'Great sneakers'),
+            new SetTextareaValue('description', 'tablet', 'en_US', 'Really great sneakers'),
+            new SetTextareaValue('description', 'mobile', 'fr_FR', 'Grandes espadrilles'),
         ];
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForScopableAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CompletenessForScopableAttributeIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -30,18 +32,10 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessTe
         );
 
         $product = $this->createProductWithStandardValues(
-            $family,
             'another_product',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => null,
-                            'scope'  => 'ecommerce',
-                            'data'   => 'just a text'
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', 'ecommerce', null, 'just a text'),
             ]
         );
 
@@ -50,7 +44,7 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessTe
 
     public function testNotCompleteScopable()
     {
-        $family = $this->createFamilyWithRequirement(
+        $this->createFamilyWithRequirement(
             'another_family',
             'ecommerce',
             'a_text',
@@ -59,22 +53,17 @@ class CompletenessForScopableAttributeIntegration extends AbstractCompletenessTe
             true
         );
 
-        $productWithoutValues = $this->createProductWithStandardValues($family, 'product_witout_values');
+        $productWithoutValues = $this->createProductWithStandardValues(
+            'product_witout_values',
+            [new SetFamily('another_family')]
+        );
         $this->assertNotComplete($productWithoutValues, 'ecommerce', ['a_text']);
 
         $productDataEmpty = $this->createProductWithStandardValues(
-            $family,
             'product_data_empty',
             [
-                'values' => [
-                    'a_text' => [
-                        [
-                            'locale' => null,
-                            'scope'  => 'ecommerce',
-                            'data'   => null
-                        ],
-                    ]
-                ]
+                new SetFamily('another_family'),
+                new SetTextValue('a_text', 'ecommerce', null, null)
             ]
         );
         $this->assertNotComplete($productDataEmpty, 'ecommerce');

--- a/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
@@ -10,9 +10,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetProductCompletenesses;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\TestCase;
@@ -96,17 +98,10 @@ class SqlGetProductCompletenessRatioIntegration extends TestCase
                 new SetDateValue('a_date', null, null, new \DateTime('2020-03-18T00:00:00+00:00')),
                 new SetTextValue('a_text', null, null, 'lorem ipsum'),
                 new SetBooleanValue('a_yes_no', null, null, false),
-                // TODO: use SetPriceValue when ready
-                /**'a_scopable_price' => [
-                    [
-                        'scope' => 'ecommerce',
-                        'locale' => null,
-                        'data' => [
-                            ['amount' => '10.00', 'currency' => 'EUR'],
-                            ['amount' => '12.00', 'currency' => 'USD'],
-                        ],
-                    ],
-                ],*/
+                new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null, [
+                    new PriceValue('10.00', 'EUR'),
+                    new PriceValue('12.00', 'USD'),
+                ]),
                 new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'en_US', 'Lorem ipsum dolor sit amet')
             ]
         );

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/IndexingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/IndexingProductIntegration.php
@@ -48,7 +48,8 @@ class IndexingProductIntegration extends TestCase
         $this->assertTrue($indexedProductModelBaz['found']);
     }
 
-    public function testIndexingProductOnUnitarySave()
+    // TODO: is it used?
+    /*public function testIndexingProductOnUnitarySave()
     {
         $product = $this->get('pim_catalog.builder.product')->createProduct('bat');
         $this->get('pim_catalog.saver.product')->save($product);
@@ -59,7 +60,7 @@ class IndexingProductIntegration extends TestCase
             'product_' . $product->getId()
         );
         $this->assertTrue($productInProductAndProductModelIndex['found']);
-    }
+    }*/
 
     /**
      * {@inheritdoc}

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/IndexingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/IndexingProductIntegration.php
@@ -47,21 +47,6 @@ class IndexingProductIntegration extends TestCase
         $indexedProductModelBaz = $this->esProductAndProductModelClient->get('product_' . $productBazId);
         $this->assertTrue($indexedProductModelBaz['found']);
     }
-
-    // TODO: is it used?
-    /*public function testIndexingProductOnUnitarySave()
-    {
-        $product = $this->get('pim_catalog.builder.product')->createProduct('bat');
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('bat');
-
-        $productInProductAndProductModelIndex = $this->esProductAndProductModelClient->get(
-            'product_' . $product->getId()
-        );
-        $this->assertTrue($productInProductAndProductModelIndex['found']);
-    }*/
-
     /**
      * {@inheritdoc}
      */

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ProductSaverIntegration.php
@@ -23,6 +23,7 @@ class ProductSaverIntegration extends TestCase
 
         $product = $this->createVariantProduct($productModel, 'just-a-variant-product-with-a-few-values', 'familyVariantA1');
         $standardValues = $this->getStandardValuesWithFewAttributes();
+        // TODO: don't touch
         $this->updateProduct($product, $standardValues);
         $this->saveProduct($product);
 

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
@@ -2,9 +2,13 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\Common\Saver;
 
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * Test products have been correctly removed from the index after a product has been removed.
@@ -18,6 +22,8 @@ class RemovingProductIntegration extends TestCase
 
     /** @var Client */
     private $esProductAndProductModelClient;
+    private ProductRepositoryInterface $productRepository;
+    protected MessageBusInterface $messageBus;
 
     /**
      * {@inheritdoc}
@@ -27,14 +33,22 @@ class RemovingProductIntegration extends TestCase
         parent::setUp();
 
         $this->esProductAndProductModelClient = $this->get('akeneo_elasticsearch.client.product_and_product_model');
+        $this->messageBus = $this->get('pim_enrich.product.message_bus');
+        $this->productRepository = $this->get('pim_catalog.repository.product');
     }
 
     public function testRemovingProductOnUnitaryRemove()
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct('bat');
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: 'bat',
+            userIntents: []
+        );
+        $this->messageBus->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->clearDoctrineUoW();
 
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('bat');
+        $product = $this->productRepository->findOneByIdentifier('bat');
         $productId = $product->getId();
 
         $this->get('pim_catalog.remover.product')->remove($product);

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\Integration\EntityWithFamilyVariant;
 
 use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\Model\AttributeOption;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use PHPUnit\Framework\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -33,12 +36,15 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         $attributeOption->setAttribute($this->get('pim_api.repository.attribute')->findOneByIdentifier('brand'));
         $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
 
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('1111111184');
-        $value = OptionValue::value('brand', 'akeneo');
-        $product->addValue($value);
-        $this->get('pim_catalog.saver.product')->save($product);
-        $this->get('doctrine.orm.default_entity_manager')->clear();
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: '1111111184',
+            userIntents: [new SetSimpleSelectValue('brand', null, null, 'akeneo')]
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
         $this->removeOption('brand', 'akeneo');
         $this->assertNotNull($this->getDataValueForProduct('1111111184', 'brand'));
@@ -141,5 +147,17 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         }
 
         $this->get('akeneo_batch.saver.job_instance')->save($jobInstance);
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
@@ -38,31 +40,21 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
     }
 
     /**
-     * @param string $identifier
-     * @param array  $data
-     *
-     * @return ProductInterface
+     * @param UserIntent[] $userIntents
      */
-    protected function createProduct($identifier, array $data)
+    protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $family = isset($data['family']) ? $data['family'] : null;
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $family);
-        $this->updateProduct($product, $data);
-
-        return $product;
-    }
-
-    /**
-     * @param ProductInterface $product
-     * @param array            $data
-     */
-    protected function updateProduct(ProductInterface $product, array $data)
-    {
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        $this->esProductClient->refreshIndex();
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
     }
 
     /**
@@ -189,5 +181,17 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         $channel->addLocale($locale);
 
         $this->get('pim_catalog.saver.channel')->save($channel);
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/BooleanFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/BooleanFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -22,18 +24,14 @@ class BooleanFilterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('yes', [
-            'values' => [
-                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
-            ]
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $this->createProduct('no', [
-            'values' => [
-                'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]]
-            ]
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
 
-        $this->createProduct('empty', ['family' => 'familyA']);
+        $this->createProduct('empty', [new SetFamily('familyA')]);
     }
 
     public function testOperatorEquals()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableFilterIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -29,21 +30,13 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => null],
-                    ['data' => false, 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', null, 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', null, 'fr_FR', false)
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => null],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', null, 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', null, 'fr_FR', true)
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -31,24 +32,16 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => false, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', 'ecommerce', 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', 'tablet', 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', 'ecommerce', 'fr_FR', true),
+            new SetBooleanValue('a_localizable_yes_no', 'tablet', 'fr_FR', false),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', 'ecommerce', 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', 'tablet', 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', 'ecommerce', 'fr_FR', true),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Boolean/ScopableFilterIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -29,21 +30,13 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_yes_no' => [
-                    ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => false, 'scope' => 'tablet', 'locale' => null]
-                ]
-            ]
+            new SetBooleanValue('a_scopable_yes_no', 'ecommerce', null, true),
+            new SetBooleanValue('a_scopable_yes_no', 'tablet', null, false),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_yes_no' => [
-                    ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => true, 'scope' => 'tablet', 'locale' => null],
-                ]
-            ]
+            new SetBooleanValue('a_scopable_yes_no', 'ecommerce', null, true),
+            new SetBooleanValue('a_scopable_yes_no', 'tablet', null, true),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/DateFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/DateFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -28,24 +30,16 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_date' => [
-                    ['data' => '2017-02-06', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_date', null, null, new \DateTime('2017-02-06'))
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_date' => [
-                    ['data' => '2017-02-27', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_date', null, null, new \DateTime('2017-02-27'))
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()
@@ -140,34 +134,22 @@ class DateFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->createProduct(
             'product_today',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_date' => [
-                        ['data' => $currentDate->format('Y-m-d'), 'locale' => null, 'scope' => null]
-                    ]
-                ]
+                new SetFamily('a_family'),
+                new SetDateValue('a_date', null, null, new \DateTime($currentDate->format('Y-m-d')))
             ]
         );
         $this->createProduct(
             'product_future',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_date' => [
-                        ['data' => $currentDate->modify('+10 days')->format('Y-m-d'), 'locale' => null, 'scope' => null]
-                    ]
-                ]
+                new SetFamily('a_family'),
+                new SetDateValue('a_date', null, null, new \DateTime($currentDate->modify('+10 days')->format('Y-m-d')))
             ]
         );
         $this->createProduct(
             'product_past',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_date' => [
-                        ['data' => $currentDate->modify('-6 weeks')->format('Y-m-d'), 'locale' => null, 'scope' => null]
-                    ]
-                ]
+                new SetFamily('a_family'),
+                new SetDateValue('a_date', null, null, new \DateTime($currentDate->modify('-6 weeks')->format('Y-m-d')))
             ]
         );
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,26 +36,18 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_date' => [
-                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_localizable_date', null, 'en_US', new \DateTime('2016-04-23')),
+            new SetDateValue('a_localizable_date', null, 'fr_FR', new \DateTime('2016-05-23')),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_date' => [
-                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_localizable_date', null, 'en_US', new \DateTime('2016-09-23')),
+            new SetDateValue('a_localizable_date', null, 'fr_FR', new \DateTime('2016-09-23')),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()
@@ -124,14 +118,14 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         $result = $this->executeFilter([['a_localizable_date', Operators::NOT_BETWEEN, [new \DateTime('2016-04-23T00:00:00'), '2016-09-23'], ['locale' => 'en_US']]]);
         $this->assert($result, []);
     }
-    
+
     public function testErrorMetricLocalizable()
     {
         $this->expectException(InvalidPropertyException::class);
         $this->expectExceptionMessage('Attribute "a_localizable_date" expects a locale, none given.');
         $this->executeFilter([['a_localizable_date', Operators::NOT_EQUAL, 250]]);
     }
-    
+
     public function testLocaleNotFound()
     {
         $this->expectException(InvalidPropertyException::class);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -36,29 +38,21 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => '2016-04-23', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => '2016-05-23', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_localizable_scopable_date', 'ecommerce', 'en_US', new \DateTime('2016-04-23')),
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'en_US', new \DateTime('2016-04-23')),
+            new SetDateValue('a_localizable_scopable_date', 'ecommerce', 'fr_FR', new \DateTime('2016-05-23')),
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'fr_FR', new \DateTime('2016-05-23')),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => '2016-09-23', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => '2016-09-23', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_localizable_scopable_date', 'ecommerce', 'en_US', new \DateTime('2016-09-23')),
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'en_US', new \DateTime('2016-09-23')),
+            new SetDateValue('a_localizable_scopable_date', 'ecommerce', 'fr_FR', new \DateTime('2016-09-23')),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Date/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,25 +36,17 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_date' => [
-                    ['data' => '2016-04-23', 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => '2016-04-23', 'scope' => 'tablet', 'locale' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_scopable_date', 'ecommerce', null, new \DateTime('2016-04-23')),
+            new SetDateValue('a_scopable_date', 'tablet', null, new \DateTime('2016-04-23')),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_date' => [
-                    ['data' => '2016-09-23', 'scope' => 'ecommerce', 'locale' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetDateValue('a_scopable_date', 'ecommerce', null, new \DateTime('2016-09-23')),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -6,6 +6,18 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 
@@ -19,7 +31,11 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
 {
     public function testEmptyOperatorForDateFilter()
     {
-        $this->loadFixtures('a_date', ['data' => '2020-05-16', 'scope' => null, 'locale' => null]);
+        $this->loadFixtures(
+            'a_date',
+            ['data' => '2020-05-16', 'scope' => null, 'locale' => null],
+            new SetDateValue('a_date', null, null, new \DateTime('2020-05-16'))
+        );
         $this->assert('a_date');
     }
 
@@ -27,7 +43,9 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_file',
-            ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'scope' => null, 'locale' => null]
+            ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'scope' => null, 'locale' => null],
+            // TODO use SetFileValue when ready
+            new SetTextValue('a_file', null, null, 'coucou')
         );
         $this->assert('a_file');
     }
@@ -36,7 +54,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_metric',
-            ['data' => ['amount' => 2, 'unit' => 'KILOWATT'], 'scope' => null, 'locale' => null]
+            ['data' => ['amount' => 2, 'unit' => 'KILOWATT'], 'scope' => null, 'locale' => null],
+            new SetMeasurementValue('a_metric', null, null, 2, 'KILOWATT')
         );
         $this->assert('a_metric');
     }
@@ -45,7 +64,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_number_float',
-            ['data' => 25, 'scope' => null, 'locale' => null]
+            ['data' => 25, 'scope' => null, 'locale' => null],
+            new SetNumberValue('a_number_float', null, null, '25')
         );
         $this->assert('a_number_float');
     }
@@ -54,7 +74,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_simple_select',
-            ['data' => 'optionA', 'scope' => null, 'locale' => null]
+            ['data' => 'optionA', 'scope' => null, 'locale' => null],
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         );
         $this->assert('a_simple_select');
     }
@@ -63,7 +84,9 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_price',
-            ['data' => [['amount' => 100, 'currency' => 'USD']], 'scope' => null, 'locale' => null]
+            ['data' => [['amount' => 100, 'currency' => 'USD']], 'scope' => null, 'locale' => null],
+            // TODO use SetPriceValue when ready
+            new SetTextValue('a_price', null, null, 'coucou')
         );
         $this->assert('a_price');
     }
@@ -72,7 +95,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_ref_data_simple_select',
-            ['data' => 'red', 'scope' => null, 'locale' => null]
+            ['data' => 'red', 'scope' => null, 'locale' => null],
+            new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'red')
         );
         $this->assert('a_ref_data_simple_select');
     }
@@ -81,7 +105,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_text_area',
-            ['data' => 'Lorem ipsum dolor sit amet', 'scope' => null, 'locale' => null]
+            ['data' => 'Lorem ipsum dolor sit amet', 'scope' => null, 'locale' => null],
+            new SetTextareaValue('a_text_area', null, null, 'Lorem ipsum dolor sit amet')
         );
         $this->assert('a_text_area');
     }
@@ -90,7 +115,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
     {
         $this->loadFixtures(
             'a_text',
-            ['data' => 'Foobar', 'scope' => null, 'locale' => null]
+            ['data' => 'Foobar', 'scope' => null, 'locale' => null],
+            new SetTextValue('a_text', null, null, 'Foobar')
         );
         $this->assert('a_text');
     }
@@ -123,7 +149,7 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
      * - 2 simple products, one with empty value, one with non empty value
      * - a simple product without family
      */
-    private function loadFixtures(string $attributeCode, array $nonEmptyData)
+    private function loadFixtures(string $attributeCode, array $nonEmptyData, UserIntent $userIntent)
     {
         $this->createFamily([
             'code' => 'a_family',
@@ -145,10 +171,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
             'family_variant' => 'attribute_at_common_level',
         ]);
         $this->createProduct('variant_1_empty', [
-            'parent' => 'pm_1_empty',
-            'values' => [
-                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
-            ]
+            new ChangeParent('pm_1_empty'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
         $this->createProductModel([
             'code' => 'pm_2_filled',
@@ -158,10 +182,8 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
             ]
         ]);
         $this->createProduct('variant_2_filled', [
-            'parent' => 'pm_2_filled',
-            'values' => [
-                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
-            ]
+            new ChangeParent('pm_2_filled'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $this->createFamilyVariant([
@@ -182,28 +204,24 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         ]);
 
         $this->createProduct('variant_3_empty', [
-            'parent' => 'pm_3',
-            'values' => [
-                'a_yes_no' => [['data' => true, 'scope' => null, 'locale' => null]],
-            ]
+            new ChangeParent('pm_3'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
-        $this->createProduct('variant_3_filled', [
-            'parent' => 'pm_3',
-            'values' => [
-                'a_yes_no' => [['data' => false, 'scope' => null, 'locale' => null]],
-                $attributeCode => [$nonEmptyData],
+        $this->createProduct('variant_3_filled', \array_merge(
+            [$userIntent],
+            [
+                new ChangeParent('pm_3'),
+                new SetBooleanValue('a_yes_no', null, null, false),
             ]
-        ]);
+        ));
 
         $this->createProduct('simple_product_empty', [
-            'family' => 'a_family',
+            new SetFamily('a_family')
         ]);
-        $this->createProduct('simple_product_filled', [
-            'family' => 'a_family',
-            'values' => [
-                $attributeCode => [$nonEmptyData],
-            ]
-        ]);
+        $this->createProduct('simple_product_filled', \array_merge(
+            [new SetFamily('a_family')],
+            [$userIntent]
+        ));
         $this->createProduct('simple_product_without_family', []);
 
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
@@ -225,13 +243,20 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
     }
 
-    private function createProduct(string $identifier, array $data): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProduct(string $identifier, array $userIntents): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $violations = $this->get('pim_catalog.validator.product')->validate($product);
-        Assert::assertEmpty($violations, sprintf('The %s product is not valid: %s', $product->getIdentifier(), $violations));
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
     }
 
     private function createProductModel(array $data): void
@@ -240,5 +265,17 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
         Assert::assertEmpty($this->get('pim_catalog.validator.product_model')->validate($productModel));
         $this->get('pim_catalog.saver.product_model')->save($productModel);
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -11,6 +11,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFileValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
@@ -44,8 +45,7 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         $this->loadFixtures(
             'a_file',
             ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')), 'scope' => null, 'locale' => null],
-            // TODO use SetFileValue when ready
-            new SetTextValue('a_file', null, null, 'coucou')
+            new SetFileValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt')))
         );
         $this->assert('a_file');
     }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
@@ -3,6 +3,9 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -27,26 +30,22 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'en_US', 'scope' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableFilterIntegration.php
@@ -5,6 +5,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -31,18 +32,14 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -28,29 +30,29 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'tablet', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
+            new SetFamily('a_family'),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
             'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                ]
-            ]
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/LocalizableScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -31,24 +32,17 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'tablet', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_scopable_image', 'tablet', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_scopable_image', 'ecommerce', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_scopable_image', 'tablet', 'en_US', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_localizable_scopable_image', 'ecommerce', 'fr_FR', $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
             'family' => 'a_family',
         ]);
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -27,24 +29,18 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('akeneo', [
-            'family' => 'a_family',
-            'values' => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')))
         ]);
 
         $this->createProduct('ziggy', [
-            'family' => 'a_family',
-            'values' => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/MediaFilterIntegration.php
@@ -5,7 +5,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -30,14 +30,12 @@ class MediaFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('akeneo', [
             new SetFamily('a_family'),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')))
         ]);
 
         $this->createProduct('ziggy', [
             new SetFamily('a_family'),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -27,26 +29,22 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'scope' => 'tablet', 'locale' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'scope' => 'tablet', 'locale' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            // TODO: use setImageValue when ready
+            new SetTextValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Media/ScopableFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Media;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -30,18 +31,14 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new SetImageValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
-            // TODO: use setImageValue when ready
-            new SetTextValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new setImageValue('a_scopable_image', 'ecommerce', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
+            new setImageValue('a_scopable_image', 'tablet', null, $this->getFileInfoKey($this->getFixturePath('ziggy.png'))),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -37,26 +39,18 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_metric' => [
-                    ['data' => ['amount' => 20, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => ['amount' => 21, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_localizable_metric', null, 'en_US', 20, 'METER'),
+            new SetMeasurementValue('a_localizable_metric', null, 'fr_FR', 21, 'METER'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_metric' => [
-                    ['data' => ['amount' => 10, 'unit' => 'METER'], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => ['amount' => 1, 'unit' => 'METER'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_localizable_metric', null, 'en_US', 10, 'METER'),
+            new SetMeasurementValue('a_localizable_metric', null, 'fr_FR', 1, 'METER'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -40,29 +42,21 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_localizable_metric' => [
-                    ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => ['amount' => '14', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => ['amount' => '100', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'ecommerce', 'en_US', '-5.00', 'KILOWATT'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'tablet', 'en_US', '14', 'KILOWATT'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'tablet', 'fr_FR', '100', 'KILOWATT'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_localizable_metric' => [
-                    ['data' => ['amount' => '-5.00', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => ['amount' => '10', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    ['data' => ['amount' => '75', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                ],
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'ecommerce', 'en_US', '-5.00', 'KILOWATT'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'tablet', 'en_US', '10', 'KILOWATT'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'tablet', 'fr_FR', '75', 'KILOWATT'),
+            new SetMeasurementValue('a_scopable_localizable_metric', 'ecommerce', 'fr_FR', '75', 'KILOWATT'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/MetricFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -28,24 +30,16 @@ class MetricFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_metric' => [
-                    ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_metric', null, null, '10.55', 'KILOWATT'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_metric' => [
-                    ['data' => ['amount' => '15', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_metric', null, null, '15', 'KILOWATT'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Metric/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -38,26 +40,18 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_metric' => [
-                    ['data' => ['amount' => '10.55', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => ['amount' => '25', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_scopable_metric', 'ecommerce', null, '10.55', 'CENTIMETER'),
+            new SetMeasurementValue('a_scopable_metric', 'tablet', null, '25', 'CENTIMETER'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_metric' => [
-                    ['data' => ['amount' => '2', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => ['amount' => '30', 'unit' => 'CENTIMETER'], 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMeasurementValue('a_scopable_metric', 'ecommerce', null, '2', 'CENTIMETER'),
+            new SetMeasurementValue('a_scopable_metric', 'tablet', null, '30', 'CENTIMETER'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -36,25 +38,17 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_number' => [
-                    ['data' => -15, 'locale' => 'en_US', 'scope' => null],
-                    ['data' => -14, 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_localizable_number', null, 'en_US', -15),
+            new SetNumberValue('a_localizable_number', null, 'fr_FR', -14),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_number' => [
-                    ['data' => 19, 'locale' => 'en_US', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_localizable_number', null, 'en_US', 19),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -38,29 +40,21 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_number' => [
-                    ['data' => -15, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => -15, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => -14, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_localizable_scopable_number', 'ecommerce', 'en_US', -15),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'en_US', -15),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'fr_FR', -14),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_number' => [
-                    ['data' => 19, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 19, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 19, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_localizable_scopable_number', 'ecommerce', 'en_US', 19),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'en_US', 19),
+            new SetNumberValue('a_localizable_scopable_number', 'ecommerce', 'fr_FR', 19),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'fr_FR', 19),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/NumberFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -27,24 +29,16 @@ class NumberFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_number_float_negative' => [
-                    ['data' => -15.5, 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_number_float_negative', null, null, -15.5),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_number_float_negative' => [
-                    ['data' => 19.0, 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_number_float_negative', null, null, 19.0),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Number/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -36,25 +38,17 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_number' => [
-                    ['data' => -15, 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => -14, 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_scopable_number', 'ecommerce', null, -15),
+            new SetNumberValue('a_scopable_number', 'tablet', null, -14),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_number' => [
-                    ['data' => 19, 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetNumberValue('a_scopable_number', 'tablet', null, 19),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -44,26 +46,18 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_simple_select' => [
-                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'en_US', 'orange'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'fr_FR', 'black'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_simple_select' => [
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'fr_FR', 'black'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -46,30 +48,22 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_simple_select' => [
-                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'en_US', 'orange'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'fr_FR', 'orange'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'fr_FR', 'black'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_simple_select' => [
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'fr_FR', 'black'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'fr_FR', 'black'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/OptionFilterIntegration.php
@@ -5,6 +5,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -38,24 +40,16 @@ class OptionFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'orange', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'orange'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'black', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'black'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Option/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -44,25 +46,17 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_select_scopable_simple_select' => [
-                    ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'ecommerce', null, 'orange'),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_select_scopable_simple_select' => [
-                    ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'ecommerce', null, 'black'),
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'tablet', null, 'black'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -49,26 +51,18 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_multi_select' => [
-                    ['data' => ['orange'], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_localizable_multi_select', null, 'en_US', ['orange']),
+            new SetMultiSelectValue('a_localizable_multi_select', null, 'fr_FR', ['black', 'purple']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_multi_select' => [
-                    ['data' => ['black', 'orange'], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => ['black', 'orange'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_localizable_multi_select', null, 'en_US', ['black', 'orange']),
+            new SetMultiSelectValue('a_localizable_multi_select', null, 'fr_FR', ['black', 'orange']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -51,30 +53,22 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_multi_select' => [
-                    ['data' => ['orange'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => ['orange'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => ['black'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => ['black'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'ecommerce', 'en_US', ['orange']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'ecommerce', 'fr_FR', ['orange']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'tablet', 'en_US', ['black']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'tablet', 'fr_FR', ['black']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_multi_select' => [
-                    ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => ['black', 'purple'], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => ['black', 'purple'], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'ecommerce', 'en_US', ['black', 'purple']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'ecommerce', 'fr_FR', ['black', 'purple']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'tablet', 'en_US', ['black', 'purple']),
+            new SetMultiSelectValue('a_localizable_scopable_multi_select', 'tablet', 'fr_FR', ['black', 'purple']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/OptionsFilterIntegration.php
@@ -5,6 +5,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -43,24 +45,16 @@ class OptionsFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_multi_select' => [
-                    ['data' => ['orange'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['orange']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_multi_select' => [
-                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['black', 'purple']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Options/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Options;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -49,25 +51,17 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_multi_select' => [
-                    ['data' => ['orange'], 'locale' => null, 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_scopable_multi_select', 'ecommerce', null, ['orange']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_multi_select' => [
-                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => ['black', 'purple'], 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_scopable_multi_select', 'ecommerce', null, ['black', 'purple']),
+            new SetMultiSelectValue('a_scopable_multi_select', 'tablet', null, ['black', 'purple']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -35,26 +37,22 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_price' => [
-                    ['data' => [['amount' => 20, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => [['amount' => 21, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_localizable_price', null, 'en_US', ['amount' => 20, 'currency' => 'EUR']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_localizable_price', null, 'fr_FR', ['amount' => 21, 'currency' => 'EUR']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_price' => [
-                    ['data' => [['amount' => 10, 'currency' => 'EUR']], 'locale' => 'en_US', 'scope' => null],
-                    ['data' => [['amount' => 1, 'currency' => 'EUR']], 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_localizable_price', null, 'en_US', ['amount' => 10, 'currency' => 'EUR']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_localizable_price', null, 'fr_FR', ['amount' => 1, 'currency' => 'EUR']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableFilterIntegration.php
@@ -3,7 +3,9 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -38,18 +40,22 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_localizable_price', null, 'en_US', ['amount' => 20, 'currency' => 'EUR']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_localizable_price', null, 'fr_FR', ['amount' => 21, 'currency' => 'EUR']),
+            new SetPriceCollectionValue('a_localizable_price', null, 'en_US',
+                [new PriceValue(20, 'EUR')]
+            ),
+            new SetPriceCollectionValue('a_localizable_price', null, 'fr_FR',
+                [new PriceValue(21, 'EUR')]
+            ),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_localizable_price', null, 'en_US', ['amount' => 10, 'currency' => 'EUR']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_localizable_price', null, 'fr_FR', ['amount' => 1, 'currency' => 'EUR']),
+            new SetPriceCollectionValue('a_localizable_price', null, 'en_US',
+                [new PriceValue(10, 'EUR')]
+            ),
+            new SetPriceCollectionValue('a_localizable_price', null, 'fr_FR',
+                [new PriceValue(1, 'EUR')]
+            ),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -37,45 +39,28 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_localizable_price' => [
-                    [
-                        'data'   => [['amount' => '-5.00', 'currency' => 'USD']],
-                        'locale' => 'en_US',
-                        'scope'  => 'ecommerce',
-                    ],
-                    ['data' => [['amount' => '14', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    [
-                        'data'   => [['amount' => '100', 'currency' => 'USD']],
-                        'locale' => 'fr_FR',
-                        'scope'  => 'tablet',
-                    ],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'en_US', ['amount' => '-5.00', 'currency' => 'USD']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'tablet', 'en_US', ['amount' => '14', 'currency' => 'USD']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'tablet', 'fr_FR', ['amount' => '100', 'currency' => 'USD']),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_localizable_price' => [
-                    [
-                        'data'   => [['amount' => '-5.00', 'currency' => 'USD']],
-                        'locale' => 'en_US',
-                        'scope'  => 'ecommerce',
-                    ],
-                    ['data' => [['amount' => '10', 'currency' => 'USD']], 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => [['amount' => '75', 'currency' => 'USD']], 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                    [
-                        'data'   => [['amount' => '75', 'currency' => 'USD']],
-                        'locale' => 'fr_FR',
-                        'scope'  => 'ecommerce',
-                    ],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'en_US', ['amount' => '-5.00', 'currency' => 'USD']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'tablet', 'en_US', ['amount' => '10', 'currency' => 'USD']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'tablet', 'fr_FR', ['amount' => '75', 'currency' => 'USD']),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'fr_FR', ['amount' => '75', 'currency' => 'USD']),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/LocalizableScopableFilterIntegration.php
@@ -3,7 +3,9 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -40,24 +42,31 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'en_US', ['amount' => '-5.00', 'currency' => 'USD']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'tablet', 'en_US', ['amount' => '14', 'currency' => 'USD']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'tablet', 'fr_FR', ['amount' => '100', 'currency' => 'USD']),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'ecommerce', 'en_US',
+                [new PriceValue('-5.00', 'USD')]
+            ),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'tablet', 'en_US',
+                [new PriceValue('14', 'USD')]
+            ),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'tablet', 'fr_FR',
+                [new PriceValue('100', 'USD')]
+            ),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'en_US', ['amount' => '-5.00', 'currency' => 'USD']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'tablet', 'en_US', ['amount' => '10', 'currency' => 'USD']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'tablet', 'fr_FR', ['amount' => '75', 'currency' => 'USD']),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_localizable_price', 'ecommerce', 'fr_FR', ['amount' => '75', 'currency' => 'USD']),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'ecommerce', 'en_US',
+                [new PriceValue('-5.00', 'USD')]
+            ),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'tablet', 'en_US',
+                [new PriceValue('10', 'USD')]
+            ),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'tablet', 'fr_FR',
+                [new PriceValue('75', 'USD')]
+            ),
+            new SetPriceCollectionValue('a_scopable_localizable_price', 'ecommerce', 'fr_FR',
+                [new PriceValue('75', 'USD')]
+            ),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -28,27 +30,21 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_price' => [
-                    ['data' => [
-                        ['amount' => '10.55', 'currency' => 'EUR'],
-                        ['amount' => '11', 'currency' => 'USD']
-                    ], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_price', null, null, [
+                ['amount' => '10.55', 'currency' => 'EUR'],
+                ['amount' => '11', 'currency' => 'USD']
+            ]),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_price' => [
-                    ['data' => [['amount' => '15', 'currency' => 'EUR']], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_price', null, null, [['amount' => '15', 'currency' => 'EUR']]),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/PriceFilterIntegration.php
@@ -4,7 +4,9 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
@@ -31,17 +33,17 @@ class PriceFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_price', null, null, [
-                ['amount' => '10.55', 'currency' => 'EUR'],
-                ['amount' => '11', 'currency' => 'USD']
+            new SetPriceCollectionValue('a_price', null, null, [
+                new PriceValue('10.55', 'EUR'),
+                new PriceValue('11', 'USD')
             ]),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_price', null, null, [['amount' => '15', 'currency' => 'EUR']]),
+            new SetPriceCollectionValue('a_price', null, null,
+                [new PriceValue('15', 'EUR')]
+            ),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -26,37 +28,25 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_price' => [
-                    [
-                        'data'   => [['amount' => '10.55', 'currency' => 'EUR']],
-                        'locale' => null,
-                        'scope'  => 'ecommerce',
-                    ],
-                    ['data' => [['amount' => '25', 'currency' => 'USD']], 'locale' => null, 'scope' => 'tablet'],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'ecommerce', null, [['amount' => '10.55', 'currency' => 'EUR']]),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'tablet', null, [['amount' => '25', 'currency' => 'USD']]),
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_price' => [
-                    [
-                        'data'   => [
-                            ['amount' => '2', 'currency' => 'EUR'],
-                            ['amount' => '2.2', 'currency' => 'USD'],
-                        ],
-                        'locale' => null,
-                        'scope'  => 'ecommerce',
-                    ],
-                    ['data' => [['amount' => '30', 'currency' => 'EUR']], 'locale' => null, 'scope' => 'tablet'],
-                ],
-            ],
+            new SetFamily('a_family'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'ecommerce', null, [
+                ['amount' => '2', 'currency' => 'EUR'],
+                ['amount' => '2.2', 'currency' => 'USD'],
+            ]),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'tablet', null, [['amount' => '30', 'currency' => 'EUR']]),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorInferior()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Price/ScopableFilterIntegration.php
@@ -3,7 +3,9 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Price;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -29,21 +31,23 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->createProduct('product_one', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'ecommerce', null, [['amount' => '10.55', 'currency' => 'EUR']]),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'tablet', null, [['amount' => '25', 'currency' => 'USD']]),
+            new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null,
+                [new PriceValue('10.55', 'EUR')]
+            ),
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null,
+                [new PriceValue('25', 'USD')]
+            ),
         ]);
 
         $this->createProduct('product_two', [
             new SetFamily('a_family'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'ecommerce', null, [
-                ['amount' => '2', 'currency' => 'EUR'],
-                ['amount' => '2.2', 'currency' => 'USD'],
+            new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null, [
+                new PriceValue('2', 'EUR'),
+                new PriceValue('2.2', 'USD'),
             ]),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'tablet', null, [['amount' => '30', 'currency' => 'EUR']]),
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null,
+                [new PriceValue('30', 'EUR')]
+            ),
         ]);
 
         $this->createProduct('empty_product', [new SetFamily('a_family')]);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataMultiSelectFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\ReferenceData;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiReferenceEntityValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -30,61 +32,37 @@ class ReferenceDataMultiSelectFilterIntegration extends AbstractProductQueryBuil
         $this->createProduct(
             'product_one',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_ref_data_multi_select' => [
-                        [
-                            'data'   => [
-                                'aertex',
-                                'ballisticnylon',
-                            ],
-                            'scope'  => null,
-                            'locale' => null,
-                        ],
-                    ],
-                ],
+                new SetFamily('a_family'),
+                new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, [
+                    'aertex',
+                    'ballisticnylon',
+                ]),
             ]
         );
 
         $this->createProduct(
             'product_two',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_ref_data_multi_select' => [
-                        [
-                            'data'   => [
-                                'argentanlace',
-                                'ballisticnylon',
-                            ],
-                            'scope'  => null,
-                            'locale' => null,
-                        ],
-                    ],
-                ],
+                new SetFamily('a_family'),
+                new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, [
+                    'argentanlace',
+                    'ballisticnylon',
+                ]),
             ]
         );
 
         $this->createProduct(
             'product_three',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_ref_data_multi_select' => [
-                        [
-                            'data'   => [
-                                'betacloth',
-                                'bobbinet',
-                            ],
-                            'scope'  => null,
-                            'locale' => null,
-                        ],
-                    ],
-                ],
+                new SetFamily('a_family'),
+                new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, [
+                    'betacloth',
+                    'bobbinet',
+                ]),
             ]
         );
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/ReferenceData/ReferenceDataSimpleSelectFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\ReferenceData;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -30,28 +32,20 @@ class ReferenceDataSimpleSelectFilterIntegration extends AbstractProductQueryBui
         $this->createProduct(
             'product_one',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_ref_data_simple_select' => [
-                        ['data' => 'acid-green', 'scope' => null, 'locale' => null],
-                    ],
-                ],
+                new SetFamily('a_family'),
+                new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'acid-green')
             ]
         );
 
         $this->createProduct(
             'product_two',
             [
-                'family' => 'a_family',
-                'values' => [
-                    'a_ref_data_simple_select' => [
-                        ['data' => 'aero-blue', 'scope' => null, 'locale' => null],
-                    ],
-                ],
+                new SetFamily('a_family'),
+                new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'aero-blue')
             ]
         );
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorIn()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,36 +36,24 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_text', null, 'en_US', 'black cat'),
+            new SetTextValue('a_localizable_text', null, 'fr_FR', 'black cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'cattle', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_text', null, 'en_US', 'cattle'),
+            new SetTextValue('a_localizable_text', null, 'fr_FR', 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_text', null, 'en_US', 'just a dog...'),
+            new SetTextValue('a_localizable_text', null, 'fr_FR', 'juste un chien'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -36,42 +38,30 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'en_US', 'black cat'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'en_US', 'cat'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'fr_FR', 'chat noir'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'fr_FR', 'chat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'en_US', 'cattle'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'en_US', 'cattle'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'fr_FR', 'bétail'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'fr_FR', 'bétail'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'en_US', 'just a dog...'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'en_US', 'dog'),
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'fr_FR', 'juste un chien...'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'fr_FR', 'chien'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,36 +36,24 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text' => [
-                    ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cat', 'locale' => null, 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_scopable_text', 'ecommerce', null, 'black cat'),
+            new SetTextValue('a_scopable_text', 'tablet', null, 'cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text' => [
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_scopable_text', 'ecommerce', null, 'cattle'),
+            new SetTextValue('a_scopable_text', 'tablet', null, 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text' => [
-                    ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_scopable_text', 'ecommerce', null, 'just a dog...'),
+            new SetTextValue('a_scopable_text', 'tablet', null, 'dog'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/Text/TextFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -27,49 +29,33 @@ class TextFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text' => [['data' => 'cat', 'locale' => null, 'scope' => null]],
-            ],
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text' => [['data' => 'cattle', 'locale' => null, 'scope' => null]],
-            ],
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text' => [['data' => 'dog', 'locale' => null, 'scope' => null]],
-            ],
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'dog'),
         ]);
 
         $this->createProduct('best_dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]],
-            ],
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'my dog is the most beautiful'),
         ]);
 
         // There is no html tags in TEXT attributes usually set in the PIM.
         // This tests shows that if it's the case they are stored as is and not stripped.
         $this->createProduct('best_cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text' => [
-                    [
-                        'data'   => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'my <bold>cat</bold> is the most <i>beautiful</i><br/>'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,36 +36,24 @@ class LocalizableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'chat <b>noir</b>', 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_text_area', null, 'en_US', 'black cat'),
+            new SetTextareaValue('a_localizable_text_area', null, 'fr_FR', 'chat <b>noir</b>'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '<h1>cattle</h1>', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_text_area', null, 'en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_text_area', null, 'fr_FR', '<h1>cattle</h1>'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_text_area', null, 'en_US', 'just a dog...'),
+            new SetTextareaValue('a_localizable_text_area', null, 'fr_FR', 'juste un chien'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/LocalizableScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -36,42 +38,30 @@ class LocalizableScopableFilterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'en_US', 'black cat'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'en_US', 'cat'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'fr_FR', 'chat noir'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'fr_FR', 'chat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'fr_FR', 'bétail'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'fr_FR', 'bétail'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'en_US', 'just a dog...'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'en_US', 'dog'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'fr_FR', 'juste un chien...'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet', 'fr_FR', 'chien'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/ScopableFilterIntegration.php
@@ -3,6 +3,8 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -34,36 +36,24 @@ class ScopableFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cat', 'locale' => null, 'scope' => 'tablet'],
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_scopable_text_area', 'ecommerce', null, 'black cat'),
+            new SetTextareaValue('a_scopable_text_area', 'tablet', null, 'cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_scopable_text_area', 'ecommerce', null, 'cattle'),
+            new SetTextareaValue('a_scopable_text_area', 'tablet', null, 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_scopable_text_area', 'ecommerce', null, 'just a dog...'),
+            new SetTextareaValue('a_scopable_text_area', 'tablet', null, 'dog'),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/TextArea/TextAreaFilterIntegration.php
@@ -4,6 +4,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,60 +33,36 @@ class TextAreaFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [['data' => 'cat', 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [['data' => 'cattle', 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [['data' => 'dog', 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'dog'),
         ]);
 
         $this->createProduct('best_dog', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'my dog is the most beautiful'),
         ]);
 
         $this->createProduct('best_cat', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [
-                    [
-                        'data' => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
-                        'locale' => null,
-                        'scope' => null,
-                    ],
-                ],
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'my <bold>cat</bold> is the most <i>beautiful</i><br/>'),
         ]);
 
         $this->createProduct('best_rabbit', [
-            'family' => 'a_family',
-            'values' => [
-                'a_text_area' => [
-                    [
-                        'data' => $this->rabbitNewLineData,
-                        'locale' => null,
-                        'scope' => null,
-                    ],
-                ],
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, $this->rabbitNewLineData),
         ]);
 
-        $this->createProduct('empty_product', ['family' => 'a_family']);
+        $this->createProduct('empty_product', [new SetFamily('a_family')]);
     }
 
     public function testOperatorStartsWith()

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -20,7 +21,7 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createProduct('foo', ['categories' => ['categoryA1', 'categoryB']]);
+        $this->createProduct('foo', [new SetCategories(['categoryA1', 'categoryB'])]);
         $this->createProduct('bar', []);
         $this->createProduct('baz', []);
     }
@@ -60,7 +61,7 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
 
     public function testOperatorInOrUnclassifiedInTwoDifferentFilters()
     {
-        $this->createProduct('qux', ['categories' => ['categoryA1']]);
+        $this->createProduct('qux', [new SetCategories(['categoryA1'])]);
 
         $result = $this->executeFilter([
             ['categories', Operators::IN_LIST_OR_UNCLASSIFIED, ['categoryB']],

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/FamilyFilterIntegration.php
@@ -5,6 +5,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -26,7 +27,7 @@ class FamilyFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->get('pim_catalog.updater.family')->update($family, ['code' => 'familyB']);
         $this->get('pim_catalog.saver.family')->save($family);
 
-        $this->createProduct('foo', ['family' => 'familyA']);
+        $this->createProduct('foo', [new SetFamily('familyA')]);
         $this->createProduct('bar', []);
         $this->createProduct('baz', []);
     }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GroupsFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/GroupsFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -28,7 +29,7 @@ class GroupsFilterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
         $this->get('pim_catalog.saver.group')->save($group);
 
-        $this->createProduct('foo', ['groups' => ['groupA', 'groupB']]);
+        $this->createProduct('foo', [new SetGroups(['groupA', 'groupB'])]);
         $this->createProduct('bar', []);
         $this->createProduct('baz', []);
     }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
@@ -3,6 +3,11 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Field\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -50,39 +55,30 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
         $this->get('pim_catalog.saver.family')->save($family);
 
         $this->createProduct('product_one', [
-            'family' => 'familyB',
-            'categories' => ['categoryA1'],
-            'values' => [
-                'a_metric' => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
-            ]
+            new SetFamily('familyB'),
+            new SetCategories(['categoryA1']),
+            new SetMeasurementValue('a_metric', null, null, 10, 'WATT')
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'familyB',
-            'categories' => ['categoryA2', 'categoryA1'],
-            'values' => [
-                'a_metric'                           => [['data' => ['amount' => 15, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]],
-                'a_localized_and_scopable_text_area' => [['data' => 'text', 'locale' => 'en_US', 'scope' => 'tablet']],
-                'a_scopable_price'                   => [
-                    [
-                        'data'      => [
-                            ['amount' => 15, 'currency' => 'EUR'],
-                            ['amount' => 15.5, 'currency' => 'USD']
-                        ], 'locale' => null, 'scope' => 'tablet'
-                    ]
-                ],
-            ]
+            new SetFamily('familyB'),
+            new SetCategories(['categoryA2', 'categoryA1']),
+            new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'text'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'tablet', null, [
+                ['amount' => 15, 'currency' => 'EUR'],
+                ['amount' => 15.5, 'currency' => 'USD']
+            ])
         ]);
 
         $this->createProduct('empty_product', [
-            'family' => 'familyB',
-            'categories' => ['categoryA2', 'categoryA1']
+            new SetFamily('familyB'),
+            new SetCategories(['categoryA2', 'categoryA1'])
         ]);
 
         $this->createProduct('no_family', [
-            'values' => [
-                'a_metric' => [['data' => ['amount' => 10, 'unit' => 'WATT'], 'locale' => null, 'scope' => null]]
-            ]
+            new SetMeasurementValue('a_metric', null, null, 10, 'WATT')
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
@@ -3,9 +3,11 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Field\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -65,10 +67,9 @@ class CompletenessFilterIntegration extends AbstractProductQueryBuilderTestCase
             new SetCategories(['categoryA2', 'categoryA1']),
             new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
             new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'text'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'tablet', null, [
-                ['amount' => 15, 'currency' => 'EUR'],
-                ['amount' => 15.5, 'currency' => 'USD']
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null, [
+                new PriceValue(15, 'EUR'),
+                new PriceValue(15.5, 'USD'),
             ])
         ]);
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/StatusFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/StatusFilterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -21,8 +22,8 @@ class StatusFilterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createProduct('foo', ['enabled' => true]);
-        $this->createProduct('bar', ['enabled' => false]);
+        $this->createProduct('foo', [new SetEnabled(true)]);
+        $this->createProduct('bar', [new SetEnabled(false)]);
     }
 
     public function testOperatorEquals()

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
@@ -4,6 +4,9 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 
 /**
  * Tests that queries results executed by combining filters with different operators are consistent.
@@ -124,74 +127,35 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
         $this->createProduct(
             'complex_product_1',
             [
-                'family' => 'familyA',
-                'values' => [
-                    'a_file' => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => $this->getFileInfoKey($this->getFixturePath('akeneo.txt')),
-                        ],
-                    ],
-
-                    'a_localizable_image'                => [
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => null,
-                            'data'   => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')),
-                        ],
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => null,
-                            'data'   => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')),
-                        ],
-                    ],
-                    'a_regexp'                           => [
-                        [
-                            'locale' => null,
-                            'scope'  => null,
-                            'data'   => '\w+ .*',
-                        ],
-                    ],
-                    'a_scopable_price'                   => [
-                        [
-                            'locale' => null,
-                            'scope'  => 'ecommerce',
-                            'data'   => [
-                                [
-                                    'amount'   => 12,
-                                    'currency' => 'EUR',
-                                ],
-                                [
-                                    'amount'   => 14,
-                                    'currency' => 'USD',
-                                ],
+                new SetFamily('familyA'),
+                // TODO: use SetFileValue when ready
+                new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))),
+                // TODO: use SetImageValue when ready
+                new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+                // TODO: use SetImageValue when ready
+                new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+                new SetTextValue('a_regexp', null, null, '\w+ .*'),
+                // TODO: use SetPriceValue when ready
+                'a_scopable_price'                   => [
+                    [
+                        'locale' => null,
+                        'scope'  => 'ecommerce',
+                        'data'   => [
+                            [
+                                'amount'   => 12,
+                                'currency' => 'EUR',
+                            ],
+                            [
+                                'amount'   => 14,
+                                'currency' => 'USD',
                             ],
                         ],
                     ],
-                    'a_localized_and_scopable_text_area' => [
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => 'ecommerce',
-                            'data'   => 'Mon textarea localisé et scopable ecommerce',
-                        ],
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => 'ecommerce',
-                            'data'   => null,
-                        ],
-                        [
-                            'locale' => 'fr_FR',
-                            'scope'  => 'tablet',
-                            'data'   => 'Mon textarea localisé et scopable tablet',
-                        ],
-                        [
-                            'locale' => 'en_US',
-                            'scope'  => 'tablet',
-                            'data'   => 'My localizable and scopable textearea tablet',
-                        ],
-                    ],
                 ],
+                new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'fr_FR', 'Mon textarea localisé et scopable ecommerce'),
+                new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'en_US', null),
+                new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'fr_FR', 'Mon textarea localisé et scopable tablet'),
+                new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'My localizable and scopable textearea tablet'),
             ]
         );
     }

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
@@ -4,9 +4,11 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
 
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFileValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 
@@ -139,23 +141,10 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
                 new SetImageValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
                 new SetImageValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
                 new SetTextValue('a_regexp', null, null, '\w+ .*'),
-                // TODO: use SetPriceValue when ready
-                'a_scopable_price'                   => [
-                    [
-                        'locale' => null,
-                        'scope'  => 'ecommerce',
-                        'data'   => [
-                            [
-                                'amount'   => 12,
-                                'currency' => 'EUR',
-                            ],
-                            [
-                                'amount'   => 14,
-                                'currency' => 'USD',
-                            ],
-                        ],
-                    ],
-                ],
+                new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null, [
+                    new PriceValue(12, 'EUR'),
+                    new PriceValue(14, 'USD'),
+                ]),
                 new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'fr_FR', 'Mon textarea localisé et scopable ecommerce'),
                 new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'en_US', null),
                 new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'fr_FR', 'Mon textarea localisé et scopable tablet'),

--- a/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/ProductQueryBuilderIntegration.php
@@ -5,6 +5,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFileValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 
@@ -128,12 +130,14 @@ class ProductQueryBuilderIntegration extends AbstractProductQueryBuilderTestCase
             'complex_product_1',
             [
                 new SetFamily('familyA'),
-                // TODO: use SetFileValue when ready
-                new SetTextValue('a_file', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))),
-                // TODO: use SetImageValue when ready
-                new SetTextValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
-                // TODO: use SetImageValue when ready
-                new SetTextValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+                new SetFileValue(
+                    'a_file',
+                    null,
+                    null,
+                    $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))
+                ),
+                new SetImageValue('a_localizable_image', null, 'en_US', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+                new SetImageValue('a_localizable_image', null, 'fr_FR', $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
                 new SetTextValue('a_regexp', null, null, '\w+ .*'),
                 // TODO: use SetPriceValue when ready
                 'a_scopable_price'                   => [

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/BooleanSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -23,21 +24,15 @@ class BooleanSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('yes', [
-            'values' => [
-                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]]
-            ]
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $this->createProduct('no', [
-            'values' => [
-                'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]]
-            ]
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
 
         $this->createProduct('null_product', [
-            'values' => [
-                'a_yes_no' => [['data' => null, 'locale' => null, 'scope' => null]]
-            ]
+            new SetBooleanValue('a_yes_no', null, null, null)
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,25 +32,17 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => false, 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'ecommerce', 'en_US', true),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'tablet', 'en_US', true),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'ecommerce', 'fr_FR', true),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'tablet', 'fr_FR', false),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_yes_no' => [
-                    ['data' => false, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => true, 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'ecommerce', 'en_US', false),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'tablet', 'en_US', true),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'ecommerce', 'fr_FR', true),
+            new SetBooleanValue('a_localizable_scopable_yes_no', 'tablet', 'fr_FR', true),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,21 +32,13 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_yes_no' => [
-                    ['data' => true, 'locale' => 'en_US', 'scope' => null],
-                    ['data' => false, 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', null, 'en_US', true),
+            new SetBooleanValue('a_localizable_yes_no', null, 'fr_FR', false),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_yes_no' => [
-                    ['data' => false, 'locale' => 'en_US', 'scope' => null],
-                    ['data' => true, 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetBooleanValue('a_localizable_yes_no', null, 'en_US', false),
+            new SetBooleanValue('a_localizable_yes_no', null, 'fr_FR', true),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Boolean/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Boolean;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,21 +32,13 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_yes_no' => [
-                    ['data' => false, 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => true, 'scope' => 'tablet', 'locale' => null]
-                ]
-            ]
+            new SetBooleanValue('a_scopable_yes_no', 'ecommerce', null, false),
+            new SetBooleanValue('a_scopable_yes_no', 'tablet', null, true),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_yes_no' => [
-                    ['data' => true, 'scope' => 'ecommerce', 'locale' => null],
-                    ['data' => false, 'scope' => 'tablet', 'locale' => null],
-                ]
-            ]
+            new SetBooleanValue('a_scopable_yes_no', 'ecommerce', null, true),
+            new SetBooleanValue('a_scopable_yes_no', 'tablet', null, false),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -4,6 +4,10 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -159,92 +163,36 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->get('pim_catalog.saver.family')->save($family);
 
         $this->createProduct('product_one', [
-            'family' => 'familyB',
-            'values' => [
-                'a_metric' => [
-                    [
-                        'data'   => ['amount' => 15, 'unit' => 'WATT'],
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetFamily('familyB'),
+            new SetMeasurementValue('a_metric', null, null, 15, 'WATT')
         ]);
 
         $this->createProduct('product_two', [
-            'family' => 'familyB',
-            'values' => [
-                'a_metric'                           => [
-                    [
-                        'data'   => ['amount' => 15, 'unit' => 'WATT'],
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-                'a_localized_and_scopable_text_area' => [
-                    [
-                        'data'   => 'text',
-                        'locale' => 'en_US',
-                        'scope'  => 'tablet',
-                    ],
-                ],
-                'a_scopable_price'                   => [
-                    [
-                        'data'   => [
-                            ['amount' => 15, 'currency' => 'EUR'],
-                            ['amount' => 15.5, 'currency' => 'USD'],
-                        ],
-                        'locale' => null,
-                        'scope'  => 'tablet',
-                    ],
-                ],
-            ],
+            new SetFamily('familyB'),
+            new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'text'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'tablet', null, [
+                ['amount' => 15, 'currency' => 'EUR'],
+                ['amount' => 15.5, 'currency' => 'USD'],
+            ])
         ]);
 
         $this->createProduct('product_three', [
-            'family' => 'familyB',
-            'values' => [
-                'a_metric'                           => [
-                    [
-                        'data'   => ['amount' => 15, 'unit' => 'WATT'],
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-                'a_localized_and_scopable_text_area' => [
-                    [
-                        'data'   => 'text',
-                        'locale' => 'fr_FR',
-                        'scope'  => 'tablet',
-                    ],
-                ],
-                'a_scopable_price'                   => [
-                    [
-                        'data'   => [
-                            ['amount' => 15, 'currency' => 'EUR'],
-                            ['amount' => 15.5, 'currency' => 'USD'],
-                        ],
-                        'locale' => null,
-                        'scope'  => 'tablet',
-                    ],
-                ],
-            ],
+            new SetFamily('familyB'),
+            new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'fr_FR', 'text'),
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_scopable_price', 'tablet', null, [
+                ['amount' => 15, 'currency' => 'EUR'],
+                ['amount' => 15.5, 'currency' => 'USD'],
+            ])
         ]);
 
-        $this->createProduct('empty_product', [
-            'family' => 'familyB',
-        ]);
+        $this->createProduct('empty_product', [new SetFamily('familyB')]);
 
         $this->createProduct('no_family', [
-            'values' => [
-                'a_metric' => [
-                    [
-                        'data'   => ['amount' => 10, 'unit' => 'WATT'],
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetMeasurementValue('a_metric', null, null, 10, 'WATT'),
         ]);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -4,8 +4,10 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
@@ -171,10 +173,9 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
             new SetFamily('familyB'),
             new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
             new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'text'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'tablet', null, [
-                ['amount' => 15, 'currency' => 'EUR'],
-                ['amount' => 15.5, 'currency' => 'USD'],
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null, [
+                new PriceValue(15, 'EUR'),
+                new PriceValue(15.5, 'USD'),
             ])
         ]);
 
@@ -182,10 +183,9 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
             new SetFamily('familyB'),
             new SetMeasurementValue('a_metric', null, null, 15, 'WATT'),
             new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'fr_FR', 'text'),
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_scopable_price', 'tablet', null, [
-                ['amount' => 15, 'currency' => 'EUR'],
-                ['amount' => 15.5, 'currency' => 'USD'],
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null, [
+                new PriceValue(15, 'EUR'),
+                new PriceValue(15.5, 'USD'),
             ])
         ]);
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/DateSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/DateSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -43,27 +44,15 @@ class DateSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_date' => [
-                    ['data' => '2017-04-11', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetDateValue('a_date', null, null, new \DateTime('2017-04-11'))
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_date' => [
-                    ['data' => '2016-03-10', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetDateValue('a_date', null, null, new \DateTime('2016-03-10'))
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_date' => [
-                    ['data' => '2015-02-09', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetDateValue('a_date', null, null, new \DateTime('2015-02-09'))
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -75,35 +76,19 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2017-04-11', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'fr_FR', new \DateTime('2017-04-11'))
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2016-03-10', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'fr_FR', new \DateTime('2016-03-10'))
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2015-02-09', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'fr_FR', new \DateTime('2015-02-09'))
         ]);
 
         $this->createProduct('product_four', [
-            'values' => [
-                'a_localizable_scopable_date' => [
-                    ['data' => '2014-01-08', 'locale' => 'en_US', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetDateValue('a_localizable_scopable_date', 'tablet', 'en_US', new \DateTime('2014-01-08'))
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -63,27 +64,15 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_date' => [
-                    ['data' => '2017-04-11', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetDateValue('a_localizable_date', null, 'fr_FR', new \DateTime('2017-04-11'))
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_date' => [
-                    ['data' => '2016-03-10', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetDateValue('a_localizable_date', null, 'fr_FR', new \DateTime('2016-03-10'))
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_date' => [
-                    ['data' => '2015-02-09', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetDateValue('a_localizable_date', null, 'fr_FR', new \DateTime('2015-02-09'))
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Date/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Date;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -63,27 +64,15 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_date' => [
-                    ['data' => '2017-04-11', 'locale' => null, 'scope' => 'ecommerce'],
-                ],
-            ],
+            new SetDateValue('a_scopable_date', 'ecommerce', null, new \DateTime('2017-04-11'))
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_date' => [
-                    ['data' => '2016-03-10', 'locale' => null, 'scope' => 'ecommerce'],
-                ],
-            ],
+            new SetDateValue('a_scopable_date', 'ecommerce', null, new \DateTime('2016-03-10'))
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_scopable_date' => [
-                    ['data' => '2015-02-09', 'locale' => null, 'scope' => 'ecommerce'],
-                ],
-            ],
+            new SetDateValue('a_scopable_date', 'ecommerce', null, new \DateTime('2015-02-09'))
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/FamilySorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/FamilySorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -20,9 +21,9 @@ class FamilySorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createProduct('fooA', ['family' => 'familyA']);
-        $this->createProduct('fooA1', ['family' => 'familyA1']);
-        $this->createProduct('fooA2', ['family' => 'familyA2']);
+        $this->createProduct('fooA', [new SetFamily('familyA')]);
+        $this->createProduct('fooA1', [new SetFamily('familyA1')]);
+        $this->createProduct('fooA2', [new SetFamily('familyA2')]);
         $this->createProduct('baz', []);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -35,35 +36,19 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_metric' => [
-                    ['data' => ['amount' => '10.5', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_scopable_metric', 'tablet', 'fr_FR', '10.5', 'KILOWATT')
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_metric' => [
-                    ['data' => ['amount' => '15000', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_scopable_metric', 'tablet', 'fr_FR', '15000', 'KILOWATT')
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_scopable_metric' => [
-                    ['data' => ['amount' => '-2.5', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_scopable_metric', 'tablet', 'fr_FR', '-2.5', 'KILOWATT')
         ]);
 
         $this->createProduct('product_four', [
-            'values' => [
-                'a_localizable_scopable_metric' => [
-                    ['data' => ['amount' => '12', 'unit' => 'KILOWATT'], 'locale' => 'en_US', 'scope' => 'tablet']
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_scopable_metric', 'tablet', 'en_US', '12', 'KILOWATT')
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -35,27 +36,15 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_metric' => [
-                    ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_metric', null, 'fr_FR', '10.55', 'KILOWATT')
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_metric' => [
-                    ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_metric', null, 'fr_FR', '15000', 'KILOWATT')
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_metric' => [
-                    ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_localizable_metric', null, 'fr_FR', '-2.5654', 'KILOWATT')
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/MetricSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/MetricSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -23,27 +24,15 @@ class MetricSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_metric' => [
-                    ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_metric', null, null, '10.55', 'KILOWATT')
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_metric' => [
-                    ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_metric', null, null, '15000', 'WATT')
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_metric' => [
-                    ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_metric', null, null, '-2.5654', 'KILOWATT')
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Metric/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Metric;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -35,27 +36,15 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_metric' => [
-                    ['data' => ['amount' => '10.55', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetMeasurementValue('a_scopable_metric', 'ecommerce', null, '10.55', 'KILOWATT')
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_metric' => [
-                    ['data' => ['amount' => '15000', 'unit' => 'WATT'], 'locale' => null, 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetMeasurementValue('a_scopable_metric', 'ecommerce', null, '15000', 'WATT')
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_scopable_metric' => [
-                    ['data' => ['amount' => '-2.5654', 'unit' => 'KILOWATT'], 'locale' => null, 'scope' => 'ecommerce']
-                ]
-            ]
+            new SetMeasurementValue('a_scopable_metric', 'ecommerce', null, '-2.5654', 'KILOWATT')
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -33,29 +34,17 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_number' => [
-                    ['data' => '192.103', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => '-16', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetNumberValue('a_localizable_scopable_number', 'ecommerce', 'en_US', '192.103'),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'fr_FR', '-16'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_number' => [
-                    ['data' => '-16', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => '192.103', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ]
-            ]
+            new SetNumberValue('a_localizable_scopable_number', 'ecommerce', 'en_US', '-16'),
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'fr_FR', '192.103'),
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_scopable_number' => [
-                    ['data' => '52', 'locale' => 'de_DE', 'scope' => 'tablet']
-                ]
-            ]
+            new SetNumberValue('a_localizable_scopable_number', 'tablet', 'de_DE', '52'),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -33,29 +34,17 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_number' => [
-                    ['data' => '192.103', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '-16', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetNumberValue('a_localizable_number', null, 'en_US', '192.103'),
+            new SetNumberValue('a_localizable_number', null, 'fr_FR', '-16'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_number' => [
-                    ['data' => '-16', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '192.103', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetNumberValue('a_localizable_number', null, 'en_US', '-16'),
+            new SetNumberValue('a_localizable_number', null, 'fr_FR', '192.103'),
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_localizable_number' => [
-                    ['data' => '52', 'locale' => 'de_DE', 'scope' => null],
-                ],
-            ],
+            new SetNumberValue('a_localizable_number', null, 'de_DE', '52'),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/NumberSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/NumberSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -23,27 +24,15 @@ class NumberSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_number_float_negative' => [
-                    ['data' => '192.103', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetNumberValue('a_number_float_negative', null, null, '192.103'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_number_float_negative' => [
-                    ['data' => '16', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetNumberValue('a_number_float_negative', null, null, '16'),
         ]);
 
         $this->createProduct('product_three', [
-            'values' => [
-                'a_number_float_negative' => [
-                    ['data' => '-162.5654', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetNumberValue('a_number_float_negative', null, null, '-162.5654'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Number/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Number;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -33,21 +34,13 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_number' => [
-                    ['data' => '192.103', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => '16', 'locale' => null, 'scope' => 'tablet'],
-                ],
-            ],
+            new SetNumberValue('a_scopable_number', 'ecommerce', null, '192.103'),
+            new SetNumberValue('a_scopable_number', 'tablet', null, '16'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_number' => [
-                    ['data' => '16', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => '192.103', 'locale' => null, 'scope' => 'tablet'],
-                ],
-            ],
+            new SetNumberValue('a_scopable_number', 'ecommerce', null, '16'),
+            new SetNumberValue('a_scopable_number', 'tablet', null, '192.103'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -41,21 +42,13 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_simple_select' => [
-                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'en_US', 'orange'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'fr_FR', 'black'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_simple_select' => [
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'ecommerce', 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_scopable_simple_select', 'tablet', 'fr_FR', 'orange'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -41,21 +42,13 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_simple_select' => [
-                    ['data' => 'black', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'orange', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'en_US', 'black'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'fr_FR', 'orange'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_simple_select' => [
-                    ['data' => 'orange', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'black', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'en_US', 'orange'),
+            new SetSimpleSelectValue('a_localizable_simple_select', null, 'fr_FR', 'black'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/OptionSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/OptionSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -33,19 +34,11 @@ class OptionSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'black', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetSimpleSelectValue('a_simple_select', null, null, 'black'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'orange', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetSimpleSelectValue('a_simple_select', null, null, 'orange'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Option/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Option;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -41,21 +42,13 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_select_scopable_simple_select' => [
-                    ['data' => 'black', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'orange', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'ecommerce', null, 'black'),
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'tablet', null, 'orange'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_select_scopable_simple_select' => [
-                    ['data' => 'orange', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'black', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'ecommerce', null, 'orange'),
+            new SetSimpleSelectValue('a_select_scopable_simple_select', 'tablet', null, 'black'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/ReferenceData/ReferenceDataSimpleSelectSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\ReferenceData;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -25,22 +26,14 @@ class ReferenceDataSimpleSelectSorterIntegration extends AbstractProductQueryBui
         $this->createProduct(
             'product_one',
             [
-                'values' => [
-                    'a_ref_data_simple_select' => [
-                        ['data' => 'acid-green', 'scope' => null, 'locale' => null],
-                    ],
-                ],
+                new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'acid-green')
             ]
         );
 
         $this->createProduct(
             'product_two',
             [
-                'values' => [
-                    'a_ref_data_simple_select' => [
-                        ['data' => 'blue', 'scope' => null, 'locale' => null],
-                    ],
-                ],
+                new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'blue')
             ]
         );
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/StatusSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/StatusSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -20,10 +21,10 @@ class StatusSorterIntegration extends AbstractProductQueryBuilderTestCase
     {
         parent::setUp();
 
-        $this->createProduct('foo', ['enabled' => false]);
-        $this->createProduct('bar', ['enabled' => true]);
-        $this->createProduct('baz', ['enabled' => false]);
-        $this->createProduct('foobar', ['enabled' => true]);
+        $this->createProduct('foo', [new SetEnabled(false)]);
+        $this->createProduct('bar', [new SetEnabled(true)]);
+        $this->createProduct('baz', [new SetEnabled(false)]);
+        $this->createProduct('foobar', [new SetEnabled(true)]);
         $this->createProduct('foobaz', []);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,21 +32,13 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_scopable_text' => [
-                    ['data' => 'cat is beautiful', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'dog is wonderful', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'en_US', 'cat is beautiful'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'fr_FR', 'dog is wonderful'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_scopable_text' => [
-                    ['data' => 'dog is wonderful', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cat is beautiful', 'locale' => 'fr_FR', 'scope' => 'tablet'],
-                ],
-            ],
+            new SetTextValue('a_localizable_scopable_text', 'ecommerce', 'en_US', 'dog is wonderful'),
+            new SetTextValue('a_localizable_scopable_text', 'tablet', 'fr_FR', 'cat is beautiful'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,21 +32,13 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_localizable_text' => [
-                    ['data' => 'cat is beautiful', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'dog is wonderful', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetTextValue('a_localizable_text', null, 'en_US', 'cat is beautiful'),
+            new SetTextValue('a_localizable_text', null, 'fr_FR', 'dog is wonderful'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_localizable_text' => [
-                    ['data' => 'dog is wonderful', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'cat is beautiful', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetTextValue('a_localizable_text', null, 'en_US', 'dog is wonderful'),
+            new SetTextValue('a_localizable_text', null, 'fr_FR', 'cat is beautiful'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,21 +32,13 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('product_one', [
-            'values' => [
-                'a_scopable_text' => [
-                    ['data' => 'cat is beautiful', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'dog is wonderful', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextValue('a_scopable_text', 'ecommerce', null, 'cat is beautiful'),
+            new SetTextValue('a_scopable_text', 'tablet', null, 'dog is wonderful'),
         ]);
 
         $this->createProduct('product_two', [
-            'values' => [
-                'a_scopable_text' => [
-                    ['data' => 'dog is wonderful', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cat is beautiful', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextValue('a_scopable_text', 'ecommerce', null, 'dog is wonderful'),
+            new SetTextValue('a_scopable_text', 'tablet', null, 'cat is beautiful'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/TextSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/Text/TextSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\Text;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -23,29 +24,17 @@ class TextSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('cat', [
-            'values' => [
-                'a_text' => [['data' => 'cat is beautiful', 'locale' => null, 'scope' => null]],
-            ],
+            new SetTextValue('a_text', null, null, 'cat is beautiful'),
         ]);
 
         $this->createProduct('dog', [
-            'values' => [
-                'a_text' => [['data' => 'dog is wonderful', 'locale' => null, 'scope' => null]],
-            ],
+            new SetTextValue('a_text', null, null, 'dog is wonderful'),
         ]);
 
         // There is no html tags in TEXT attributes usually set in the PIM.
         // This tests shows that if it's the case they are stored as is and not stripped.
         $this->createProduct('best_cat', [
-            'values' => [
-                'a_text' => [
-                    [
-                        'data'   => '<bold>dog</bold> is the most <i>beautiful</i><br/>',
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetTextValue('a_text', null, null, '<bold>dog</bold> is the most <i>beautiful</i><br/>'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,36 +32,25 @@ class LocalizableScopableSorterIntegration extends AbstractProductQueryBuilderTe
         ]);
 
         $this->createProduct('cat', [
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cat', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'chat noir', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chat', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce', 'en_US', 'black cat'),
+            new SetTextareaValue('a_localizable_scopable_text_area','tablet', 'en_US','cat'),
+            new SetTextareaValue('a_localizable_scopable_text_area','ecommerce', 'fr_FR','chat noir'),
+            new SetTextareaValue('a_localizable_scopable_text_area','tablet', 'fr_FR','chat'),
+
         ]);
 
         $this->createProduct('cattle', [
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'bétail', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextareaValue('a_localizable_scopable_text_area','ecommerce','en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_scopable_text_area','tablet','en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_scopable_text_area','ecommerce','fr_FR', 'bétail'),
+            new SetTextareaValue('a_localizable_scopable_text_area','tablet','fr_FR', 'bétail'),
         ]);
 
         $this->createProduct('dog', [
-            'values' => [
-                'a_localizable_scopable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => 'en_US', 'scope' => 'tablet'],
-                    ['data' => 'juste un chien...', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                    ['data' => 'chien', 'locale' => 'fr_FR', 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce','en_US', 'just a dog...'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet','en_US', 'dog'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'ecommerce','fr_FR', 'juste un chien...'),
+            new SetTextareaValue('a_localizable_scopable_text_area', 'tablet','fr_FR', 'chien'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/LocalizableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,30 +32,18 @@ class LocalizableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'black cat', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'chat <b>noir</b>', 'locale' => 'fr_FR', 'scope' => null],
-                ]
-            ]
+            new SetTextareaValue('a_localizable_text_area',null,'en_US', 'black cat'),
+            new SetTextareaValue('a_localizable_text_area',null,'fr_FR', 'chat <b>noir</b>'),
         ]);
 
         $this->createProduct('cattle', [
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'cattle', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => '<h1>cattle</h1>', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetTextareaValue('a_localizable_text_area', null, 'en_US', 'cattle'),
+            new SetTextareaValue('a_localizable_text_area', null, 'fr_FR', '<h1>cattle</h1>'),
         ]);
 
         $this->createProduct('dog', [
-            'values' => [
-                'a_localizable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => 'en_US', 'scope' => null],
-                    ['data' => 'juste un chien', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetTextareaValue('a_localizable_text_area', null, 'en_US', 'just a dog...'),
+            new SetTextareaValue('a_localizable_text_area', null, 'fr_FR', 'juste un chien'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/ScopableSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
@@ -31,30 +32,18 @@ class ScopableSorterIntegration extends AbstractProductQueryBuilderTestCase
         ]);
 
         $this->createProduct('cat', [
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'black cat', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'red cat', 'locale' => null, 'scope' => 'tablet'],
-                ]
-            ]
+            new SetTextareaValue('a_scopable_text_area', 'ecommerce', null, 'black cat'),
+            new SetTextareaValue('a_scopable_text_area', 'tablet', null, 'red cat'),
         ]);
 
         $this->createProduct('cattle', [
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'cattle', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextareaValue('a_scopable_text_area','ecommerce', null, 'cattle'),
+            new SetTextareaValue('a_scopable_text_area','tablet', null, 'cattle'),
         ]);
 
         $this->createProduct('dog', [
-            'values' => [
-                'a_scopable_text_area' => [
-                    ['data' => 'just a dog...', 'locale' => null, 'scope' => 'ecommerce'],
-                    ['data' => 'dog', 'locale' => null, 'scope' => 'tablet']
-                ]
-            ]
+            new SetTextareaValue('a_scopable_text_area', 'ecommerce', null,'just a dog...'),
+            new SetTextareaValue('a_scopable_text_area', 'tablet', null,'dog'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/TextAreaSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/TextArea/TextAreaSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Sorter\TextArea;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -27,39 +28,19 @@ class TextAreaSorterIntegration extends AbstractProductQueryBuilderTestCase
         parent::setUp();
 
         $this->createProduct('cat', [
-            'values' => [
-                'a_text_area' => [['data' => 'cat', 'locale' => null, 'scope' => null]],
-            ],
+            new SetTextareaValue('a_text_area' ,null, null,'cat'),
         ]);
 
         $this->createProduct('best_cat', [
-            'values' => [
-                'a_text_area' => [
-                    [
-                        'data'   => 'my <bold>cat</bold> is the most <i>beautiful</i><br/>',
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetTextareaValue('a_text_area' ,null, null,'my <bold>cat</bold> is the most <i>beautiful</i><br/>'),
         ]);
 
         $this->createProduct('super_dog', [
-            'values' => [
-                'a_text_area' => [
-                    [
-                        'data'   => $this->superDog,
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            new SetTextareaValue('a_text_area' ,null, null, $this->superDog),
         ]);
 
         $this->createProduct('best_dog', [
-            'values' => [
-                'a_text_area' => [['data' => 'my dog is the most beautiful', 'locale' => null, 'scope' => null]],
-            ],
+            new SetTextareaValue('a_text_area' ,null, null, 'my dog is the most beautiful'),
         ]);
 
         $this->createProduct('empty_product', []);

--- a/tests/back/Pim/Enrichment/Integration/Product/Association/CreateTwoWayAssociationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Association/CreateTwoWayAssociationIntegration.php
@@ -11,6 +11,9 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateGroups;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProductModels;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateGroups;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateProductModels;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateProducts;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
@@ -107,7 +110,7 @@ class CreateTwoWayAssociationIntegration extends TestCase
      */
     public function it_removes_inversed_association_when_removing_associated_entities()
     {
-        $product = $this->createProduct(
+        $this->createProduct(
             'test',
             [
                 new AssociateProducts('COMPATIBILITY', ['product_1', 'product_2']),
@@ -115,19 +118,12 @@ class CreateTwoWayAssociationIntegration extends TestCase
                 new AssociateGroups('COMPATIBILITY', ['groupA']),
             ]
         );
-        $this->get('pim_catalog.updater.product')->update(
-            $product,
-            [
-                'associations' => [
-                    'COMPATIBILITY' => [
-                        'products' => ['product_2'],
-                        'product_models' => ['product_model_2'],
-                        'groups' => [],
-                    ],
-                ],
-            ]
-        );
-        $this->get('pim_catalog.saver.product')->save($product);
+
+        $this->createProduct('test', [
+            new DissociateProducts('COMPATIBILITY', ['product_1']),
+            new DissociateProductModels('COMPATIBILITY', ['product_model_1']),
+            new DissociateGroups('COMPATIBILITY', ['groupA'])
+        ]);
 
         $productModel = $this->createProductModel(
             [

--- a/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
@@ -4,6 +4,9 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Common\EntityBuilder;
 use Akeneo\Test\Common\EntityWithValue\Builder;
@@ -21,7 +24,7 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
     public function test_that_unique_value_is_deleted_in_database_when_values_is_deleted_in_product_raw_value()
     {
         $attributeId = $this->createAttributeWithUniqueConstraint('name');
-        $this->createProductWithUniqueValue('name', 'my_unique_value');
+        $this->createProductWithUniqueValue([new SetTextValue('name', null, null, 'my_unique_value')]);
 
         $isValueExistingInUniqueTable = $this
             ->get('database_connection')
@@ -64,24 +67,20 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         return $attribute->getId();
     }
 
-    private function createProductWithUniqueValue(string $attributeCode, string $uniqueValueData): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProductWithUniqueValue(array $userIntents): void
     {
-        $product = $this->getProductBuilder()->withIdentifier('foo')->withValue($attributeCode, $uniqueValueData)->build();
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        // We have the following flow:
-        //      1. create a product "foo". Currently, it has no ID as it has not been saved yet to database.
-        //      2. validate this product
-        //              pim_catalog.validator.unique_value_set is called and foo is assigned to a spl_object_hash (see https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Enrichment/Component/Product/Validator/UniqueValuesSet.php#L86)
-        //      3. save this project to database, "foo" now has the ID 1
-        //      3. update this product
-        //      4. validate this product again
-        //              foo is assigned to a spl_object_hash while our product now has an ID... the "value" foo
-        //              is considered as already existing
-        //      BOOOM
-        // so, that's why we need to reset the unique value set...
-        // TODO: ideally, after each unitary or bulk product save, this set should be reset
-        $this->get('pim_catalog.validator.unique_value_set')->reset();
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: 'foo',
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
     }
 
     private function deleteUniqueValueForAttribute(string $attributeCode): void
@@ -102,8 +101,15 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         return $this->get('akeneo_integration_tests.base.attribute.builder');
     }
 
-    private function getProductBuilder(): Builder\Product
+    protected function getUserId(string $username): int
     {
-        return $this->get('akeneo_integration_tests.catalog.product.builder');
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsIntegration.php
@@ -2,6 +2,12 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\Product;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 /**
@@ -139,39 +145,30 @@ class ExportProductsIntegration extends AbstractExportTestCase
 
     public function testVariantProductExport()
     {
-        $this->createVariantProduct(
-            'apollon_pink_m',
-            [
-                'family' => 'clothing',
-                'parent' => 'apollon_pink',
-                'categories' => ['spring'],
-                'values'  => [
-                    'size'  => [['data' => 'm', 'locale' => null, 'scope' => null]],
-                    'ean'  => [['data' => '12345678', 'locale' => null, 'scope' => null]],
-                ]
-            ]
-        );
-        $this->createVariantProduct(
+        $this->createProduct('apollon_pink_m', [
+            new SetFamily('clothing'),
+            new ChangeParent('apollon_pink'),
+            new SetCategories(['spring']),
+            new SetSimpleSelectValue('size', null, null, 'm'),
+            new SetTextValue('ean', null, null, '12345678')
+        ]);
+        $this->createProduct(
             'apollon_pink_l',
             [
-                'family' => 'clothing',
-                'parent' => 'apollon_pink',
-                'values'  => [
-                    'size'  => [['data' => 'l', 'locale' => null, 'scope' => null]],
-                    'ean'  => [['data' => '12345679', 'locale' => null, 'scope' => null]],
-                ]
+                new SetFamily('clothing'),
+                new ChangeParent('apollon_pink'),
+                new SetSimpleSelectValue('size', null, null, 'l'),
+                new SetTextValue('ean', null, null, '12345679')
             ]
         );
-        $this->createVariantProduct(
+        $this->createProduct(
             'apollon_pink_xl',
             [
-                'family' => 'clothing',
-                'parent' => 'apollon_pink',
-                'categories' => ['tshirt','summer'],
-                'values'  => [
-                    'size'  => [['data' => 'xl', 'locale' => null, 'scope' => null]],
-                    'ean'  => [['data' => '12345465', 'locale' => null, 'scope' => null]],
-                ]
+                new SetFamily('clothing'),
+                new ChangeParent('apollon_pink'),
+                new SetCategories(['tshirt','summer']),
+                new SetSimpleSelectValue('size', null, null, 'xl'),
+                new SetTextValue('ean', null, null, '12345465')
             ]
         );
 
@@ -189,12 +186,8 @@ CSV;
     public function testItEscapeCharacterCorrectly()
     {
         $this->createProduct('product_1', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text_area' => [
-                    ['data' => 'test "1234" DLE test  \" joli produit ; vive la data "', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'test "1234" DLE test  \" joli produit ; vive la data "')
         ]);
 
         $expectedCsv = <<<CSV

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsWithLabelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/Product/ExportProductsWithLabelsIntegration.php
@@ -2,6 +2,21 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\Product;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProductModels;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProductModels;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\QuantifiedEntity;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiReferenceEntityValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 /**
@@ -179,47 +194,35 @@ CSV;
                 ]
             ]
         );
-        $this->createVariantProduct(
+        $this->createProduct(
             'apollon_pink_m',
             [
-                'family' => 'clothing',
-                'parent' => 'apollon',
-                'categories' => [],
-                'values'  => [
-                    'size'  => [['data' => 'm', 'locale' => null, 'scope' => null]],
-                    'color'  => [['data' => ['pink','blue'], 'locale' => null, 'scope' => null]],
-                ]
+                new SetFamily('clothing'),
+                new ChangeParent('apollon'),
+                new SetCategories([]),
+                new SetSimpleSelectValue('size', null, null, 'm'),
+                new SetMultiSelectValue('color', null, null, ['pink','blue'])
             ]
         );
 
         $this->createProduct(
             'summer_shirt',
             [
-                'family' => 'clothing',
-                'categories' => ['tshirt', 'summer'],
-                'values'  => [
-                    'name' => [['data' => 'summer_shirt_2020', 'locale' => 'fr_FR', 'scope' => null]],
-                    'color' => [['data' => ['pink', 'blue'], 'locale' => null, 'scope' => null]],
-                    'size'  => [['data' => 'l', 'locale' => null, 'scope' => null]],
-                    'is_on_sale' => [['data' => false, 'locale' => null, 'scope' => null]],
-                    'metric'  => [['data' => ['amount' => 12, 'unit' => 'KILOGRAM'], 'locale' => null, 'scope' => null]],
-                ],
-                'associations' => [
-                    'X_SELL' => [
-                        'products'=> ['apollon_pink_m'],
-                        'product_models'=> ['apollon'],
-                    ]
-                ],
-                'quantified_associations' => [
-                    'QUANTITY' => [
-                        'products' => [
-                            ['identifier'=> 'apollon_pink_m', 'quantity' => 12]
-                        ],
-                        'product_models' => [
-                            ['identifier'=> 'apollon', 'quantity' => 5]
-                        ]
-                    ]
-                ]
+                new SetFamily('clothing'),
+                new SetCategories(['tshirt', 'summer']),
+                new SetTextValue('name', null, 'fr_FR', 'summer_shirt_2020'),
+                new SetMultiReferenceEntityValue('color', null, null, ['pink', 'blue']),
+                new SetSimpleSelectValue('size', null, null, 'l'),
+                new SetBooleanValue('is_on_sale', null, null, false),
+                new SetMeasurementValue('metric', null, null, 12, 'KILOGRAM'),
+                new AssociateProducts('X_SELL', ['apollon_pink_m']),
+                new AssociateProductModels('X_SELL', ['apollon']),
+                new AssociateQuantifiedProducts('QUANTITY', [
+                    new QuantifiedEntity('apollon_pink_m', 12)]
+                ),
+                new AssociateQuantifiedProductModels('QUANTITY', [
+                    new QuantifiedEntity('apollon', 5)
+                ])
             ]
         );
     }

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByBooleanIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByBooleanIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByBooleanIntegration extends AbstractExportTestCase
@@ -20,27 +22,19 @@ class ExportProductsByBooleanIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_with_localisable_scopable_boolean', [
-            'values'     => [
-                'a_boolean_scopable_localizable' => [['data' => true, 'locale' => 'en_US', 'scope' => 'tablet']],
-            ]
+            new SetBooleanValue('a_boolean_scopable_localizable', 'tablet', 'en_US', true)
         ]);
 
         $this->createProduct('product_with_boolean_true', [
-            'values'     => [
-                'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]],
-            ]
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
         $this->createProduct('product_with_boolean_false', [
-            'values'     => [
-                'a_yes_no' => [['data' => false, 'locale' => null, 'scope' => null]],
-            ]
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
 
         $this->createproduct('product_without_boolean', [
-            'values'     => [
-                'a_number_float' => [['data' => '20.09', 'locale' => null, 'scope' => null]],
-            ]
+            new SetNumberValue('a_number_float', null, null, '20.09')
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByCategoriesIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByCategoriesIntegration extends AbstractExportTestCase
@@ -13,15 +14,15 @@ class ExportProductsByCategoriesIntegration extends AbstractExportTestCase
     {
 
         $this->createProduct('product_with_categories', [
-            'categories' => ['categoryA', 'categoryA1', 'categoryA2']
+            new SetCategories(['categoryA', 'categoryA1', 'categoryA2'])
         ]);
 
         $this->createProduct('product_with_single_category_A', [
-            'categories' => ['categoryA']
+            new SetCategories(['categoryA'])
         ]);
 
         $this->createProduct('product_with_single_category_B', [
-            'categories' => ['categoryB']
+            new SetCategories(['categoryB'])
         ]);
 
         $this->createProduct('product_without_category');

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByCompletenessIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByCompletenessIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByCompletenessIntegration extends AbstractExportTestCase
@@ -29,34 +31,22 @@ class ExportProductsByCompletenessIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('french', [
-            'family' => 'localized',
-            'values'     => [
-                'name' => [
-                    ['data' => 'French name', 'locale' => 'fr_FR', 'scope' => null]
-                ]
-            ]
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'fr_FR', 'French name')
         ]);
 
         $this->createProduct('english', [
-            'family' => 'localized',
-            'values'     => [
-                'name' => [
-                    ['data' => 'English name', 'locale' => 'en_US', 'scope' => null]
-                ]
-            ]
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'en_US', 'English name')
         ]);
 
         $this->createProduct('complete', [
-            'family' => 'localized',
-            'values'     => [
-                'name' => [
-                    ['data' => 'French complete', 'locale' => 'fr_FR', 'scope' => null],
-                    ['data' => 'English complete', 'locale' => 'en_US', 'scope' => null],
-                ]
-            ]
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'fr_FR', 'French complete'),
+            new SetTextValue('name', null, 'en_US', 'English complete')
         ]);
 
-        $this->createProduct('empty', ['family' => 'localized']);
+        $this->createProduct('empty', [new SetFamily('localized')]);
     }
 
     public function testProductExportWithCompleteProductsOnAtLeastOneLocale()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByDateIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByDateIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByDateIntegration extends AbstractExportTestCase
@@ -12,19 +13,11 @@ class ExportProductsByDateIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'a_date' => [
-                    ['data' => '2025-12-31', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetDateValue('a_date', null, null, new \DateTime('2025-12-31'))
         ]);
 
         $this->createProduct('product_2', [
-            'values'     => [
-                'a_date' => [
-                    ['data' => '2016-06-15', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetDateValue('a_date', null, null, new \DateTime('2016-06-15'))
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFamiliesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFamiliesIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByFamiliesIntegration extends AbstractExportTestCase
@@ -11,9 +12,9 @@ class ExportProductsByFamiliesIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
-        $this->createProduct('product_1', ['family' => 'familyA']);
-        $this->createProduct('product_2', ['family' => 'familyA1']);
-        $this->createProduct('product_3', ['family' => 'familyA2']);
+        $this->createProduct('product_1', [new SetFamily('familyA')]);
+        $this->createProduct('product_2', [new SetFamily('familyA1')]);
+        $this->createProduct('product_3', [new SetFamily('familyA2')]);
         $this->createProduct('product_4');
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFilesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFilesIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByFilesIntegration extends AbstractExportTestCase
@@ -12,19 +13,13 @@ class ExportProductsByFilesIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.png')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
 
         $this->createProduct('product_2', [
-            'values'     => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFilesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByFilesIntegration.php
@@ -2,7 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByFilesIntegration extends AbstractExportTestCase
@@ -13,13 +13,11 @@ class ExportProductsByFilesIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
 
         $this->createProduct('product_2', [
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByImagesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByImagesIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByImagesIntegration extends AbstractExportTestCase
@@ -12,19 +13,13 @@ class ExportProductsByImagesIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
 
         $this->createProduct('product_2', [
-            'values'     => [
-                'an_image' => [
-                    ['data' => $this->getFileInfoKey($this->getFixturePath('ziggy.png')), 'locale' => null, 'scope' => null]
-                ]
-            ]
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByImagesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByImagesIntegration.php
@@ -2,7 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByImagesIntegration extends AbstractExportTestCase
@@ -13,13 +13,11 @@ class ExportProductsByImagesIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.png')))
         ]);
 
         $this->createProduct('product_2', [
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getFixturePath('ziggy.png')))
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByLocalesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByLocalesIntegration.php
@@ -2,6 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByLocalesIntegration extends AbstractExportTestCase
@@ -65,54 +68,30 @@ class ExportProductsByLocalesIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('french', [
-            'family' => 'localized',
-            'values' => [
-                'name'        => [
-                    ['data' => 'French name', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-                'description' => [
-                    ['data' => 'French desc', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'fr_FR', 'French name'),
+            new SetTextareaValue('description', null, 'fr_FR', 'French desc')
         ]);
 
         $this->createProduct('english', [
-            'family' => 'localized',
-            'values' => [
-                'name'        => [
-                    ['data' => 'English name', 'locale' => 'en_US', 'scope' => null],
-                ],
-                'description' => [
-                    ['data' => 'French desc', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'en_US', 'English name'),
+            new SetTextareaValue('description', null, 'fr_FR', 'French desc')
         ]);
 
         $this->createProduct('complete', [
-            'family' => 'localized',
-            'values' => [
-                'name'        => [
-                    ['data' => 'French name', 'locale' => 'fr_FR', 'scope' => null],
-                    ['data' => 'English name', 'locale' => 'en_US', 'scope' => null],
-                ],
-                'description' => [
-                    ['data' => 'French desc', 'locale' => 'fr_FR', 'scope' => null],
-                ],
-            ],
+            new SetFamily('localized'),
+            new SetTextValue('name', null, 'fr_FR', 'French name'),
+            new SetTextValue('name', null, 'en_US', 'English name'),
+            new SetTextareaValue('description', null, 'fr_FR', 'French desc'),
         ]);
 
-        $this->createProduct('empty', ['family' => 'localized']);
+        $this->createProduct('empty', [new SetFamily('localized')]);
 
         $this->createProduct('withLocaleSpecificAttribute', [
-            'family' => 'accessories',
-            'values' => [
-                'name'        => [
-                    ['data' => 'English name', 'locale' => 'en_US', 'scope' => null],
-                ],
-                'localeSpecificAttribute' => [
-                    ['data' => 'Locale Specific Value', 'locale' => null, 'scope' => null, 'available_locales' => 'en_US'],
-                ],
-            ],
+            new SetFamily('accessories'),
+            new SetTextValue('name', null, 'en_US', 'English name'),
+            new SetTextareaValue('localeSpecificAttribute', null, null, 'Locale Specific Value')
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMetricsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMetricsIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByMetricsIntegration extends AbstractExportTestCase
@@ -12,19 +13,11 @@ class ExportProductsByMetricsIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'a_metric_without_decimal_negative' => [
-                    ['data' => ['amount' => -10, 'unit' => 'CELSIUS'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetMeasurementValue('a_metric_without_decimal_negative', null, null, -10, 'CELSIUS'),
         ]);
 
         $this->createProduct('product_2', [
-            'values' => [
-                'a_metric_without_decimal_negative' => [
-                    ['data' => ['amount' => 20, 'unit' => 'CELSIUS'], 'locale' => null, 'scope' => null]
-                ]
-            ],
+            new SetMeasurementValue('a_metric_without_decimal_negative', null, null, 20, 'CELSIUS'),
         ]);
 
         $this->createProduct('product_3');

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
@@ -17,42 +19,26 @@ class ExportProductsByMultiSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_option_A', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_multi_select' => [
-                    ['data' => ['optionA'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionA'])
         ]);
 
         $this->createProduct('product_option_B', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_multi_select' => [
-                    ['data' => ['optionB'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionB'])
         ]);
 
         $this->createProduct('product_option_A_B', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_multi_select' => [
-                    ['data' => ['optionA', 'optionB'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'optionB'])
         ]);
 
         $this->createProduct('product_without_option', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_multi_select' => [
-                    ['data' => [], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiSelectValue('a_multi_select', null, null, [])
         ]);
 
-        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
+        $this->createProduct('product_without_option_attribute', [new SetFamily('a_family')]);
 
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectReferenceDataIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByMultiSelectReferenceDataIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiReferenceEntityValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExportTestCase
@@ -17,42 +19,26 @@ class ExportProductsByMultiSelectReferenceDataIntegration extends AbstractExport
         ]);
 
         $this->createProduct('product_airguard', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_multi_select' => [
-                    ['data' => ['airguard'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, ['airguard'])
         ]);
 
         $this->createProduct('product_braid', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_multi_select' => [
-                    ['data' => ['braid'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, ['braid'])
         ]);
 
         $this->createProduct('product_airguard_braid', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_multi_select' => [
-                    ['data' => ['airguard', 'braid'], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, ['airguard', 'braid'])
         ]);
 
         $this->createProduct('product_without_option', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_multi_select' => [
-                    ['data' => [], 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetMultiReferenceEntityValue('a_ref_data_multi_select', null, null, [])
         ]);
 
-        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
+        $this->createProduct('product_without_option_attribute', [new SetFamily('a_family')]);
     }
 
     public function testProductExportByFilteringOnOneOption()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByNumberIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByNumberIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByNumberIntegration extends AbstractExportTestCase
@@ -12,19 +13,11 @@ class ExportProductsByNumberIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'a_number_integer' => [
-                    ['data' => 100, 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetNumberValue('a_number_integer', null, null, 100),
         ]);
 
         $this->createProduct('product_2', [
-            'values' => [
-                'a_number_integer' => [
-                    ['data' => 110, 'locale' => null, 'scope' => null]
-                ]
-            ],
+            new SetNumberValue('a_number_integer', null, null, 110),
         ]);
 
         $this->createProduct('product_3');

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByPriceCollectionsIntegration extends AbstractExportTestCase
@@ -12,29 +13,19 @@ class ExportProductsByPriceCollectionsIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            'values'     => [
-                'a_price' => [[
-                    'data' => [
-                        ['amount' => 10, 'currency' => 'EUR'],
-                        ['amount' => 20, 'currency' => 'USD']
-                    ],
-                    'locale' => null,
-                    'scope' => null
-                ]]
-            ]
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_price', null, null, [
+                ['amount' => 10, 'currency' => 'EUR'],
+                ['amount' => 20, 'currency' => 'USD']
+            ]),
         ]);
 
         $this->createProduct('product_2', [
-            'values' => [
-                'a_price' => [[
-                    'data' => [
-                        ['amount' => 20, 'currency' => 'EUR'],
-                        ['amount' => 10, 'currency' => 'USD']
-                    ],
-                    'locale' => null,
-                    'scope' => null
-                ]]
-            ],
+            // TODO: use SetPriceValue when ready
+            new SetTextValue('a_price', null, null, [
+                ['amount' => 20, 'currency' => 'EUR'],
+                ['amount' => 10, 'currency' => 'USD']
+            ]),
         ]);
 
         $this->createProduct('product_3');

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByPriceCollectionsIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
@@ -13,18 +15,16 @@ class ExportProductsByPriceCollectionsIntegration extends AbstractExportTestCase
     protected function loadFixtures() : void
     {
         $this->createProduct('product_1', [
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_price', null, null, [
-                ['amount' => 10, 'currency' => 'EUR'],
-                ['amount' => 20, 'currency' => 'USD']
+            new SetPriceCollectionValue('a_price', null, null, [
+                new PriceValue(10, 'EUR'),
+                new PriceValue(20, 'USD'),
             ]),
         ]);
 
         $this->createProduct('product_2', [
-            // TODO: use SetPriceValue when ready
-            new SetTextValue('a_price', null, null, [
-                ['amount' => 20, 'currency' => 'EUR'],
-                ['amount' => 10, 'currency' => 'USD']
+            new SetPriceCollectionValue('a_price', null, null, [
+                new PriceValue(20, 'EUR'),
+                new PriceValue(10, 'USD')
             ]),
         ]);
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
@@ -17,33 +19,21 @@ class ExportProductsBySimpleSelectIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_option_A', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_simple_select' => [
-                    ['data' => 'optionA', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
 
         $this->createProduct('product_option_B', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_simple_select' => [
-                    ['data' => 'optionB', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')
         ]);
 
         $this->createProduct('product_without_option', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_simple_select' => [
-                    ['data' => null, 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleSelectValue('a_simple_select', null, null, null)
         ]);
 
-        $this->createProduct('product_without_option_attribute', ['family' => 'a_family']);
+        $this->createProduct('product_without_option_attribute', [new SetFamily('a_family')]);
 
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectReferenceDataIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySimpleSelectReferenceDataIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleReferenceEntityValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExportTestCase
@@ -17,33 +19,21 @@ class ExportProductsBySimpleSelectReferenceDataIntegration extends AbstractExpor
         ]);
 
         $this->createProduct('product_option_baby_blue', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_simple_select' => [
-                    ['data' => 'baby-blue', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'baby-blue'),
         ]);
 
         $this->createProduct('product_option_champagne', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_simple_select' => [
-                    ['data' => 'champagne', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, 'champagne'),
         ]);
 
         $this->createProduct('product_without_option', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_ref_data_simple_select' => [
-                    ['data' => null, 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetSimpleReferenceEntityValue('a_ref_data_simple_select', null, null, null),
         ]);
 
-        $this->createProduct('product_without_option_attribute',['family' => 'a_family']);
+        $this->createProduct('product_without_option_attribute',[new SetFamily('a_family')]);
 
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySpecificDateIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsBySpecificDateIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsBySpecificDateIntegration extends AbstractExportTestCase
@@ -11,11 +12,11 @@ class ExportProductsBySpecificDateIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
-        $this->createProduct('product_1', ['family' => 'familyA2']);
+        $this->createProduct('product_1', [new SetFamily('familyA2')]);
 
-        $this->createProduct('product_2', ['family' => 'familyA2']);
+        $this->createProduct('product_2', [new SetFamily('familyA2')]);
 
-        $this->createProduct('product_3', ['family' => 'familyA2']);
+        $this->createProduct('product_3', [new SetFamily('familyA2')]);
     }
 
     public function testProductExportByFilteringOnDateSinceLastJob()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByStatusIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByStatusIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByStatusIntegration extends AbstractExportTestCase
@@ -11,9 +12,9 @@ class ExportProductsByStatusIntegration extends AbstractExportTestCase
      */
     protected function loadFixtures() : void
     {
-        $this->createProduct('product_1', ['enabled' => true]);
+        $this->createProduct('product_1', [new SetEnabled(true)]);
 
-        $this->createProduct('product_2', ['enabled' => false]);
+        $this->createProduct('product_2', [new SetEnabled(false)]);
 
         $this->createProduct('product_3');
     }

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextAreaIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextAreaIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
@@ -17,33 +19,21 @@ class ExportProductsByTextAreaIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_1', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text_area' => [
-                    ['data' => 'Awesome', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'Awesome')
         ]);
 
         $this->createProduct('product_2', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text_area' => [
-                    ['data' => 'Awesome product', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'Awesome product')
         ]);
 
         $this->createProduct('product_3', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text_area' => [
-                    ['data' => 'This is nice', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextareaValue('a_text_area', null, null, 'This is nice')
         ]);
 
-        $this->createProduct('product_4', ['family' => 'a_family']);
+        $this->createProduct('product_4', [new SetFamily('a_family')]);
     }
 
     public function testProductExportByFilteringWithEqualsOperatorOnTextArea()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsByTextIntegration.php
@@ -2,6 +2,8 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsByTextIntegration extends AbstractExportTestCase
@@ -17,33 +19,21 @@ class ExportProductsByTextIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_1', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text' => [
-                    ['data' => 'Awesome', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'Awesome')
         ]);
 
         $this->createProduct('product_2', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text' => [
-                    ['data' => 'Awesome product', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'Awesome product')
         ]);
 
         $this->createProduct('product_3', [
-            'family' => 'a_family',
-            'values'     => [
-                'a_text' => [
-                    ['data' => 'This is nice', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('a_family'),
+            new SetTextValue('a_text', null, null, 'This is nice')
         ]);
 
-        $this->createProduct('product_4', ['family' => 'a_family']);
+        $this->createProduct('product_4', [new SetFamily('a_family')]);
     }
 
     public function testProductExportByFilteringWithEqualsOperatorOnText()

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsWithAttributesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/ProductQueryBuilder/ExportProductsWithAttributesIntegration.php
@@ -2,6 +2,9 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Product\Export\ProductQueryBuilder;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use AkeneoTest\Pim\Enrichment\Integration\Product\Export\AbstractExportTestCase;
 
 class ExportProductsWithAttributesIntegration extends AbstractExportTestCase
@@ -21,24 +24,14 @@ class ExportProductsWithAttributesIntegration extends AbstractExportTestCase
         ]);
 
         $this->createProduct('product_1', [
-            'family'     => 'my_family',
-            'values'     => [
-                'a_text' => [
-                    ['data' => 'Awesome', 'locale' => null, 'scope' => null]
-                ],
-                'a_text_area' => [
-                    ['data' => 'Amazing', 'locale' => null, 'scope' => null]
-                ],
-            ]
+            new SetFamily('my_family'),
+            new SetTextValue('a_text', null, null, 'Awesome'),
+            new SetTextareaValue('a_text_area', null, null, 'Amazing')
         ]);
 
         $this->createProduct('product_2', [
-            'family'     => 'my_family',
-            'values'     => [
-                'a_text' => [
-                    ['data' => 'Awesome product', 'locale' => null, 'scope' => null]
-                ]
-            ]
+            new SetFamily('my_family'),
+            new SetTextValue('a_text', null, null, 'Awesome product'),
         ]);
 
         $this->createProduct('product_4');

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
@@ -7,6 +7,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder\Filter;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -211,8 +213,8 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
             'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
         ]);
         $this->createProduct('another-shoe', [
-            'categories' => ['women', 'winter-2018'],
-            'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
+            new SetCategories(['women', 'winter-2018']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
         ]);
         $this->createProduct('unclassified-product', []);
     }

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
@@ -7,6 +7,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder\Filter;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
@@ -192,25 +193,25 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
             'family_variant' => 'shoe_size_color',
             'values'         => ['size' => [['data' => 'm', 'locale' => null, 'scope' => null]]],
         ]);
-        $this->createVariantProduct('red-s', [
-            'parent'     => 'model-s',
-            'categories' => ['women'],
-            'values'     => ['color' => [['data' => 'red', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('red-s', [
+            new ChangeParent('model-s'),
+            new SetCategories(['women']),
+            new SetSimpleSelectValue('color', null, null, 'red'),
         ]);
-        $this->createVariantProduct('blue-s', [
-            'parent'     => 'model-s',
-            'categories' => ['men'],
-            'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('blue-s', [
+            new ChangeParent('model-s'),
+            new SetCategories(['men']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
         ]);
-        $this->createVariantProduct('red-m', [
-            'parent'     => 'model-m',
-            'categories' => ['women'],
-            'values'     => ['color' => [['data' => 'red', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('red-m', [
+            new ChangeParent('model-m'),
+            new SetCategories(['women']),
+            new SetSimpleSelectValue('color', null, null, 'red'),
         ]);
         $this->createVariantProduct('blue-m', [
-            'parent'     => 'model-m',
-            'categories' => ['men'],
-            'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
+            new ChangeParent('model-m'),
+            new SetCategories(['men']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
         ]);
         $this->createProduct('another-shoe', [
             new SetCategories(['women', 'winter-2018']),
@@ -307,20 +308,6 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-    }
-
-    /**
-     * @param string $identifier
-     * @param array  $data
-     */
-    protected function createVariantProduct(string $identifier, array $data = [])
-    {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
-        $this->assertEquals(0, $constraintList->count());
-        $this->get('pim_catalog.saver.product')->save($product);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
     }
 

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/SearchOnAttributesAndCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/SearchOnAttributesAndCategoriesIntegration.php
@@ -7,6 +7,9 @@ namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -305,17 +308,13 @@ class SearchOnAttributesAndCategoriesIntegration extends AbstractProductQueryBui
             'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
         ]);
         $this->createProduct('another-shoe', [
-            'categories' => ['women', 'winter-2018'],
-            'values' => [
-                'color'       => [['data' => 'blue', 'locale' => null, 'scope' => null]],
-                'description' => [['data' => 'Superb other shoe!', 'locale' => null, 'scope' => null]],
-                'brand' => [['data' => 'nyke', 'locale' => null, 'scope' => null]],
-            ],
+            new SetCategories(['women', 'winter-2018']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
+            new SetTextValue('description', null, null, 'Superb other shoe!'),
+            new SetTextValue('brand', null, null, 'nyke!'),
         ]);
         $this->createProduct('unclassified-product', [
-            'values' => [
-                'description' => [['data' => 'quantum mechanics', 'locale' => null, 'scope' => null]],
-            ],
+            new SetTextValue('description', null, null, 'quantum mechanics'),
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/SearchOnAttributesAndCategoriesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/SearchOnAttributesAndCategoriesIntegration.php
@@ -7,6 +7,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
@@ -287,25 +288,25 @@ class SearchOnAttributesAndCategoriesIntegration extends AbstractProductQueryBui
             'family_variant' => 'shoe_size_color',
             'values'         => ['size' => [['data' => 'm', 'locale' => null, 'scope' => null]]],
         ]);
-        $this->createVariantProduct('red-s', [
-            'parent'     => 'model-s',
-            'categories' => ['women'],
-            'values'     => ['color' => [['data' => 'red', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('red-s', [
+            new ChangeParent('model-s'),
+            new SetCategories(['women']),
+            new SetSimpleSelectValue('color', null, null, 'red'),
         ]);
-        $this->createVariantProduct('blue-s', [
-            'parent'     => 'model-s',
-            'categories' => ['men'],
-            'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('blue-s', [
+            new ChangeParent('model-s'),
+            new SetCategories(['men']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
         ]);
-        $this->createVariantProduct('red-m', [
-            'parent'     => 'model-m',
-            'categories' => ['women'],
-            'values'     => ['color' => [['data' => 'red', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('red-m', [
+            new ChangeParent('model-m'),
+            new SetCategories(['women']),
+            new SetSimpleSelectValue('color', null, null, 'red'),
         ]);
-        $this->createVariantProduct('blue-m', [
-            'parent'     => 'model-m',
-            'categories' => ['men'],
-            'values'     => ['color' => [['data' => 'blue', 'locale' => null, 'scope' => null]]],
+        $this->createProduct('blue-m', [
+            new ChangeParent('model-m'),
+            new SetCategories(['men']),
+            new SetSimpleSelectValue('color', null, null, 'blue'),
         ]);
         $this->createProduct('another-shoe', [
             new SetCategories(['women', 'winter-2018']),
@@ -413,20 +414,6 @@ class SearchOnAttributesAndCategoriesIntegration extends AbstractProductQueryBui
 
         $this->get('pim_catalog.saver.product_model')->save($productModel);
 
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-    }
-
-    /**
-     * @param string $identifier
-     * @param array  $data
-     */
-    protected function createVariantProduct(string $identifier, array $data = [])
-    {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $constraintList = $this->get('pim_catalog.validator.product')->validate($product);
-        $this->assertEquals(0, $constraintList->count());
-        $this->get('pim_catalog.saver.product')->save($product);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
     }
 

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Sorter/InGroupSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Sorter/InGroupSorterIntegration.php
@@ -4,6 +4,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\ProductQueryBuilder\Sorter;
 
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 
 /**
@@ -50,9 +51,9 @@ class InGroupSorterIntegration extends AbstractProductQueryBuilderTestCase
         );
         $this->get('pim_catalog.saver.group')->save($group);
 
-        $this->createProduct('foo', ['groups' => ['groupA', 'groupB']]);
-        $this->createProduct('bar', ['groups' => ['groupB']]);
-        $this->createProduct('baz', ['groups' => ['groupC']]);
+        $this->createProduct('foo', [new SetGroups(['groupA', 'groupB'])]);
+        $this->createProduct('bar', [new SetGroups(['groupB'])]);
+        $this->createProduct('baz', [new SetGroups(['groupC'])]);
         $this->createProduct('empty', []);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocaleIntegration.php
@@ -8,6 +8,10 @@ use Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\FollowUp\GetComplet
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\ChannelCompleteness;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\CompletenessWidget;
 use Akeneo\Pim\Enrichment\Component\FollowUp\ReadModel\LocaleCompleteness;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
@@ -246,31 +250,21 @@ class GetCompletenessPerChannelAndLocaleIntegration extends AbstractProductQuery
     {
         for ($i = 0; $i < $numberComplete; $i++) {
             $this->createProduct('product_complete_'.$i, [
-                'family' => 'family_for_complete',
-                'categories' => ['shoes'],
-                'values' => [
-                    'name'       => [
-                        ['data' => 'name_ecom_fr_'.$i, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'name_ecom_us_'.$i, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'name_mobile_us_'.$i, 'locale' => 'en_US', 'scope' => 'mobile']
-                    ],
-                    'description' => [
-                        ['data' => 'descr_ecom_fr_'.$i, 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
-                        ['data' => 'descr_ecom_us_'.$i, 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                        ['data' => 'descr_mobile_us_'.$i, 'locale' => 'en_US', 'scope' => 'mobile']
-                    ]
-                ]
+                new SetFamily('family_for_complete'),
+                new SetCategories(['shoes']),
+                new SetTextValue('name', 'ecommerce', 'fr_FR', 'name_ecom_fr_'.$i),
+                new SetTextValue('name', 'ecommerce', 'en_US', 'name_ecom_us_'.$i),
+                new SetTextValue('name', 'mobile', 'en_US', 'name_mobile_us_'.$i),
+                new SetTextareaValue('description', 'ecommerce', 'fr_FR', 'descr_ecom_fr_'.$i),
+                new SetTextareaValue('description', 'ecommerce', 'en_US', 'descr_ecom_us_'.$i),
+                new SetTextareaValue('description', 'mobile', 'en_US', 'descr_mobile_us_'.$i),
             ]);
         }
         for ($i = 0; $i < $numberIncomplete; $i++) {
             $this->createProduct('product_incomplete_'.$i, [
-                'family' => 'family_for_incomplete',
-                'categories' => ['shoes'],
-                'values' => [
-                    'name'       => [
-                        ['data' => 'name_mobile_US_'.$i, 'locale' => 'en_US', 'scope' => 'mobile']
-                    ]
-                ]
+                new SetFamily('family_for_incomplete'),
+                new SetCategories(['shoes']),
+                new SetTextValue('name', 'mobile', 'en_US', 'name_mobile_US_'.$i)
             ]);
         }
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Product;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
@@ -41,16 +47,12 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
             ],
         ]);
         $this->createProduct('variant_A1_A_yes', [
-            'parent' => 'subpm_A1_optionA',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
-            ],
+            new ChangeParent('subpm_A1_optionA'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
         $this->createProduct('variant_A1_A_no', [
-            'parent' => 'subpm_A1_optionA',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => false]],
-            ],
+            new ChangeParent('subpm_A1_optionA'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
         $this->createProductModel([
             'code' => 'subpm_A1_optionB',
@@ -61,34 +63,26 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
             ]
         ]);
         $this->createProduct('variant_A1_B_yes', [
-            'parent' => 'subpm_A1_optionB',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
-            ],
+            new ChangeParent('subpm_A1_optionB'),
+            new SetBooleanValue('a_yes_no', null, null, true)
         ]);
         $this->createProduct('variant_A1_B_no', [
-            'parent' => 'subpm_A1_optionB',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => false]],
-            ],
+            new ChangeParent('subpm_A1_optionB'),
+            new SetBooleanValue('a_yes_no', null, null, false)
         ]);
         $this->createProductModel(['code' => 'root_A2', 'family_variant' => 'familyVariantA2']);
         $this->createProduct('variant_A2_A_yes', [
-            'parent' => 'root_A2',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => true]],
-                'a_simple_select' => [['scope' => null, 'locale' => null, 'data' => 'optionA']],
-            ],
+            new ChangeParent('root_A2'),
+            new SetBooleanValue('a_yes_no', null, null, true),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
         $this->createProduct('variant_A2_B_no', [
-            'parent' => 'root_A2',
-            'values' => [
-                'a_yes_no' => [['scope' => null, 'locale' => null, 'data' => false]],
-                'a_simple_select' => [['scope' => null, 'locale' => null, 'data' => 'optionB']],
-            ],
+            new ChangeParent('root_A2'),
+            new SetBooleanValue('a_yes_no', null, null, false),
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionB'),
         ]);
-        $this->createProduct('simple_product', ['family' => 'familyA3']);
-        $this->createProduct('another_product', ['family' => 'familyA2']);
+        $this->createProduct('simple_product', [new SetFamily('familyA3')]);
+        $this->createProduct('another_product', [new SetFamily('familyA2')]);
     }
 
     protected function getConfiguration(): Configuration
@@ -103,10 +97,31 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
         $this->get('pim_catalog.saver.product_model')->save($productModel);
     }
 
-    private function createProduct(string $identifier, array $data): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProduct(string $identifier, array $userIntents): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $this->get('pim_catalog.saver.product')->save($product);
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
@@ -9,6 +9,9 @@ use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Row;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Webmozart\Assert\Assert;
@@ -173,19 +176,30 @@ class FetchProductRowsFromIdentifiersIntegration extends TestCase
 
     private function createVariantProduct(string $identifier, string $parentCode): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-
-        $this->get('pim_catalog.updater.product')->update($product, [
-            'parent' => $parentCode,
-            'values' => [
-                'a_simple_select' => [
-                    ['data' => 'optionA', 'locale' => null, 'scope' => null],
-                ],
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: [
+                new ChangeParent($parentCode),
+                new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
             ]
-        ]);
-        $errors = $this->get('validator')->validate($product);
-        Assert::same(0, $errors->count());
-        $this->get('pim_catalog.saver.product')->save($product);
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        \PHPUnit\Framework\Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductGrid;
 
 use Akeneo\Pim\Enrichment\Component\Product\Value\MediaValueInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
@@ -54,12 +60,11 @@ class ProductModelImagesFromCodesIntegration extends TestCase
             'family_variant' => 'variant',
         ]);
         $this->createProduct('child', [
-            'family' => 'familyA',
-            'parent' => 'parent',
-            'values' => [
-                'yesno' => [['locale' => null, 'scope' => null, 'data' => true]],
-                '123' => [['data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')), 'locale' => null, 'scope' => null]],
-            ],
+            new SetFamily('familyA'),
+            new ChangeParent('parent'),
+            new SetBooleanValue('yesno', null, null, true),
+            // TODO: use SetImageValue when ready
+            new SetTextValue('123', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
 
         $productModelImagesFromCodes = $this->get('akeneo.pim.enrichment.product.grid.query.product_model_images_from_codes');
@@ -131,16 +136,31 @@ class ProductModelImagesFromCodesIntegration extends TestCase
         $this->get('pim_catalog.saver.product_model')->save($model);
     }
 
-    private function createProduct(string $identifier, array $data): void
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function createProduct(string $identifier, array $userIntents): void
     {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier);
-        $this->get('pim_catalog.updater.product')->update($product, $data);
-        $violations = $this->get('pim_catalog.validator.product')->validate($product);
-        Assert::assertCount(
-            0,
-            $violations,
-            \sprintf('The product is invalid: %s', (string)$violations)
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: $userIntents
         );
-        $this->get('pim_catalog.saver.product')->save($product);
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+    }
+
+    protected function getUserId(string $username): int
+    {
+        $query = <<<SQL
+            SELECT id FROM oro_user WHERE username = :username
+        SQL;
+        $stmt = $this->get('database_connection')->executeQuery($query, ['username' => $username]);
+        $id = $stmt->fetchOne();
+        Assert::assertNotNull($id);
+
+        return \intval($id);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
@@ -9,7 +9,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\Configuration;
@@ -63,8 +63,7 @@ class ProductModelImagesFromCodesIntegration extends TestCase
             new SetFamily('familyA'),
             new ChangeParent('parent'),
             new SetBooleanValue('yesno', null, null, true),
-            // TODO: use SetImageValue when ready
-            new SetTextValue('123', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
+            new SetImageValue('123', null, null, $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))),
         ]);
 
         $productModelImagesFromCodes = $this->get('akeneo.pim.enrichment.product.grid.query.product_model_images_from_codes');

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiersIntegration.php
@@ -6,8 +6,13 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\ProductModel;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
+use Cassandra\Set;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -34,10 +39,10 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $shirtProductModel = $this->createProductModel(['code' => 'a_shirt', 'family_variant' => 'shirt_size']);
-        $this->createProduct('a_small_shirt', 'clothing_size_color', $shirtProductModel);
-        $this->createProduct('a_medium_shirt', 'clothing_size_color', $shirtProductModel);
-        $this->createProduct('a_large_shirt', 'clothing_size_color', $shirtProductModel);
+        $this->createProductModel(['code' => 'a_shirt', 'family_variant' => 'shirt_size']);
+        $this->createProduct('a_small_shirt', 'clothing_size_color', 'a_shirt');
+        $this->createProduct('a_medium_shirt', 'clothing_size_color', 'a_shirt');
+        $this->createProduct('a_large_shirt', 'clothing_size_color', 'a_shirt');
 
         $this->createFamilyVariant(
             [
@@ -48,10 +53,10 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $shoeProductModel = $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
-        $this->createProduct('a_small_shoe', 'clothing_size_color', $shoeProductModel);
-        $this->createProduct('a_medium_shoe', 'clothing_size_color', $shoeProductModel);
-        $this->createProduct('a_large_shoe', 'clothing_size_color', $shoeProductModel);
+        $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
+        $this->createProduct('a_small_shoe', 'clothing_size_color', 'a_shoe');
+        $this->createProduct('a_medium_shoe', 'clothing_size_color', 'a_shoe');
+        $this->createProduct('a_large_shoe', 'clothing_size_color', 'a_shoe');
 
         Assert::assertEqualsCanonicalizing(
             ['a_small_shirt', 'a_medium_shirt', 'a_large_shirt', 'a_small_shoe', 'a_medium_shoe', 'a_large_shoe'],
@@ -85,7 +90,7 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $largeShirtProductModel = $this->createProductModel(
+        $this->createProductModel(
             [
                 'code' => 'a_large_shirt',
                 'family_variant' => 'shirt_size_color',
@@ -97,9 +102,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_medium_red_shirt', 'shirt_size_color', $mediumShirtProductModel);
-        $this->createProduct('a_medium_blue_shirt', 'shirt_size_color', $mediumShirtProductModel);
-        $this->createProduct('a_large_black_shirt', 'shirt_size_color', $largeShirtProductModel);
+        $this->createProduct('a_medium_red_shirt', 'shirt_size_color', 'a_medium_shirt');
+        $this->createProduct('a_medium_blue_shirt', 'shirt_size_color', 'a_medium_shirt');
+        $this->createProduct('a_large_black_shirt', 'shirt_size_color', 'a_large_shirt');
 
         $this->createFamilyVariant(
             [
@@ -124,8 +129,8 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_large_red_shoe', 'shoe_size_color', $largeShoeProductModel);
-        $this->createProduct('a_large_green_shoe', 'shoe_size_color', $largeShoeProductModel);
+        $this->createProduct('a_large_red_shoe', 'shoe_size_color', 'a_large_shoe');
+        $this->createProduct('a_large_green_shoe', 'shoe_size_color', 'a_large_shoe');
 
         Assert::assertEqualsCanonicalizing(
             ['a_medium_red_shirt', 'a_medium_blue_shirt', 'a_large_black_shirt', 'a_large_red_shoe', 'a_large_green_shoe'],
@@ -147,7 +152,7 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
             ]
         );
         $this->createProductModel(['code' => 'a_shirt', 'family_variant' => 'shirt_size_color']);
-        $mediumShirtProductModel = $this->createProductModel(
+        $this->createProductModel(
             [
                 'code' => 'a_medium_shirt',
                 'family_variant' => 'shirt_size_color',
@@ -159,7 +164,7 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $largeShirtProductModel = $this->createProductModel(
+        $this->createProductModel(
             [
                 'code' => 'a_large_shirt',
                 'family_variant' => 'shirt_size_color',
@@ -171,9 +176,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_medium_red_shirt', 'shirt_size_color', $mediumShirtProductModel);
-        $this->createProduct('a_medium_blue_shirt', 'shirt_size_color', $mediumShirtProductModel);
-        $this->createProduct('a_large_black_shirt', 'shirt_size_color', $largeShirtProductModel);
+        $this->createProduct('a_medium_red_shirt', 'shirt_size_color', 'a_medium_shirt');
+        $this->createProduct('a_medium_blue_shirt', 'shirt_size_color', 'a_medium_shirt');
+        $this->createProduct('a_large_black_shirt', 'shirt_size_color', 'a_large_shirt');
 
         $this->createFamilyVariant(
             [
@@ -184,9 +189,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $shoeProductModel = $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
-        $this->createProduct('a_large_shoe', 'shoe_size_color', $shoeProductModel);
-        $this->createProduct('a_medium_shoe', 'shoe_size_color', $shoeProductModel);
+        $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
+        $this->createProduct('a_large_shoe', 'shoe_size_color', 'a_shoe');
+        $this->createProduct('a_medium_shoe', 'shoe_size_color', 'a_shoe');
 
         Assert::assertEqualsCanonicalizing(
             ['a_medium_red_shirt', 'a_medium_blue_shirt', 'a_large_black_shirt', 'a_large_shoe', 'a_medium_shoe'],
@@ -226,20 +231,22 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
         return $productModel;
     }
 
-    private function createProduct(
-        string $identifier,
-        ?string $familyCode,
-        ?ProductModelInterface $productModel,
-        array $values = []
-    ): ProductInterface {
-        $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $familyCode);
-        if (null !== $productModel) {
-            $product->setParent($productModel);
-        }
+    private function createProduct(string $identifier, string $familyCode, string $parentCode): ProductInterface {
+        $command = UpsertProductCommand::createFromCollection(
+            userId: $this->getUserId('admin'),
+            productIdentifier: $identifier,
+            userIntents: \array_merge(
+                [
+                    new SetFamily($familyCode),
+                    new ChangeParent($parentCode)
+                ]
+            )
+        );
+        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
-        $this->get('pim_catalog.updater.product')->update($product, ['values' => $values]);
-        $this->get('pim_catalog.saver.product')->save($product);
-
-        return $product;
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -3,6 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Updater\Copier;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
 
 /**
@@ -16,15 +17,13 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_localizable_media';
         $parameters = [
-            'values' => [
-                'a_scopable_image' => [
-                    [
-                        'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'),
-                        'locale' => null,
-                        'scope'  => 'tablet',
-                    ],
-                ],
-            ],
+            // TODO: use SetImageValue when ready
+            new SetTextValue(
+                'a_scopable_image',
+                'tablet',
+                null,
+                $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png')
+            )
         ];
 
         $product = $this->createProduct($sku, $parameters);
@@ -56,15 +55,13 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_scopable_media';
         $parameters = [
-            'values' => [
-                'a_localizable_image' => [
-                    [
-                        'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'),
-                        'locale' => 'fr_FR',
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            // TODO: use SetImageValue when ready
+            new SetTextValue(
+                'a_localizable_image',
+                null,
+                'fr_FR',
+                $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png')
+            )
         ];
 
         $product = $this->createProduct($sku, $parameters);
@@ -96,15 +93,8 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_scopable_localizable_media';
         $parameters = [
-            'values' => [
-                'an_image' => [
-                    [
-                        'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'),
-                        'locale' => null,
-                        'scope'  => null,
-                    ],
-                ],
-            ],
+            // TODO: use SetImageValue when ready
+            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'))
         ];
 
         $product = $this->createProduct($sku, $parameters);

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/MediaAttributeCopierIntegration.php
@@ -3,7 +3,7 @@
 namespace AkeneoTest\Pim\Enrichment\Integration\Updater\Copier;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
 
 /**
@@ -17,8 +17,7 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_localizable_media';
         $parameters = [
-            // TODO: use SetImageValue when ready
-            new SetTextValue(
+            new SetImageValue(
                 'a_scopable_image',
                 'tablet',
                 null,
@@ -55,8 +54,7 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_scopable_media';
         $parameters = [
-            // TODO: use SetImageValue when ready
-            new SetTextValue(
+            new SetImageValue(
                 'a_localizable_image',
                 null,
                 'fr_FR',
@@ -93,8 +91,7 @@ class MediaAttributeCopierIntegration extends AbstractCopierTestCase
     {
         $sku = 'test_scopable_localizable_media';
         $parameters = [
-            // TODO: use SetImageValue when ready
-            new SetTextValue('an_image', null, null, $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'))
+            new SetImageValue('an_image', null, null, $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'))
         ];
 
         $product = $this->createProduct($sku, $parameters);

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/MultiSelectAttributeCopierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/MultiSelectAttributeCopierIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Updater\Copier;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -14,15 +15,7 @@ class MultiSelectAttributeCopierIntegration extends AbstractCopierTestCase
     public function testCopyMultiSelectAttributeValue()
     {
         $product = $this->createProduct('test-copy-multi-select', [
-            'values' => [
-                'a_multi_select' => [
-                    [
-                        'data' => ['optionA', 'optionB'],
-                        'locale' => null,
-                        'scope' => null,
-                    ],
-                ],
-            ],
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'optionB'])
         ]);
 
         $this->get('pim_catalog.updater.property_copier')->copyData(

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/SimpleSelectAttributeCopierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/SimpleSelectAttributeCopierIntegration.php
@@ -2,6 +2,7 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Updater\Copier;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 
 /**
@@ -14,15 +15,7 @@ class SimpleSelectAttributeCopierIntegration extends AbstractCopierTestCase
     public function testCopySimpleSelectAttributeValue()
     {
         $product = $this->createProduct('test-copy-simple-select', [
-            'values' => [
-                'a_simple_select' => [
-                    [
-                        'data' => 'optionA',
-                        'locale' => null,
-                        'scope' => null,
-                    ],
-                ],
-            ],
+            new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
 
         $this->get('pim_catalog.updater.property_copier')->copyData(

--- a/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -28,7 +28,6 @@ class MediaAttributeSetterIntegration extends TestCase
         $attributeName = 'a_localizable_image';
 
         $parameters = [
-            // TODO : use SetImageValue when ready
             'values' => [
                 $attributeName => [
                     [
@@ -57,7 +56,6 @@ class MediaAttributeSetterIntegration extends TestCase
 
         $parameters = [
             'values' => [
-                // TODO: use SetImageValue when ready
                 $attributeName => [
                     [
                         'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1C-t.png'),
@@ -85,7 +83,6 @@ class MediaAttributeSetterIntegration extends TestCase
 
         $parameters = [
             'values' => [
-                // TODO: use SetMediaValue when ready
                 $attributeName => [
                     [
                         'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'),
@@ -113,7 +110,6 @@ class MediaAttributeSetterIntegration extends TestCase
 
         $parameters = [
             'values' => [
-                // TODO: use SetMediaValue when ready
                 $attributeName => [
                     [
                         'data'   => $this->getFileInfoKey($this->getParameter('kernel.project_dir').'/tests/legacy/features/Context/fixtures/SNKRS-1R.png'),

--- a/tests/back/Pim/Structure/Integration/Family/FamilyAttributeAsLabelChangedSubscriberIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/FamilyAttributeAsLabelChangedSubscriberIntegration.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Structure\Integration\Family;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Test\Integration\Configuration;
@@ -41,11 +43,9 @@ class FamilyAttributeAsLabelChangedSubscriberIntegration extends AbstractProduct
         ]);
 
         $this->createProduct('my_product1', [
-            'family' => $familyCode,
-            'values' => [
-                'name' => [['scope' => null, 'locale' => null, 'data' => 'ABCD']],
-                'meta_title' => [['scope' => null, 'locale' => null, 'data' => 'DCBA']],
-            ]
+            new SetFamily($familyCode),
+            new SetTextValue('name', null, null, 'ABCD'),
+            new SetTextValue('meta_title', null, null, 'DCBA'),
         ]);
 
         $family = $this->get('pim_catalog.repository.family')->findOneByCode($familyCode);


### PR DESCRIPTION
Replace the use of pim_catalog.saver.product with UpsertProductCommand and its related user intents inside enrichment tests

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
