### PR TITLE
DPE: COMPOSER_MEMORY_LIMIT env var in php container

### DIFF
--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -293,7 +293,7 @@ jobs:
                   command: PIM_CONTEXT=onboarder make add-bundle-specific-dev-dependencies
             - run:
                   name: Composer update for tests dependencies
-                  command: docker-compose run --rm php php -d memory_limit=4G /usr/local/bin/composer update --no-interaction
+                  command: docker-compose run --rm php composer update --no-interaction
             - run:
                   name: Add configuration files to run the bundle tests from the PIM
                   command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY docker/build/akeneo.ini /etc/php/8.0/fpm/conf.d/99-akeneo.ini
 FROM base as dev
 
 ENV PHP_CONF_OPCACHE_VALIDATE_TIMESTAMP=1
+ENV COMPOSER_MEMORY_LIMIT=4G
 
 RUN apt-get update && \
     apt-get --yes install gnupg &&\


### PR DESCRIPTION
Using the COMPOSER_MEMORY_LIMIT directly inside our PHP container allows us to not have to define this limit anywhere when using the container.

This can still be overridden in CLI if more memory is needed.

It has no impact on the overall PHP memory limit and is used only by Composer