### PR TITLE
PIM-10471: Do not generate 2 files when making a quick export of 1 type of products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PIM-10443: Search for system product grid filters in System > Users > Additional is now case insensitive
 - PIM-10459: Fix product grid selection
 - PIM-10447: Do not hydrate product/model in UniqueEntityValidator
+- PIM-10471: Do not generate 2 files when making a quick export of 1 type of products
 - PIM-10475: Fix option existence validation for numeric option codes
 
 ## Improvements

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/FlatItemBufferFlusher.php
@@ -53,6 +53,10 @@ class FlatItemBufferFlusher implements StepExecutionAwareInterface
         $basePathname,
         $maxLinesPerFile = -1
     ) {
+        if (0 === $buffer->count()) {
+            return [];
+        }
+
         if ($this->areSeveralFilesNeeded($buffer, $maxLinesPerFile)) {
             $writtenFiles = $this->writeIntoSeveralFiles(
                 $buffer,

--- a/src/Akeneo/Tool/Component/Connector/spec/Writer/File/FlatItemBufferFlusherSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Writer/File/FlatItemBufferFlusherSpec.php
@@ -46,7 +46,7 @@ class FlatItemBufferFlusherSpec extends ObjectBehavior
         $this->filesystem->remove($this->directory);
     }
 
-    function it(FlatItemBuffer $buffer)
+    function it_should_not_create_file_if_buffer_is_empty(FlatItemBuffer $buffer)
     {
         $buffer->count()->willReturn(0);
 

--- a/src/Akeneo/Tool/Component/Connector/spec/Writer/File/FlatItemBufferFlusherSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Writer/File/FlatItemBufferFlusherSpec.php
@@ -46,6 +46,13 @@ class FlatItemBufferFlusherSpec extends ObjectBehavior
         $this->filesystem->remove($this->directory);
     }
 
+    function it(FlatItemBuffer $buffer)
+    {
+        $buffer->count()->willReturn(0);
+
+        $this->flush($buffer, ['type' => 'csv'], $this->directory . 'output')->shouldReturn([]);
+    }
+
     function it_flushes_a_buffer_without_a_max_number_of_lines($columnSorter, FlatItemBuffer $buffer, StepExecution $stepExecution, JobParameters $parameters)
     {
         $columnSorter->sort(Argument::any(), [])->willReturn(['colA', 'colB']);
@@ -54,6 +61,7 @@ class FlatItemBufferFlusherSpec extends ObjectBehavior
         $stepExecution->incrementSummaryInfo('write')->shouldBeCalled();
         $parameters->all()->willReturn([]);
 
+        $buffer->count()->willReturn(3);
         $buffer->key()->willReturn(0);
         $buffer->rewind()->willReturn();
         $buffer->valid()->willReturn(true, false);
@@ -144,6 +152,7 @@ class FlatItemBufferFlusherSpec extends ObjectBehavior
     function it_throws_an_exception_if_type_is_not_defined($columnSorter, FlatItemBuffer $buffer, StepExecution $stepExecution, JobParameters $parameters)
     {
         $columnSorter->sort(Argument::any(), [])->willReturn(['colA', 'colB']);
+        $buffer->count()->willReturn(1);
 
         $stepExecution->getJobParameters()->willReturn($parameters);
         $parameters->all()->willReturn([]);
@@ -157,6 +166,7 @@ class FlatItemBufferFlusherSpec extends ObjectBehavior
     function it_throws_an_exception_if_type_is_not_recognized($columnSorter, FlatItemBuffer $buffer, StepExecution $stepExecution, JobParameters $parameters)
     {
         $columnSorter->sort(Argument::any(), [])->willReturn(['colA', 'colB']);
+        $buffer->count()->willReturn(1);
 
         $stepExecution->getJobParameters()->willReturn($parameters);
         $parameters->all()->willReturn([]);

--- a/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Launcher/JobLauncher.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
@@ -100,7 +101,7 @@ class JobLauncher
         }
 
         if (!is_readable($filePath)) {
-            throw new \Exception(sprintf('Exported file "%s" is not readable for the job "%s".', $filePath, $jobCode));
+            return '';
         }
 
         $content = file_get_contents($filePath);

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export.feature
@@ -44,7 +44,7 @@ Feature: Quick export many products from datagrid
       | success | Quick export CSV product quick export finished |
     When I go on the last executed job resume of "csv_product_quick_export"
     Then I should see the text "COMPLETED"
-    And the names of the exported files of "csv_product_quick_export" should be "1_products_export_en_US_tablet.csv,2_product_models_export_en_US_tablet.csv"
+    And the names of the exported files of "csv_product_quick_export" should be "1_products_export_en_US_tablet.csv"
     And first exported file of "csv_product_quick_export" should contain:
       """
       sku;123;categories;color;description-en_US-tablet;enabled;family;groups;lace_color;manufacturer;name-en_US;price-EUR;price-USD;rating;side_view;size;top_view;weather_conditions
@@ -72,7 +72,7 @@ Feature: Quick export many products from datagrid
       | success | Quick Export Quick export XLSX product quick export finished |
     When I go on the last executed job resume of "xlsx_product_quick_export"
     Then I should see the text "COMPLETED"
-    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_tablet.xlsx,2_product_models_export_en_US_tablet.xlsx"
+    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_tablet.xlsx"
     And exported xlsx file 1 of "xlsx_product_quick_export" should contain:
       | sku      | 123 | categories        | color | description-en_US-tablet | enabled | family   | groups | lace_color | manufacturer | name-en_US    | price-EUR | price-USD | rating | side_view | size | top_view | weather_conditions |
       | boots    | aaa | winter_collection | black |                          | 1       | boots    |        |            |              | Amazing boots | 20        | 25        |        |           | 40   |          |                    |

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_grid_context.feature
@@ -32,8 +32,8 @@ Feature: Quick export products according to the product grid context
       | success | Quick export XLSX product quick export grid context finished |
     When I go on the last executed job resume of "xlsx_product_grid_context_quick_export"
     Then I should see the text "COMPLETED"
-    And the names of the exported files of "xlsx_product_grid_context_quick_export" should be "1_products_export_grid_context_en_US_tablet.xlsx,2_product_models_export_grid_context_en_US_tablet.xlsx"
-    And exported xlsx file 1 of "xlsx_product_grid_context_quick_export" should contain:
+    And the names of the exported files of "xlsx_product_grid_context_quick_export" should be "1_products_export_grid_context_en_US_tablet.xlsx"
+    And exported xlsx file of "xlsx_product_grid_context_quick_export" should contain:
       | sku      | color | description-en_US-tablet | family   | groups | name-en_US    | price-EUR | price-USD | size | weight | weight-unit |
       | boots    | black | Mob                      | boots    |        | Amazing boots | 20        | 25        | 40   |        |             |
       | sneakers | white | ylette                   | sneakers |        | Sneakers      | 50        | 60        | 42   |        |             |

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -38,7 +38,7 @@ Feature: Export products and product models
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
     Then I should see the text "COMPLETED"
-    And second exported file of "csv_product_grid_context_quick_export" should contain:
+    And exported file of "csv_product_grid_context_quick_export" should contain:
       """
       code;description-de_DE-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce
       amor;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";
@@ -56,7 +56,7 @@ Feature: Export products and product models
     And I wait for the "csv_product_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_quick_export"
     Then I should see the text "COMPLETED"
-    And second exported file of "csv_product_quick_export" should contain:
+    And exported file of "csv_product_quick_export" should contain:
       """
       code;brand;care_instructions;categories;collection;description-de_DE-ecommerce;description-en_US-ecommerce;description-fr_FR-ecommerce;erp_name-de_DE;erp_name-en_US;erp_name-fr_FR;family_variant;image;keywords-de_DE;keywords-en_US;keywords-fr_FR;material;meta_description-de_DE;meta_description-en_US;meta_description-fr_FR;meta_title-de_DE;meta_title-en_US;meta_title-fr_FR;name-de_DE;name-en_US;name-fr_FR;notice;parent;price-EUR;price-USD;supplier;wash_temperature;weight;weight-unit
       amor;;;master_men_blazers,supplier_zaro;summer_2016;;"Heritage jacket navy blue tweed suit with single breasted 2 button. 53% wool, 22% polyester, 18% acrylic, 5% nylon, 1% cotton, 1% viscose. Dry Cleaning uniquement.Le mannequin measuring 1m85 and wears UK size 40, size 50 FR";;;amor;;clothing_colorsize;;;;;;;;;;;;;"Heritage jacket navy";;;;999;;zaro;800;;

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -22,7 +22,7 @@ Feature: Export products and product models
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
     Then I should see the text "COMPLETED"
-    And the names of the exported files of "csv_product_grid_context_quick_export" should be "product_models_export_grid_context_en_US_ecommerce.csv"
+    And the names of the exported files of "csv_product_grid_context_quick_export" should be "2_product_models_export_grid_context_en_US_ecommerce.csv"
 
   Scenario: Successfully export the grid columns for quick export product models
     When I display in the products grid the columns ID, Label, Model description

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -22,7 +22,7 @@ Feature: Export products and product models
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
     Then I should see the text "COMPLETED"
-    And I should see "product_models_export_grid_context_en_US_ecommerce.csv" on the "Download generated files" dropdown button
+    And the names of the exported files of "csv_product_grid_context_quick_export" should be "product_models_export_grid_context_en_US_ecommerce.csv"
 
   Scenario: Successfully export the grid columns for quick export product models
     When I display in the products grid the columns ID, Label, Model description

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_products_and_product_models.feature
@@ -9,7 +9,7 @@ Feature: Export products and product models
     And I am logged in as "Julia"
     And I am on the products grid
 
-  Scenario: Successfully export 2 files on quick export
+  Scenario: Successfully export 1 file on quick export
     When I display in the products grid the columns ID, Label, Model description
     And I search "amor"
     And I select row amor
@@ -22,7 +22,6 @@ Feature: Export products and product models
     And I wait for the "csv_product_grid_context_quick_export" quick export to finish
     And I go on the last executed job resume of "csv_product_grid_context_quick_export"
     Then I should see the text "COMPLETED"
-    And I should see "products_export_grid_context_en_US_ecommerce.csv" on the "Download generated files" dropdown button
     And I should see "product_models_export_grid_context_en_US_ecommerce.csv" on the "Download generated files" dropdown button
 
   Scenario: Successfully export the grid columns for quick export product models

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
@@ -44,8 +44,8 @@ Feature: Quick export many products with localized attributes from datagrid
       | success | L'export rapide XLSX product quick export est terminé |
     When I go on the last executed job resume of "xlsx_product_quick_export"
     Then I should see the text "TERMINÉ"
-    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_mobile.xlsx,2_product_models_export_en_US_mobile.xlsx"
-    And exported xlsx file 1 of "xlsx_product_quick_export" should contain:
+    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_mobile.xlsx"
+    And exported xlsx file of "xlsx_product_quick_export" should contain:
       | sku      | categories        | color | description-en_US-mobile | description-fr_FR-mobile | destocking_date | enabled | family   | groups | lace_color | manufacturer | name-en_US    | name-fr_FR | price-EUR | price-USD | rate_sale | rating | side_view | size | top_view | weather_conditions | weight | weight-unit |
       | boots    | winter_collection | black |                          |                          | 28/12/1999      | 1       | boots    |        |            |              | Amazing boots |            | 20,80     | 25,35     | 75,50     |        |           | 40   |          |                    | 250    | GRAM        |
       | sneakers | summer_collection | white |                          |                          |                 | 1       | sneakers |        |            |              | Sneakers      |            | 50        | 60        | 75        |        |           | 42   |          |                    | 125,50 | GRAM        |

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_media.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_media.feature
@@ -43,8 +43,8 @@ Feature: Quick export many products with media from datagrid
       | success | Quick Export Quick export XLSX product quick export finished |
     When I go on the last executed job resume of "xlsx_product_quick_export"
     Then I should see the text "COMPLETED"
-    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_tablet.xlsx,2_product_models_export_en_US_tablet.xlsx"
-    And exported xlsx file 1 of "xlsx_product_quick_export" should contain:
+    And the names of the exported files of "xlsx_product_quick_export" should be "1_products_export_en_US_tablet.xlsx"
+    And exported xlsx file of "xlsx_product_quick_export" should contain:
       | sku      | 123 | categories        | color | description-en_US-tablet | enabled | family   | groups | lace_color | manufacturer | name-en_US    | price-EUR | price-USD | rating | side_view                            | size | top_view | weather_conditions |
       | boots    | aaa | winter_collection | black |                          | 1       | boots    |        |            |              | Amazing boots | 20        | 25        |        | files/boots/side_view/akeneo.jpg     | 40   |          |                    |
       | sneakers | bbb | summer_collection | white |                          | 1       | sneakers |        |            |              | Sneakers      | 50        | 60        |        | files/sneakers/side_view/akeneo2.jpg | 42   |          |                    |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR we change the behavior of the export writter to flush only if the buffer count at least 1 item

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
