### PR TITLE
RAB-791: Make the job fail when the storage is not available

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -319,7 +319,7 @@ class JobInstanceController
         /* TODO remove it when we will migrate to storage unification */
         if ($this->remoteStorageFeatureFlag->isEnabled($jobInstance->getJobName())) {
             $rawParameters = $jobInstance->getRawParameters();
-            $rawParameters['filePath'] = 'fake_path.zip';
+            $rawParameters['filePath'] = '/tmp/fake_path.xlsx';
             $jobInstance->setRawParameters($rawParameters);
         }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/DownloadFileFromStorageBeforeImportSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/DownloadFileFromStorageBeforeImportSubscriber.php
@@ -54,7 +54,7 @@ final class DownloadFileFromStorageBeforeImportSubscriber implements EventSubscr
             return;
         }
 
-        $this->eventDispatcher->addSubscriber(new UpdateJobExecutionStorageSummarySubscriber($jobExecution));
+        $this->eventDispatcher->addSubscriber(new UpdateJobExecutionStorageSummarySubscriber());
 
         $command = new DownloadFileFromStorageCommand(
             $jobParameters[self::STORAGE_KEY],

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/ExportFileToStorageAfterExportSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/ExportFileToStorageAfterExportSubscriber.php
@@ -61,7 +61,7 @@ final class ExportFileToStorageAfterExportSubscriber implements EventSubscriberI
             return;
         }
 
-        $this->eventDispatcher->addSubscriber(new UpdateJobExecutionStorageSummarySubscriber($jobExecution));
+        $this->eventDispatcher->addSubscriber(new UpdateJobExecutionStorageSummarySubscriber());
         $command = new TransferFilesToStorageCommand(
             $this->extractFileToTransfer($jobExecution),
             $jobParameters[self::STORAGE_KEY],

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/UpdateJobExecutionStorageSummarySubscriber.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/UpdateJobExecutionStorageSummarySubscriber.php
@@ -16,9 +16,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class UpdateJobExecutionStorageSummarySubscriber implements EventSubscriberInterface
 {
-    public function __construct(
-        private JobExecution $jobExecution,
-    ) {
+    public function __construct()
+    {
     }
 
     /**
@@ -34,7 +33,7 @@ class UpdateJobExecutionStorageSummarySubscriber implements EventSubscriberInter
 
     public function onFileCannotBeExported(FileCannotBeExported $event): void
     {
-        $this->jobExecution->addFailureException(new \RuntimeException($event->getReason()));
+        throw new \RuntimeException($event->getReason());
     }
 
     public function onFileCannotBeImported(FileCannotBeImported $event): void

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/UpdateJobExecutionStorageSummarySubscriber.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/EventSubscriber/UpdateJobExecutionStorageSummarySubscriber.php
@@ -11,15 +11,10 @@ namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\EventSubscrib
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Event\FileCannotBeExported;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Event\FileCannotBeImported;
-use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class UpdateJobExecutionStorageSummarySubscriber implements EventSubscriberInterface
 {
-    public function __construct()
-    {
-    }
-
     /**
      * @return array<string, string>
      */


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I made the job failed when the storage is not available instead of just add a error message in the page
![Screenshot from 2022-06-15 09-03-38](https://user-images.githubusercontent.com/7239572/173763895-0f8362b1-8e5b-4df0-a202-56bd1bd5e7f6.png)


