### PR TITLE
BH-1159: Rework BatchCommand to use execution ID without batch code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,10 @@
 - PIM-10293: add batch-size option to pim:completness:calculate command
 - PIM-10229: Enforce strict samesite policy for session cookies
 - Improvement: Use Debian Bullseye (v11) in Dockerfiles for akeneo/pim-php-dev:master
+- BH-1159: Refactor BatchCommand to use execution ID without batch code
 
 ## New features
 
 ## BC Breaks
 
-- BH-1159: Refactor BatchCommand to use execution ID without batch code
+- BH-1159: Add `JobInterface::getJobRepository` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,5 @@
 ## New features
 
 ## BC Breaks
+
+- BH-1159: Refactor BatchCommand to use execution ID without batch code

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
@@ -146,6 +146,7 @@ class BatchCommand extends Command
                 $jobExecution->setExecutionContext(new ExecutionContext());
             }
             $jobInstance = $jobExecution->getJobInstance();
+            $job = $this->jobRegistry->get($jobInstance->getJobName());
         } else {
             $code = $input->getArgument('code');
             $jobInstance = $this->getJobManager()->getRepository($this->jobInstanceClass)->findOneBy(['code' => $code]);

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
@@ -15,10 +15,12 @@ use Akeneo\Tool\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Tool\Component\Batch\Job\JobParametersValidator;
 use Akeneo\Tool\Component\Batch\Job\JobRegistry;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Doctrine\ORM\EntityManagerInterface;
-use Psr\Log\LoggerInterface;
+use Doctrine\Persistence\ObjectManager;
+use Monolog\Logger;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Bridge\Monolog\Handler\ConsoleHandler;
 use Symfony\Component\Console\Command\Command;
@@ -40,70 +42,26 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class BatchCommand extends Command
 {
     protected static $defaultName = 'akeneo:batch:job';
+    protected static $defaultDescription = '[Internal] Please use "akeneo:batch:publish-job-to-queue" to launch a registered job instance';
 
     const EXIT_SUCCESS_CODE = 0;
     const EXIT_ERROR_CODE = 1;
     const EXIT_WARNING_CODE = 2;
 
-
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var BatchLogHandler */
-    private $batchLogHandler;
-
-    /** @var JobRepositoryInterface */
-    private $jobRepository;
-
-    private ManagerRegistry $doctrine;
-
-    /** @var ValidatorInterface */
-    private $validator;
-
-    /** @var Notifier */
-    private $notifier;
-
-    /** @var JobRegistry */
-    private $jobRegistry;
-
-    /** @var JobParametersFactory */
-    private $jobParametersFactory;
-
-    /** @var JobParametersValidator */
-    private $jobParametersValidator;
-
-    /** @var string */
-    private $jobInstanceClass;
-
-    /** @var string */
-    private $jobExecutionClass;
-
     public function __construct(
-        LoggerInterface $logger,
-        BatchLogHandler $batchLogHandler,
-        JobRepositoryInterface $jobRepository,
-        ManagerRegistry $doctrine,
-        ValidatorInterface $validator,
-        Notifier $notifier,
-        JobRegistry $jobRegistry,
-        JobParametersFactory $jobParametersFactory,
-        JobParametersValidator $jobParametersValidator,
-        string $jobInstanceClass,
-        string $jobExecutionClass
+        private Logger $logger,
+        private BatchLogHandler $batchLogHandler,
+        private JobRepositoryInterface $jobRepository,
+        private ManagerRegistry $doctrine,
+        private ValidatorInterface $validator,
+        private Notifier $notifier,
+        private JobRegistry $jobRegistry,
+        private JobParametersFactory $jobParametersFactory,
+        private JobParametersValidator $jobParametersValidator,
+        private string $jobInstanceClass,
+        private string $jobExecutionClass
     ) {
         parent::__construct();
-
-        $this->logger = $logger;
-        $this->batchLogHandler = $batchLogHandler;
-        $this->jobRepository = $jobRepository;
-        $this->doctrine = $doctrine;
-        $this->validator = $validator;
-        $this->notifier = $notifier;
-        $this->jobRegistry = $jobRegistry;
-        $this->jobParametersFactory = $jobParametersFactory;
-        $this->jobParametersValidator = $jobParametersValidator;
-        $this->jobInstanceClass = $jobInstanceClass;
-        $this->jobExecutionClass = $jobExecutionClass;
     }
 
     /**
@@ -112,9 +70,6 @@ class BatchCommand extends Command
     protected function configure()
     {
         $this
-            ->setDescription(
-                '[DEPRECATED] Please use "akeneo:batch:publish-job-to-queue" to launch a registered job instance'
-            )
             ->addArgument('code', InputArgument::REQUIRED, 'Job instance code')
             ->addArgument('execution', InputArgument::OPTIONAL, 'Job execution id')
             ->addOption(
@@ -155,13 +110,6 @@ class BatchCommand extends Command
             $this->logger->pushHandler(new ConsoleHandler($output));
         }
 
-        $code = $input->getArgument('code');
-        $jobInstance = $this->getJobManager()->getRepository($this->jobInstanceClass)->findOneBy(['code' => $code]);
-
-        if (null === $jobInstance) {
-            throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
-        }
-
         // Override mail notifier recipient email
         if ($email = $input->getOption('email')) {
             $errors = $this->validator->validate($email, new Assert\Email());
@@ -173,7 +121,6 @@ class BatchCommand extends Command
             $this->notifier->setRecipientEmail($email);
         }
 
-        $job = $this->jobRegistry->get($jobInstance->getJobName());
         $executionId = $input->hasArgument('execution') ? $input->getArgument('execution') : null;
 
         if (null !== $executionId && null !== $input->getOption('config')) {
@@ -184,18 +131,8 @@ class BatchCommand extends Command
             throw new \InvalidArgumentException('Username option cannot be specified when launching a job execution.');
         }
 
-        if (null === $executionId) {
-            $job = $this->jobRegistry->get($jobInstance->getJobName());
-            $jobParameters = $this->createJobParameters($job, $jobInstance, $input);
-            $this->validateJobParameters($job, $jobInstance, $jobParameters, $code);
-            $jobExecution = $job->getJobRepository()->createJobExecution($job, $jobInstance, $jobParameters);
-
-            $username = $input->getOption('username');
-            if (null !== $username) {
-                $jobExecution->setUser($username);
-                $job->getJobRepository()->updateJobExecution($jobExecution);
-            }
-        } else {
+        if (null !== $executionId) {
+            /** @var JobExecution $jobExecution */
             $jobExecution = $this->getJobManager()->getRepository($this->jobExecutionClass)->find($executionId);
             if (!$jobExecution) {
                 throw new \InvalidArgumentException(sprintf('Could not find job execution "%s".', $executionId));
@@ -207,6 +144,24 @@ class BatchCommand extends Command
             }
             if (null === $jobExecution->getExecutionContext()) {
                 $jobExecution->setExecutionContext(new ExecutionContext());
+            }
+            $jobInstance = $jobExecution->getJobInstance();
+        } else {
+            $code = $input->getArgument('code');
+            $jobInstance = $this->getJobManager()->getRepository($this->jobInstanceClass)->findOneBy(['code' => $code]);
+            if (null === $jobInstance) {
+                throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
+            }
+
+            $job = $this->jobRegistry->get($jobInstance->getJobName());
+            $jobParameters = $this->createJobParameters($job, $jobInstance, $input);
+            $this->validateJobParameters($job, $jobInstance, $jobParameters, $code);
+            $jobExecution = $job->getJobRepository()->createJobExecution($job, $jobInstance, $jobParameters);
+
+            $username = $input->getOption('username');
+            if (null !== $username) {
+                $jobExecution->setUser($username);
+                $job->getJobRepository()->updateJobExecution($jobExecution);
             }
         }
 
@@ -286,7 +241,7 @@ class BatchCommand extends Command
      * @param array[]         $exceptions
      * @param boolean         $verbose
      */
-    protected function writeExceptions(OutputInterface $output, array $exceptions, $verbose)
+    protected function writeExceptions(OutputInterface $output, array $exceptions, ?bool $verbose)
     {
         foreach ($exceptions as $exception) {
             $output->write(
@@ -304,28 +259,16 @@ class BatchCommand extends Command
         }
     }
 
-    /**
-     * @return EntityManagerInterface
-     */
     protected function getJobManager(): EntityManagerInterface
     {
         return $this->jobRepository->getJobManager();
     }
 
-    /**
-     * @return EntityManagerInterface
-     */
-    protected function getDefaultEntityManager(): EntityManagerInterface
+    protected function getDefaultEntityManager(): ObjectManager
     {
         return $this->doctrine->getManager();
     }
 
-    /**
-     * @param JobInstance    $jobInstance
-     * @param InputInterface $input
-     *
-     * @return JobParameters
-     */
     protected function createJobParameters(JobInterface $job, JobInstance $jobInstance, InputInterface $input): JobParameters
     {
         $rawParameters = $jobInstance->getRawParameters();
@@ -333,23 +276,18 @@ class BatchCommand extends Command
         $config = $input->getOption('config') ? $this->decodeConfiguration($input->getOption('config')) : [];
 
         $rawParameters = array_merge($rawParameters, $config);
-        $jobParameters = $this->jobParametersFactory->create($job, $rawParameters);
 
-        return $jobParameters;
+        return $this->jobParametersFactory->create($job, $rawParameters);
     }
 
     /**
-     * @param JobInstance   $jobInstance
-     * @param JobParameters $jobParameters
-     * @param string        $code
-     *
      * @throws \RuntimeException
      */
     protected function validateJobParameters(JobInterface $job, JobInstance $jobInstance, JobParameters $jobParameters, string $code) : void
     {
         // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
         // in order to be able to have a working UniqueEntity validation
-        $defaultJobInstance = $this->getDefaultEntityManager()->merge($jobInstance);
+        $this->getDefaultEntityManager()->merge($jobInstance);
         $errors = $this->jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution']);
 
         if (count($errors) > 0) {
@@ -365,11 +303,6 @@ class BatchCommand extends Command
         }
     }
 
-    /**
-     * @param ConstraintViolationList $errors
-     *
-     * @return string
-     */
     private function getErrorMessages(ConstraintViolationList $errors): string
     {
         $errorsStr = '';
@@ -382,17 +315,13 @@ class BatchCommand extends Command
     }
 
     /**
-     * @param string $data
-     *
      * @throws \InvalidArgumentException
-     *
-     * @return array
      */
-    private function decodeConfiguration($data): array
+    private function decodeConfiguration(string $data): array
     {
-        $config = json_decode($data, true);
+        $config = \json_decode($data, true);
 
-        switch (json_last_error()) {
+        switch (\json_last_error()) {
             case JSON_ERROR_DEPTH:
                 $error = 'Maximum stack depth exceeded';
                 break;

--- a/src/Akeneo/Tool/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
@@ -97,13 +97,14 @@ class SimpleJobLauncherSpec extends ObjectBehavior
         $constraintViolation->__toString()->willReturn('error');
 
         $jobRegistry->get('job_instance_name')->willReturn($job);
+        $job->getName()->willReturn('job_name');
         $jobParametersFactory->create($job, ['foo' => 'bar'])->willReturn($jobParameters);
         $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
 
         $eventDispatcher->dispatch(Argument::type(JobExecutionEvent::class), EventInterface::JOB_EXECUTION_CREATED)->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(new \RuntimeException('Job instance "job_instance_code" running the job "" with parameters "" is invalid because of "' . PHP_EOL .'  - error"'))
+            ->shouldThrow(new \RuntimeException('Job instance "job_instance_code" running the job "job_name" with parameters "" is invalid because of "' . PHP_EOL .'  - error"'))
             ->during('launch', [$jobInstance, $user, []]);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
@@ -68,6 +68,7 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
 
         $jobRegistry->get('job_instance_name')->willReturn($job);
+        $job->getName()->willReturn('job_name');
         $jobParametersFactory->create($job, ['foo' => 'bar', 'baz' => 'foz'])->willReturn($jobParameters);
         $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
         $jobRepository->createJobExecution($job, $jobInstance, $jobParameters)->willReturn($jobExecution);
@@ -108,6 +109,7 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $user->getEmail()->willReturn('julia@akeneo.com');
 
         $jobRegistry->get('job_instance_name')->willReturn($job);
+        $job->getName()->willReturn('job_name');
         $jobParametersFactory->create($job, ['foo' => 'bar', 'baz' => 'foz'])->willReturn($jobParameters);
         $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
         $jobRepository->createJobExecution($job, $jobInstance, $jobParameters)->willReturn($jobExecution);
@@ -152,13 +154,16 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $constraintViolation->__toString()->willReturn('error');
 
         $jobRegistry->get('job_instance_name')->willReturn($job);
+        $job->getName()->willReturn('job_name');
         $jobParametersFactory->create($job, ['foo' => 'bar'])->willReturn($jobParameters);
         $jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution'])->willReturn($constraintViolationList);
 
         $eventDispatcher->dispatch(Argument::type(JobExecutionEvent::class), EventInterface::JOB_EXECUTION_CREATED)->shouldNotBeCalled();
 
         $this
-            ->shouldThrow(new \RuntimeException('Job instance "job_instance_code" running the job "" with parameters "" is invalid because of "' . PHP_EOL .'  - error"'))
+            ->shouldThrow(
+                new \RuntimeException('Job instance "job_instance_code" running the job "job_name" with parameters "" is invalid because of "' . PHP_EOL .'  - error"')
+            )
             ->during('launch', [$jobInstance, $user, []]);
     }
 }

--- a/src/Akeneo/Tool/Component/Batch/Job/Job.php
+++ b/src/Akeneo/Tool/Component/Batch/Job/Job.php
@@ -51,12 +51,7 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
         $this->filesystem = new Filesystem();
     }
 
-    /**
-     * Get the job's name
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -69,12 +64,8 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
     /**
      * Retrieve the step with the given name. If there is no Step with the given
      * name, then return null.
-     *
-     * @param string $stepName
-     *
-     * @return StepInterface the Step
      */
-    public function getStep($stepName)
+    public function getStep(string $stepName): ?StepInterface
     {
         foreach ($this->steps as $step) {
             if ($step->getName() == $stepName) {
@@ -86,11 +77,9 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
     }
 
     /**
-     * Retrieve the step names.
-     *
-     * @return array the step names
+     * @return string[]
      */
-    public function getStepNames()
+    public function getStepNames(): array
     {
         $names = [];
         foreach ($this->steps as $step) {
@@ -100,24 +89,12 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
         return $names;
     }
 
-    /**
-     * Public getter for the {@link JobRepositoryInterface} that is needed to manage the
-     * state of the batch meta domain (jobs, steps, executions) during the life
-     * of a job.
-     *
-     * @return JobRepositoryInterface
-     */
-    public function getJobRepository()
+    public function getJobRepository(): JobRepositoryInterface
     {
         return $this->jobRepository;
     }
 
-    /**
-     * To string
-     *
-     * @return string
-     */
-    public function __toString()
+    public function __toString(): string
     {
         return get_class($this) . ': [name=' . $this->name . ']';
     }
@@ -133,7 +110,7 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
      * The working directory is created in the temporary filesystem. Its pathname is placed in the JobExecutionContext
      * via the key {@link \Akeneo\Tool\Component\Batch\Job\JobInterface::WORKING_DIRECTORY_PARAMETER}
      */
-    final public function execute(JobExecution $jobExecution)
+    final public function execute(JobExecution $jobExecution): void
     {
         try {
             $workingDirectory = $this->createWorkingDirectory();
@@ -251,14 +228,10 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
 
     /**
      * Handle a step and return the execution for it.
-     * @param StepInterface $step         Step
-     * @param JobExecution  $jobExecution Job execution
      *
      * @throws JobInterruptedException
-     *
-     * @return StepExecution
      */
-    protected function handleStep(StepInterface $step, JobExecution $jobExecution)
+    protected function handleStep(StepInterface $step, JobExecution $jobExecution): StepExecution
     {
         if ($jobExecution->isStopping()) {
             throw new JobInterruptedException("JobExecution interrupted.");
@@ -320,12 +293,8 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
     /**
      * Default mapping from throwable to {@link ExitStatus}. Clients can modify the exit code using a
      * {@link StepExecutionListener}.
-     *
-     * @param \Exception $e the cause of the failure
-     *
-     * @return ExitStatus an {@link ExitStatus}
      */
-    private function getDefaultExitStatusForFailure(\Exception $e)
+    private function getDefaultExitStatusForFailure(\Exception $e): ExitStatus
     {
         if ($e instanceof JobInterruptedException || $e->getPrevious() instanceof JobInterruptedException) {
             $exitStatus = new ExitStatus(ExitStatus::STOPPED);
@@ -341,23 +310,16 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
     /**
      * Default mapping from throwable to {@link ExitStatus}. Clients can modify the exit code using a
      * {@link StepExecutionListener}.
-     *
-     * @param JobExecution $jobExecution Execution of the job
-     * @param string       $status       Status of the execution
-     *
-     * @return an {@link ExitStatus}
      */
-    private function updateStatus(JobExecution $jobExecution, $status)
+    private function updateStatus(JobExecution $jobExecution, int $status): void
     {
         $jobExecution->setStatus(new BatchStatus($status));
     }
 
     /**
      * Create a unique working directory
-     *
-     * @return string the working directory path
      */
-    private function createWorkingDirectory()
+    private function createWorkingDirectory(): string
     {
         $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('akeneo_batch_') . DIRECTORY_SEPARATOR;
         try {
@@ -370,12 +332,7 @@ class Job implements JobInterface, StoppableJobInterface, JobWithStepsInterface,
         return $path;
     }
 
-    /**
-     * Delete the working directory
-     *
-     * @param string $directory
-     */
-    private function deleteWorkingDirectory($directory)
+    private function deleteWorkingDirectory(string $directory)
     {
         if ($this->filesystem->exists($directory)) {
             $this->filesystem->remove($directory);

--- a/src/Akeneo/Tool/Component/Batch/Job/JobInterface.php
+++ b/src/Akeneo/Tool/Component/Batch/Job/JobInterface.php
@@ -18,18 +18,20 @@ interface JobInterface
 {
     const WORKING_DIRECTORY_PARAMETER = 'working_directory';
 
-    /**
-     * @return string the name of this job
-     */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Run the {@link JobExecution} and update the meta information like status
      * and statistics as necessary. This method should not throw any exceptions
      * for failed execution. Clients should be careful to inspect the
      * {@link JobExecution} status to determine success or failure.
-     *
-     * @param JobExecution $execution a {@link JobExecution}
      */
-    public function execute(JobExecution $execution);
+    public function execute(JobExecution $execution): void;
+
+    /**
+     * Public getter for the {@link JobRepositoryInterface} that is needed to manage the
+     * state of the batch meta domain (jobs, steps, executions) during the life
+     * of a job.
+     */
+    public function getJobRepository(): JobRepositoryInterface;
 }

--- a/tests/back/Pim/Enrichment/Integration/Category/ConfigureCategoryTreeForExportJobsAfterChangingTheChannelCategoryTreeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Category/ConfigureCategoryTreeForExportJobsAfterChangingTheChannelCategoryTreeIntegration.php
@@ -22,6 +22,7 @@ use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters\DefaultValuesProviderInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters\DefaultValuesProviderRegistry;
 use Akeneo\Tool\Component\Batch\Job\JobRegistry;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use PHPUnit\Framework\Assert;
@@ -140,13 +141,11 @@ final class ConfigureCategoryTreeForExportJobsAfterChangingTheChannelCategoryTre
     {
         /** @var JobRegistry $jobRegistry */
         $jobRegistry = $this->get('akeneo_batch.job.job_registry');
+        $jobRepository = $this->get('akeneo_batch.job_repository');
         try {
-            $jobRegistry->register(new class($jobName) implements JobInterface {
-                private string $jobName;
-
-                public function __construct(string $jobName)
+            $jobRegistry->register(new class($jobName, $jobRepository) implements JobInterface {
+                public function __construct(private string $jobName, private JobRepositoryInterface $jobRepository)
                 {
-                    $this->jobName = $jobName;
                 }
 
                 public function getName(): string
@@ -156,6 +155,11 @@ final class ConfigureCategoryTreeForExportJobsAfterChangingTheChannelCategoryTre
 
                 public function execute(JobExecution $execution): void
                 {
+                }
+
+                public function getJobRepository(): JobRepositoryInterface
+                {
+                    return $this->jobRepository;
                 }
 
             }, 'export', 'Akeneo CSV Connector');


### PR DESCRIPTION
Rework the BatchCommand to make it ignore the batch `code` parameter when an execution ID (`execution` parameter`) is already provided. Indeed, the batch code is part of the execution parameter.

This would allow us to launch some batches by knowing only the execution ID.

If the execution ID is not provided, the batch code is still used as before.

Also added a `getJobRepository` in the interface because it was internally required and was using polymorphic calls.