### PR TITLE
DPE-38: Keep dependabot only for Composer ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,35 +1,6 @@
-# This is an example with only required properties:
 version: 2
 updates:
   # Default branch (master)
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "npm"
-    directory: "/front-packages/akeneo-design-system"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "npm"
-    directory: "/front-packages/shared"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "npm"
-    directory: "/front-packages/measurement"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "production"
-
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -38,22 +9,6 @@ updates:
       - dependency-type: "production"
 
   #5.0
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "5.0"
-    allow:
-      - dependency-type: "production"
-
-  - package-ecosystem: "npm"
-    directory: "/front-packages/akeneo-design-system"
-    schedule:
-      interval: "daily"
-    target-branch: "5.0"
-    allow:
-      - dependency-type: "production"
-
   - package-ecosystem: "composer"
     directory: "/"
     schedule:
@@ -63,14 +18,6 @@ updates:
       - dependency-type: "production"
 
   #4.0
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "4.0"
-    allow:
-      - dependency-type: "production"
-
   - package-ecosystem: "composer"
     directory: "/"
     schedule:


### PR DESCRIPTION
We will re-add the npm ecosystem when we will be ready to handle upgrades