### PR TITLE
PIM-10425: Fix notifications can't be displayed because of removed routes

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10425: Fix notifications can't be displayed because of removed routes
+
 ## Improvements
 
 - Use Node v14 in docker-compose files

--- a/upgrades/schema/Version_6_0_20220509143200_use_the_new_process_tracker_route.php
+++ b/upgrades/schema/Version_6_0_20220509143200_use_the_new_process_tracker_route.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20220509143200_use_the_new_process_tracker_route extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('UPDATE pim_notification_notification SET route = "akeneo_job_process_tracker_details" WHERE route IN ("pim_importexport_export_execution_show", "pim_importexport_import_execution_show")');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20220509143200_use_the_new_process_tracker_route_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220509143200_use_the_new_process_tracker_route_Integration.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+class Version_6_0_20220509143200_use_the_new_process_tracker_route_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_6_0_20220509143200_use_the_new_process_tracker_route';
+
+    public function test_it_replaces_old_import_export_routes(): void
+    {
+        $this->addNotifications();
+
+        $this->assertTrue($this->notificationTableContainOldProcessTrackerRoute());
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->assertFalse($this->notificationTableContainOldProcessTrackerRoute());
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function addNotifications(): void
+    {
+        $this->getConnection()->executeStatement(<<<SQL
+            INSERT INTO pim_notification_notification (route, routeParams, message, messageParams, comment, created, type, context)
+            VALUES ('pim_importexport_import_execution_show', 'a:1:{s:2:"id";i:609;}', 'pim_import_export.notification.export.success', 'a:1:{s:7:"%label%";s:17:"Export Kategorien";}', NULL, '2019-11-29 13:38:51', 'success', 'a:1:{s:10:"actionType";s:6:"export";}');
+        SQL);
+
+        $this->getConnection()->executeStatement(<<<SQL
+            INSERT INTO pim_notification_notification (route, routeParams, message, messageParams, comment, created, type, context)
+            VALUES ('pim_importexport_export_execution_show', 'a:1:{s:2:"id";i:607;}', 'pim_import_export.notification.import.warning', 'a:1:{s:7:"%label%";s:10:"Kategorien";}', NULL, '2019-11-29 13:18:07', 'warning', 'a:1:{s:10:"actionType";s:6:"import";}');
+        SQL);
+    }
+
+    private function notificationTableContainOldProcessTrackerRoute(): bool
+    {
+        $query = <<<SQL
+SELECT *
+FROM pim_notification_notification
+WHERE route IN('pim_importexport_export_execution_show', 'pim_importexport_import_execution_show')
+SQL;
+
+        return !empty($this->getConnection()->fetchAllAssociative($query));
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, i fixed the following error :

`Uncaught PHP Exception Twig\Error\RuntimeError: "An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route "pim_importexport_export_execution_show" as such route does not exist.")." at /home/akeneo/pim/vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/NotificationBundle/Resources/views/Notification/list.json.twig line 6`

Why we have this error ?
Because when we deployed the process tracker revamp we have renamed the route name (see https://github.com/akeneo/pim-community-dev/pull/15795 )
Because notification redirect url is stored in database we forget it.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
