### PR TITLE
OBS-157: Remove the 500ms waiting between the screenshot of each story

### DIFF
--- a/front-packages/akeneo-design-system/src/all.visual.tsx
+++ b/front-packages/akeneo-design-system/src/all.visual.tsx
@@ -28,7 +28,6 @@ describe('Visual tests', () => {
     const root = await page.$('#root');
     if (null === root) return;
 
-    await new Promise(resolve => setTimeout(resolve, 500));
     const image = await root.screenshot();
 
     expect(image).toMatchImageSnapshot({


### PR DESCRIPTION
The goal of this PR is to speed up the CI of the DSM.

The "Launch visual tests" step of the CI is currently taking ~ 4 min 30 sec.

This step is running the following npm script: `yarn test:visual:run` that finally runs `sb extract storybook-static stories.json && jest --config ./jest.visual.config.js`.
The `sb extract storybook-static stories.json` part is extracting all the stories from the `stories.mdx` files, see: [main.js](https://github.com/akeneo/pim-community-dev/blob/master/front-packages/akeneo-design-system/.storybook/main.js#L7) 
This way the stories are extracted in a `stories.json` file. Then, we are using jest to execute the [all.visual.tsx](https://github.com/akeneo/pim-community-dev/blob/master/front-packages/akeneo-design-system/src/all.visual.tsx) file. This file takes a screenshot for each stories described in the `stories.json` input file. 

It was executing a promise that waits for 500 ms between each story, this was added in order to try to stabilize page loading issues before taking the screenshot. We are removing this line to speed up the step by ~ 113 seconds (226 stories x 500ms / 1000) or 226 seconds when the "Update visual tests" is executed as it runs `test:visual:update` too. We will be watching for the next builds and check that there is no instability with the visual tests again.

**Note**: I wonder if the screenshots could be taken concurrently, wdyt?