### PR TITLE
PIM-10495: Fix product datagrid by increasing sort_buffer_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - PIM-10475: Fix option existence validation for numeric option codes
 - PIM-10483: Fix slow loading products when filtering by variants
 - PIM-10484: Fix job filter on status being incoherent with job interrupted by demon crash
+- PIM-10495: Fix product datagrid by increasing sort_buffer_size
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductGrid/ProductModelImagesFromCodes.php
@@ -232,6 +232,7 @@ SQL;
 
         $sql = <<<SQL
             SELECT 
+            /*+ SET_VAR(sort_buffer_size = 1000000) */
                 pm_root.code,
                 a_image.code as attribute_code,
                 pm_child.raw_values,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Quick fix: increase sort_buffer_size to display product datagrid

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
