### PR TITLE
PIM-10462: Fix ComputeFamilyVariantStructureChanges job not launched after import

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -28,6 +28,8 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberInterface
 {
+    public const DISABLE_JOB_LAUNCHING = 'DISABLE_JOB_LAUNCHING';
+
     /** @var array<string, bool> */
     private array $isFamilyVariantNew = [];
 
@@ -72,6 +74,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
 
         if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')
             || ($event->hasArgument('is_new') && $event->getArgument('is_new'))
+            || ($event->hasArgument(self::DISABLE_JOB_LAUNCHING) && $event->getArgument(self::DISABLE_JOB_LAUNCHING))
             || !$this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant)
         ) {
             return;
@@ -90,6 +93,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
         if (!is_array($familyVariants)
             || [] === $familyVariants
             || !current($familyVariants) instanceof FamilyVariantInterface
+            || ($event->hasArgument(self::DISABLE_JOB_LAUNCHING) && $event->getArgument(self::DISABLE_JOB_LAUNCHING))
         ) {
             return;
         }

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * The job is not launched if:
  *  - no changes on level's attribute list
  *  - no changes in the axes
- *  - a previous job is in progress
+ *  - a previous job concerning this family variant is about to start
  *
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
@@ -106,6 +106,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             )
         ));
 
+        $this->isFamilyVariantNew = [];
         if ([] === $familyVariantCodesToCompute) {
             return;
         }

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Exception\AnotherJobStillRunningException;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModel;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Pim\Structure\Component\Repository\FamilyVariantRepositoryInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
-use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Doctrine\DBAL\Connection;
@@ -41,7 +40,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
         private IdentifiableObjectRepositoryInterface $jobInstanceRepository,
         private Connection $connection,
         private LoggerInterface $logger,
-        private IdentifiableObjectRepositoryInterface $familyVariantRepository,
+        private FamilyVariantRepositoryInterface $familyVariantRepository,
         string $jobName
     ) {
         $this->jobName = $jobName;
@@ -107,7 +106,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
 
         try {
-            $this->ensureNoOtherJobExecutionIsRunning($jobInstance, $familyVariant);
+            $this->ensureNoOtherJobExecutionIsRunning($jobInstance->getId(), $familyVariant->getCode());
 
             $this->jobLauncher->launch($jobInstance, $user, [
                 'family_variant_codes' => [$familyVariant->getCode()]
@@ -116,32 +115,37 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
         }
     }
 
-    private function ensureNoOtherJobExecutionIsRunning(JobInstance $jobInstance, FamilyVariantInterface $familyVariant): void
+    private function ensureNoOtherJobExecutionIsRunning(int $jobInstanceId, string $familyVariantCode): void
     {
         $query = <<<SQL
-        SELECT *
-        FROM akeneo_batch_job_execution abje,
-         JSON_TABLE(JSON_EXTRACT(abje.raw_parameters, '$.family_variant_codes'), '$[*]' COLUMNS (
-            `code` VARCHAR(100) PATH '$'
-             )) pmd_attribute_codes
-    WHERE job_instance_id = :instanceId
-        AND exit_code in ('UNKNOWN', 'EXECUTED')
-        AND code = :familyVariantCode;
+        SELECT EXISTS(
+            SELECT *
+               FROM akeneo_batch_job_execution abje
+               WHERE job_instance_id = :instanceId
+                   AND exit_code in ('UNKNOWN', 'EXECUTING')
+             AND :familyVariantCode MEMBER OF (JSON_EXTRACT(raw_parameters, '$.family_variant_codes'))
+            AND (health_check_time IS NULL OR health_check_time > SUBTIME(UTC_TIMESTAMP(), '0:0:10'))
+        );
 SQL;
         $stmt = $this->connection->executeQuery(
             $query,
             [
-                'instanceId' => $jobInstance->getId(),
-                'familyVariantCode' => $familyVariant->getCode(),
+                'instanceId' => $jobInstanceId,
+                'familyVariantCode' => $familyVariantCode,
             ]
-        )->fetchAllAssociative();
+        );
 
-        if (\count($stmt) === 0) {
+        if ((int) $stmt->fetchOne() === 0) {
             return;
         }
 
         $this->logger->warning('Another job execution is still running (id = {job_id})', ['message' => 'another_job_execution_is_still_running', 'job_id' => $stmt[0]['id']]);
-        // TODO: should we stop job execution kill when longer than 8h ?
+
+        // In case of an old job execution that has not been marked as failed.
+        /**if ($jobExecutionRunning->getUpdatedTime() < new \DateTime(self::OUTDATED_JOB_EXECUTION_TIME)) {
+            $this->logger->info('Job execution "{job_id}" is outdated: let\'s mark it has failed.', ['message' => 'job_execution_outdated', 'job_id' => $jobExecutionRunning->getId()]);
+            $this->executionManager->markAsFailed($jobExecutionRunning->getId());
+        }*/
 
         throw new AnotherJobStillRunningException();
     }
@@ -165,6 +169,7 @@ SQL;
             }
         }
 
-        return false;
+        // TODO: change to return false;
+        return true;
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -28,7 +28,8 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberInterface
 {
-    public const DISABLE_JOB_LAUNCHING = 'DISABLE_JOB_LAUNCHING';
+    public const DISABLE_JOB_LAUNCHING = 'DISABLE_COMPUTE_FAMILY_VARIANT_STRUCTURE_CHANGES_LAUNCHING';
+    public const FORCE_JOB_LAUNCHING = 'FORCE_COMPUTE_FAMILY_VARIANT_STRUCTURE_CHANGES_LAUNCHING';
 
     /** @var array<string, bool> */
     private array $isFamilyVariantNew = [];
@@ -72,10 +73,11 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             return;
         }
 
+        $forceJobLaunching = $event->hasArgument(self::FORCE_JOB_LAUNCHING) && $event->getArgument(self::FORCE_JOB_LAUNCHING);
         if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')
             || ($event->hasArgument('is_new') && $event->getArgument('is_new'))
             || ($event->hasArgument(self::DISABLE_JOB_LAUNCHING) && $event->getArgument(self::DISABLE_JOB_LAUNCHING))
-            || !$this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant)
+            || (!$forceJobLaunching && !$this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
         ) {
             return;
         }
@@ -98,6 +100,8 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             return;
         }
 
+        $forceJobLaunching = $event->hasArgument(self::FORCE_JOB_LAUNCHING) && $event->getArgument(self::FORCE_JOB_LAUNCHING);
+
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
         $familyVariantCodesToCompute = \array_values(\array_map(
             static fn (FamilyVariantInterface $familyVariant): string => $familyVariant->getCode(),
@@ -105,7 +109,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
                 $familyVariants,
                 fn (FamilyVariantInterface $familyVariant): bool =>
                     !($this->isFamilyVariantNew[$familyVariant->getCode()] ?? false)
-                    && $this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant)
+                    && ($forceJobLaunching || $this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
                     && $this->noOtherJobExecutionIsPending($jobInstance->getId(), $familyVariant->getCode())
             )
         ));

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -151,6 +151,9 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
     private function variantAttributeSetOfFamilyVariantIsUpdated(FamilyVariantInterface $familyVariant): bool
     {
         // Warning: releaseEvents can be called only once by family variant (events are cleared after the first call)
-        return \in_array(FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT, $familyVariant->releaseEvents());
+        $events = $familyVariant->releaseEvents();
+
+        return \in_array(FamilyVariantInterface::AXES_WERE_UPDATED_ON_LEVEL, $events)
+            || \in_array(FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL, $events);
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
-use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -42,7 +42,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
      * As we are not in an import context, the `compute_family_variant_structure_changes` job is triggered
-     * by the bulkFamilyVariantSaver->saveAll().
+     * by the bulkFamilyVariantSaver->saveAll(). We force the launch of this job because if an attribute
+     * at the common level is removed, the family variant stays unchanged but we need to recompute the root/sub
+     * product models.
      *
      * hence, updating the catalog asynchronously.
      *
@@ -64,7 +66,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
-        $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants);
+        $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
+            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true,
+        ]);
 
         if (!empty($allViolations)) {
             $errorMessage = $this->getErrorMessage($allViolations);

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -14,7 +14,6 @@ services:
             - '@akeneo_batch.job.job_instance_repository'
             - '@database_connection'
             - '@logger'
-            - '@pim_catalog.repository.family_variant'
             - '%pim_catalog.compute_family_variant_structure_changes.job_name%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -14,6 +14,7 @@ services:
             - '@akeneo_batch.job.job_instance_repository'
             - '@database_connection'
             - '@logger'
+            - '@pim_catalog.repository.family_variant'
             - '%pim_catalog.compute_family_variant_structure_changes.job_name%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -12,6 +12,8 @@ services:
             - '@security.token_storage'
             - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
+            - '@database_connection'
+            - '@logger'
             - '%pim_catalog.compute_family_variant_structure_changes.job_name%'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -164,7 +164,7 @@ class FamilyVariant implements FamilyVariantInterface
             $formerAxeIds = [];
         } else {
             $formerAxeIds = $attributeSet->getAxes()->map(
-                static fn(AttributeInterface $attribute): int => $attribute->getId()
+                static fn (AttributeInterface $attribute): int => $attribute->getId()
             )->toArray();
         }
 
@@ -194,7 +194,7 @@ class FamilyVariant implements FamilyVariantInterface
             $formerAttributeIds = [];
         } else {
             $formerAttributeIds = $attributeSet->getAttributes()->map(
-                static fn(AttributeInterface $attribute): int => $attribute->getId()
+                static fn (AttributeInterface $attribute): int => $attribute->getId()
             )->toArray();
         }
 

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -161,11 +161,13 @@ class FamilyVariant implements FamilyVariantInterface
             $attributeSet = new VariantAttributeSet();
             $attributeSet->setLevel($level);
             $this->addVariantAttributeSet($attributeSet);
+            $formerAxeIds = [];
+        } else {
+            $formerAxeIds = $attributeSet->getAxes()->map(
+                static fn(AttributeInterface $attribute): int => $attribute->getId()
+            )->toArray();
         }
 
-        $formerAxeIds = $attributeSet->getAxes()->map(
-            static fn (AttributeInterface $attribute): int => $attribute->getId()
-        )->toArray();
         $newAxeIds = \array_map(
             static fn (AttributeInterface $attribute): int => $attribute->getId(),
             $axes
@@ -189,11 +191,13 @@ class FamilyVariant implements FamilyVariantInterface
             $attributeSet = new VariantAttributeSet();
             $attributeSet->setLevel($level);
             $this->addVariantAttributeSet($attributeSet);
+            $formerAttributeIds = [];
+        } else {
+            $formerAttributeIds = $attributeSet->getAttributes()->map(
+                static fn(AttributeInterface $attribute): int => $attribute->getId()
+            )->toArray();
         }
 
-        $formerAttributeIds = $attributeSet->getAttributes()->map(
-            static fn (AttributeInterface $attribute): int => $attribute->getId()
-        )->toArray();
         $newAttributeIds = \array_map(
             static fn (AttributeInterface $attribute): int => $attribute->getId(),
             $attributes

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -164,12 +164,12 @@ class FamilyVariant implements FamilyVariantInterface
             $formerAxeIds = [];
         } else {
             $formerAxeIds = $attributeSet->getAxes()->map(
-                static fn (AttributeInterface $attribute): int => $attribute->getId()
+                static fn (AttributeInterface $attribute): int => $attribute->getId() ?? 0
             )->toArray();
         }
 
         $newAxeIds = \array_map(
-            static fn (AttributeInterface $attribute): int => $attribute->getId(),
+            static fn (AttributeInterface $attribute): int => $attribute->getId() ?? 0,
             $axes
         );
         sort($formerAxeIds);
@@ -194,12 +194,12 @@ class FamilyVariant implements FamilyVariantInterface
             $formerAttributeIds = [];
         } else {
             $formerAttributeIds = $attributeSet->getAttributes()->map(
-                static fn (AttributeInterface $attribute): int => $attribute->getId()
+                static fn (AttributeInterface $attribute): int => $attribute->getId() ?? 0
             )->toArray();
         }
 
         $newAttributeIds = \array_map(
-            static fn (AttributeInterface $attribute): int => $attribute->getId(),
+            static fn (AttributeInterface $attribute): int => $attribute->getId() ?? 0,
             $attributes
         );
         sort($formerAttributeIds);

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -176,7 +176,7 @@ class FamilyVariant implements FamilyVariantInterface
         sort($newAxeIds);
 
         if ($formerAxeIds !== $newAxeIds) {
-            $this->events[] = FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT;
+            $this->events[] = FamilyVariantInterface::AXES_WERE_UPDATED_ON_LEVEL;
             $attributeSet->setAxes($axes);
         }
     }
@@ -206,7 +206,7 @@ class FamilyVariant implements FamilyVariantInterface
         sort($newAttributeIds);
 
         if ($formerAttributeIds !== $newAttributeIds) {
-            $this->events[] = FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT;
+            $this->events[] = FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL;
             $attributeSet->setAttributes($attributes);
         }
     }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
@@ -13,6 +13,11 @@ use Doctrine\Common\Collections\Collection;
 interface FamilyVariantInterface extends TranslatableInterface
 {
     /**
+     * For now the events are a list of strings, but they can be converted to object when needed.
+     */
+    public const ATTRIBUTE_SET_IS_UPDATED_EVENT = 'ATTRIBUTE_SET_IS_UPDATED';
+
+    /**
      * @return null|int
      */
     public function getId(): ?int;
@@ -96,4 +101,19 @@ interface FamilyVariantInterface extends TranslatableInterface
      * @return array
      */
     public static function getAvailableAxesAttributeTypes(): array;
+
+    /**
+     * @param AttributeInterface[] $axes
+     */
+    public function updateAxesForLevel(int $level, array $axes): void;
+
+    /**
+     * @param AttributeInterface[] $attributes
+     */
+    public function updateAttributesForLevel(int $level, array $attributes): void;
+
+    /**
+     * @return string[]
+     */
+    public function releaseEvents(): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
@@ -15,7 +15,8 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * For now the events are a list of strings, but they can be converted to object when needed.
      */
-    public const ATTRIBUTE_SET_IS_UPDATED_EVENT = 'ATTRIBUTE_SET_IS_UPDATED';
+    public const AXES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
+    public const ATTRIBUTES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
 
     /**
      * @return null|int

--- a/src/Akeneo/Pim/Structure/Component/Updater/FamilyVariantUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/FamilyVariantUpdater.php
@@ -175,21 +175,16 @@ class FamilyVariantUpdater implements ObjectUpdaterInterface
                         );
                     }
 
-                    if (null === $attributeSet = $familyVariant->getVariantAttributeSet($attributeSetData['level'])) {
-                        $attributeSet = $this->attributeSetFactory->create();
-                        $attributeSet->setLevel($attributeSetData['level']);
-
-                        $familyVariant->addVariantAttributeSet($attributeSet);
-                    }
-
                     if (isset($attributeSetData['axes'])) {
-                        $attributeSet->setAxes(
+                        $familyVariant->updateAxesForLevel(
+                            $attributeSetData['level'],
                             $this->getAttributes($attributeSetData['axes'], $attributeSetData['level'])
                         );
                     }
 
                     if (isset($attributeSetData['attributes'])) {
-                        $attributeSet->setAttributes(
+                        $familyVariant->updateAttributesForLevel(
+                            $attributeSetData['level'],
                             $this->getAttributes($attributeSetData['attributes'], $attributeSetData['level'])
                         );
                     }

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
@@ -272,6 +272,7 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
 
     public function testItDoesNotRunBackgroundJobWhenAFamilyVariantHasNotChanged()
     {
+        // is this test relevant?
         $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size_color');
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
         $this->assertCount(

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
@@ -279,7 +279,19 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
 
         $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size_color');
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+        $this->assertCount(
+            0,
+            $this->jobExecutionObserver->jobExecutionsWithJobName('compute_family_variant_structure_changes')
+        );
 
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size_color');
+        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
+            'labels' => ['en_US' => 'test'],
+        ]);
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+
+        $this->get('doctrine.orm.default_entity_manager')->clear();
         $this->assertCount(
             0,
             $this->jobExecutionObserver->jobExecutionsWithJobName('compute_family_variant_structure_changes')
@@ -293,14 +305,44 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
             $this->jobExecutionObserver->jobExecutionsWithJobName('compute_family_variant_structure_changes')
         );
 
-        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size_color');
-        $this->get('pim_catalog.updater.family_variant')->update($familyVariant, [
-            'labels' => ['en_US' => 'test'],
-        ]);
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size');
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'variant_attribute_sets' => [
+                    [
+                        'level' => 1,
+                        'attributes' => ['size'],
+                        'axes' => ['eu_shoes_size'],
+                    ],
+                ],
+            ]
+        );
         $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
 
+        $this->get('doctrine.orm.default_entity_manager')->clear();
         $this->assertCount(
-            0,
+            1,
+            $this->jobExecutionObserver->jobExecutionsWithJobName('compute_family_variant_structure_changes')
+        );
+
+        $familyVariant = $this->get('pim_catalog.repository.family_variant')->findOneByIdentifier('shoes_size');
+        $this->get('pim_catalog.updater.family_variant')->update(
+            $familyVariant,
+            [
+                'variant_attribute_sets' => [
+                    [
+                        'level' => 1,
+                        'attributes' => ['size', 'weight'],
+                        'axes' => ['eu_shoes_size'],
+                    ],
+                ],
+            ]
+        );
+        $this->get('pim_catalog.saver.family_variant')->save($familyVariant);
+        $this->get('doctrine.orm.default_entity_manager')->clear();
+        $this->assertCount(
+            1,
             $this->jobExecutionObserver->jobExecutionsWithJobName('compute_family_variant_structure_changes')
         );
     }
@@ -318,13 +360,9 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
             [
                 'variant_attribute_sets' => [
                     [
-                        'level'      => 1,
-                        'attributes' => [
-                            'size',
-                        ],
-                        'axes'       => [
-                            'eu_shoes_size',
-                        ],
+                        'level' => 1,
+                        'attributes' => ['size'],
+                        'axes' => ['eu_shoes_size'],
                     ],
                 ],
             ]

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
@@ -6,10 +6,13 @@ use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\SimpleJobLauncher;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Result;
 use PhpSpec\ObjectBehavior;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Prophecy\Argument;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -20,12 +23,16 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     function let(
         TokenStorage $tokenStorage,
         SimpleJobLauncher $jobLauncher,
-        JobInstanceRepository $jobInstanceRepository
+        JobInstanceRepository $jobInstanceRepository,
+        Connection $connection,
+        LoggerInterface $logger
     ) {
         $this->beConstructedWith(
             $tokenStorage,
             $jobLauncher,
             $jobInstanceRepository,
+            $connection,
+            $logger,
             'compute_family_variant_structure_changes'
         );
     }
@@ -33,7 +40,6 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::PRE_SAVE => 'checkIsFamilyVariantNew',
             StorageEvents::POST_SAVE => 'computeVariantStructureChanges',
         ]);
     }
@@ -46,8 +52,11 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         GenericEvent $event,
         TokenInterface $token,
         UserInterface $user,
-        JobInstance $jobInstance
+        JobInstance $jobInstance,
+        Connection $connection,
+        Result $result,
     ) {
+        $event->getArgument('is_new')->willReturn(false);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(true);
         $event->getSubject()->willReturn($familyVariant);
@@ -60,15 +69,17 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
 
         $familyVariant->getCode()->willReturn('family_variant_one');
 
+        $connection->executeQuery(Argument::cetera())->willReturn($result);
+        $result->fetchAllAssociative()->willReturn([]);
+
         $jobLauncher->launch($jobInstance, $user, [
             'family_variant_codes' => ['family_variant_one']
         ])->shouldBeCalled();
 
-        $this->checkIsFamilyVariantNew($event);
         $this->computeVariantStructureChanges($event);
     }
 
-    function it_does_not_comute_variant_structure_for_non_unitary_save(
+    function it_does_not_compute_variant_structure_for_non_unitary_save(
         $tokenStorage,
         $jobLauncher,
         $jobInstanceRepository,
@@ -80,6 +91,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     ) {
         $familyVariant->getId()->willReturn(150);
         $familyVariant->getCode()->willReturn('my_family_variant');
+        $event->getArgument('is_new')->willReturn(false);
         $event->getSubject()->willReturn($familyVariant);
 
         $event->hasArgument('unitary')->willReturn(true);
@@ -91,7 +103,6 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
             ->willReturn($jobInstance);
         $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 
-        $this->checkIsFamilyVariantNew($event);
         $this->computeVariantStructureChanges($event);
     }
 
@@ -101,11 +112,11 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         $jobLauncher
     ) {
         $event->getSubject()->willReturn($familyVariant);
+        $event->getArgument('is_new')->willReturn(true);
         $familyVariant->getId()->willReturn(null);
 
         $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
 
-        $this->checkIsFamilyVariantNew($event);
         $this->computeVariantStructureChanges($event);
     }
 
@@ -115,6 +126,39 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         $jobLauncher
     ) {
         $event->getSubject()->willReturn($object);
+        $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
+
+        $this->computeVariantStructureChanges($event);
+    }
+
+    function it_does_not_launch_a_job_if_another_job_is_already_running(
+        $tokenStorage,
+        $jobLauncher,
+        $jobInstanceRepository,
+        FamilyVariantInterface $familyVariant,
+        GenericEvent $event,
+        TokenInterface $token,
+        UserInterface $user,
+        JobInstance $jobInstance,
+        Connection $connection,
+        Result $result,
+    ) {
+        $event->getArgument('is_new')->willReturn(false);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+        $event->getSubject()->willReturn($familyVariant);
+        $familyVariant->getId()->willReturn(12);
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
+        $jobInstanceRepository->findOneByIdentifier('compute_family_variant_structure_changes')
+            ->willReturn($jobInstance);
+
+        $familyVariant->getCode()->willReturn('family_variant_one');
+
+        $connection->executeQuery(Argument::cetera())->willReturn($result);
+        $result->fetchAllAssociative()->willReturn([['id' => 'job_id_already_started']]);
+
         $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
 
         $this->computeVariantStructureChanges($event);

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
@@ -3,8 +3,10 @@
 namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\SimpleJobLauncher;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Result;
@@ -15,6 +17,7 @@ use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 
@@ -132,21 +135,17 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     }
 
     function it_does_not_launch_a_job_if_another_job_is_already_running(
-        $tokenStorage,
-        $jobLauncher,
-        $jobInstanceRepository,
+        TokenStorageInterface $tokenStorage,
+        JobLauncherInterface $jobLauncher,
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
         FamilyVariantInterface $familyVariant,
-        GenericEvent $event,
         TokenInterface $token,
         UserInterface $user,
         JobInstance $jobInstance,
         Connection $connection,
         Result $result,
     ) {
-        $event->getArgument('is_new')->willReturn(false);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-        $event->getSubject()->willReturn($familyVariant);
+        $event = new GenericEvent($familyVariant, ['is_new' => false, 'unitary' => true]);
         $familyVariant->getId()->willReturn(12);
 
         $tokenStorage->getToken()->willReturn($token);

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
@@ -43,7 +43,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::PRE_SAVE => 'checkIsNewFamilyVariant',
+            StorageEvents::PRE_SAVE => 'recordIsNewFamilyVariant',
             StorageEvents::POST_SAVE => 'computeVariantStructureChanges',
             StorageEvents::POST_SAVE_ALL => 'bulkComputeVariantStructureChanges',
         ]);
@@ -70,7 +70,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
 
         $familyVariant->getId()->willReturn(12);
         $familyVariant->getCode()->willReturn('family_variant_one');
-        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
 
         $connection->executeQuery(Argument::cetera())->willReturn($result);
         $result->fetchOne()->willReturn(false);
@@ -140,7 +140,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     ) {
         $event = new GenericEvent($familyVariant->getWrappedObject(), ['is_new' => false, 'unitary' => true]);
         $familyVariant->getId()->willReturn(12);
-        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
 
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
@@ -187,13 +187,13 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
 
         $familyVariant1->getId()->willReturn(12);
         $familyVariant1->getCode()->willReturn('family_variant_one');
-        $familyVariant1->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $familyVariant1->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
         $familyVariant2->getId()->willReturn(13);
         $familyVariant2->getCode()->willReturn('family_variant_two');
-        $familyVariant2->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $familyVariant2->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
         $newFamilyVariant->getId()->willReturn(null);
         $newFamilyVariant->getCode()->willReturn('new_family_variant');
-        $newFamilyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $newFamilyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
 
         $connection->executeQuery(Argument::any(), ['instanceId' => 124, 'familyVariantCode' => 'family_variant_one'])
             ->willReturn($result);
@@ -209,7 +209,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
             'family_variant_codes' => ['family_variant_two']
         ])->shouldBeCalledOnce();
 
-        $this->checkIsNewFamilyVariant(new GenericEvent($newFamilyVariant->getWrappedObject()));
+        $this->recordIsNewFamilyVariant(new GenericEvent($newFamilyVariant->getWrappedObject()));
         $this->bulkComputeVariantStructureChanges($event);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriberSpec.php
@@ -2,17 +2,17 @@
 
 namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
+use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\SimpleJobLauncher;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Result;
 use PhpSpec\ObjectBehavior;
-use Akeneo\UserManagement\Component\Model\UserInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -43,37 +43,37 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     function it_subscribes_to_events()
     {
         $this->getSubscribedEvents()->shouldReturn([
+            StorageEvents::PRE_SAVE => 'checkIsNewFamilyVariant',
             StorageEvents::POST_SAVE => 'computeVariantStructureChanges',
+            StorageEvents::POST_SAVE_ALL => 'bulkComputeVariantStructureChanges',
         ]);
     }
 
     function it_computes_variant_structure_changes(
-        $tokenStorage,
-        $jobLauncher,
-        $jobInstanceRepository,
+        TokenStorage $tokenStorage,
+        SimpleJobLauncher $jobLauncher,
+        JobInstanceRepository $jobInstanceRepository,
         FamilyVariantInterface $familyVariant,
-        GenericEvent $event,
         TokenInterface $token,
         UserInterface $user,
         JobInstance $jobInstance,
         Connection $connection,
         Result $result,
     ) {
-        $event->getArgument('is_new')->willReturn(false);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-        $event->getSubject()->willReturn($familyVariant);
-        $familyVariant->getId()->willReturn(12);
+        $event = new GenericEvent($familyVariant->getWrappedObject(), ['is_new' => false, 'unitary' => true]);
 
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
         $jobInstanceRepository->findOneByIdentifier('compute_family_variant_structure_changes')
             ->willReturn($jobInstance);
+        $jobInstance->getId()->willReturn(124);
 
+        $familyVariant->getId()->willReturn(12);
         $familyVariant->getCode()->willReturn('family_variant_one');
+        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
 
         $connection->executeQuery(Argument::cetera())->willReturn($result);
-        $result->fetchAllAssociative()->willReturn([]);
+        $result->fetchOne()->willReturn(false);
 
         $jobLauncher->launch($jobInstance, $user, [
             'family_variant_codes' => ['family_variant_one']
@@ -83,10 +83,9 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     }
 
     function it_does_not_compute_variant_structure_for_non_unitary_save(
-        $tokenStorage,
-        $jobLauncher,
-        $jobInstanceRepository,
-        GenericEvent $event,
+        TokenStorage $tokenStorage,
+        SimpleJobLauncher $jobLauncher,
+        JobInstanceRepository $jobInstanceRepository,
         FamilyVariantInterface $familyVariant,
         TokenInterface $token,
         UserInterface $user,
@@ -94,11 +93,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     ) {
         $familyVariant->getId()->willReturn(150);
         $familyVariant->getCode()->willReturn('my_family_variant');
-        $event->getArgument('is_new')->willReturn(false);
-        $event->getSubject()->willReturn($familyVariant);
-
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(false);
+        $event = new GenericEvent($familyVariant->getWrappedObject(), ['is_new' => false, 'unitary' => false]);
 
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
@@ -111,11 +106,9 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
 
     function it_does_not_launch_a_job_if_it_is_a_new_family_variant(
         FamilyVariantInterface $familyVariant,
-        GenericEvent $event,
-        $jobLauncher
+        SimpleJobLauncher $jobLauncher
     ) {
-        $event->getSubject()->willReturn($familyVariant);
-        $event->getArgument('is_new')->willReturn(true);
+        $event = new GenericEvent($familyVariant->getWrappedObject(), ['is_new' => true, 'unitary' => true]);
         $familyVariant->getId()->willReturn(null);
 
         $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
@@ -126,7 +119,7 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
     function it_does_not_launch_a_job_if_it_is_not_a_family_variant(
         \stdClass $object,
         GenericEvent $event,
-        $jobLauncher
+        SimpleJobLauncher $jobLauncher
     ) {
         $event->getSubject()->willReturn($object);
         $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
@@ -145,21 +138,78 @@ class ComputeFamilyVariantStructureChangesSubscriberSpec extends ObjectBehavior
         Connection $connection,
         Result $result,
     ) {
-        $event = new GenericEvent($familyVariant, ['is_new' => false, 'unitary' => true]);
+        $event = new GenericEvent($familyVariant->getWrappedObject(), ['is_new' => false, 'unitary' => true]);
         $familyVariant->getId()->willReturn(12);
+        $familyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
 
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
         $jobInstanceRepository->findOneByIdentifier('compute_family_variant_structure_changes')
             ->willReturn($jobInstance);
+        $jobInstance->getId()->willReturn(124);
 
         $familyVariant->getCode()->willReturn('family_variant_one');
 
         $connection->executeQuery(Argument::cetera())->willReturn($result);
-        $result->fetchAllAssociative()->willReturn([['id' => 'job_id_already_started']]);
+        $result->fetchOne()->willReturn(4000);
 
         $jobLauncher->launch(Argument::any())->shouldNotBeCalled();
 
         $this->computeVariantStructureChanges($event);
+    }
+
+    function it_computes_variant_structure_changes_for_a_batch_of_family_variants(
+        TokenStorage $tokenStorage,
+        SimpleJobLauncher $jobLauncher,
+        JobInstanceRepository $jobInstanceRepository,
+        FamilyVariantInterface $familyVariant1,
+        FamilyVariantInterface $familyVariant2,
+        FamilyVariantInterface $newFamilyVariant,
+        TokenInterface $token,
+        UserInterface $user,
+        JobInstance $jobInstance,
+        Connection $connection,
+        Result $result,
+        Result $result2,
+        Result $result3
+    ) {
+        $event = new GenericEvent([
+            $familyVariant1->getWrappedObject(),
+            $familyVariant2->getWrappedObject(),
+            $newFamilyVariant->getWrappedObject(),
+        ]);
+
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
+        $jobInstanceRepository->findOneByIdentifier('compute_family_variant_structure_changes')
+            ->willReturn($jobInstance);
+        $jobInstance->getId()->willReturn(124);
+
+        $familyVariant1->getId()->willReturn(12);
+        $familyVariant1->getCode()->willReturn('family_variant_one');
+        $familyVariant1->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $familyVariant2->getId()->willReturn(13);
+        $familyVariant2->getCode()->willReturn('family_variant_two');
+        $familyVariant2->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $newFamilyVariant->getId()->willReturn(null);
+        $newFamilyVariant->getCode()->willReturn('new_family_variant');
+        $newFamilyVariant->releaseEvents()->willReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+
+        $connection->executeQuery(Argument::any(), ['instanceId' => 124, 'familyVariantCode' => 'family_variant_one'])
+            ->willReturn($result);
+        $result->fetchOne()->willReturn(4000);
+        $connection->executeQuery(Argument::any(), ['instanceId' => 124, 'familyVariantCode' => 'family_variant_two'])
+            ->willReturn($result2);
+        $result2->fetchOne()->willReturn(false);
+        $connection->executeQuery(Argument::any(), ['instanceId' => 124, 'familyVariantCode' => 'new_family_variant'])
+            ->willReturn($result3);
+        $result3->fetchOne()->willReturn(false);
+
+        $jobLauncher->launch($jobInstance, $user, [
+            'family_variant_codes' => ['family_variant_two']
+        ])->shouldBeCalledOnce();
+
+        $this->checkIsNewFamilyVariant(new GenericEvent($newFamilyVariant->getWrappedObject()));
+        $this->bulkComputeVariantStructureChanges($event);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
+use Akeneo\Pim\Structure\Bundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber;
 use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
@@ -11,6 +12,7 @@ use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -20,11 +22,10 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 {
     function let(
         ValidatorInterface $validator,
-        SaverInterface $familyVariantSaver,
         BulkSaverInterface $bulkFamilyVariantSaver,
         BulkObjectDetacherInterface $objectDetacher
     ) {
-        $this->beConstructedWith($validator, $familyVariantSaver, $bulkFamilyVariantSaver, $objectDetacher);
+        $this->beConstructedWith($validator, $bulkFamilyVariantSaver, $objectDetacher);
     }
 
     function it_is_initializable()
@@ -42,12 +43,12 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
     function it_only_supports_families_object(
         $validator,
-        $familyVariantSaver,
+        BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
         \stdClass $object
     ) {
         $validator->validate()->shouldNotBeCalled();
-        $familyVariantSaver->save()->shouldNotBeCalled();
+        $bulkFamilyVariantSaver->saveAll(Argument::cetera())->shouldNotBeCalled();
 
         $event->getSubject()->willReturn($object);
         $this->onUnitarySave($event);
@@ -55,98 +56,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
     function it_validates_and_saves_family_variants_on_family_update_on_unitary_save(
         $validator,
-        $familyVariantSaver,
-        GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        ConstraintViolationList $constraintViolationList
-    ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
-        $familyVariantsIterator->valid()->willReturn(true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
-
-        $validator->validate($familyVariants1)->willReturn($constraintViolationList);
-        $constraintViolationList->count()->willReturn(0);
-        $validator->validate($familyVariants2)->willReturn($constraintViolationList);
-        $constraintViolationList->count()->willReturn(0);
-
-        $familyVariantSaver->save($familyVariants1)->shouldBeCalled();
-        $familyVariantSaver->save($familyVariants2)->shouldBeCalled();
-
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-        $this->onUnitarySave($event);
-    }
-
-    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_unitary_save(
-        $validator,
-        $familyVariantSaver,
-        GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        FamilyVariantInterface $familyVariants3
-    ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
-        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
-
-        $familyVariants1->getCode()->willReturn('family_variant_1');
-        $familyVariants2->getCode()->willReturn('family_variant_2');
-
-        $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
-        $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
-
-        $constraintViolationList1 = new ConstraintViolationList([$constraintViolation1, $constraintViolation2]);
-        $constraintViolationList2 = new ConstraintViolationList([$constraintViolation1]);
-        $constraintViolationList3 = new ConstraintViolationList();
-
-        $validator->validate($familyVariants1)->willReturn($constraintViolationList1);
-        $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
-        $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
-
-        $familyVariantSaver->save($familyVariants3)->shouldBeCalled();
-
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(true);
-        $errorMessage = 'One or more errors occurred while updating the following family variants:\n' .
-            'family_variant_1:\n- Error 1 with family variant\n- Error 2 with family variant\n' .
-            'family_variant_2:\n- Error 1 with family variant\n';
-        $this->shouldThrow(new \LogicException($errorMessage))->during('onUnitarySave', [$event]);
-    }
-
-    function it_does_not_save_if_on_non_unitary_save_and_POST_SAVE(
-        $familyVariantSaver,
-        GenericEvent $event,
-        FamilyInterface $family
-    ) {
-        $familyVariantSaver->save()->shouldNotBeCalled();
-
-        $event->getSubject()->willReturn($family);
-        $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(false);
-
-        $this->onUnitarySave($event);
-    }
-
-    function it_validates_and_saves_family_variants_on_family_update_on_bulk_save(
-        $validator,
-        $bulkFamilyVariantSaver,
+        BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
         FamilyInterface $family,
         Collection $familyVariants,
@@ -172,13 +82,13 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
-        $event->getArgument('unitary')->willReturn(false);
-        $this->onBulkSave($event);
+        $event->getArgument('unitary')->willReturn(true);
+        $this->onUnitarySave($event);
     }
 
-    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_bulk_save(
+    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_unitary_save(
         $validator,
-        $bulkFamilyVariantSaver,
+        BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
         FamilyInterface $family,
         Collection $familyVariants,
@@ -210,6 +120,102 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
 
         $bulkFamilyVariantSaver->saveAll([$familyVariants3])->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(true);
+        $errorMessage = 'One or more errors occurred while updating the following family variants:\n' .
+            'family_variant_1:\n- Error 1 with family variant\n- Error 2 with family variant\n' .
+            'family_variant_2:\n- Error 1 with family variant\n';
+        $this->shouldThrow(new \LogicException($errorMessage))->during('onUnitarySave', [$event]);
+    }
+
+    function it_does_not_save_if_on_non_unitary_save_and_POST_SAVE(
+        BulkSaverInterface $bulkFamilyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family
+    ) {
+        $bulkFamilyVariantSaver->saveAll(Argument::cetera())->shouldNotBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+
+        $this->onUnitarySave($event);
+    }
+
+    function it_validates_and_saves_family_variants_on_family_update_on_bulk_save(
+        $validator,
+        BulkSaverInterface $bulkFamilyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        ConstraintViolationList $constraintViolationList
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
+        $familyVariantsIterator->valid()->willReturn(true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList);
+        $constraintViolationList->count()->willReturn(0);
+
+        $bulkFamilyVariantSaver->saveAll(
+            [$familyVariants1, $familyVariants2],
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+        )->shouldBeCalled();
+
+        $event->getSubject()->willReturn($family);
+        $event->hasArgument('unitary')->willReturn(true);
+        $event->getArgument('unitary')->willReturn(false);
+        $this->onBulkSave($event);
+    }
+
+    function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_bulk_save(
+        $validator,
+        BulkSaverInterface $bulkFamilyVariantSaver,
+        GenericEvent $event,
+        FamilyInterface $family,
+        Collection $familyVariants,
+        \ArrayIterator $familyVariantsIterator,
+        FamilyVariantInterface $familyVariants1,
+        FamilyVariantInterface $familyVariants2,
+        FamilyVariantInterface $familyVariants3
+    ) {
+        $family->getFamilyVariants()->willReturn($familyVariants);
+
+        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
+        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
+        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
+        $familyVariantsIterator->rewind()->shouldBeCalled();
+        $familyVariantsIterator->next()->shouldBeCalled();
+
+        $familyVariants1->getCode()->willReturn('family_variant_1');
+        $familyVariants2->getCode()->willReturn('family_variant_2');
+
+        $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
+        $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
+
+        $constraintViolationList1 = new ConstraintViolationList([$constraintViolation1, $constraintViolation2]);
+        $constraintViolationList2 = new ConstraintViolationList([$constraintViolation1]);
+        $constraintViolationList3 = new ConstraintViolationList();
+
+        $validator->validate($familyVariants1)->willReturn($constraintViolationList1);
+        $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
+        $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
+
+        $bulkFamilyVariantSaver->saveAll(
+            [$familyVariants3],
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+        )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -78,7 +78,10 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator->validate($familyVariants2)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
 
-        $bulkFamilyVariantSaver->saveAll([$familyVariants1, $familyVariants2])->shouldBeCalled();
+        $bulkFamilyVariantSaver->saveAll(
+            [$familyVariants1, $familyVariants2],
+            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+        )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
@@ -119,7 +122,10 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator->validate($familyVariants2)->willReturn($constraintViolationList2);
         $validator->validate($familyVariants3)->willReturn($constraintViolationList3);
 
-        $bulkFamilyVariantSaver->saveAll([$familyVariants3])->shouldBeCalled();
+        $bulkFamilyVariantSaver->saveAll(
+            [$familyVariants3],
+            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+        )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilyVariantSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilyVariantSpec.php
@@ -272,7 +272,7 @@ class FamilyVariantSpec extends ObjectBehavior
         $color = new Attribute();
         $color->setId(1);
         $this->updateAxesForLevel(1, [$color]);
-        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::AXES_WERE_UPDATED_ON_LEVEL]);
         $this->releaseEvents()->shouldReturn([]);
 
         $this->updateAxesForLevel(1, [$color]);
@@ -281,7 +281,7 @@ class FamilyVariantSpec extends ObjectBehavior
         $size = new Attribute();
         $size->setId(2);
         $this->updateAxesForLevel(1, [$size]);
-        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::AXES_WERE_UPDATED_ON_LEVEL]);
     }
 
     function it_returns_events_when_attributes_of_level_are_updated()
@@ -291,7 +291,7 @@ class FamilyVariantSpec extends ObjectBehavior
         $color = new Attribute();
         $color->setId(1);
         $this->updateAttributesForLevel(1, [$color]);
-        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
         $this->releaseEvents()->shouldReturn([]);
 
         $this->updateAttributesForLevel(1, [$color]);
@@ -300,6 +300,6 @@ class FamilyVariantSpec extends ObjectBehavior
         $size = new Attribute();
         $size->setId(2);
         $this->updateAttributesForLevel(1, [$size]);
-        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL]);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilyVariantSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilyVariantSpec.php
@@ -206,4 +206,100 @@ class FamilyVariantSpec extends ObjectBehavior
 
         $this->getLevelForAttributeCode('name')->shouldReturn(0);
     }
+
+    function it_updates_axes_for_level()
+    {
+        $this->getVariantAttributeSet(1)->shouldReturn(null);
+
+        $color = new Attribute();
+        $color->setId(1);
+        $size = new Attribute();
+        $size->setId(2);
+        $this->updateAxesForLevel(1, [$color, $size]);
+
+        $variantAttributeSet = $this->getVariantAttributeSet(1);
+        $variantAttributeSet->shouldHaveType(VariantAttributeSet::class);
+        $variantAttributeSet->getLevel()->shouldBe(1);
+        $variantAttributeSet->getAxes()->toArray()->shouldBe([$color, $size]);
+
+        $other = new Attribute();
+        $other->setId(1);
+        $this->updateAxesForLevel(1, [$other]);
+        $variantAttributeSet = $this->getVariantAttributeSet(1);
+        $variantAttributeSet->shouldHaveType(VariantAttributeSet::class);
+        $variantAttributeSet->getLevel()->shouldBe(1);
+        $variantAttributeSet->getAxes()->toArray()->shouldBe([$other]);
+    }
+
+    function it_can_updates_axes_for_level_only_with_attributes()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('updateAxesForLevel', [1, ['color']]);
+    }
+
+    function it_updates_attributes_for_level()
+    {
+        $this->getVariantAttributeSet(1)->shouldReturn(null);
+
+        $color = new Attribute();
+        $color->setId(1);
+        $size = new Attribute();
+        $size->setId(2);
+        $this->updateAttributesForLevel(1, [$color, $size]);
+
+        $variantAttributeSet = $this->getVariantAttributeSet(1);
+        $variantAttributeSet->shouldHaveType(VariantAttributeSet::class);
+        $variantAttributeSet->getLevel()->shouldBe(1);
+        $variantAttributeSet->getAttributes()->toArray()->shouldBe([$color, $size]);
+
+        $other = new Attribute();
+        $other->setId(1);
+        $this->updateAttributesForLevel(1, [$other]);
+        $variantAttributeSet = $this->getVariantAttributeSet(1);
+        $variantAttributeSet->shouldHaveType(VariantAttributeSet::class);
+        $variantAttributeSet->getLevel()->shouldBe(1);
+        $variantAttributeSet->getAttributes()->toArray()->shouldBe([$other]);
+    }
+
+    function it_can_updates_attributes_for_level_only_with_attributes()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during('updateAttributesForLevel', [1, ['color']]);
+    }
+
+    function it_returns_events_when_axes_are_updated()
+    {
+        $this->releaseEvents()->shouldReturn([]);
+
+        $color = new Attribute();
+        $color->setId(1);
+        $this->updateAxesForLevel(1, [$color]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([]);
+
+        $this->updateAxesForLevel(1, [$color]);
+        $this->releaseEvents()->shouldReturn([]);
+
+        $size = new Attribute();
+        $size->setId(2);
+        $this->updateAxesForLevel(1, [$size]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+    }
+
+    function it_returns_events_when_attributes_of_level_are_updated()
+    {
+        $this->releaseEvents()->shouldReturn([]);
+
+        $color = new Attribute();
+        $color->setId(1);
+        $this->updateAttributesForLevel(1, [$color]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+        $this->releaseEvents()->shouldReturn([]);
+
+        $this->updateAttributesForLevel(1, [$color]);
+        $this->releaseEvents()->shouldReturn([]);
+
+        $size = new Attribute();
+        $size->setId(2);
+        $this->updateAttributesForLevel(1, [$size]);
+        $this->releaseEvents()->shouldReturn([FamilyVariantInterface::ATTRIBUTE_SET_IS_UPDATED_EVENT]);
+    }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Updater/FamilyVariantUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/FamilyVariantUpdaterSpec.php
@@ -4,7 +4,6 @@ namespace Specification\Akeneo\Pim\Structure\Component\Updater;
 
 use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Structure\Component\Model\CommonAttributeCollection;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Pim\Structure\Component\Model\VariantAttributeSetInterface;
@@ -17,7 +16,6 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
-use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -57,11 +55,7 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
         AttributeInterface $color,
         AttributeInterface $description,
         AttributeInterface $sku,
-        AttributeInterface $other,
-        Collection $axes1,
-        Collection $axes2,
-        CommonAttributeCollection $commonAttributes,
-        \Iterator $commonAttributesIterator
+        AttributeInterface $other
     ) {
         $familyRepository->findOneByIdentifier('t-shirt')->willReturn($family);
 
@@ -86,21 +80,11 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
 
         $attributeSetFactory->create()->willReturn($attributeSet1, $attributeSet2, $commonAttributeSet);
 
-        $familyVariant->addVariantAttributeSet($attributeSet1)->shouldBeCalled();
-        $attributeSet1->setAttributes([$description])->shouldBeCalled();
-        $attributeSet1->setAxes([$color])->shouldBeCalled();
-        $attributeSet1->setLevel(1)->shouldBeCalled();
-        $attributeSet1->getAxes()->willReturn($axes1);
-        $axes1->isEmpty()->willReturn(true);
-        $axes1->map(Argument::any())->shouldNotBeCalled();
+        $familyVariant->updateAxesForLevel(1, [$color])->shouldBeCalledOnce();
+        $familyVariant->updateAttributesForLevel(1, [$description])->shouldBeCalledOnce();
 
-        $familyVariant->addVariantAttributeSet($attributeSet2)->shouldBeCalled();
-        $attributeSet2->setAttributes([$size, $sku])->shouldBeCalled();
-        $attributeSet2->setAxes([$size, $other])->shouldBeCalled();
-        $attributeSet2->setLevel(2)->shouldBeCalled();
-        $attributeSet2->getAxes()->willReturn($axes2);
-        $axes2->isEmpty()->willReturn(true);
-        $axes2->map(Argument::any())->shouldNotBeCalled();
+        $familyVariant->updateAxesForLevel(2, [$size, $other])->shouldBeCalledOnce();
+        $familyVariant->updateAttributesForLevel(2, [$size, $sku])->shouldBeCalledOnce();
 
         $this->update($familyVariant, [
             'code' => 'my-tshirt',
@@ -137,13 +121,7 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
         AttributeInterface $color,
         AttributeInterface $description,
         AttributeInterface $sku,
-        AttributeInterface $other,
-        Collection $axes1,
-        Collection $axes2,
-        Collection $axisCodes1,
-        Collection $axisCodes2,
-        Collection $attributes1,
-        \Iterator $attributesIterator1
+        AttributeInterface $other
     ) {
         $familyRepository->findOneByIdentifier('t-shirt')->willReturn($family);
 
@@ -169,25 +147,11 @@ class FamilyVariantUpdaterSpec extends ObjectBehavior
 
         $attributeSetFactory->create()->shouldNotBeCalled();
 
-        $axes1->isEmpty()->willReturn(false);
-        $axes1->map(Argument::any())->willReturn($axisCodes1);
-        $axisCodes1->toArray()->willReturn(['color']);
+        $familyVariant->updateAxesForLevel(1, [$color])->shouldBeCalledOnce();
+        $familyVariant->updateAttributesForLevel(1, [$description])->shouldBeCalledOnce();
 
-        $attributeSet1->setAttributes([$description])->shouldBeCalled();
-        $attributeSet1->setAxes([$color])->shouldBeCalled();
-        $attributeSet1->setLevel(Argument::any())->shouldNotBeCalled();
-        $attributeSet1->getAxes()->willReturn($axes1);
-        $attributeSet1->getAttributes()->willReturn($attributes1);
-
-        $attributeSet2->getAxes()->willReturn($axes2);
-        $axes2->isEmpty()->willReturn(false);
-        $axes2->map(Argument::any())->willReturn($axisCodes2);
-        $axisCodes2->toArray()->willReturn(['size', 'other']);
-        $attributeSet2->setAxes([$size, $other])->shouldBeCalled();
-
-        $attributeSet2->setAttributes([$size, $sku])->shouldBeCalled();
-        $attributeSet2->setLevel(Argument::any())->shouldNotBeCalled();
-        $familyVariant->addVariantAttributeSet(Argument::any())->shouldNotBeCalled();
+        $familyVariant->updateAxesForLevel(2, [$size, $other])->shouldBeCalledOnce();
+        $familyVariant->updateAttributesForLevel(2, [$size, $sku])->shouldBeCalledOnce();
 
         $this->update($familyVariant, [
             'code' => 'my-tshirt',


### PR DESCRIPTION
The subscriber did not listen the POST_SAVE_ALL events and only triggered the job on unitary POST_SAVE event.
Now we listen the POST_SAVE_ALL events, but this PR improves the decision if the job should be launched or not (before we always launch the job, even for a change on a label!)

So we avoid to launch job on a family variant if:
- the family variant is new
- the attributes or the axes of a level are updated (there is a validator to check the axes are not changed, but this part of code is ready just in case)
- another job containing this family variant is in "starting" status (!= started!)

When we update a family, before the `compute_family_variant_structure_changes` was always launched. We keep this behaviour by force it to be launched. 
When we update several families, we are in an import use case, and before we never launched the job because there is additional step in the import that recompute the products. We keep this behaviour too by disable the job launching