### PR TITLE
PIM-10472: Fix attributes list limit in the family mass edit

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,7 @@
 # 5.0.x
 
+- PIM-10472: Fix attributes list limit in the family mass edit
+
 # 5.0.97 (2022-05-30)
 
 # 5.0.96 (2022-05-24)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -357,12 +357,7 @@ define([
             return !_.contains(existingAttributes, attribute) && attribute !== identifier.code;
           });
 
-          return FetcherRegistry.getFetcher('attribute').search({
-            options: {
-              identifiers: attributesToAdd,
-              limit: attributesToAdd.length,
-            },
-          });
+          return this.getPaginatedAttributes(attributesToAdd);
         })
         .then(attributes => {
           _.each(attributes, attribute => {
@@ -374,6 +369,23 @@ define([
         .always(() => {
           loadingMask.hide().$el.remove();
         });
+    },
+
+    async getPaginatedAttributes(attributesToAdd) {
+      const chunkSize = 200;
+      let result = [];
+      for (let i = 0; i < attributesToAdd.length; i += chunkSize) {
+        const chunk = attributesToAdd.slice(i, i + chunkSize);
+        const attributes = await FetcherRegistry.getFetcher('attribute').search({
+          options: {
+            identifiers: chunk,
+            limit: chunk.length,
+          },
+        });
+        result = result.concat(attributes);
+      }
+
+      return result;
     },
 
     /**


### PR DESCRIPTION
PHP configuration does not allow more than 1000 parameters.
We split the front query to split calls 200 by 200, then merge the attributes.