### PR TITLE
PIM-10451: Add start_time index on JobInstaller

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,8 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10451: Add migration to add an index on start_time on the job_execution table
 - MW-373: Prepare the marketplace migration to another subdomain
 
 # 6.0.28 (2022-05-13)

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Installer/JobInstaller.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Installer/JobInstaller.php
@@ -31,6 +31,7 @@ class JobInstaller implements EventSubscriberInterface
         CREATE INDEX user_idx ON akeneo_batch_job_execution (user);
         CREATE INDEX status_idx ON akeneo_batch_job_execution (status);
         CREATE INDEX code_idx ON akeneo_batch_job_instance (code);
+        CREATE INDEX start_time_idx ON akeneo_batch_job_execution (start_time);
         CREATE INDEX is_visible_idx ON akeneo_batch_job_execution (is_visible);
         CREATE INDEX job_instance_id_user_status_is_visible_idx ON akeneo_batch_job_execution (job_instance_id, user, status, is_visible);
 SQL;

--- a/upgrades/schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution.php
+++ b/upgrades/schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_6_0_20220520114800_add_start_time_index_on_job_execution extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf($this->indexExists(), 'Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
+
+        $this->addSql('CREATE INDEX start_time_idx ON akeneo_batch_job_execution (start_time)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function indexExists(): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexesIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset(
+            $indexesIndexedByName['start_time_idx'],
+        );
+    }
+}

--- a/upgrades/test_schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2021 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_6_0_20220520114800_add_start_time_index_on_job_execution_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_6_0_20220520114800_add_start_time_index_on_job_execution';
+
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_new_index_on_job_execution_table(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertTrue($this->indexExists('start_time_idx'));
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->indexExists());
+    }
+
+    private function dropIndexIfExists(): void
+    {
+        if ($this->indexExists()) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX start_time_idx;');
+        }
+
+        Assert::assertEquals(false, $this->indexExists());
+    }
+
+    private function indexExists(): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexesIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset($indexesIndexedByName['start_time_idx']);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

See : [PIM-10451](https://akeneo.atlassian.net/jira/software/c/projects/PIM/boards/9?modal=detail&selectedIssue=PIM-10451)

Updating JobInstaller.php to add an index on start_time
Add migration to add an index on start_time on the job_execution table  for client that started on 6.0

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
