### PR TITLE
DSM Fix checkbox to not shrink when constrained by container size

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
+++ b/front-packages/akeneo-design-system/src/components/Checkbox/Checkbox.tsx
@@ -42,6 +42,7 @@ const CheckboxContainer = styled.div<{checked: boolean; readOnly: boolean} & Ake
   transition: background-color 0.2s ease-out;
   box-sizing: border-box;
   color: ${getColor('white')};
+  flex-shrink: 0;
 
   ${props =>
     props.checked &&


### PR DESCRIPTION

If the checkbox is constrained by its container element size, the checkbox will shrink in size.

![checkbox](https://user-images.githubusercontent.com/1671213/169571727-8c8d5c73-2075-4dfd-8e5e-a0ee240d32d4.png)

