### PR TITLE
DPE: Use www-data user for Docker Compose php container

### DIFF
--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -58,8 +58,8 @@ cp -R vendor/akeneo/pim-community-dev/upgrades/schema/* upgrades/schema
 
 echo "Enable Onboarder bundle on 5.0 branch..."
 sudo chown 1000:1000 composer.json
-docker-compose run -u www-data --rm php php /usr/local/bin/composer config repositories.onboarder '{ "type": "vcs", "url": "https://github.com/akeneo/pim-onboarder.git", "branch": "master" }'
-docker-compose run -u www-data --rm php php -d memory_limit=5G /usr/local/bin/composer require "akeneo/pim-onboarder:^4.2.1"
+docker-compose run --rm php composer config repositories.onboarder '{ "type": "vcs", "url": "https://github.com/akeneo/pim-onboarder.git", "branch": "master" }'
+docker-compose run --rm php php -d memory_limit=5G /usr/local/bin/composer require "akeneo/pim-onboarder:^4.2.1"
 if [ -d "vendor/akeneo/pim-onboarder" ]; then
     sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
 fi
@@ -115,7 +115,7 @@ echo "Clean cache..."
 APP_ENV=test make cache
 
 echo "Launch branch migrations..."
-docker-compose run -u www-data php bin/console doctrine:migrations:migrate --env=test --no-interaction
+docker-compose run --rm php bin/console doctrine:migrations:migrate --env=test --no-interaction
 
 echo "Dump 5.0 with migrations database..."
 docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_50_database_with_migrations.sql

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -293,7 +293,7 @@ jobs:
                   command: PIM_CONTEXT=onboarder make add-bundle-specific-dev-dependencies
             - run:
                   name: Composer update for tests dependencies
-                  command: docker-compose run -u www-data --rm php php -d memory_limit=4G /usr/local/bin/composer update --no-interaction
+                  command: docker-compose run --rm php php -d memory_limit=4G /usr/local/bin/composer update --no-interaction
             - run:
                   name: Add configuration files to run the bundle tests from the PIM
                   command: |

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -10,14 +10,14 @@ CONFIG_DIRECTORY=$1
 FIND_PHPUNIT_SCRIPT=$2
 TEST_SUITES=$3
 
-TEST_FILES=$(docker-compose run -u www-data --rm -T php php $FIND_PHPUNIT_SCRIPT -c $CONFIG_DIRECTORY --testsuite $TEST_SUITES | circleci tests split --split-by=timings)
+TEST_FILES=$(docker-compose run --rm -T php php $FIND_PHPUNIT_SCRIPT -c $CONFIG_DIRECTORY --testsuite $TEST_SUITES | circleci tests split --split-by=timings)
 
 fail=0
 for TEST_FILE in $TEST_FILES; do
     echo $TEST_FILE
 
     set +e
-    APP_ENV=test docker-compose run -u www-data -T php ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
+    APP_ENV=test docker-compose run -T php ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
     TEST_RESULT=$?
     if [ $TEST_RESULT -ne 0 ]; then
         echo "Test has failed (with code $TEST_RESULT): $TEST_FILE"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER_COMPOSE = docker-compose
 NODE_RUN = $(DOCKER_COMPOSE) run -u node --rm -e YARN_REGISTRY -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 -e PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome node
 YARN_RUN = $(NODE_RUN) yarn
-PHP_RUN = $(DOCKER_COMPOSE) run -u www-data --rm php php
+PHP_RUN = $(DOCKER_COMPOSE) run --rm php php
 PHP_EXEC = $(DOCKER_COMPOSE) exec -u www-data fpm php
 
 .DEFAULT_GOAL := help
@@ -38,12 +38,12 @@ dsm:
 
 .PHONY: assets
 assets:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/bundles public/js
+	$(DOCKER_COMPOSE) run --rm php rm -rf public/bundles public/js
 	$(PHP_RUN) bin/console --env=prod pim:installer:assets --symlink --clean
 
 .PHONY: css
 css:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf public/css
+	$(DOCKER_COMPOSE) run --rm php rm -rf public/css
 	$(YARN_RUN) run less
 
 .PHONY: javascript-prod
@@ -82,7 +82,7 @@ var/cache/dev:
 
 .PHONY: cache
 cache:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache && $(PHP_RUN) bin/console cache:warmup
+	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache && $(PHP_RUN) bin/console cache:warmup
 
 .PHONY: vendor
 vendor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - '${HOST_COMPOSER_HOME:-~/.composer}:/var/www/.composer'
     working_dir: '/srv/pim'
     command: 'php'
+    user: 'www-data'
     init: true
     networks:
       - 'pim'

--- a/make-file/communication-channel.mk
+++ b/make-file/communication-channel.mk
@@ -81,8 +81,8 @@ communication-channel-unit-front:
 # Developpement
 
 communication-channel-back:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
-	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
+	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache/dev
+	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 --rm php bin/console cache:warmup
 	${PHP_RUN} vendor/bin/php-cs-fixer fix --config=.php_cs.php src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back
 	$(MAKE) communication-channel-lint-back
 	$(MAKE) communication-channel-coupling-back

--- a/make-file/connectivity-connection.mk
+++ b/make-file/connectivity-connection.mk
@@ -62,8 +62,8 @@ connectivity-connection-coupling-back:
 
 connectivity-connection-lint-back:
 ifneq ($(CI),true)
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
-	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
+	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache/dev
+	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 --rm php bin/console cache:warmup
 endif
 	$(PHP_RUN) vendor/bin/php-cs-fixer fix --diff --dry-run --config=src/Akeneo/Connectivity/Connection/back/tests/.php_cs.php
 	$(PHP_RUN) vendor/bin/phpstan analyse \
@@ -81,7 +81,7 @@ connectivity-connection-lint-back_fix:
 
 connectivity-connection-unit-back:
 ifeq ($(CI),true)
-	$(DOCKER_COMPOSE) run -T -u www-data --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
+	$(DOCKER_COMPOSE) run -T --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 endif
 	$(PHP_RUN) vendor/bin/phpspec run src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/
@@ -163,11 +163,11 @@ connectivity-connection-coverage:
 		--coverage-html coverage/Connectivity/Back/EndToEnd/ \
 		--testsuite EndToEnd $(0)
 
-	$(DOCKER_COMPOSE) run -u www-data --rm php mkdir -p var/tests/behat/connectivity/connection
+	$(DOCKER_COMPOSE) run --rm php mkdir -p var/tests/behat/connectivity/connection
 	# download phpcov binary
-	$(DOCKER_COMPOSE) run -u www-data --rm php sh -c "test -e phpcov.phar || wget https://phar.phpunit.de/phpcov.phar && php phpcov.phar --version"
+	$(DOCKER_COMPOSE) run --rm php sh -c "test -e phpcov.phar || wget https://phar.phpunit.de/phpcov.phar && php phpcov.phar --version"
 	# create a coverage global folder
-	$(DOCKER_COMPOSE) run -u www-data --rm php sh -c "\
+	$(DOCKER_COMPOSE) run --rm php sh -c "\
 		if [ -d coverage/Connectivity/Back/Global/ ]; then rm -r coverage/Connectivity/Back/Global/; fi && \
 		mkdir -p coverage/Connectivity/Back/Global/ && \
 		cp coverage/Connectivity/Back/Unit/coverage.php coverage/Connectivity/Back/Global/Unit.cov && \

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -1,5 +1,5 @@
 var/tests/%:
-	$(DOCKER_COMPOSE) run -u www-data --rm php mkdir -p $@
+	$(DOCKER_COMPOSE) run --rm php mkdir -p $@
 
 .PHONY: find-legacy-translations
 find-legacy-translations:
@@ -24,9 +24,9 @@ check-sf-services:
 ### Lint tests
 .PHONY: lint-back
 lint-back:
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
-	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bin/console cache:warmup
-	$(DOCKER_COMPOSE) run -u www-data --rm php php -d memory_limit=1G vendor/bin/phpstan analyse src/Akeneo/Pim --level 2
+	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache/dev
+	APP_ENV=dev $(DOCKER_COMPOSE) run -e APP_DEBUG=1 --rm php bin/console cache:warmup
+	$(DOCKER_COMPOSE) run --rm php php -d memory_limit=1G vendor/bin/phpstan analyse src/Akeneo/Pim --level 2
 	${PHP_RUN} vendor/bin/php-cs-fixer fix --diff --dry-run --config=.php_cs.php
 	$(MAKE) connectivity-connection-lint-back
 	$(MAKE) communication-channel-lint-back
@@ -35,7 +35,7 @@ lint-back:
 	$(MAKE) job-lint-back
 	$(MAKE) enrichment-product-lint-back
 	# Cache was created with debug enabled, removing it allows a faster one to be created for upcoming tests
-	$(DOCKER_COMPOSE) run -u www-data --rm php rm -rf var/cache/dev
+	$(DOCKER_COMPOSE) run --rm php rm -rf var/cache/dev
 
 .PHONY: lint-front
 lint-front:
@@ -46,7 +46,7 @@ lint-front:
 .PHONY: unit-back
 unit-back: var/tests/phpspec
 ifeq ($(CI),true)
-	$(DOCKER_COMPOSE) run -T -u www-data --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
+	$(DOCKER_COMPOSE) run -T --rm php php vendor/bin/phpspec run --format=junit > var/tests/phpspec/specs.xml
 	.circleci/find_non_executed_phpspec.sh
 else
 	${PHP_RUN} vendor/bin/phpspec run
@@ -126,5 +126,5 @@ endif
 
 .PHONY: test-database-structure
 test-database-structure: #Doc: test database structure
-	$(DOCKER_COMPOSE) run -e APP_DEBUG=1 -u www-data --rm php bash -c 'bin/console pimee:database:inspect -f --env=test && bin/console pimee:database:diff --env=test'
+	$(DOCKER_COMPOSE) run -e APP_DEBUG=1 --rm php bash -c 'bin/console pimee:database:inspect -f --env=test && bin/console pimee:database:diff --env=test'
 


### PR DESCRIPTION
Setting the user for `php` container in the docker-compose file will avoid the need to always add it in the command line.

This should avoid annoying side effects like when you forget to use `-u www-data` with a `composer update` command and you find yourself with your composer cache file permissions spoiled by root user.

### Before PR:

```bash
$ docker-compose run --rm php id
Creating ee-master_php_run ... done
uid=0(root) gid=0(root) groups=0(root)

$ docker-compose run --rm -u www-data php id
Creating ee-master_php_run ... done
uid=1000(www-data) gid=1000(www-data) groups=1000(www-data)
```

### After PR:

```bash
$ docker-compose run --rm php id
Creating ee-master_php_run ... done
uid=1000(www-data) gid=1000(www-data) groups=1000(www-data)

$ docker-compose run --rm -u www-data php id
Creating ee-master_php_run ... done
uid=1000(www-data) gid=1000(www-data) groups=1000(www-data)
```

As we can see in the last example, it's always possible to override the user in command line, and we can still use `root` if needed:

```bash
$ docker-compose run --rm -u root php id
Creating ee-master_php_run ... done
uid=0(root) gid=0(root) groups=0(root)
```
