### PR TITLE
[adr-uuid] Store success on db

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/LaunchEvaluationsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/LaunchEvaluationsCommand.php
@@ -60,12 +60,14 @@ class LaunchEvaluationsCommand extends Command
                 SELECT 1
                 FROM pim_one_time_task
                 WHERE code=:code
+                AND status=:status
                 LIMIT 1
             ) AS missing
         SQL;
 
         return (bool) $this->connection->fetchOne($sql, [
             ':code' => 'pim:product:migrate-to-uuid',
+            ':status' => 'started',
         ]);
     }
 }


### PR DESCRIPTION
Before this PR, we have to check if every state was already done
The issue is that our biggest client takes a very long time to compute.
With this solution, we store the success of the migration, and only check for it when we run the cmd.