### PR TITLE
PIM-10447: Do not use repositories to check for product existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PIM-10435: Fix search_after requests with codes using uppercase accented characters
 - PIM-10443: Search for system product grid filters in System > Users > Additional is now case insensitive
 - PIM-10459: Fix product grid selection
+- PIM-10447: Do not hydrate product/model in UniqueEntityValidator
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validators.yml
@@ -333,7 +333,7 @@ services:
     pim_catalog.validator.constraint.unique_product_entity:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductEntityValidator'
         arguments:
-            - '@pim_catalog.repository.product'
+            - '@akeneo.pim.enrichment.product.query.find_id'
             - '@pim_catalog.validator.unique_value_set'
             - '@pim_catalog.repository.attribute'
         tags:
@@ -342,7 +342,7 @@ services:
     pim_catalog.validator.constraint.unique_product_model_entity:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Product\UniqueProductModelEntityValidator'
         arguments:
-            - '@pim_catalog.repository.product_model'
+            - '@akeneo.pim.enrichment.product_model.query.find_id'
             - '@pim_catalog.validator.unique_value_set'
         tags:
             - { name: validator.constraint_validator, alias: pim_unique_product_model_validator_entity }

--- a/tests/back/Acceptance/Product/InMemoryFindProductId.php
+++ b/tests/back/Acceptance/Product/InMemoryFindProductId.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Acceptance\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\FindId;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryFindProductId implements FindId
+{
+    public function __construct(private ProductRepositoryInterface $productRepository)
+    {
+    }
+
+    public function fromIdentifier(string $identifier): null|string
+    {
+        $product = $this->productRepository->findOneByIdentifier($identifier);
+
+        return $product ? (string)$product->getId() : null;
+    }
+}

--- a/tests/back/Acceptance/ProductModel/InMemoryFindProductModelId.php
+++ b/tests/back/Acceptance/ProductModel/InMemoryFindProductModelId.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Acceptance\ProductModel;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\FindId;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductModelRepositoryInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryFindProductModelId implements FindId
+{
+    public function __construct(private ProductModelRepositoryInterface $productModelRepository)
+    {
+    }
+
+    public function fromIdentifier(string $identifier): null|string
+    {
+        $productModel = $this->productModelRepository->findOneByIdentifier($identifier);
+
+        return $productModel ? (string) $productModel->getId() : null;
+    }
+}

--- a/tests/back/Acceptance/Resources/config/pim/queries.yml
+++ b/tests/back/Acceptance/Resources/config/pim/queries.yml
@@ -34,6 +34,16 @@ services:
         arguments:
             - '@pim_catalog.repository.product_model'
 
+    akeneo.pim.enrichment.product.query.find_id:
+        class: 'AkeneoTest\Acceptance\Product\InMemoryFindProductId'
+        arguments:
+            - '@pim_catalog.repository.product'
+
+    akeneo.pim.enrichment.product_model.query.find_id:
+        class: 'AkeneoTest\Acceptance\ProductModel\InMemoryFindProductModelId'
+        arguments:
+            - '@pim_catalog.repository.product_model'
+
     akeneo.pim.enrichment.product.query.find_quantified_association_codes:
         class: Akeneo\Test\Acceptance\AssociationType\InMemoryFindQuantifiedAssociationTypeCodes
         arguments:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The UniqueEntityValidator used a repository to check for existence in db, but it only needed to get the id. I replaced it with the FindId query, which avoids to hydrate the whole product/product model (filter/check values, and in EE apply permissions on locales/categories/attribute groups, etc.)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
