### PR TITLE
DPE: Build Akeneo Node v16 docker image

### DIFF
--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -615,18 +615,18 @@ jobs:
             - run:
                   name: Display PHP version
                   command: |
-                      docker-compose run --rm php php -v
+                      docker run --rm akeneo/pim-php-dev:master php -v
             - run:
                   name: Build Akeneo Node image
-                  command: docker build -t akeneo/node:18 -f docker/Dockerfile_node .
+                  command: docker build -t akeneo/node:16 -f docker/Dockerfile_node .
             - run:
                   name: Display Node and Yarn versions
                   command: |
-                      docker-compose run --rm node node --version
-                      docker-compose run --rm node yarn --version
+                      docker run --rm akeneo/node:16 node --version
+                      docker run --rm akeneo/node:16 yarn --version
             - run:
                   name: Push images to Dockerhub
                   command: |
                       docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PWD"
                       docker push akeneo/pim-php-dev:master
-                      docker push akeneo/node:18
+                      docker push akeneo/node:16

--- a/.circleci/workflows/editions/community.yml
+++ b/.circleci/workflows/editions/community.yml
@@ -11,13 +11,6 @@ aliases:
                   webhook: $SLACK_NIGHTLY_STATUS
                   fail_only: true
 
-    - &slack-post-step
-        post-steps:
-            - slack/status:
-                  channel: ci
-                  webhook: $SLACK_NIGHTLY_STATUS
-                  fail_only: false
-
 workflows:
     version: 2
 
@@ -28,9 +21,6 @@ workflows:
                 - equal: [ "nightly_master", << pipeline.schedule.name >> ]
         jobs:
             - checkout_ce
-            - build_docker_images:
-                requires:
-                    - checkout_ce
             - build_dev:
                   <<: *slack-fail-post-step
                   is_ee_built: false
@@ -57,6 +47,13 @@ workflows:
                   requires:
                       - build_dev
 
+    nightly_docker:
+        jobs:
+            - checkout_ce
+            - build_docker_images:
+                requires:
+                    - checkout_ce
+
     on_demand:
         when:
             not:
@@ -70,9 +67,6 @@ workflows:
             - checkout_ce:
                   requires:
                       - ready_to_build?
-            - build_docker_images:
-                  requires:
-                      - checkout_ce
             - build_dev:
                   is_ee_built: false
                   requires:

--- a/.circleci/workflows/editions/community.yml
+++ b/.circleci/workflows/editions/community.yml
@@ -48,6 +48,10 @@ workflows:
                       - build_dev
 
     nightly_docker:
+        when:
+            and:
+                - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+                - equal: [ "nightly_docker_master", << pipeline.schedule.name >> ]
         jobs:
             - checkout_ce
             - build_docker_images:

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
         php8.0-zip \
         php8.0-xml \
         php8.0-gd \
+        php8.0-grpc \
         php8.0-curl \
         php8.0-mbstring \
         php8.0-bcmath \

--- a/docker/Dockerfile_node
+++ b/docker/Dockerfile_node
@@ -11,9 +11,9 @@ RUN echo 'path-exclude=/usr/share/man/*' > /etc/dpkg/dpkg.cfg.d/path_exclusions 
     apt-get clean && apt-get --yes --quiet autoremove --purge && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# NodeJS 18 and Yarn
+# NodeJS 16 and Yarn
 RUN sh -c 'wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' && \
-    sh -c 'echo "deb https://deb.nodesource.com/node_18.x bullseye main" > /etc/apt/sources.list.d/nodesource.list' && \
+    sh -c 'echo "deb https://deb.nodesource.com/node_16.x bullseye main" > /etc/apt/sources.list.d/nodesource.list' && \
     sh -c 'wget -q -O - https://dl.yarnpkg.com/debian/pubkey.gpg | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn apt-key add -' && \
     sh -c 'echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list' && \
     apt-get update && \


### PR DESCRIPTION
Build Node v16 instead of v18 because we are not ready for v18

Move the docker builds in a specific nightly workflow