### PR TITLE
PIM-10475: Fix option existence validation for numeric option codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PIM-10443: Search for system product grid filters in System > Users > Additional is now case insensitive
 - PIM-10459: Fix product grid selection
 - PIM-10447: Do not hydrate product/model in UniqueEntityValidator
+- PIM-10475: Fix option existence validation for numeric option codes
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AttributeOptionsExistValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/AttributeOptionsExistValidator.php
@@ -54,7 +54,7 @@ class AttributeOptionsExistValidator extends ConstraintValidator
 
         foreach ($optionValues as $key => $value) {
             if ($value instanceof OptionValueInterface) {
-                if (!in_array(strtolower($value->getData()), ($existingOptionCodes[$value->getAttributeCode()] ?? []))) {
+                if (!in_array(strtolower($value->getData()), ($existingOptionCodes[$value->getAttributeCode()] ?? []), true)) {
                     $this->context->buildViolation(
                         $constraint->message,
                         [

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptions.php
@@ -88,7 +88,8 @@ class LRUCachedGetExistingAttributeOptions implements GetExistingAttributeOption
     {
         $optionsIndexedByAttributeCode = [];
         foreach ($cacheKeys as $cacheKey) {
-            [$attributeCode, $optionCode] = explode('.', $cacheKey);
+            $attributeCode = \strstr($cacheKey, '.', true);
+            $optionCode = \substr(\strstr($cacheKey, '.', false), 1);
             $optionsIndexedByAttributeCode[$attributeCode][] = $optionCode;
         }
 

--- a/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Query/PublicApi/AttributeOption/Cache/LRUCachedGetExistingAttributeOptionsSpec.php
@@ -28,11 +28,11 @@ class LRUCachedGetExistingAttributeOptionsSpec extends ObjectBehavior
     function it_gets_existing_options_by_performing_an_sql_query_if_the_cache_is_not_hit(
         GetExistingAttributeOptionCodes $sqlQuery
     ) {
-        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+        $sqlQuery->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2', '3.000']])
                  ->shouldBeCalledOnce()
                  ->willReturn(['attribute_1' => ['option2']]);
 
-        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2']])
+        $this->fromOptionCodesByAttributeCode(['attribute_1' => ['option1', 'option2', '3.000']])
              ->shouldReturn(['attribute_1' => ['option2']]);
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This PR fixes two related issues, which used to cause issues when validating the existence of options with numeric codes:
- The LRU cached get existing options used to return wrong results when querying the existence of option codes containing a dot
- The OptionsExistValidator returned false positives when comparing a numeric (integerish) option code and a numeric (floatish) option code (from user input, as an option code cannot contain a non alphanumeric char), e.g: "3.00" and "3"

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
