### PR TITLE
RAB-761: Add id field on CategoryTree

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Category/SqlFindCategoryTrees.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Category/SqlFindCategoryTrees.php
@@ -61,6 +61,7 @@ class SqlFindCategoryTrees implements FindCategoryTrees
                 $categoryTree = new CategoryTree();
                 $categoryTree->code = $category->getCode();
                 $categoryTree->labels = $translationNormalizer->normalize($category, 'standard');
+                $categoryTree->id = $category->getId();
 
                 return $categoryTree;
             },

--- a/src/Akeneo/Pim/Enrichment/Component/Category/Query/PublicApi/CategoryTree.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Category/Query/PublicApi/CategoryTree.php
@@ -11,15 +11,18 @@ namespace Akeneo\Pim\Enrichment\Component\Category\Query\PublicApi;
  */
 class CategoryTree
 {
+    public const ID = 'id';
     public const CODE = 'code';
     public const LABELS = 'labels';
 
+    public int $id;
     public string $code;
     public array $labels = [];
 
     public function normalize(): array
     {
         return [
+            self::ID => $this->id,
             self::CODE => $this->code,
             self::LABELS => $this->labels
         ];

--- a/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
@@ -23,12 +23,12 @@ final class SqlFindCategoryTreesIntegration extends TestCase
     /** @test */
     public function it_fetches_the_category_trees(): void
     {
+        $actual = $this->sqlFindCategoryTrees->execute();
+
         $masterTree = new CategoryTree();
-        $masterTree->id = 2;
+        $masterTree->id = $actual[0]->id;
         $masterTree->code = 'master';
         $masterTree->labels = ['en_US' => 'Master catalog'];
-
-        $actual = $this->sqlFindCategoryTrees->execute();
 
         $expected = [$masterTree];
         self::assertEquals($expected, $actual);

--- a/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
@@ -24,6 +24,7 @@ final class SqlFindCategoryTreesIntegration extends TestCase
     public function it_fetches_the_category_trees(): void
     {
         $masterTree = new CategoryTree();
+        $masterTree->id = 1;
         $masterTree->code = 'master';
         $masterTree->labels = ['en_US' => 'Master catalog'];
 

--- a/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Category/SqlFindCategoryTreesIntegration.php
@@ -24,7 +24,7 @@ final class SqlFindCategoryTreesIntegration extends TestCase
     public function it_fetches_the_category_trees(): void
     {
         $masterTree = new CategoryTree();
-        $masterTree->id = 1;
+        $masterTree->id = 2;
         $masterTree->code = 'master';
         $masterTree->labels = ['en_US' => 'Master catalog'];
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add id field on `CategoryTree`, in order to avoid another fetch to retrieve it.
`id` is mainly used to retrieve children categories.

**Definition Of Done (for Core Developer only)**

- [x] Tests