### PR TITLE
OCT-67: Add symfony container lint check

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -45,6 +45,7 @@ endif
 	$(PHP_RUN) vendor/bin/phpinsights analyse $(PHPINSIGHTS_ARGS) --no-interaction \
 		--config-path=$(CATALOGS_PATH)/back/phpinsights.php \
 		$(CATALOGS_PATH)/back/src/
+	$(PHP_RUN) bin/console lint:container
 
 .PHONY: catalogs-coupling-back
 catalogs-coupling-back:

--- a/make-file/connectivity-connection.mk
+++ b/make-file/connectivity-connection.mk
@@ -75,6 +75,7 @@ endif
 		--level=5 \
 		--configuration src/Akeneo/Connectivity/Connection/back/tests/phpstan.neon \
 		src/Akeneo/Connectivity/Connection/back/Infrastructure
+	$(PHP_RUN) bin/console lint:container
 
 connectivity-connection-lint-back_fix:
 	$(PHP_RUN) vendor/bin/php-cs-fixer fix --config=src/Akeneo/Connectivity/Connection/back/tests/.php_cs.php


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

I caught that there was a service definition error in CXP-1197 but the CI did not catch it because all tests were passing anyway.
Adding `bin/console lint:container` will catch those small errors.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
