### PR TITLE
PIM-10451-serenity: Add index on start_time on job_execution table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - PIM-10435: Fix search_after requests with codes using uppercase accented characters
 - PIM-10443: Search for system product grid filters in System > Users > Additional is now case insensitive
 - PIM-10459: Fix product grid selection
+- PIM-10451: Add migration to add an index on start_time on the job_execution table
 
 ## Improvements
 

--- a/upgrades/schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution.php
+++ b/upgrades/schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution.php
@@ -11,7 +11,7 @@ final class Version_7_0_20220520114800_add_start_time_index_on_job_execution ext
 {
     public function up(Schema $schema): void
     {
-        $this->skipIf($this->indexesExists(), 'Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
+        $this->skipIf($this->indexExists(), 'Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
 
         $this->addSql('CREATE INDEX start_time_idx ON akeneo_batch_job_execution (start_time)');
     }
@@ -21,7 +21,7 @@ final class Version_7_0_20220520114800_add_start_time_index_on_job_execution ext
         $this->throwIrreversibleMigrationException();
     }
 
-    private function indexesExists(): bool
+    private function indexExists(): bool
     {
         $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
         $indexesIndexedByName = array_column($indexes, null, 'Key_name');

--- a/upgrades/schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution.php
+++ b/upgrades/schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_7_0_20220520114800_add_start_time_index_on_job_execution extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf($this->indexesExists(), 'Indexed IDX_START_TIME already exists in akeneo_batch_job_execution');
+
+        $this->addSql('CREATE INDEX start_time_idx ON akeneo_batch_job_execution (start_time)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function indexesExists(): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexesIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset(
+            $indexesIndexedByName['start_time_idx'],
+        );
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
@@ -47,23 +47,23 @@ class Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integrati
         $this->reExecuteMigration(self::MIGRATION_LABEL);
         $this->reExecuteMigration(self::MIGRATION_LABEL);
 
-        Assert::assertTrue($this->indexExists('start_time_idx'));
+        Assert::assertTrue($this->indexExists());
     }
 
     private function dropIndexIfExists(): void
     {
-        if ($this->indexExists('start_time_idx')) {
+        if ($this->indexExists()) {
             $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX start_time_idx;');
         }
 
-        Assert::assertEquals(false, $this->indexExists('start_time_idx'));
+        Assert::assertEquals(false, $this->indexExists());
     }
 
-    private function indexExists(string $indexName): bool
+    private function indexExists(): bool
     {
         $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
         $indexesIndexedByName = array_column($indexes, null, 'Key_name');
 
-        return isset($indexesIndexedByName[$indexName]);
+        return isset($indexesIndexedByName['start_time_idx']);
     }
 }

--- a/upgrades/test_schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integration.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2021 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_7_0_20220520114800_add_start_time_index_on_job_execution_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220520114800_add_start_time_index_on_job_execution';
+
+    private Connection $connection;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_new_index_on_job_execution_table(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertTrue($this->indexExists('start_time_idx'));
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->dropIndexIfExists();
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->indexExists('start_time_idx'));
+    }
+
+    private function dropIndexIfExists(): void
+    {
+        if ($this->indexExists('start_time_idx')) {
+            $this->connection->executeQuery('ALTER TABLE akeneo_batch_job_execution DROP INDEX start_time_idx;');
+        }
+
+        Assert::assertEquals(false, $this->indexExists('start_time_idx'));
+    }
+
+    private function indexExists(string $indexName): bool
+    {
+        $indexes = $this->connection->executeQuery('SHOW INDEX FROM akeneo_batch_job_execution')->fetchAllAssociative();
+        $indexesIndexedByName = array_column($indexes, null, 'Key_name');
+
+        return isset($indexesIndexedByName[$indexName]);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

See : [PIM-10451](https://akeneo.atlassian.net/jira/software/c/projects/PIM/boards/9?modal=detail&selectedIssue=PIM-10451)

Add migration to add an index on start_time on the job_execution table (for users upgrading from 6.0 to Serenity).

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
