### PR TITLE
Fix boolean value factory for non-boolean data

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/BooleanValueFactory.php
@@ -16,17 +16,12 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
  */
 final class BooleanValueFactory extends ScalarValueFactory implements ValueFactory
 {
-    public function createWithoutCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
-    {
-        return parent::createWithoutCheckingData($attribute, $channelCode, $localeCode, $data);
-    }
-
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (!\is_scalar($data) || (\is_string($data) && '' === \trim($data))) {
+        if (!\is_bool($data)) {
             throw InvalidPropertyTypeException::booleanExpected(
                 $attribute->code(),
-                static::class,
+                self::class,
                 $data
             );
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Boolean.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/Boolean.php
@@ -17,6 +17,8 @@ class Boolean extends Constraint
 
     public string $message = 'pim_catalog.constraint.boolean.boolean_value_is_required';
 
+    public ?string $attributeCode;
+
     /**
      * {@inheritdoc}
      */

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/BooleanValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/BooleanValidator.php
@@ -29,7 +29,7 @@ class BooleanValidator extends ConstraintValidator
             return;
         }
 
-        $code = '';
+        $code = $constraint->attributeCode ?? '';
         $checkedValue = $value;
 
         if ($value instanceof ValueInterface) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/ExternalApi/PayloadFormatValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi;
 
+use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\Boolean;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
@@ -102,6 +103,8 @@ final class PayloadFormatValidator extends ConstraintValidator
                         ]),
                     ]),
                 ];
+            } elseif (AttributeTypes::BOOLEAN === $attributeType) {
+                $dataConstraints = [new Boolean(['attributeCode' => $attributeCode])];
             }
 
             $constraintsByAttribute[$attributeCode] = [

--- a/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/PayloadFormatValidatorIntegration.php
@@ -36,6 +36,9 @@ final class PayloadFormatValidatorIntegration extends TestCase
                     ['locale' => 'en_US', 'scope' => null, 'data' => [['amount' => 100, 'currency' => 'USD']]],
                     ['locale' => 'fr_FR', 'scope' => null, 'data' => [['amount' => '100', 'currency' => 'USD']]],
                 ],
+                'a_yes_no' => [
+                    ['locale' => null, 'scope' => null, 'data' => false],
+                ],
             ],
         ]);
     }
@@ -53,7 +56,7 @@ final class PayloadFormatValidatorIntegration extends TestCase
         $violations = $this->validator->validate($payload, new PayloadFormat());
         self::assertStringContainsString(
             'Property "a_text" expects an array with the key "data". Check the expected format on the API documentation.',
-            (string) $violations,
+            (string)$violations,
             \sprintf('Violation message is not found, have: %s', $violations)
         );
 
@@ -65,7 +68,7 @@ final class PayloadFormatValidatorIntegration extends TestCase
         $violations = $this->validator->validate($payload, new PayloadFormat());
         self::assertStringContainsString(
             'Property "a_text" expect to be an array of array',
-            (string) $violations,
+            (string)$violations,
             \sprintf('Violation message is not found, have: %s', $violations)
         );
     }
@@ -107,10 +110,28 @@ final class PayloadFormatValidatorIntegration extends TestCase
             $violations = $this->validator->validate($payload, new PayloadFormat());
             self::assertStringContainsString(
                 'The data format sent for the "a_price" attribute is wrong. Please, fill in one value per amount field.',
-                (string) $violations,
+                (string)$violations,
                 \sprintf('Violation message is not found, have: %s', $violations)
             );
         }
+    }
+
+    /** @test */
+    public function it_adds_violations_when_validating_a_wrong_boolean_value_format(): void
+    {
+        $payload = [
+            'values' => [
+                'a_yes_no' => [
+                    ['locale' => null, 'scope' => null, 'data' => 0],
+                ],
+            ],
+        ];
+        $violations = $this->validator->validate($payload, new PayloadFormat());
+        self::assertStringContainsString(
+            'The a_yes_no attribute requires a boolean value (true or false) as data, a integer was detected.',
+            (string)$violations,
+            \sprintf('Violation message is not found, have: %s', $violations)
+        );
     }
 
     private function assertNoViolationForPayload(array $payload): void

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/BooleanValueFactorySpec.php
@@ -87,7 +87,7 @@ final class BooleanValueFactorySpec extends ObjectBehavior
             $this->getAttribute(true, true),
             'ecommerce',
             'fr_FR',
-            new \stdClass()
+            1
         ]);
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ExternalApi/PayloadFormatValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ExternalApi/PayloadFormatValidatorSpec.php
@@ -49,12 +49,16 @@ class PayloadFormatValidatorSpec extends ObjectBehavior
                 'price' => [
                     ['locale' => null, 'scope' => null, 'data' => [['amount' => 100, 'currency' => 'USD']]],
                 ],
+                '5g_enabled' => [
+                    ['locale' => null, 'scope' => null, 'data' => true],
+                ],
             ],
         ];
 
-        $attributeRepository->getAttributeTypeByCodes(['sku', 'price'])->shouldBeCalledOnce()->willReturn([
+        $attributeRepository->getAttributeTypeByCodes(['sku', 'price', '5g_enabled'])->shouldBeCalledOnce()->willReturn([
             'sku' => AttributeTypes::IDENTIFIER,
             'price' => AttributeTypes::PRICE_COLLECTION,
+            '5g_enabled' => AttributeTypes::BOOLEAN,
         ]);
 
         $context->getValidator()->shouldBeCalledOnce()->willReturn($validator);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Forbids the instantiation of a boolean value with non-boolean data. 
In case of a wrong data in the DB (e.g '1' instead of true), the corresponding values will be ignored, this allows to
- not pass a wrong data to the API
- not index wrong data 

Regarding API, an additional payload validation was added in order to keep the same behavior as before

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
