### PR TITLE
RAB-723: Create tag before submitting with non-empty input

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Block/Block.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Block/Block.unit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {fireEvent, render, screen} from '../../storybook/test-util';
+import {fireEvent, render, screen, act} from '../../storybook/test-util';
 import {Block} from './Block';
 import {IconButton} from '../IconButton/IconButton';
 import {CloseIcon, EditIcon, PlusIcon} from '../../icons';
@@ -53,19 +53,18 @@ test('it renders actions passed by props', () => {
 
 test('it supports collapsing', () => {
   const onCollapse = jest.fn();
-  const isOpen = false;
   jest.useFakeTimers();
 
   render(
-    <Block title="My block" isOpen={isOpen} onCollapse={onCollapse} collapseButtonLabel="Collapse" actions={<></>}>
+    <Block title="My block" isOpen={false} onCollapse={onCollapse} collapseButtonLabel="Collapse">
       I am a block
     </Block>
   );
 
-  const collapseIconButton = screen.getByTitle('Collapse');
-  fireEvent.click(collapseIconButton);
-
-  jest.runAllTimers();
+  act(() => {
+    fireEvent.click(screen.getByTitle('Collapse'));
+    jest.runAllTimers();
+  });
 
   expect(onCollapse).toBeCalled();
   expect(screen.getByText('I am a block')).toBeInTheDocument();
@@ -90,7 +89,7 @@ test('it renders children with icon', () => {
   const isOpen = false;
 
   render(
-    <Block title="My block" isOpen={isOpen} onCollapse={onCollapse} collapseButtonLabel="Collapse" actions={<></>}>
+    <Block title="My block" isOpen={isOpen} onCollapse={onCollapse} collapseButtonLabel="Collapse">
       <PlusIcon data-testid="children-icon" />
       Icon
     </Block>

--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.stories.mdx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.stories.mdx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
 import {Meta, Story, ArgsTable, Canvas} from '@storybook/addon-docs';
+import {action} from '@storybook/addon-actions';
 import {TagInput} from './TagInput.tsx';
 import {Section} from '../../../storybook/PreviewGallery';
 
@@ -35,7 +36,7 @@ Tags can be separated thanks to the following characters:
   <Story name="Standard">
     {args => {
       const [tags, setTags] = useState([]);
-      return <TagInput {...args} value={tags} onChange={setTags} />;
+      return <TagInput {...args} value={tags} onChange={setTags} onSubmit={action('submit')} />;
     }}
   </Story>
 </Canvas>

--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
@@ -118,6 +118,11 @@ const TagInput: FC<TagInputProps> = ({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if (Key.Enter === event.key && !isLastTagSelected && !readOnly) {
+        const inputCurrentValue = inputRef?.current?.value.trim() ?? '';
+        if ('' !== inputCurrentValue) {
+          createTags([...value, ...[inputCurrentValue]]);
+        }
+
         onSubmit?.();
 
         return;
@@ -159,7 +164,7 @@ const TagInput: FC<TagInputProps> = ({
             readOnly={readOnly}
           >
             {!readOnly && <RemoveTagIcon onClick={() => removeTag(index)} data-testid={`remove-${index}`} />}
-            {tag}
+            <TagText>{tag}</TagText>
           </Tag>
         );
       })}
@@ -218,6 +223,14 @@ const Tag = styled.li<AkeneoThemedProps & {isSelected: boolean; readOnly: boolea
   align-items: center;
   height: 30px;
   box-sizing: border-box;
+  max-width: 100%;
+`;
+
+const TagText = styled.span`
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 const InputContainer = styled.li<AkeneoThemedProps>`

--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
@@ -117,23 +117,20 @@ const TagInput: FC<TagInputProps> = ({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
-      if (Key.Enter === event.key && !isLastTagSelected && !readOnly) {
-        const inputCurrentValue = inputRef?.current?.value.trim() ?? '';
-        if ('' !== inputCurrentValue) {
-          createTags([...value, ...[inputCurrentValue]]);
-        }
+      const inputCurrentValue = inputRef?.current?.value.trim() ?? '';
 
-        onSubmit?.();
+      if (Key.Enter === event.key && !isLastTagSelected && !readOnly) {
+        '' === inputCurrentValue ? onSubmit?.() : createTags([...value, ...[inputCurrentValue]]);
 
         return;
       }
 
       const isDeleteKeyPressed = [Key.Backspace.toString(), Key.Delete.toString()].includes(event.key);
       const tagsAreEmpty = value.length === 0;
-      const inputFieldIsNotEmpty = inputRef && inputRef.current && inputRef.current.value.trim() !== '';
 
-      if (!isDeleteKeyPressed || tagsAreEmpty || inputFieldIsNotEmpty) {
+      if (!isDeleteKeyPressed || tagsAreEmpty || '' !== inputCurrentValue) {
         setLastTagAsSelected(false);
+
         return;
       }
 

--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.unit.tsx
@@ -21,7 +21,7 @@ test('it allows tags to be created', () => {
   expect(handleChange).toHaveBeenCalledWith(['gucci']);
 });
 
-test('it handles on submit callback', () => {
+test('it handles on submit callback and creates a tag when submitting', () => {
   const handleChange = jest.fn();
   const handleSubmit = jest.fn();
 
@@ -32,11 +32,9 @@ test('it handles on submit callback', () => {
     </>
   );
 
-  const input = screen.getByLabelText('My label');
-  userEvent.type(input, 'nice{space}');
-  userEvent.type(input, '{enter}');
+  userEvent.type(screen.getByLabelText('My label'), 'nice{enter}');
 
-  expect(handleChange).toHaveBeenCalled();
+  expect(handleChange).toHaveBeenCalledWith(['12', 'nice']);
   expect(handleSubmit).toHaveBeenCalled();
 });
 

--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.unit.tsx
@@ -21,20 +21,21 @@ test('it allows tags to be created', () => {
   expect(handleChange).toHaveBeenCalledWith(['gucci']);
 });
 
-test('it handles on submit callback and creates a tag when submitting', () => {
+test('it can create tags using Enter and handles on submit callback', () => {
   const handleChange = jest.fn();
   const handleSubmit = jest.fn();
 
-  render(
-    <>
-      <label htmlFor="myInput">My label</label>
-      <TagInput id="myInput" value={['12']} onChange={handleChange} onSubmit={handleSubmit} />
-    </>
-  );
+  render(<TagInput value={['12']} onChange={handleChange} onSubmit={handleSubmit} />);
 
-  userEvent.type(screen.getByLabelText('My label'), 'nice{enter}');
+  const input = screen.getByRole('textbox');
+
+  userEvent.type(input, 'nice{enter}');
 
   expect(handleChange).toHaveBeenCalledWith(['12', 'nice']);
+  expect(handleSubmit).not.toHaveBeenCalled();
+
+  userEvent.type(input, '{enter}');
+
   expect(handleSubmit).toHaveBeenCalled();
 });
 


### PR DESCRIPTION
- Create a tag when submitting (hitting Enter) with a non-empty input
- Add ellipsis when having a very long tag

Before: 
<img width="975" alt="image" src="https://user-images.githubusercontent.com/3492179/168847081-dc5a732a-5f02-42c3-af0d-7c78621e763f.png">


After:
<img width="998" alt="image" src="https://user-images.githubusercontent.com/3492179/168846934-8a86e09e-9af4-42d7-8fa5-49888e24a727.png">

Also fixing warning in Block.unit.tsx
<img width="408" alt="Screenshot 2022-05-18 at 11 09 34" src="https://user-images.githubusercontent.com/3492179/169004217-27e90b79-148b-412d-80df-546c4851803c.png">

