### PR TITLE
BH-1176: UCS - Webhooks

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -64,7 +64,11 @@ class SendBusinessEventToWebhooksHandler
             foreach ($webhooks as $webhook) {
                 $user = $this->webhookUserAuthenticator->authenticate($webhook->userId());
 
-                $filteredPimEventBulk = $this->filterConnectionOwnEvents($webhook, $user->getUsername(), $pimEventBulk);
+                $filteredPimEventBulk = $this->filterConnectionOwnEvents(
+                    $webhook,
+                    $user->getUserIdentifier(),
+                    $pimEventBulk
+                );
                 if (null === $filteredPimEventBulk) {
                     continue;
                 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/DependencyInjection/AkeneoConnectivityConnectionExtension.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/DependencyInjection/AkeneoConnectivityConnectionExtension.php
@@ -78,5 +78,9 @@ class AkeneoConnectivityConnectionExtension extends Extension
         $loader->load('Webhook/validators.yml');
 
         $loader->load('services.yml');
+
+        if ('test' === $container->getParameter('kernel.environment')) {
+            $loader->load('Webhook/services_test.yml');
+        }
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
@@ -8,9 +8,9 @@ services:
 
     Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command\SendBusinessEventToWebhooks:
         arguments:
+            - '@Akeneo\Platform\Component\EventQueue\BulkEventNormalizer'
             - '@Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler'
             - '@event_dispatcher'
-            - '@logger'
         tags:
             - { name: console.command }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
@@ -5,3 +5,12 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persistence\PurgeEventsApiErrorLogsQuery'
         tags:
             - {name: 'console.command'}
+
+    Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command\SendBusinessEventToWebhooks:
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler'
+            - '@event_dispatcher'
+            - '@logger'
+        tags:
+            - { name: console.command }
+

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/message_handlers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/message_handlers.yml
@@ -1,6 +1,7 @@
 services:
     Akeneo\Connectivity\Connection\Infrastructure\Webhook\MessageHandler\BusinessEventHandler:
         arguments:
-            - '@Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler'
-            - '@event_dispatcher'
+            - '%kernel.project_dir%'
+            - '@logger'
+            - '@Akeneo\Platform\Component\EventQueue\BulkEventNormalizer'
         tags: [messenger.message_handler]

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/services_test.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/services_test.yml
@@ -1,0 +1,10 @@
+services:
+    Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistory:
+        arguments:
+            - '%kernel.project_dir%/var/cache/test/guzzle_history.json'
+
+    akeneo_connectivity.connection.webhook.guzzle_handler:
+        class: 'Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack'
+        factory: ['Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack', 'createWithHistoryContainer']
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistory'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Command/SendBusinessEventToWebhooks.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Command/SendBusinessEventToWebhooks.php
@@ -7,8 +7,8 @@ namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand;
 use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
-use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
-use Psr\Log\LoggerInterface;
+use Akeneo\Platform\Component\EventQueue\BulkEvent;
+use Akeneo\Platform\Component\EventQueue\BulkEventNormalizer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,9 +21,9 @@ class SendBusinessEventToWebhooks extends Command
     protected static $defaultDescription = 'Send business event to webhooks';
 
     public function __construct(
+        private BulkEventNormalizer $bulkEventNormalizer,
         private SendBusinessEventToWebhooksHandler $commandHandler,
-        private EventDispatcherInterface $eventDispatcher,
-        private LoggerInterface $logger
+        private EventDispatcherInterface $eventDispatcher
     ) {
         parent::__construct();
     }
@@ -44,9 +44,8 @@ class SendBusinessEventToWebhooks extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $message = $input->getArgument('message');
-
-
+        $message = \json_decode($input->getArgument('message'), true);
+        $event = $this->bulkEventNormalizer->denormalize($message, BulkEvent::class);
 
         $this->commandHandler->handle(new SendBusinessEventToWebhooksCommand($event));
         $this->eventDispatcher->dispatch(new MessageProcessedEvent());

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Command/SendBusinessEventToWebhooks.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Command/SendBusinessEventToWebhooks.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command;
+
+use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand;
+use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler;
+use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
+use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class SendBusinessEventToWebhooks extends Command
+{
+    protected static $defaultName = 'akeneo:connectivity:send-business-event';
+    protected static $defaultDescription = 'Send business event to webhooks';
+
+    public function __construct(
+        private SendBusinessEventToWebhooksHandler $commandHandler,
+        private EventDispatcherInterface $eventDispatcher,
+        private LoggerInterface $logger
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setHidden(true)
+            ->addArgument(
+                'message',
+                InputArgument::REQUIRED,
+                'Symfony Messenger serialized message'
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $message = $input->getArgument('message');
+
+
+
+        $this->commandHandler->handle(new SendBusinessEventToWebhooksCommand($event));
+        $this->eventDispatcher->dispatch(new MessageProcessedEvent());
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/MessageHandler/BusinessEventHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/MessageHandler/BusinessEventHandler.php
@@ -4,36 +4,66 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Webhook\MessageHandler;
 
-use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksCommand;
-use Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler;
-use Akeneo\Connectivity\Connection\Domain\Webhook\Event\MessageProcessedEvent;
+use Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command\SendBusinessEventToWebhooks;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Akeneo\Platform\Component\EventQueue\BulkEventNormalizer;
+use Akeneo\Tool\Bundle\MessengerBundle\Serialization\JsonSerializer;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Handler\MessageSubscriberInterface;
+use Symfony\Component\Process\Process;
 
 class BusinessEventHandler implements MessageSubscriberInterface
 {
-    private SendBusinessEventToWebhooksHandler $commandHandler;
-    private EventDispatcherInterface $eventDispatcher;
-
     public function __construct(
-        SendBusinessEventToWebhooksHandler $commandHandler,
-        EventDispatcherInterface $eventDispatcher
+        private string $projectDir,
+        private LoggerInterface $logger,
+        private BulkEventNormalizer $normalizer
     ) {
-        $this->commandHandler = $commandHandler;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     public static function getHandledMessages(): iterable
     {
         yield BulkEventInterface::class => [
-            'from_transport' => 'webhook'
+            'from_transport' => 'webhook',
         ];
     }
 
     public function __invoke(BulkEventInterface $event): void
     {
-        $this->commandHandler->handle(new SendBusinessEventToWebhooksCommand($event));
-        $this->eventDispatcher->dispatch(new MessageProcessedEvent());
+        try {
+            $processArguments = $this->buildBatchCommand($event);
+
+            $env = [
+                'SYMFONY_DOTENV_VARS' => false,
+            ];
+
+            $process = new Process($processArguments, null, $env);
+            $process->setTimeout(null);
+
+            $this->logger->debug(sprintf('Command line: "%s"', $process->getCommandLine()));
+
+            $process->run(function ($type, $buffer): void {
+                \fwrite(Process::ERR === $type ? \STDERR : \STDOUT, $buffer);
+            });
+        } catch (\Throwable $t) {
+            $this->logger->error(
+                sprintf('An error occurred: %s', $t->getMessage()),
+                ['exception' => $t]
+            );
+        }
     }
+
+    private function buildBatchCommand(BulkEventInterface $event): array
+    {
+        $message = $this->normalizer->normalize($event);
+        $processArguments = [
+            sprintf('%s/bin/console', $this->projectDir),
+            '--quiet',
+            SendBusinessEventToWebhooks::getDefaultName(),
+            $message,
+        ];
+
+        return $processArguments;
+    }
+
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleJsonHistory.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleJsonHistory.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\EndToEnd;
+
+use GuzzleHttp\Psr7\Message;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author JMLeroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * A filesystem container to store Guzzle history in a json file.
+ * We need this filesytem json file to share it between process and keep track of the history in the tests
+ */
+class GuzzleJsonHistory implements \ArrayAccess, \Countable
+{
+    public function __construct(private string $filepath)
+    {
+    }
+
+    public function resetHistory(): void
+    {
+        if (\file_exists($this->filepath)) {
+            \unlink($this->filepath);
+        }
+    }
+
+    public function offsetExists(mixed $offset)
+    {
+        $history = $this->readFile();
+
+        return isset($history[$offset]);
+    }
+
+    public function offsetGet(mixed $offset)
+    {
+        $history = $this->readFile();
+        Assert::isArray($history);
+
+        return $history[$offset];
+    }
+
+    public function offsetSet(mixed $offset, mixed $value)
+    {
+        $history = $this->readFile();
+        $history[] = [
+            'request' => Message::toString($value['request']),
+            'response' => $value['response'] ? Message::toString($value['response']) : null,
+        ];
+        $this->writeFile($history);
+    }
+
+    public function offsetUnset(mixed $offset)
+    {
+        $history = $this->readFile();
+        unset($history[$offset]);
+        $this->writeFile($history);
+    }
+
+    public function count(): int
+    {
+        $history = $this->readFile();
+
+        return \count($history);
+    }
+
+    private function readFile(): array
+    {
+        if (!\file_exists($this->filepath)) {
+            return [];
+        }
+
+        return \json_decode(\file_get_contents($this->filepath), true);
+    }
+
+    private function writeFile(array $history): void
+    {
+        \file_put_contents($this->filepath, \json_encode($history));
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleMockHandlerStack.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleMockHandlerStack.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\EndToEnd;
+
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * @author JMLeroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ *
+ * A sub class of the Guzzle handler stack providing a JSON filesystem history.
+ * The purpose of this handler is to share its history between a parent process and subprocess. It is useful to  keep track of the history of the webhook call in the tests. Indeed, the webhook call is performed in a subprocess.
+ */
+class GuzzleMockHandlerStack extends HandlerStack
+{
+    private ?GuzzleJsonHistory $container;
+
+    public function historyContainer(): GuzzleJsonHistory
+    {
+        return $this->container;
+    }
+
+    public static function createWithHistoryContainer(GuzzleJsonHistory $historyContainer)
+    {
+        $stack = new self(new MockHandler([new Response(200)]));
+        $stack->push(Middleware::httpErrors(), 'http_errors');
+        $stack->push(Middleware::redirect(), 'allow_redirects');
+        $stack->push(Middleware::cookies(), 'cookies');
+        $stack->push(Middleware::prepareBody(), 'prepare_body');
+
+        $historyContainer->resetHistory();
+        $history = Middleware::history($historyContainer);
+        $stack->push($history);
+
+        $stack->container = $historyContainer;
+
+        return $stack;
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/WebTestCase.php
@@ -30,7 +30,7 @@ abstract class WebTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = self::$container->get('test.client');
+        $this->client = static::getContainer()->get('test.client');
     }
 
     protected function createConnection(string $code, string $label, string $flowType, bool $auditable): ConnectionWithCredentials

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
@@ -57,8 +57,8 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
             ->create(['code' => 'pant', 'attributes' => ['boolean_attribute', 'text_attribute']]);
 
         $this->referenceAuthor = Author::fromNameAndType('julia', Author::TYPE_UI);
-        $this->dbalConnection = self::$container->get('database_connection');
-        $this->productLoader = self::$container->get('akeneo_connectivity.connection.fixtures.enrichment.product');
+        $this->dbalConnection = static::getContainer()->get('database_connection');
+        $this->productLoader = static::getContainer()->get('akeneo_connectivity.connection.fixtures.enrichment.product');
 
         $this->tshirtProduct = $this->productLoader->create(
             'blue-t-shirt',

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
@@ -8,6 +8,7 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCred
 use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType;
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\MessageHandler\BusinessEventHandler;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
+use Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
@@ -18,16 +19,13 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use Doctrine\DBAL\Connection as DbalConnection;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
- * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 class ConsumeProductEventEndToEnd extends ApiTestCase
 {
@@ -58,7 +56,9 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
 
         $this->referenceAuthor = Author::fromNameAndType('julia', Author::TYPE_UI);
         $this->dbalConnection = static::getContainer()->get('database_connection');
-        $this->productLoader = static::getContainer()->get('akeneo_connectivity.connection.fixtures.enrichment.product');
+        $this->productLoader = static::getContainer()->get(
+            'akeneo_connectivity.connection.fixtures.enrichment.product'
+        );
 
         $this->tshirtProduct = $this->productLoader->create(
             'blue-t-shirt',
@@ -96,12 +96,8 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
 
     public function test_it_sends_a_product_created_webhook_event()
     {
-        $container = [];
-        /** @var HandlerStack $handlerStack */
+        /** @var GuzzleMockHandlerStack $handlerStack */
         $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
-        $handlerStack->setHandler(new MockHandler([new Response(200)]));
-        $history = Middleware::history($container);
-        $handlerStack->push($history);
 
         $message = new BulkEvent(
             [
@@ -124,25 +120,22 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         $businessEventHandler = $this->get(BusinessEventHandler::class);
         $businessEventHandler->__invoke($message);
 
-        Assert::assertCount(1, $container);
+        Assert::assertCount(1, $handlerStack->historyContainer());
 
-        /** @var Request $request */
-        $request = $container[0]['request'];
-        $requestContent = \json_decode($request->getBody()->getContents(), true)['events'][0];
+        /** @var Request $requestObject */
+        $request = $handlerStack->historyContainer()[0]['request'];
+        $requestObject = Message::parseRequest($request);
+        $requestContent = \json_decode($requestObject->getBody()->getContents(), true)['events'][0];
         $requestContent = $this->cleanRequestContent($requestContent);
 
-        Assert::assertEquals(2, (int) $this->getEventCount('ecommerce'));
+        Assert::assertEquals(2, (int)$this->getEventCount('ecommerce'));
         $this->assertEquals($this->expectedProductCreatedPayload($this->tshirtProduct), $requestContent);
     }
 
     public function test_it_sends_a_product_updated_webhook_event()
     {
-        $container = [];
-        /** @var HandlerStack $handlerStack */
+        /** @var GuzzleMockHandlerStack $handlerStack */
         $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
-        $handlerStack->setHandler(new MockHandler([new Response(200)]));
-        $history = Middleware::history($container);
-        $handlerStack->push($history);
 
         $message = new BulkEvent(
             [
@@ -159,25 +152,21 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         $businessEventHandler = $this->get(BusinessEventHandler::class);
         $businessEventHandler->__invoke($message);
 
-        Assert::assertCount(1, $container);
+        Assert::assertCount(1, $handlerStack->historyContainer());
 
-        /** @var Request $request */
-        $request = $container[0]['request'];
-        $requestContent = \json_decode($request->getBody()->getContents(), true)['events'][0];
+        $request = $handlerStack->historyContainer()[0]['request'];
+        $requestObject = Message::parseRequest($request);
+        $requestContent = \json_decode($requestObject->getBody()->getContents(), true)['events'][0];
         $requestContent = $this->cleanRequestContent($requestContent);
 
-        Assert::assertEquals(1, (int) $this->getEventCount('ecommerce'));
+        Assert::assertEquals(1, (int)$this->getEventCount('ecommerce'));
         $this->assertEquals($this->expectedProductUpdatedPayload($this->tshirtProduct), $requestContent);
     }
 
     public function test_it_sends_a_product_removed_webhook_event()
     {
-        $container = [];
-        /** @var HandlerStack $handlerStack */
+        /** @var GuzzleMockHandlerStack $handlerStack */
         $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
-        $handlerStack->setHandler(new MockHandler([new Response(200)]));
-        $history = Middleware::history($container);
-        $handlerStack->push($history);
 
         $message = new BulkEvent(
             [
@@ -197,21 +186,13 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         $businessEventHandler = $this->get(BusinessEventHandler::class);
         $businessEventHandler->__invoke($message);
 
-        $this->assertCount(1, $container);
+        $this->assertCount(1, $handlerStack->historyContainer());
 
-        /** @var Request $request */
-        $request = $container[0]['request'];
+        $request = Message::parseRequest($handlerStack->historyContainer()[0]['request']);
         $requestContent = \json_decode($request->getBody()->getContents(), true)['events'][0];
 
-        Assert::assertEquals(1, (int) $this->getEventCount('ecommerce'));
+        Assert::assertEquals(1, (int)$this->getEventCount('ecommerce'));
         $this->assertEquals($this->expectedProductRemovedPayload($this->tshirtProduct), $requestContent);
-    }
-
-    private function loadReferenceProduct(string $identifier): ProductInterface
-    {
-        return $this->get('akeneo_connectivity.connection.fixtures.enrichment.product')->create(
-            $identifier,
-        );
     }
 
     private function loadConnection(): ConnectionWithCredentials
@@ -229,7 +210,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
             $connection->flowType(),
             $connection->image(),
             $connection->userRoleId(),
-            (string) $this->get('pim_user.repository.group')->findOneByIdentifier('IT support')->getId(),
+            (string)$this->get('pim_user.repository.group')->findOneByIdentifier('IT support')->getId(),
             $connection->auditable(),
         );
 
@@ -253,7 +234,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         return [
             'action' => 'product.created',
             'event_id' => '0d931d13-8eae-4f4a-bf37-33d3a932b8c9',
-            'event_datetime' => '2020-12-04T16:02:47+01:00',
+            'event_datetime' => '2020-12-04T15:02:47+00:00',
             'author' => 'julia',
             'author_type' => 'ui',
             'pim_source' => 'http://localhost:8080',
@@ -266,7 +247,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         return [
             'action' => 'product.updated',
             'event_id' => '0d931d13-8eae-4f4a-bf37-33d3a932b8c9',
-            'event_datetime' => '2020-12-04T16:02:47+01:00',
+            'event_datetime' => '2020-12-04T15:02:47+00:00',
             'author' => 'julia',
             'author_type' => 'ui',
             'pim_source' => 'http://localhost:8080',
@@ -279,7 +260,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
         return [
             'action' => 'product.removed',
             'event_id' => '0d931d13-8eae-4f4a-bf37-33d3a932b8c9',
-            'event_datetime' => '2020-12-04T16:02:47+01:00',
+            'event_datetime' => '2020-12-04T15:02:47+00:00',
             'author' => 'julia',
             'author_type' => 'ui',
             'pim_source' => 'http://localhost:8080',
@@ -342,11 +323,11 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
     private function getEventCount(string $connectionCode)
     {
         $sql = <<<SQL
-SELECT event_count
-FROM akeneo_connectivity_connection_audit_product
-WHERE connection_code = :connection_code
-AND event_type = 'product_read'
-SQL;
+        SELECT event_count
+        FROM akeneo_connectivity_connection_audit_product
+        WHERE connection_code = :connection_code
+        AND event_type = 'product_read'
+        SQL;
 
         return $this->dbalConnection->fetchOne($sql, [
             'connection_code' => $connectionCode,

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
@@ -10,6 +10,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\CategoryLoade
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
+use Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
@@ -17,10 +18,6 @@ use Akeneo\Platform\Component\EventQueue\BulkEvent;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Doctrine\DBAL\Connection as DbalConnection;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Assert;
 
 /**
@@ -63,12 +60,8 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
 
     public function test_it_increments_events_api_request_count()
     {
-        $container = [];
-        /** @var HandlerStack $handlerStack */
+        /** @var GuzzleMockHandlerStack $handlerStack */
         $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
-        $handlerStack->setHandler(new MockHandler([new Response(200)]));
-        $history = Middleware::history($container);
-        $handlerStack->push($history);
 
         $message = new BulkEvent(
             [
@@ -85,7 +78,7 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
         $businessEventHandler = $this->get(BusinessEventHandler::class);
         $businessEventHandler->__invoke($message);
 
-        Assert::assertCount(1, $container);
+        Assert::assertCount(1, $handlerStack->historyContainer());
 
         $eventsApiRequestCount = $this->getEventsApiRequestCount();
 
@@ -120,9 +113,9 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
     private function getEventsApiRequestCount(): array
     {
         $sql = <<<SQL
-SELECT event_minute, event_count, updated
-FROM akeneo_connectivity_connection_events_api_request_count
-SQL;
+        SELECT event_minute, event_count, updated
+        FROM akeneo_connectivity_connection_events_api_request_count
+        SQL;
 
         return $this->dbalConnection->executeQuery($sql)->fetchAllAssociative();
     }

--- a/src/Akeneo/Platform/Component/EventQueue/BulkEvent.php
+++ b/src/Akeneo/Platform/Component/EventQueue/BulkEvent.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Component\EventQueue;
 
+use Akeneo\Tool\Component\Messenger\Tenant\TenantAwareInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -13,6 +14,7 @@ use Webmozart\Assert\Assert;
 class BulkEvent implements BulkEventInterface
 {
     private array $events;
+    private ?string $tenantId = null;
 
     /**
      * @param array<EventInterface> $events
@@ -30,5 +32,15 @@ class BulkEvent implements BulkEventInterface
     public function getEvents(): array
     {
         return $this->events;
+    }
+
+    public function getTenantId(): ?string
+    {
+        return $this->tenantId;
+    }
+
+    public function setTenantId(string $tenantId): void
+    {
+        $this->tenantId = $tenantId;
     }
 }

--- a/src/Akeneo/Platform/Component/EventQueue/BulkEventInterface.php
+++ b/src/Akeneo/Platform/Component/EventQueue/BulkEventInterface.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Component\EventQueue;
 
+use Akeneo\Tool\Component\Messenger\Tenant\TenantAwareInterface;
+
 /**
  * @copyright 202O Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface BulkEventInterface
+interface BulkEventInterface extends TenantAwareInterface
 {
     /**
      * @return array<EventInterface>

--- a/src/Akeneo/Platform/Component/EventQueue/BulkEventNormalizer.php
+++ b/src/Akeneo/Platform/Component/EventQueue/BulkEventNormalizer.php
@@ -21,20 +21,20 @@ class BulkEventNormalizer implements NormalizerInterface, DenormalizerInterface
         $this->eventNormalizer = $eventNormalizer;
     }
 
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof BulkEvent;
     }
 
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return $type === BulkEvent::class;
     }
 
     /**
-     * @param BulkEvent $object
+     * @param BulkEventInterface $object
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         if (false === $this->supportsNormalization($object, $format)) {
             throw new \InvalidArgumentException();
@@ -45,7 +45,7 @@ class BulkEventNormalizer implements NormalizerInterface, DenormalizerInterface
         }, $object->getEvents());
     }
 
-    public function denormalize($data, $type, $format = null, array $context = [])
+    public function denormalize($data, $type, $format = null, array $context = []): BulkEvent
     {
         if (false === $this->supportsDenormalization($data, $type, $format)) {
             throw new \InvalidArgumentException();

--- a/src/Akeneo/Platform/Component/EventQueue/EventNormalizer.php
+++ b/src/Akeneo/Platform/Component/EventQueue/EventNormalizer.php
@@ -14,12 +14,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class EventNormalizer implements NormalizerInterface, DenormalizerInterface
 {
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof Event;
     }
 
-    public function supportsDenormalization($data, $type, $format = null)
+    public function supportsDenormalization($data, $type, $format = null): bool
     {
         return is_subclass_of($type, Event::class);
     }
@@ -27,7 +27,7 @@ class EventNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @param Event $object
      */
-    public function normalize($object, $format = null, array $context = [])
+    public function normalize($object, $format = null, array $context = []): array
     {
         if (false === $this->supportsNormalization($object, $format)) {
             throw new \InvalidArgumentException();
@@ -44,7 +44,7 @@ class EventNormalizer implements NormalizerInterface, DenormalizerInterface
         ];
     }
 
-    public function denormalize($data, $type, $format = null, array $context = [])
+    public function denormalize($data, $type, $format = null, array $context = []): Event
     {
         if (false === $this->supportsDenormalization($data, $type, $format)) {
             throw new \InvalidArgumentException();

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/ApiTestCase.php
@@ -201,7 +201,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return static::getContainer()->get($service);
     }
 
     /**
@@ -211,7 +211,7 @@ abstract class ApiTestCase extends WebTestCase
      */
     protected function getParameter(string $parameter)
     {
-        return self::$container->getParameter($parameter);
+        return static::getContainer()->getParameter($parameter);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Tool\Bundle\MessengerBundle\Middleware;
 
 use Akeneo\Tool\Bundle\MessengerBundle\Stamp\TenantIdStamp;
+use Akeneo\Tool\Component\Messenger\Tenant\TenantAwareInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
@@ -17,8 +18,16 @@ class UcsMiddleware implements MiddlewareInterface
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
-        if ($this->pimTenantId && null === $envelope->last(TenantIdStamp::class)) {
+        if (!$this->pimTenantId) {
+            return $stack->next()->handle($envelope, $stack);
+        }
+
+        if (null === $envelope->last(TenantIdStamp::class)) {
             $envelope = $envelope->with(new TenantIdStamp($this->pimTenantId));
+        }
+
+        if ($envelope->getMessage() instanceof TenantAwareInterface) {
+            $envelope->getMessage()->setTenantId($this->pimTenantId);
         }
 
         return $stack->next()->handle($envelope, $stack);

--- a/src/Akeneo/Tool/Component/Messenger/Tenant/TenantAwareInterface.php
+++ b/src/Akeneo/Tool/Component/Messenger/Tenant/TenantAwareInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Messenger\Tenant;
+
+interface TenantAwareInterface
+{
+    public function getTenantId(): ?string;
+    public function setTenantId(string $tenantId): void;
+}


### PR DESCRIPTION
### Before

![srnt_webhook](https://user-images.githubusercontent.com/1516770/174273223-f73d6bed-0d27-43e1-92d5-2734d17a47a2.jpg)

### After

![ucs_webhook](https://user-images.githubusercontent.com/1516770/174273245-360bcc14-b8b1-4562-b7b3-f57ea392999c.jpg)

I had another solution in mind when starting the PR but it's  not possible for now to use the enveloppe in handler.
See this issue and conversation: https://github.com/symfony/symfony/issues/31075