### PR TITLE
Fix completeness compute during an alter table on completeness

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlSaveProductCompletenesses.php
@@ -63,7 +63,8 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
             // Clean completeness rows that do not concern existing channels or activated locales anymore
             foreach ($productCompletenessCollections as $productCompletenessCollection) {
                 $conditions = [];
-                $values = [$productCompletenessCollection->productId()];
+                $productId = $productCompletenessCollection->productId();
+                $values = [$productId];
                 foreach ($productCompletenessCollection as $productCompleteness) {
                     $conditions[] = '(?, ?)';
                     $values[] = $localeIdsFromCode[$productCompleteness->localeCode()];
@@ -90,7 +91,7 @@ final class SqlSaveProductCompletenesses implements SaveProductCompletenesses
                 } else {
                     $this->connection->executeQuery(
                         'DELETE FROM pim_catalog_completeness WHERE product_id = ?',
-                        [$productCompletenessCollection->productId()]
+                        [$productId]
                     );
                 }
             }


### PR DESCRIPTION
**The bug**

During the uuid migration we do an alter table on the completeness table to add a new unique index:

```
ALTER TABLE pim_catalog_completeness ADD CONSTRAINT channel_locale_product_unique_idx UNIQUE (`channel_id`, `locale_id`, `product_uuid`), ALGORITHM=INPLACE, LOCK=NONE;
```

Today 3 envs, on a total of ~950 envs, encounter an issue during this operation:
```
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
```

We check these envs, there is no duplicate before the alter table.  

**Analyze and fix**

But we reproduce the bug in local with:
- create a lot of products and completeness rows, so that the alter table is a little long to execute (~30s but in production it could take several minutes)
- launch a background job that recompute the completeness of random products, in an infinite loop
- play the alter table

Following the documentation, the alter table recopy the rows in a new place on the disk. It don't block the insert/update/delete operations thanks to the algorythm in place, but keep all them in temporary file. When it finish to recopy the rows, it takes care of these operations to ensure there is no duplicate. I assume the problem is here, according to the documentation:

https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-limitations.html

> When running an online ALTER TABLE operation, the thread that runs the ALTER TABLE operation will apply an "online log" of DML operations that were run concurrently on the same table from other connection threads. When the DML operations are applied, it is possible to encounter a duplicate key entry error (ERROR 1062 (23000): Duplicate entry), even if the duplicate entry is only temporary and would be reverted by a later entry in the "online log". This is similar to the idea of a foreign key constraint check in InnoDB in which constraints must hold during a transaction.


When we recompute the completeness, we delete former rows for the product and recreate new ones. The alter table should not take these operations in the order, so at some point there is some duplicate and it crashes.


So the fix here is to replace the DELETE/INSERT operations by INSERT ON DUPLICATE KEY UPDATE. With these fix we can compute completeness and perform the alter table.
The ON DUPLICATE KEY works before/during/after the migration thanks to the searchunique_idx unique index (unique on locale_id / channel_id / product_id) and the new unique key we add 