### PR TITLE
BH-1160: Job execution watchdog

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/JobLauncher/RunUniqueProcessJob.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/JobLauncher/RunUniqueProcessJob.php
@@ -69,13 +69,13 @@ final class RunUniqueProcessJob
         $this->logger->info('Job execution "{job_id}" is starting', ['message' => 'job_execution_started', 'job_id' => $jobExecution->getId()]);
 
         try {
-            $this->executionManager->updateHealthCheck($jobExecutionMessage);
+            $this->executionManager->updateHealthCheck($jobExecutionMessage->getJobExecutionId());
             $process = $this->initializeProcess($jobInstance, $jobExecution);
             $process->start();
 
             while ($process->isRunning()) {
                 sleep(self::RUNNING_PROCESS_CHECK_INTERVAL);
-                $this->executionManager->updateHealthCheck($jobExecutionMessage);
+                $this->executionManager->updateHealthCheck($jobExecutionMessage->getJobExecutionId());
                 $this->writeProcessOutput($process);
             }
         } catch (\Throwable $e) {
@@ -87,7 +87,7 @@ final class RunUniqueProcessJob
             ]);
         } finally {
             // update status if the job execution failed due to an uncaught error as a fatal error
-            $exitStatus = $this->executionManager->getExitStatus($jobExecutionMessage);
+            $exitStatus = $this->executionManager->getExitStatus($jobExecutionMessage->getJobExecutionId());
             if ($exitStatus->isRunning()) {
                 $this->executionManager->markAsFailed($jobExecutionMessage->getJobExecutionId());
             }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchQueueBundle\Command;
+
+use Akeneo\Tool\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+
+/**
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class JobExecutionWatchdogCommand extends Command
+{
+    protected static $defaultName = 'akeneo:batch:watchdog';
+    protected static $defaultDescription = '[Internal] Launched by the job queue consumer';
+
+    /** Interval in seconds before updating health check if job is still running. */
+    public const HEALTH_CHECK_INTERVAL = 5;
+
+    /** Interval in microseconds before checking if the process is still running. */
+    private const RUNNING_PROCESS_CHECK_INTERVAL = 200000;
+
+    public function __construct(
+        private JobExecutionManager $executionManager,
+        private LoggerInterface $logger,
+        private string $projectDir
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setHidden(true)
+            ->addArgument('job_execution_id', InputArgument::OPTIONAL, 'Job execution ID')
+            ->addOption(
+                'username',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Username to launch the job instance with'
+            )
+            ->addOption(
+                'email',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'The email to notify at the end of the job execution'
+            )
+            ->addOption(
+                'no-log',
+                null,
+                InputOption::VALUE_NONE,
+                "Don't display logs"
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $pathFinder = new PhpExecutableFinder();
+        $console = sprintf('%s/bin/console', $this->projectDir);
+        $startTime = time();
+        $jobExecutionId = (int)$input->getArgument('job_execution_id');
+        try {
+            $processArguments = $this->buildBatchCommand(
+                $console,
+                $pathFinder->find(),
+                $jobExecutionId,
+                $input->getOptions()
+            );
+            $process = new Process($processArguments);
+            $process->setTimeout(null);
+
+            $this->logger->notice('Launching job execution "{job_execution_id}".', [
+                'job_execution_id' => $jobExecutionId,
+            ]);
+            $this->logger->debug(sprintf('Command line: "%s"', $process->getCommandLine()));
+
+            $this->executeProcess($process, $jobExecutionId);
+        } catch (\Throwable $t) {
+            $this->logger->error(sprintf('An error occurred: %s', $t->getMessage()));
+            $this->logger->error($t->getTraceAsString());
+        } finally {
+            // update status if the job execution failed due to an uncatchable error as a fatal error
+            $exitStatus = $this->executionManager->getExitStatus((int)$jobExecutionId);
+            if ($exitStatus && $exitStatus->isRunning()) {
+                $this->executionManager->markAsFailed($jobExecutionId);
+            }
+        }
+
+        $executionTimeInSec = time() - $startTime;
+        $this->logger->notice('Job execution "{job_execution_id}" is finished in {execution_time_in_sec} seconds.', [
+            'job_execution_id' => $jobExecutionId,
+            'execution_time_in_sec' => $executionTimeInSec,
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    private function buildBatchCommand(
+        string $console,
+        string $phpPath,
+        int $jobExecutionId,
+        array $watchdogOptions
+    ): array {
+        $processArguments = [
+            $phpPath,
+            $console,
+            'akeneo:batch:job',
+            'dummy_batch_code',
+            $jobExecutionId,
+            '--quiet',
+        ];
+
+        foreach ($watchdogOptions as $optionName => $optionValue) {
+            if (true === $optionValue) {
+                $processArguments[] = sprintf('--%s', $optionName);
+            } elseif (false !== $optionValue && null !== $optionValue) {
+                $processArguments[] = sprintf('--%s=%s', $optionName, $optionValue);
+            }
+        }
+
+        return $processArguments;
+    }
+
+    private function executeProcess(Process $process, int $jobExecutionId): void
+    {
+        $this->executionManager->updateHealthCheck($jobExecutionId);
+        $process->start();
+
+        $nbIterationBeforeUpdatingHealthCheck = self::HEALTH_CHECK_INTERVAL * 1000000 / self::RUNNING_PROCESS_CHECK_INTERVAL;
+        $iteration = 1;
+        while ($process->isRunning()) {
+            if ($iteration < $nbIterationBeforeUpdatingHealthCheck) {
+                $iteration++;
+                usleep(self::RUNNING_PROCESS_CHECK_INTERVAL);
+
+                continue;
+            }
+
+            $this->writeProcessOutput($process);
+            $this->executionManager->updateHealthCheck($jobExecutionId);
+            $iteration = 1;
+        }
+
+        $this->writeProcessOutput($process);
+    }
+
+    private function writeProcessOutput(Process $process): void
+    {
+        $errors = $process->getIncrementalErrorOutput();
+        if ($errors) {
+            $this->logger->error($errors);
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -15,6 +15,10 @@ use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
 
 /**
+ * The watchdog process is launched by the daemon consuming messages to run jobs. This watchdog process  launches itself a child process to run a single Akeneo job. 
+ The daemon does not run directly the jobs:
+ - the daemon is tenant agnostic whereas watchdog process is dedicated for a tenant
+ - if the job die for unexpected reason, the job status is updated by the watchdog, which is possible as it can access to the database (tenant specific)
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -42,7 +42,7 @@ final class JobExecutionWatchdogCommand extends Command
     {
         $this
             ->setHidden(true)
-            ->addArgument('job_execution_id', InputArgument::OPTIONAL, 'Job execution ID')
+            ->addArgument('job_execution_id', InputArgument::REQUIRED, 'Job execution ID')
             ->addOption(
                 'username',
                 null,
@@ -86,12 +86,13 @@ final class JobExecutionWatchdogCommand extends Command
 
             $this->executeProcess($process, $jobExecutionId);
         } catch (\Throwable $t) {
-            $this->logger->error(sprintf('An error occurred: %s', $t->getMessage()));
-            $this->logger->error($t->getTraceAsString());
+            $this->logger->error(
+                sprintf('An error occurred: %s', $t->getMessage()),
+                ['exception' => $t]
+            );
         } finally {
             // update status if the job execution failed due to an uncatchable error as a fatal error
-            $exitStatus = $this->executionManager->getExitStatus((int)$jobExecutionId);
-            if ($exitStatus && $exitStatus->isRunning()) {
+            if ($this->executionManager->getExitStatus((int)$jobExecutionId)?->isRunning()) {
                 $this->executionManager->markAsFailed($jobExecutionId);
             }
         }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Manager/JobExecutionManager.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\BatchQueueBundle\Manager;
 
-use Akeneo\Tool\Bundle\BatchQueueBundle\MessageHandler\JobExecutionMessageHandler;
+use Akeneo\Tool\Bundle\BatchQueueBundle\Command\JobExecutionWatchdogCommand;
 use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use Akeneo\Tool\Component\Batch\Job\ExitStatus;
 use Akeneo\Tool\Component\Batch\Model\JobExecution;
-use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessageInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 
@@ -25,11 +24,8 @@ class JobExecutionManager
 {
     private const MAX_TIME_TO_UPDATE_HEALTH_CHECK = 5;
 
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**
@@ -51,7 +47,7 @@ class JobExecutionManager
         $now = new \DateTime('now', new \DateTimeZone('UTC'));
         $diffInSeconds = $now->getTimestamp() - $healthCheck->getTimestamp();
 
-        if ($diffInSeconds > JobExecutionMessageHandler::HEALTH_CHECK_INTERVAL + self::MAX_TIME_TO_UPDATE_HEALTH_CHECK) {
+        if ($diffInSeconds > JobExecutionWatchdogCommand::HEALTH_CHECK_INTERVAL + self::MAX_TIME_TO_UPDATE_HEALTH_CHECK) {
             $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED));
             $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED));
         }
@@ -62,12 +58,12 @@ class JobExecutionManager
     /**
      * Get the exit status of job execution associated to a job execution message.
      */
-    public function getExitStatus(JobExecutionMessageInterface $jobExecutionMessage): ?ExitStatus
+    public function getExitStatus(int $jobExecutionId): ?ExitStatus
     {
         $sql = 'SELECT je.exit_code FROM akeneo_batch_job_execution je WHERE je.id = :id';
 
         $stmt = $this->connection->prepare($sql);
-        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('id', $jobExecutionId);
         $row = $stmt->executeQuery()->fetchAssociative();
 
         return isset($row['exit_code']) ? new ExitStatus($row['exit_code']) : null;
@@ -79,43 +75,43 @@ class JobExecutionManager
     public function markAsFailed(int $jobExecutionId): void
     {
         $sql = <<<SQL
-UPDATE 
-    akeneo_batch_job_execution je
-SET 
-    je.status = :status,
-    je.exit_code = :exit_code,
-    je.updated_time = :updated_time
-WHERE
-    je.id = :id;
-SQL;
+        UPDATE 
+            akeneo_batch_job_execution je
+        SET 
+            je.status = :status,
+            je.exit_code = :exit_code,
+            je.updated_time = :updated_time
+        WHERE
+            je.id = :id;
+        SQL;
 
         $stmt = $this->connection->prepare($sql);
         $stmt->bindValue('id', $jobExecutionId);
         $stmt->bindValue('status', BatchStatus::FAILED);
         $stmt->bindValue('exit_code', ExitStatus::FAILED);
         $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Types::DATETIME_MUTABLE);
-        $stmt->execute();
+        $stmt->executeStatement();
     }
 
     /**
      * Update the health check of the job execution associated to a job execution message.
      */
-    public function updateHealthCheck(JobExecutionMessageInterface $jobExecutionMessage): void
+    public function updateHealthCheck(int $jobExecutionId): void
     {
         $sql = <<<SQL
-UPDATE 
-    akeneo_batch_job_execution je
-SET 
-    je.health_check_time = :health_check_time,
-    je.updated_time = :updated_time
-WHERE
-    je.id = :id;
-SQL;
+        UPDATE 
+            akeneo_batch_job_execution je
+        SET 
+            je.health_check_time = :health_check_time,
+            je.updated_time = :updated_time
+        WHERE
+            je.id = :id;
+        SQL;
 
         $stmt = $this->connection->prepare($sql);
-        $stmt->bindValue('id', $jobExecutionMessage->getJobExecutionId());
+        $stmt->bindValue('id', $jobExecutionId);
         $stmt->bindValue('health_check_time', new \DateTime('now', new \DateTimeZone('UTC')), Types::DATETIME_MUTABLE);
         $stmt->bindValue('updated_time', new \DateTime('now', new \DateTimeZone('UTC')), Types::DATETIME_MUTABLE);
-        $stmt->execute();
+        $stmt->executeStatement();
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobExecutionMessageHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobExecutionMessageHandler.php
@@ -1,10 +1,9 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\BatchQueueBundle\MessageHandler;
 
-use Akeneo\Tool\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
-use Akeneo\Tool\Component\Batch\Query\GetJobInstanceCode;
 use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionMessageInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -18,27 +17,10 @@ use Symfony\Component\Process\Process;
  */
 final class JobExecutionMessageHandler implements MessageHandlerInterface
 {
-    /** Interval in seconds before updating health check if job is still running. */
-    public const HEALTH_CHECK_INTERVAL = 5;
-
-    /** Interval in microseconds before checking if the process is still running. */
-    private const RUNNING_PROCESS_CHECK_INTERVAL = 200000;
-
-    private GetJobInstanceCode $getJobInstanceCode;
-    private JobExecutionManager $executionManager;
-    private LoggerInterface $logger;
-    private string $projectDir;
-
     public function __construct(
-        GetJobInstanceCode $getJobInstanceCode,
-        JobExecutionManager $executionManager,
-        LoggerInterface $logger,
-        string $projectDir
+        private LoggerInterface $logger,
+        private string $projectDir
     ) {
-        $this->getJobInstanceCode = $getJobInstanceCode;
-        $this->executionManager = $executionManager;
-        $this->logger = $logger;
-        $this->projectDir = $projectDir;
     }
 
     public function __invoke(JobExecutionMessageInterface $jobExecutionMessage)
@@ -49,57 +31,28 @@ final class JobExecutionMessageHandler implements MessageHandlerInterface
         $startTime = time();
         try {
             $arguments = array_merge(
-                [$pathFinder->find(), $console, 'akeneo:batch:job', '--quiet'],
+                [$pathFinder->find(), $console, 'akeneo:batch:watchdog', '--quiet'],
                 $this->extractArgumentsFromMessage($jobExecutionMessage)
             );
             $process = new Process($arguments);
             $process->setTimeout(null);
 
-            $this->logger->notice('Launching job execution "{job_execution_id}".', [
+            $this->logger->notice('Launching job watchdog for ID "{job_execution_id}".', [
                 'job_execution_id' => $jobExecutionMessage->getJobExecutionId(),
             ]);
             $this->logger->debug(sprintf('Command line: "%s"', $process->getCommandLine()));
 
-            $this->executeProcess($process, $jobExecutionMessage);
+            $process->run();
         } catch (\Throwable $t) {
             $this->logger->error(sprintf('An error occurred: %s', $t->getMessage()));
             $this->logger->error($t->getTraceAsString());
-        } finally {
-            // update status if the job execution failed due to an uncatchable error as a fatal error
-            $exitStatus = $this->executionManager->getExitStatus($jobExecutionMessage);
-            if ($exitStatus && $exitStatus->isRunning()) {
-                $this->executionManager->markAsFailed($jobExecutionMessage->getJobExecutionId());
-            }
         }
 
         $executionTimeInSec = time() - $startTime;
-        $this->logger->notice('Job execution "{job_execution_id}" is finished in {execution_time_in_sec} seconds.', [
+        $this->logger->notice('Watchdog for "{job_execution_id}" finished in {execution_time_in_sec} seconds.', [
             'job_execution_id' => $jobExecutionMessage->getJobExecutionId(),
             'execution_time_in_sec' => $executionTimeInSec,
         ]);
-    }
-
-    private function executeProcess(Process $process, JobExecutionMessageInterface $jobExecutionMessage): void
-    {
-        $this->executionManager->updateHealthCheck($jobExecutionMessage);
-        $process->start();
-
-        $nbIterationBeforeUpdatingHealthCheck = self::HEALTH_CHECK_INTERVAL * 1000000 / self::RUNNING_PROCESS_CHECK_INTERVAL;
-        $iteration = 1;
-        while ($process->isRunning()) {
-            if ($iteration < $nbIterationBeforeUpdatingHealthCheck) {
-                $iteration++;
-                usleep(self::RUNNING_PROCESS_CHECK_INTERVAL);
-
-                continue;
-            }
-
-            $this->writeProcessOutput($process);
-            $this->executionManager->updateHealthCheck($jobExecutionMessage);
-            $iteration = 1;
-        }
-
-        $this->writeProcessOutput($process);
     }
 
     /**
@@ -108,29 +61,18 @@ final class JobExecutionMessageHandler implements MessageHandlerInterface
      */
     private function extractArgumentsFromMessage(JobExecutionMessageInterface $jobExecutionMessage): array
     {
-        $jobInstanceCode = $this->getJobInstanceCode->fromJobExecutionId($jobExecutionMessage->getJobExecutionId());
-
         $arguments = [
-            $jobInstanceCode,
             $jobExecutionMessage->getJobExecutionId(),
         ];
 
         foreach ($jobExecutionMessage->getOptions() as $optionName => $optionValue) {
             if (true === $optionValue) {
                 $arguments[] = sprintf('--%s', $optionName);
-            } elseif (false !== $optionValue) {
+            } elseif (false !== $optionValue && null !== $optionValue) {
                 $arguments[] = sprintf('--%s=%s', $optionName, $optionValue);
             }
         }
 
         return $arguments;
-    }
-
-    private function writeProcessOutput(Process $process): void
-    {
-        $errors = $process->getIncrementalErrorOutput();
-        if ($errors) {
-            $this->logger->error($errors);
-        }
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -71,6 +71,14 @@ services:
         tags:
             - { name: console.command }
 
+    Akeneo\Tool\Bundle\BatchQueueBundle\Command\JobExecutionWatchdogCommand:
+        arguments:
+            - '@akeneo_batch_queue.manager.job_execution_manager'
+            - '@logger'
+            - '%kernel.project_dir%'
+        tags:
+            - { name: console.command }
+
     Akeneo\Tool\Bundle\BatchQueueBundle\Command\MigrateJobMessagesFromOldQueueCommand:
         arguments:
             - '@akeneo_batch_queue.factory.job_execution_message'
@@ -104,8 +112,6 @@ services:
 
     Akeneo\Tool\Bundle\BatchQueueBundle\MessageHandler\JobExecutionMessageHandler:
         arguments:
-            - '@akeneo_batch.query.get_job_instance_code'
-            - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@logger'
             - '%kernel.project_dir%'
         tags:

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Queue/ConsumeJobMessageIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Queue/ConsumeJobMessageIntegration.php
@@ -16,6 +16,7 @@ use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\BatchQueue\Queue\DataMaintenanceJobExecutionMessage;
 use Akeneo\Tool\Component\BatchQueue\Queue\JobExecutionQueueInterface;
 use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Process\Process;
 
@@ -23,6 +24,7 @@ class ConsumeJobMessageIntegration extends TestCase
 {
     private JobLauncher $jobLauncher;
     private JobExecutionRepository $jobExecutionRepository;
+    private EntityManager $em;
 
     /**
      * {@inheritdoc}
@@ -36,6 +38,7 @@ class ConsumeJobMessageIntegration extends TestCase
         $jobInstanceSaver = $this->get('akeneo_batch.saver.job_instance');
         $jobInstanceSaver->save($jobInstance);
 
+        $this->em = $this->get('doctrine.orm.entity_manager');
         $this->jobLauncher = $this->get('akeneo_integration_tests.launcher.job_launcher');
         $this->jobExecutionRepository = $this->get('pim_enrich.repository.job_execution');
     }
@@ -81,6 +84,7 @@ class ConsumeJobMessageIntegration extends TestCase
         Assert::assertEquals(ExitStatus::FAILED, $row['exit_code']);
         Assert::assertNotNull($row['health_check_time']);
 
+        $this->em->clear(JobExecution::class);
         $jobExecution = $this->jobExecutionRepository->findOneBy(['id' => $jobExecution->getId()]);
         $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution);
 
@@ -122,6 +126,7 @@ class ConsumeJobMessageIntegration extends TestCase
         Assert::assertEquals(ExitStatus::UNKNOWN, $row['exit_code']);
         Assert::assertNotNull($row['health_check_time']);
 
+        $this->em->clear(JobExecution::class);
         $jobExecution = $this->jobExecutionRepository->findOneBy(['id' => $jobExecution->getId()]);
         $jobExecution = $this->getJobExecutionManager()->resolveJobExecutionStatus($jobExecution);
 


### PR DESCRIPTION
Split the Job consumer with a dedicated job execution watchdog.
This allow us to have a mutualized, context agnostic message consumer launching a watchdog responsible for initiating the context and running the health check.

### Before:

<img src="https://user-images.githubusercontent.com/1516770/169960614-44603631-611f-4dec-9069-e2ca6b040441.png" width="80%">

### After:

<img src="https://user-images.githubusercontent.com/1516770/169960700-07972dd6-fce8-45af-a5f9-27cf50be3003.png" width="80%">
