### PR TITLE
fix(datagrid views): PIM-10461: Proper pagination for view search end…

### DIFF
--- a/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Repository/DatagridViewRepositoryInterface.php
@@ -34,6 +34,19 @@ interface DatagridViewRepositoryInterface
         array $options = []
     ): array;
 
+    /**
+     * Search datagrid views for the given $user and grid $alias.
+     * The search is applied on label with the given $term.
+     * Results are not paginated
+     *
+     * Returns a collection of DatagridView objects
+     */
+    public function findAllDatagridViewsBySearch(
+        UserInterface $user,
+        string $alias,
+        string $term = ''
+    ): array;
+
     public function findPublicDatagridViewByLabel(string $label): ?DatagridView;
 
     public function findPrivateDatagridViewByLabel(string $label, UserInterface $user): ?DatagridView;


### PR DESCRIPTION
…point (can only be done PHP-side)

**Description (for Contributor and Core Developer)**

Endpoint /datagrid_view/rest/product-grid/views mission is to return a list of views the caller user can use to filter the product grid.
It is SQL-paginated but filtered afterward PHP-side, this is a problem because :
- A page can be empty whereas subsequent page would not be (contract violation) : bug PIM-10461

Theses modifications make pagination consistent, at the cost of loading all views for each request.

("searchAfter" technic is not possible without heavy front modifications)


**Definition Of Done (for Core Developer only)**

- [ ] PM Validation (Story)
