### PR TITLE
CXP-1163: Fixed linting error for DeleteTestAppAction

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/TestApps/Controller/External/DeleteTestAppAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/TestApps/Controller/External/DeleteTestAppAction.php
@@ -50,7 +50,7 @@ final class DeleteTestAppAction
 
         $this->deleteTestAppHandler->handle(new DeleteTestAppCommand($clientId));
 
-        if ($testAppData['connected'] ?? false) {
+        if ($testAppData['connected']) {
             $this->deleteAppHandler->handle(new DeleteAppCommand($clientId));
         }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/TestApps/Controller/External/DeleteTestAppActionSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/TestApps/Controller/External/DeleteTestAppActionSpec.php
@@ -95,6 +95,7 @@ class DeleteTestAppActionSpec extends ObjectBehavior
 
         $getTestAppQuery->execute('test_client_id')->willReturn([
             'some' => 'data',
+            'connected' => false,
         ]);
 
         $deleteTestAppHandler


### PR DESCRIPTION
CXP-1163: Fixed linting error for DeleteTestAppAction
```
 ------ ----------------------------------------------------------------------- 
  Line   Marketplace/TestApps/Controller/External/DeleteTestAppAction.php       
 ------ ----------------------------------------------------------------------- 
  53     Offset 'connected' on array{id: string, secret: string, name: string,  
         author: string|null, activate_url: string, callback_url: string,       
         connected: bool} on left side of ?? always exists and is not           
         nullable.                                                              
 ------ ----------------------------------------------------------------------- 
```