### PR TITLE
Fix composer allow plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,7 +190,11 @@
     },
     "minimum-stability": "stable",
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "symfony": {


### PR DESCRIPTION
The nightlies are blocked because of composer https://app.circleci.com/pipelines/github/akeneo/pim-community-dev/35133/workflows/3c462c14-200e-48e1-b4fd-f7594bc9d520/jobs/176385  
He now asks if we want to add the plugins.  

Until now the current behavior were it added the plugins by default, see https://getcomposer.org/doc/06-config.md#allow-plugins

We also could allow all plugins, but we prefered to allow them one by one explicitely