### PR TITLE
PIM-10487: Fix import of very tiny measurement values (e.g. 0.000075 GRAM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-10487: Fix import of very tiny measurement values (e.g. 0.000075 GRAM)
 - PIM-10215: Fixed last operation widget job type translation key
 - PIM-10233: Fix the saved value by an empty wysiwyg
 - PIM-10232: Fix "A new entity is found through the relationship" errors in jobs

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard;
 
 use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Tool\Component\Connector\Exception\BusinessArrayConversionException;
 
 /**
@@ -145,10 +146,16 @@ class ColumnsMerger
     protected function mergeMetricData(array $resultRow, array $collectedMetrics)
     {
         foreach ($collectedMetrics as $fieldName => $metricData) {
+            $metricValue = $metricData['data'];
+
+            if (is_float($metricValue)) {
+                $metricValue = number_format($metricValue, MeasureConverter::SCALE);
+            }
+
             $resultRow[$fieldName] = trim(
                 sprintf(
                     '%s%s%s',
-                    $metricData['data'],
+                    $metricValue,
                     AttributeColumnInfoExtractor::UNIT_SEPARATOR,
                     $metricData['unit']
                 )

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -16,7 +16,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Provider\LegacyMeasurementProvider;
  */
 class MeasureConverter
 {
-    private const SCALE = 12;
+    public const SCALE = 12;
 
     private ?string $family = null;
     private LegacyMeasurementProvider $legacyMeasurementProvider;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
@@ -163,6 +163,37 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
+    function it_merges_columns_which_represents_metric_attribute_value_with_scientific_notation_in_two_columns(
+        $fieldExtractor,
+        AttributeInterface $weight
+    ) {
+        $row = [
+            'weight' => 0.000075,
+            'weight-unit' => 'GRAM'
+        ];
+        $attributeInfoData = [
+            'attribute' => $weight,
+            'locale_code' => null,
+            'scope_code' => null,
+            'metric_unit' => null
+        ];
+        $fieldExtractor->extractColumnInfo('weight')->willReturn($attributeInfoData);
+
+        $attributeInfoUnit = [
+            'attribute' => $weight,
+            'locale_code' => null,
+            'scope_code' => null,
+            'metric_unit' => 'unit'
+        ];
+        $fieldExtractor->extractColumnInfo('weight-unit')->willReturn($attributeInfoUnit);
+
+        $weight->getCode()->willReturn('weight');
+        $weight->getBackendType()->willReturn('metric');
+
+        $mergedRow = ['weight' => '0.000075000000 GRAM'];
+        $this->merge($row)->shouldReturn($mergedRow);
+    }
+
     function it_merges_columns_which_represents_a_localizable_metric_attribute_value_in_a_two_columns(
         $fieldExtractor,
         AttributeInterface $weight


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When Excel cell is formatted as number, the file reader gives us a float.
Problem comes with very small values (0.000075) that comes with scientific notation (7.5E-5), because we merge it with its metric unit : "7.5E-5 GRAM".

So now, we enforce decimal notation.

**Definition Of Done (for Core Developer only)**
- [x] Tests
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)