### PR TITLE
TIP-1579: hide catalog volume from disabled features

### DIFF
--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/DependencyInjection/Compiler/VolumeQueryPass.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/DependencyInjection/Compiler/VolumeQueryPass.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass is useful to create a list of volume queries and the associated feature flag required to
+ * make it available in the catalog volume monitoring screen.
+ *
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class VolumeQueryPass implements CompilerPassInterface
+{
+    /** @staticvar string */
+    const VOLUME_NORMALIZER_SERVICE = 'pim_volume_monitoring.volume.normalizer.volumes';
+
+    /** @staticvar string */
+    const COUNT_QUERY_TAG = 'pim_volume_monitoring.persistence.count_query';
+
+    /** @staticvar string */
+    const AVERAGE_MAX_QUERY_TAG = 'pim_volume_monitoring.persistence.average_max_query';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->register($container, self::COUNT_QUERY_TAG, 'addCountVolumeQuery');
+        $this->register($container, self::AVERAGE_MAX_QUERY_TAG, 'addAverageMaxVolumeQuery');
+    }
+
+    private function register(ContainerBuilder $container, string $tagName, string $functionName)
+    {
+        $volumeNormalizer = $container->getDefinition(self::VOLUME_NORMALIZER_SERVICE);
+
+        $taggedServices = $container->findTaggedServiceIds($tagName);
+        foreach ($taggedServices as $id => $attributes) {
+            $attributes = current($attributes);
+            $feature = $attributes['feature'] ?? null;
+
+            $volumeNormalizer->addMethodCall($functionName, [new Reference($id), $feature]);
+        }
+    }
+}

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/PimCatalogVolumeMonitoringBundle.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/PimCatalogVolumeMonitoringBundle.php
@@ -2,6 +2,11 @@
 
 namespace Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle;
 
+use Akeneo\Pim\Structure\Bundle\DependencyInjection\Compiler\RegisterReferenceDataConfigurationsPass;
+use Akeneo\Pim\Structure\Bundle\DependencyInjection\Compiler\ResolveDoctrineTargetModelPass;
+use Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\DependencyInjection\Compiler\VolumeQueryPass;
+use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -11,4 +16,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class PimCatalogVolumeMonitoringBundle extends Bundle
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new VolumeQueryPass());
+    }
 }

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Resources/config/normalizers.yml
@@ -15,6 +15,5 @@ services:
         arguments:
             - '@pim_volume_monitoring.volume.normalizer.count_volume'
             - '@pim_volume_monitoring.volume.normalizer.average_max_volumes'
-            - !tagged pim_volume_monitoring.persistence.count_query
-            - !tagged pim_volume_monitoring.persistence.average_max_query
+            - '@feature_flags'
 

--- a/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringControllerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringControllerSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Controller;
 
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Controller\VolumeMonitoringController;
@@ -18,7 +19,8 @@ class VolumeMonitoringControllerSpec extends ObjectBehavior
     function let(
         CountVolumeNormalizer $countVolumeNormalizer,
         AverageMaxVolumesNormalizer $averageMaxVolumesNormalizer,
-        SecurityFacade $securityFacade
+        SecurityFacade $securityFacade,
+        FeatureFlags $featureFlags
     ) {
         $countVolumeNormalizer->normalize()->willReturn([]);
         $averageMaxVolumesNormalizer->normalize()->willReturn([]);
@@ -26,8 +28,7 @@ class VolumeMonitoringControllerSpec extends ObjectBehavior
             new Volumes(
                 $countVolumeNormalizer->getWrappedObject(),
                 $averageMaxVolumesNormalizer->getWrappedObject(),
-                [],
-                []
+                $featureFlags->getWrappedObject()
             ),
             $securityFacade
         );


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

![Screenshot from 2022-05-23 10-22-41](https://user-images.githubusercontent.com/1942439/169776245-60db50a0-9cd5-401e-94c5-7a476fc9f3d9.png)

Allow to enable/disable display of values in catalog volume monitoring screen, depending on the activation of the feature or not (needed for asset/ref entities)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
