### PR TITLE
PIM-10470: Refresh process tracker job detail page when job execution id param changes

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10470: Refresh process tracker job detail page when job execution id param changes
+
 # 6.0.29 (2022-05-25)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/ProcessTrackerApp.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/ProcessTrackerApp.tsx
@@ -6,9 +6,15 @@ import {JobExecutionDetail} from './pages/JobExecutionDetail';
 const ProcessTrackerApp = () => (
   <Router basename="/job">
     <Switch>
-      <Route path="/show/:jobExecutionId">
-        <JobExecutionDetail />
-      </Route>
+      <Route
+        path="/show/:jobExecutionId"
+        render={props => (
+          <JobExecutionDetail
+            key={props.match.params.jobExecutionId}
+            jobExecutionId={props.match.params.jobExecutionId}
+          />
+        )}
+      />
       <Route path="/">
         <JobExecutionList />
       </Route>

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.test.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.test.tsx
@@ -3,7 +3,6 @@ import {renderWithProviders} from '@akeneo-pim-community/shared';
 import {screen} from '@testing-library/react';
 import {JobExecutionDetail} from './JobExecutionDetail';
 import {JobExecution} from '../models';
-import {useParams} from 'react-router-dom';
 import userEvent from '@testing-library/user-event';
 
 beforeEach(() => {
@@ -90,8 +89,6 @@ jest.mock('../hooks/useJobExecution', () => ({
   },
 }));
 
-jest.mock('react-router-dom', () => ({useParams: jest.fn()}));
-
 jest.mock('@akeneo-pim-community/shared/lib/components/PimView', () => ({
   PimView: () => <></>,
 }));
@@ -111,41 +108,38 @@ jest.mock('../components/common/StopJobAction', () => ({
 }));
 
 test('it renders the job execution detail page without a job', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '23'}));
-  renderWithProviders(<JobExecutionDetail />);
+  renderWithProviders(<JobExecutionDetail jobExecutionId="23" />);
+
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
 });
 test('it renders the job execution detail page', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '24'}));
-  renderWithProviders(<JobExecutionDetail />);
+  renderWithProviders(<JobExecutionDetail jobExecutionId="24" />);
+
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
   expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
 });
 
 test('it renders the job execution export detail page', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '25'}));
+  renderWithProviders(<JobExecutionDetail jobExecutionId="25" />);
 
-  renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
   expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
 });
 
 test('it renders the job execution import detail page', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '26'}));
+  renderWithProviders(<JobExecutionDetail jobExecutionId="26" />);
 
-  renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
   expect(screen.getByText('akeneo_job.job_status.STARTED 1/1')).toBeInTheDocument();
 });
 
 test('it stops the job execution', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '27'}));
+  renderWithProviders(<JobExecutionDetail jobExecutionId="26" />);
 
-  renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
   expect(screen.getByText('stop job')).toBeInTheDocument();
@@ -155,9 +149,8 @@ test('it stops the job execution', () => {
 });
 
 test('it can show every downloadable files', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '27'}));
+  renderWithProviders(<JobExecutionDetail jobExecutionId="27" />);
 
-  renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('pim_menu.tab.activity')).toBeInTheDocument();
   expect(screen.getByText('pim_menu.item.job_tracker')).toBeInTheDocument();
   expect(screen.getByText('pim_enrich.entity.job_execution.module.download.output')).toBeInTheDocument();
@@ -166,9 +159,8 @@ test('it can show every downloadable files', () => {
 });
 
 test('it displays an error if needed', () => {
-  useParams.mockImplementation(() => ({jobExecutionId: '28'}));
+  renderWithProviders(<JobExecutionDetail jobExecutionId="28" />);
 
-  renderWithProviders(<JobExecutionDetail />);
   expect(screen.getByText('not found')).toBeInTheDocument();
   expect(screen.getByText('404')).toBeInTheDocument();
 });

--- a/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.tsx
+++ b/src/Akeneo/Platform/Job/front/process-tracker/src/feature/pages/JobExecutionDetail.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {useParams} from 'react-router-dom';
 import styled from 'styled-components';
 import {
   PageContent,
@@ -77,13 +76,16 @@ const canDownloadArchive = ({isGranted}: Security, jobExecution: JobExecution | 
   return true;
 };
 
-const JobExecutionDetail = () => {
+type JobExecutionDetailProps = {
+  jobExecutionId: string;
+};
+
+const JobExecutionDetail = ({jobExecutionId}: JobExecutionDetailProps) => {
   const translate = useTranslate();
   const security = useSecurity();
   const router = useRouter();
 
   const jobTypeWithProfile = ['import', 'export'];
-  const {jobExecutionId} = useParams<{jobExecutionId: string}>();
   const [jobExecution, error, reloadJobExecution, isAutoRefreshing] = useJobExecution(jobExecutionId);
 
   const handleStop = async () => {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When we are on a job execution detail page and the job execution id changes (manually or through a click on notification), the job execution detail component is not correctly rerendered. It is now thanks to the params id used as key. Also, the component now receives a prop for job execution id.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
