### PR TITLE
CPM-654: Fix behat Select2Decorator::open() method

### DIFF
--- a/tests/legacy/features/Behat/Decorator/Field/Select2Decorator.php
+++ b/tests/legacy/features/Behat/Decorator/Field/Select2Decorator.php
@@ -91,10 +91,9 @@ class Select2Decorator extends ElementDecorator
      */
     public function open()
     {
-        $openerElement = $this->find('css', '.select2-arrow');
-        if (null === $openerElement) {
-            $openerElement = $this->find('css', '.select2-search-field');
-        }
+        $openerElement = $this->spin(function () {
+            return $this->find('css', '.select2-arrow') ?? $this->find('css', '.select2-search-field');
+        }, 'Could not find opener element');
 
         if (!$this->element->hasClass('select2-dropdown-open')) {
             $openerElement->click();


### PR DESCRIPTION
Fixes open() method when the select2 field is not fully rendered yet (see https://app.circleci.com/pipelines/github/akeneo/pim-enterprise-dev/68341/workflows/c150c905-2f7f-4c88-98cf-9b25f0ef2e22/jobs/415833)