### PR TITLE
CPM: clean product's getId() and setId()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -191,7 +191,11 @@
     },
     "minimum-stability": "stable",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "symfony": {

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEnrichment/GetDescendantVariantProductUuidsQueryInterface.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Domain/Query/ProductEnrichment/GetDescendantVariantProductUuidsQueryInterface.php
@@ -6,7 +6,10 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichme
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdCollection;
 
-interface GetDescendantVariantProductIdsQueryInterface
+interface GetDescendantVariantProductUuidsQueryInterface
 {
+    /**
+     * @return string[]
+     */
     public function fromProductModelIds(ProductEntityIdCollection $productModelIdCollection): array;
 }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQueryIntegration.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Integration/Infrastructure/Persistence/Query/KeyIndicator/ComputeProductsEnrichmentStatusQueryIntegration.php
@@ -111,7 +111,7 @@ final class ComputeProductsEnrichmentStatusQueryIntegration extends DataQualityI
 
     private function givenNotInvolvedProduct(): void
     {
-        $this->createProduct('not_involved_product', ['family' => 'family_with_5_attributes'])->getId();
+        $this->createProduct('not_involved_product', ['family' => 'family_with_5_attributes']);
     }
 
     private function givenProductWithoutEvaluations(): array

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -468,7 +468,7 @@ class ProductController
 
         // don't filter during creation, because identifier is needed
         // but not sent by the frontend during creation (it sends the sku in the values)
-        if (null !== $product->getCreated() && $product->isVariant()) {
+        if (!$product->isNew() && $product->isVariant()) {
             $data = $this->productAttributeFilter->filter($data);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -468,7 +468,7 @@ class ProductController
 
         // don't filter during creation, because identifier is needed
         // but not sent by the frontend during creation (it sends the sku in the values)
-        if (null !== $product->getId() && $product->isVariant()) {
+        if (null !== $product->getCreated() && $product->isVariant()) {
             $data = $this->productAttributeFilter->filter($data);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Category/AscendantCategories.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Category/AscendantCategories.php
@@ -54,8 +54,8 @@ final class AscendantCategories implements AscendantCategoriesInterface
                 ->leftJoin('product_model.parent', 'parent_product_model')
                 ->leftJoin('product_model.categories', 'category')
                 ->leftJoin('parent_product_model.categories', 'parent_category')
-                ->where('variant_product.id = :id')
-                ->setParameter(':id', $entity->getId());
+                ->where('variant_product.uuid = :uuid')
+                ->setParameter(':uuid', $entity->getUuid()->getBytes());
 
             foreach ($queryBuilder->getQuery()->getResult() as $resultItem) {
                 if (!in_array(intval($resultItem['id']), $result)) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/MassEdit/AddAttributeValueProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/MassEdit/AddAttributeValueProcessor.php
@@ -5,7 +5,6 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Processor\MassEdit;
 use Akeneo\Pim\Enrichment\Component\Product\EntityWithFamilyVariant\CheckAttributeEditable;
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithFamilyInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\PropertyAdderInterface;
@@ -181,7 +180,9 @@ class AddAttributeValueProcessor extends AbstractProcessor
             new DataInvalidItem(
                 [
                     'class'  => ClassUtils::getClass($entity),
-                    'id'     => $entity->getId(),
+                    'id'     => $entity instanceof ProductInterface && get_class($entity) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface'
+                        ? $entity->getUuid()->toString()
+                        : $entity->getId(),
                     'string' => $entity->getIdentifier(),
                 ]
             )

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriter.php
@@ -91,7 +91,7 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
      */
     protected function incrementCount(EntityWithFamilyInterface $entity)
     {
-        if (null !== $entity->getCreated()) {
+        if (!$entity->isNew()) {
             $this->stepExecution->incrementSummaryInfo('process');
         } else {
             $this->stepExecution->incrementSummaryInfo('create');

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriter.php
@@ -91,7 +91,7 @@ class ProductAndProductModelWriter implements ItemWriterInterface, StepExecution
      */
     protected function incrementCount(EntityWithFamilyInterface $entity)
     {
-        if ($entity->getId()) {
+        if (null !== $entity->getCreated()) {
             $this->stepExecution->incrementSummaryInfo('process');
         } else {
             $this->stepExecution->incrementSummaryInfo('create');

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -82,6 +82,8 @@ abstract class AbstractProduct implements ProductInterface
     }
 
     /**
+     * @TODO: remove this method?
+     *
      * {@inheritdoc}
      */
     public function getId()
@@ -91,6 +93,8 @@ abstract class AbstractProduct implements ProductInterface
     }
 
     /**
+     * @TODO: remove this method?
+     *
      * {@inheritdoc}
      */
     public function setId($id)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -82,14 +82,11 @@ abstract class AbstractProduct implements ProductInterface
     }
 
     /**
-     * @TODO: remove this method?
-     *
      * {@inheritdoc}
      */
     public function getId()
     {
-        throw new \Exception('getId() should not be called');
-        return $this->uuid->toString();
+        throw new \LogicException('Product getId() should not be called');
     }
 
     public function getUuid(): UuidInterface

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -89,7 +89,7 @@ abstract class AbstractProduct implements ProductInterface
     public function getId()
     {
         throw new \Exception('getId() should not be called');
-        return $this->id;
+        return $this->uuid->toString();
     }
 
     /**
@@ -1096,5 +1096,13 @@ abstract class AbstractProduct implements ProductInterface
         $associationsCollection->add($association);
 
         return $associationsCollection;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNew(): bool
+    {
+        return null === $this->created;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -86,6 +86,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function getId()
     {
+        throw new \Exception('getId() should not be called');
         return $this->id;
     }
 
@@ -94,6 +95,7 @@ abstract class AbstractProduct implements ProductInterface
      */
     public function setId($id)
     {
+        throw new \Exception('setId() should not be called');
         $this->id = $id;
 
         return $this;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -92,19 +92,6 @@ abstract class AbstractProduct implements ProductInterface
         return $this->uuid->toString();
     }
 
-    /**
-     * @TODO: remove this method?
-     *
-     * {@inheritdoc}
-     */
-    public function setId($id)
-    {
-        throw new \Exception('setId() should not be called');
-        $this->id = $id;
-
-        return $this;
-    }
-
     public function getUuid(): UuidInterface
     {
         return $this->uuid;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/EntityWithValuesInterface.php
@@ -88,4 +88,6 @@ interface EntityWithValuesInterface
      * Get the list of used attribute codes from the indexed values
      */
     public function getUsedAttributeCodes(): array;
+
+    public function isNew(): bool;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
@@ -40,15 +40,6 @@ interface ProductInterface extends
      */
     public function getId();
 
-    /**
-     * Set id
-     *
-     * @param int|string $id
-     *
-     * @return ProductInterface
-     */
-    public function setId($id);
-
     public function getUuid(): UuidInterface;
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductInterface.php
@@ -33,13 +33,6 @@ interface ProductInterface extends
     EntityWithQuantifiedAssociationsInterface,
     StateUpdatedAware
 {
-    /**
-     * Get the ID of the product
-     *
-     * @return int|string
-     */
-    public function getId();
-
     public function getUuid(): UuidInterface;
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/ProductModel.php
@@ -998,4 +998,12 @@ class ProductModel implements ProductModelInterface
 
         return $associationsCollection;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isNew(): bool
+    {
+        return null === $this->id;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -123,7 +123,7 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface, Cacheabl
         }
 
         return [
-            'id'                 => $entity->getId(),
+            'id' => $entity instanceof ProductInterface ? $entity->getUuid()->toString() : $entity->getId(),
             'identifier'         => $identifier,
             'axes_values_labels' => $this->getAxesValuesLabelsForLocales($entity, $localeCodes),
             'labels'             => $labels,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductEntityValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductEntityValidator.php
@@ -21,23 +21,11 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class UniqueProductEntityValidator extends ConstraintValidator
 {
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $productRepository;
-
-    /** @var UniqueValuesSet */
-    private $uniqueValuesSet;
-
-    /** @var AttributeRepositoryInterface */
-    private $attributeRepository;
-
     public function __construct(
-        IdentifiableObjectRepositoryInterface $productRepository,
-        UniqueValuesSet $uniqueValuesSet,
-        AttributeRepositoryInterface $attributeRepository
+        private IdentifiableObjectRepositoryInterface $productRepository,
+        private UniqueValuesSet $uniqueValuesSet,
+        private AttributeRepositoryInterface $attributeRepository
     ) {
-        $this->productRepository = $productRepository;
-        $this->uniqueValuesSet = $uniqueValuesSet;
-        $this->attributeRepository = $attributeRepository;
     }
 
     /**
@@ -82,7 +70,7 @@ class UniqueProductEntityValidator extends ConstraintValidator
          * We don't want to validate a product identifier if we update a product because we have already validated the
          * product identifier during the creation
          */
-        if ($entity->getId() !== $entityInDatabase->getId()) {
+        if (!$entity->getUuid()->equals($entityInDatabase->getUuid())) {
             $this->context->buildViolation($constraint->message, ['%identifier%' => $identifierValue->getData()])
                 ->atPath('identifier')
                 ->setCode(UniqueProductEntity::UNIQUE_PRODUCT_ENTITY)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Product/UniqueProductModelEntityValidator.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product;
 
-use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ValueInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueValuesSet;
@@ -41,7 +40,7 @@ class UniqueProductModelEntityValidator extends ConstraintValidator
     public function validate($entity, Constraint $constraint): void
     {
         if (!$constraint instanceof UniqueProductModelEntity) {
-            throw new UnexpectedTypeException($constraint, UniqueProductEntity::class);
+            throw new UnexpectedTypeException($constraint, UniqueProductModelEntity::class);
         }
 
         if (!$entity instanceof ProductModelInterface) {

--- a/src/Akeneo/Tool/Bundle/ClassificationBundle/Doctrine/ORM/Repository/AbstractItemCategoryRepository.php
+++ b/src/Akeneo/Tool/Bundle/ClassificationBundle/Doctrine/ORM/Repository/AbstractItemCategoryRepository.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ClassificationBundle\Doctrine\ORM\Repository;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Tool\Component\Classification\Repository\CategoryFilterableRepositoryInterface;
 use Akeneo\Tool\Component\Classification\Repository\ItemCategoryRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
@@ -76,8 +77,14 @@ abstract class AbstractItemCategoryRepository implements
             $config['relation']
         );
 
+        if ($item instanceof ProductInterface && get_class($item) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface') {
+            $id = $item->getUuid()->getBytes();
+        } else {
+            $id = $item->getId();
+        }
+
         $stmt = $this->em->getConnection()->prepare($sql);
-        $stmt->bindValue('itemId', $item->getId());
+        $stmt->bindValue('itemId', $id);
         $items = $stmt->executeQuery()->fetchAllAssociative();
 
         return $this->buildItemCountByTree($items, $config['categoryClass']);

--- a/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
@@ -471,16 +471,16 @@ class StepExecution
             $data = [];
         }
 
-        $id = '[unknown]';
-        if (\method_exists($data, 'getUuid')
-            && get_class($data) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface'
-        ) {
-            $id = $data->getUuid()->toString();
-        } elseif (\method_exists($data, 'getId')) {
-            $id = $data->getId();
-        }
-
         if (is_object($data)) {
+            $id = '[unknown]';
+            if (\method_exists($data, 'getUuid')
+                && get_class($data) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface'
+            ) {
+                $id = $data->getUuid()->toString();
+            } elseif (\method_exists($data, 'getId')) {
+                $id = $data->getId();
+            }
+
             $data = [
                 'class'  => ClassUtils::getClass($data),
                 'id'     => $id,

--- a/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/StepExecution.php
@@ -471,10 +471,19 @@ class StepExecution
             $data = [];
         }
 
+        $id = '[unknown]';
+        if (\method_exists($data, 'getUuid')
+            && get_class($data) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface'
+        ) {
+            $id = $data->getUuid()->toString();
+        } elseif (\method_exists($data, 'getId')) {
+            $id = $data->getId();
+        }
+
         if (is_object($data)) {
             $data = [
                 'class'  => ClassUtils::getClass($data),
-                'id'     => method_exists($data, 'getId') ? $data->getId() : '[unknown]',
+                'id'     => $id,
                 'string' => method_exists($data, '__toString') ? (string) $data : '[unknown]',
             ];
         }

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductDatasource.php
@@ -3,6 +3,7 @@
 namespace Oro\Bundle\PimDataGridBundle\Datasource;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\EntityWithValuesInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -123,7 +124,9 @@ class ProductDatasource extends Datasource
     private function normalizeEntityWithValues(EntityWithValuesInterface $item, array $context): array
     {
         $defaultNormalizedItem = [
-            'id'               => $item->getId(),
+            'id'               => $item instanceof ProductInterface && get_class($item) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProductInterface'
+                ? $item->getUuid()->toString()
+                : $item->getId(),
             'dataLocale'       => $this->getParameters()['dataLocale'],
             'family'           => null,
             'values'           => [],

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductDatasourceSpec.php
@@ -16,6 +16,7 @@ use Oro\Bundle\PimDataGridBundle\Extension\Pager\PagerExtension;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class ProductDatasourceSpec extends ObjectBehavior
@@ -51,6 +52,7 @@ class ProductDatasourceSpec extends ObjectBehavior
         ProductInterface $product1,
         CursorInterface $productCursor
     ) {
+        $product1->getUuid()->willReturn(Uuid::uuid4());
         $config = [
             'displayed_attribute_ids' => [1, 2],
             'attributes_configuration' => [

--- a/src/Oro/Bundle/SecurityBundle/Acl/Domain/ObjectIdAccessor.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Domain/ObjectIdAccessor.php
@@ -21,6 +21,11 @@ class ObjectIdAccessor
     {
         if ($domainObject instanceof DomainObjectInterface) {
             return $domainObject->getObjectIdentifier();
+        } elseif (method_exists($domainObject, 'getUuid')
+            // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
+            && get_class($domainObject) !== 'Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProduct'
+        ) {
+            return $domainObject->getUuid()->toString();
         } elseif (method_exists($domainObject, 'getId')) {
             return $domainObject->getId();
         }

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/Standard/ProductStandardSortedCollectionIntegration.php
@@ -26,8 +26,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
             ])
             ->build();
 
-        $product->setId(111);
-
         $expected = [
             'identifier' => 'my-product',
             'family' => null,
@@ -87,8 +85,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
             ->withValue('a_multi_select', ['optionB', 'optionA'])
             ->build();
 
-        $product->setId(111);
-
         $expected = [
             'identifier' => 'my-product',
             'family' => null,
@@ -143,8 +139,6 @@ class ProductStandardSortedCollectionIntegration extends TestCase
         $product = $this->getProductBuilder()
             ->withValue('a_ref_data_multi_select', ['zibeline', 'tapestry', 'brilliantine'])
             ->build();
-
-        $product->setId(111);
 
         $expected = [
             'identifier' => 'my-product',

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnSave/ApiAggregatorForProductPostSaveEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnSave/ApiAggregatorForProductPostSaveEventSubscriberSpec.php
@@ -45,7 +45,6 @@ class ApiAggregatorForProductPostSaveEventSubscriberSpec extends ObjectBehavior
         $this->activate();
 
         $product = new Product();
-        $product->setId(1);
         $event->getSubject()->willReturn($product);
         $event->getArguments()->willReturn(['unitary' => true]);
         $event->setArgument('unitary', false)->shouldBeCalled();
@@ -54,7 +53,6 @@ class ApiAggregatorForProductPostSaveEventSubscriberSpec extends ObjectBehavior
         $this->getEventProducts()->shouldHaveCount(1);
 
         $product = new Product();
-        $product->setId(2);
         $event = new GenericEvent($product, ['unitary' => true]);
         $this->batchEvents($event);
         $this->getEventProducts()->shouldHaveCount(2);
@@ -91,7 +89,6 @@ class ApiAggregatorForProductPostSaveEventSubscriberSpec extends ObjectBehavior
         $this->activate();
 
         $product = new Product();
-        $product->setId(1);
         $event->getSubject()->willReturn($product);
         $event->getArguments()->willReturn(['unitary' => false]);
         $event->setArgument(Argument::cetera())->shouldNotBeCalled();
@@ -124,13 +121,11 @@ class ApiAggregatorForProductPostSaveEventSubscriberSpec extends ObjectBehavior
         $this->activate();
 
         $product = new Product();
-        $product->setId(1);
         $event = new GenericEvent($product, ['unitary' => true]);
         $this->batchEvents($event);
         $this->getEventProducts()->shouldHaveCount(1);
 
         $product = new Product();
-        $product->setId(2);
         $event = new GenericEvent($product, ['unitary' => true]);
         $this->batchEvents($event);
         $this->getEventProducts()->shouldHaveCount(2);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Writer/Database/MassEdit/ProductAndProductModelWriterSpec.php
@@ -58,7 +58,9 @@ class ProductAndProductModelWriterSpec extends ObjectBehavior
         $jobParameters->get('realTimeVersioning')->willReturn(true);
 
         $items = [$product1, $productModel1, $product2];
-        $productModel1->getId()->willReturn(1);
+        $product1->isNew()->willReturn(true);
+        $product2->isNew()->willReturn(true);
+        $productModel1->isNew()->willReturn(false);
         $productModel1->getCode()->willReturn('product_model');
 
         $products = $items;
@@ -90,9 +92,9 @@ class ProductAndProductModelWriterSpec extends ObjectBehavior
 
         $items = [$product1, $productModel1, $product2];
 
-        $product1->getId()->willReturn('45');
-        $product2->getId()->willReturn(null);
-        $productModel1->getId()->willReturn('89');
+        $product1->isNew()->willReturn(false);
+        $product2->isNew()->willReturn(true);
+        $productModel1->isNew()->willReturn(false);
         $productModel1->getCode()->willReturn('product_model');
 
         $productSaver->saveAll(Argument::any())->shouldBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
@@ -27,6 +27,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeOptionValueInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 
 class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
 {
@@ -110,7 +111,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $variantProduct->getLabel('en_US')->willReturn('Tshirt White S');
         $variantProduct->getIdentifier()->willReturn('tshirt_white_s');
         $variantProduct->getImage()->willReturn(null);
-        $variantProduct->getId()->willReturn(42);
+        $variantProduct->getUuid()->willReturn(Uuid::fromString('359a2a04-5fa4-4f15-9c08-09b819327c8f'));
 
         $attributesProvider->getAxes($variantProduct)->willReturn([
             $colorAttribute,
@@ -157,7 +158,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $metricNormalizer->normalize($weightValue, 'en_US')->willReturn('10 KILOGRAM');
 
         $this->normalize($variantProduct, 'internal_api', $context)->shouldReturn([
-            'id'                 => 42,
+            'id'                 => '359a2a04-5fa4-4f15-9c08-09b819327c8f',
             'identifier'         => 'tshirt_white_s',
             'axes_values_labels' => [
                 'fr_FR' => 'Blanc, S, 10 KILOGRAM',

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/Product/UniqueProductEntityValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/Product/UniqueProductEntityValidatorSpec.php
@@ -14,6 +14,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueValuesSet;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -60,8 +61,8 @@ class UniqueProductEntityValidatorSpec extends ObjectBehavior
         $product->getIdentifier()->willReturn('identifier');
         $objectRepository->findOneByIdentifier('identifier')->willReturn($productInDatabase);
 
-        $productInDatabase->getId()->willReturn(40);
-        $product->getId()->willReturn(64);
+        $productInDatabase->getUuid()->willReturn(Uuid::uuid4());
+        $product->getUuid()->willReturn(Uuid::uuid4());
 
         $context->buildViolation(Argument::type('string'), Argument::type('array'))
             ->willReturn($constraintViolationBuilder);

--- a/tests/legacy/features/Context/SecurityContext.php
+++ b/tests/legacy/features/Context/SecurityContext.php
@@ -130,7 +130,7 @@ class SecurityContext extends PimContext
 
         $this->doCall('GET', $url, [
             'inset' => 1,
-            'values' => $product->getId()
+            'values' => $product->getUuid()->toString()
         ]);
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Remove all remaining usages of getId/setId on Product. 

- setId is removed
- getId is kept because the shared interfaces (EntityWithValuesInterface, ...) but it throws an exception now
- a new `isNew` method is added (before we checked the id is null or not)