### PR TITLE
Fix Gherkin parser deprecation warnings

### DIFF
--- a/tests/legacy/features/channel/edit_channel.feature
+++ b/tests/legacy/features/channel/edit_channel.feature
@@ -24,7 +24,7 @@ Feature: Edit a channel
     Then the grid should contain 2 element
     And I should see locale "en_US" and "fr_FR"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6025
+  # @jira https://akeneo.atlassian.net/browse/PIM-6025
   Scenario: Successfully replace a channel locale by another one when there is only one channel
     Given I am logged in as "Peter"
     And I am on the channels page

--- a/tests/legacy/features/pim/enrichment/product-group/remove_products_from_a_group.feature
+++ b/tests/legacy/features/pim/enrichment/product-group/remove_products_from_a_group.feature
@@ -16,7 +16,7 @@ Feature: Remove products from a group
       | sandal-white-39 | CROSS_SELL | sandals | winter_collection | 39   | white |
     And I am logged in as "Julia"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3736
+  # @jira https://akeneo.atlassian.net/browse/PIM-3736
   Scenario: Successfully remove a product from the group
     Given I am on the "CROSS_SELL" product group page
     Then the grid should contain 3 elements

--- a/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/create_product_model.feature
@@ -132,7 +132,7 @@ Feature: Create a product model
     And I press the "Create product and product models" button
     Then I should see the SKU and Family fields
 
-  @jira https://akeneo.atlassian.net/browse/PIM-7299
+  # @jira https://akeneo.atlassian.net/browse/PIM-7299
   Scenario: Search family variants in the product model create form
     Given the following family:
       | code                      | label-en_US   | attributes      |

--- a/tests/legacy/features/pim/enrichment/product-model/edit_product_model.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/edit_product_model.feature
@@ -49,7 +49,7 @@ Feature: Edit a product model
     Then the field Notice should be read only
     And I should see the text "This attribute can be updated in the common attributes."
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6861
+  # @jira https://akeneo.atlassian.net/browse/PIM-6861
   Scenario: Display a product model without any children
     Given I am logged in as "Mary"
     When I am on the "1111111113" product page
@@ -68,7 +68,7 @@ Feature: Edit a product model
     And I visit the "Marketing" group
     Then the product Model name should be "Heritage jacket navy"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6816
+  # @jira https://akeneo.atlassian.net/browse/PIM-6816
   Scenario: Successfully display a validation error message
     Given I am logged in as "Mary"
     And I am on the "amor" product model page
@@ -92,7 +92,7 @@ Feature: Edit a product model
     And I visit the "All" group
     Then the Care instructions, Collection, Model picture fields should be highlighted
 
-  @jira https://akeneo.atlassian.net/browse/PIM-7382
+  # @jira https://akeneo.atlassian.net/browse/PIM-7382
   Scenario: Successfully display a product model's scopable value after editing it
     Given I am logged in as "Mary"
     And I am on the "bacchus" product model page

--- a/tests/legacy/features/pim/enrichment/product/create_product_and_save_added_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/create_product_and_save_added_attributes.feature
@@ -4,7 +4,7 @@ Feature: Create product and save a new product value
   As a product manager
   I need to be able to create a product, add attributes and save
 
-  @jira https://akeneo.atlassian.net/browse/PIM-5666
+  # @jira https://akeneo.atlassian.net/browse/PIM-5666
   @purge-messenger
   Scenario: Successfully create a product, fill in product values with 0 and save
     Given a "footwear" catalog configuration

--- a/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_product_per_boolean.feature
+++ b/tests/legacy/features/pim/enrichment/product/datagrid/filtering/filter_product_per_boolean.feature
@@ -8,7 +8,8 @@ Feature: Filter products by boolean field
     Given the "apparel" catalog configuration
     And I am logged in as "Mary"
 
-  @critical  @jira https://akeneo.atlassian.net/browse/PIM-3406
+  # @jira https://akeneo.atlassian.net/browse/PIM-3406
+  @critical
   Scenario: Successfully filter products by boolean value for boolean attributes
     Given the following products:
       | sku   |

--- a/tests/legacy/features/pim/enrichment/product/import/import_products.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_products.feature
@@ -152,7 +152,7 @@ Feature: Import products coming from an external application
     And product "SKU-003" should be disabled
     And product "SKU-004" should be enabled
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6085
+  # @jira https://akeneo.atlassian.net/browse/PIM-6085
   @javascript
   Scenario: Successfully import product associations with modified column name
     Given I am logged in as "Julia"

--- a/tests/legacy/features/pim/enrichment/product/import/import_products_with_associations.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_products_with_associations.feature
@@ -207,7 +207,7 @@ Feature: Execute a job
     And I visit the "Upsell (0)" association type
     Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6019
+  # @jira https://akeneo.atlassian.net/browse/PIM-6019
   @javascript
   Scenario: Successfully import product without remove already existing associations when option "compare values" is set to false
     Given the following product:
@@ -234,7 +234,7 @@ Feature: Execute a job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see the text "skipped product (no associations detected)"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6042
+  # @jira https://akeneo.atlassian.net/browse/PIM-6042
   Scenario: Successfully import product associations without removing already existing associations when option "compare values" is set to true
     Given the following product:
       | sku     | name-en_US |
@@ -257,7 +257,7 @@ Feature: Execute a job
       | X_SELL | SKU-002  |
       | UPSELL | SKU-003  |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6071
+  # @jira https://akeneo.atlassian.net/browse/PIM-6071
   Scenario: Successfully import product associations with an attribute having the same code
     Given the following product:
       | sku     | name-en_US |

--- a/tests/legacy/features/pim/enrichment/product/import/import_products_with_invalid_data.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_products_with_invalid_data.feature
@@ -11,7 +11,7 @@ Feature: Execute a job
       | CROSS | Bag Cross   | RELATED |
     And I am logged in as "Julia"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3266
+  # @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip existing products with invalid prices during an import
     Given the following products:
       | sku     | price  |
@@ -60,7 +60,7 @@ Feature: Execute a job
       | price |  |
     And I should see the text "The price attribute requires a number, and the submitted gruik value is not.: gruik EUR"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3266
+  # @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip existing products with invalid metrics during an import
     Given the following products:
       | sku     | length        |
@@ -84,7 +84,7 @@ Feature: Execute a job
     And the product "SKU-002" should have the following value:
       | length | 2.0000 KILOMETER |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3266
+  # @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip existing products with invalid number during an import
     Given the following products:
       | sku     | number_in_stock |
@@ -108,7 +108,7 @@ Feature: Execute a job
     And the product "SKU-002" should have the following value:
       | number_in_stock | 100 |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3266
+  # @jira https://akeneo.atlassian.net/browse/PIM-3266
   Scenario: Skip new products with non-existing media attributes during an import
     Given the following attributes:
       | label-en_US | type              | allowed_extensions | group | code       |
@@ -138,7 +138,7 @@ Feature: Execute a job
       | frontView  | fanatic-freewave-76.gif |
       | userManual | fanatic-freewave-76.txt |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3311
+  # @jira https://akeneo.atlassian.net/browse/PIM-3311
   Scenario: Skip products with a SKU that has just been created
     Given the following CSV file to import:
       """

--- a/tests/legacy/features/pim/enrichment/product/import/import_products_with_invalid_headers.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_products_with_invalid_headers.feature
@@ -8,7 +8,7 @@ Feature: Execute a job
     Given the "footwear" catalog configuration
     And I am logged in as "Julia"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3376
+  # @jira https://akeneo.atlassian.net/browse/PIM-3376
   Scenario: Skip import with a not expected locale and channel provided for a global attribute
     Given the following CSV file to import:
       """
@@ -23,7 +23,7 @@ Feature: Execute a job
     Then I should see job execution status "FAILED"
     And I should see the text " The field \"comment-fr_FR-mobile\" does not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3374
+  # @jira https://akeneo.atlassian.net/browse/PIM-3374
   Scenario: Skip import with a not expected channel for a global attribute
     Given the following CSV file to import:
       """
@@ -38,7 +38,7 @@ Feature: Execute a job
     Then I should see job execution status "FAILED"
     And I should see the text " The field \"comment-mobile\" does not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3375
+  # @jira https://akeneo.atlassian.net/browse/PIM-3375
   Scenario: Skip import with a not expected locale for a global attribute
     Given the following CSV file to import:
       """
@@ -53,7 +53,7 @@ Feature: Execute a job
     Then I should see job execution status "FAILED"
     And I should see the text " The field \"comment-fr_FR\" does not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3372
+  # @jira https://akeneo.atlassian.net/browse/PIM-3372
   Scenario: Skip import with a not available locale for a localizable attribute
     Given the following CSV file to import:
       """
@@ -68,7 +68,7 @@ Feature: Execute a job
     Then I should see job execution status "FAILED"
     And I should see the text " The field \"name-fr_CA\" does not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3370
+  # @jira https://akeneo.atlassian.net/browse/PIM-3370
   Scenario: Skip import with a not existing channel for a scopable attribute
     Given the following CSV file to import:
       """
@@ -84,7 +84,7 @@ Feature: Execute a job
     And I should see the text " The field \"description-en_US-noexistingchannel\" does not exist"
 
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3312
+  # @jira https://akeneo.atlassian.net/browse/PIM-3312
   Scenario: Stop imports with attributes where channel is wrong (PIM-3312)
     Given the following CSV file to import:
       """
@@ -101,7 +101,7 @@ Feature: Execute a job
     And I should see the text "FAILED"
     And there should be 0 product
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3312
+  # @jira https://akeneo.atlassian.net/browse/PIM-3312
   Scenario: Stop imports with attributes where channel is wrong (PIM-3312)
     Given the following CSV file to import:
       """
@@ -118,7 +118,7 @@ Feature: Execute a job
     And I should see the text "FAILED"
     And there should be 0 product
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3312
+  # @jira https://akeneo.atlassian.net/browse/PIM-3312
   Scenario: Stop imports with attributes where local is wrong (PIM-3312)
     Given the following CSV file to import:
       """
@@ -135,7 +135,7 @@ Feature: Execute a job
     And I should see the text "FAILED"
     And there should be 0 product
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3377
+  # @jira https://akeneo.atlassian.net/browse/PIM-3377
   Scenario: Fail when import invalid attribute with nonexistent specific locale
     Given the following attributes:
       | code                      | type             | localizable | available_locales | group |
@@ -154,7 +154,7 @@ Feature: Execute a job
     And I wait for the "csv_footwear_product_import" job to finish
     Then I should see the text "The field \"locale_specific_attribute-fr_FR\" does not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3369
+  # @jira https://akeneo.atlassian.net/browse/PIM-3369
   Scenario: Skip import with a not available locale for channel of a localizable attribute
     Given the following CSV file to import:
       """
@@ -183,7 +183,7 @@ Feature: Execute a job
     Then I should see job execution status "FAILED"
     And I should see the text "The fields \"unknownfield1, unknownfield2\" do not exist"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3369
+  # @jira https://akeneo.atlassian.net/browse/PIM-3369
   Scenario: Skip import with an unset locale on a localizable attribute
     Given the following CSV file to import:
       """

--- a/tests/legacy/features/pim/enrichment/product/import/import_products_with_product_model_associations.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/import_products_with_product_model_associations.feature
@@ -23,7 +23,7 @@ Feature: Execute a job
       | type   | product_models   |
       | UPSELL | brookspink      |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-7852
+  # @jira https://akeneo.atlassian.net/browse/PIM-7852
   Scenario: Successfully import a csv file of products with product model associations using a job with comparison disabled
     Given the following CSV file to import:
       """

--- a/tests/legacy/features/pim/enrichment/product/import/upload_and_import_products_with_media.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/upload_and_import_products_with_media.feature
@@ -35,13 +35,13 @@ Feature: Upload and import products with media
     And the product "CAT-003" should have the following values:
       | side_view | cat_003.png |
 
-  @info https://akeneo.atlassian.net/browse/PIM-2090
+  # @info https://akeneo.atlassian.net/browse/PIM-2090
   Scenario: Fail to launch an import through file upload when no file was selected
     Given I am on the "csv_footwear_product_import" import job page
     Then I should see the text "Import now"
     But I should not see the text "Import and launch now"
 
-  @info https://akeneo.atlassian.net/browse/PIM-6491
+  # @info https://akeneo.atlassian.net/browse/PIM-6491
   Scenario: Fail to launch an import through file upload when the file extension is invalid
     Given the following CSV file to import:
       """

--- a/tests/legacy/features/pim/enrichment/product/import/validate_unicity_when_importing_products.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/validate_unicity_when_importing_products.feature
@@ -59,7 +59,7 @@ Feature: Validate values for unique attributes when importing products
     Then I should see the text "The text attribute can not have the same value more than once. The foo value is already set on another product."
     And there should be 1 product
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3309
+  # @jira https://akeneo.atlassian.net/browse/PIM-3309
   Scenario: Import a file with same value in unique attribute and with existing product with this value
     Given the following products:
       | sku         | test_unique_attribute |

--- a/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products.feature
@@ -41,7 +41,7 @@ Feature: Import XLSX products
     When the products are imported via the job xlsx_footwear_product_import
     Then there should be 2 products
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6085
+  # @jira https://akeneo.atlassian.net/browse/PIM-6085
   @javascript
   Scenario: Successfully import product associations with modified column name
     Given I am logged in as "Julia"

--- a/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_associations.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_associations.feature
@@ -133,7 +133,7 @@ Feature: Execute a job
     And I visit the "Cross sell (0)" association type
     Then I should see the text "0 product(s), 0 product model(s) and 0 group(s)"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-5696
+  # @jira https://akeneo.atlassian.net/browse/PIM-5696
   Scenario: Successfully import products with associations and numeric value as SKU
     Given the following XLSX file to import:
       """

--- a/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_dates.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_dates.feature
@@ -11,7 +11,7 @@ Feature: Import XLSX products with dates
       | date_family | destocking_date |
     And I am logged in as "Julia"
 
-  @info If Excel opens a file containing dates that match its locale config it will be transformed into a timestamp
+  # @info If Excel opens a file containing dates that match its locale config it will be transformed into a timestamp
   Scenario: Successfully import an XLSX file of products with dates as timestamps
     Given I am on the "xlsx_footwear_product_import" import job page
     When I upload and import the file "products_with_timestamp_dates.xlsx"

--- a/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_numbers.feature
+++ b/tests/legacy/features/pim/enrichment/product/import/xlsx/import_products_with_numbers.feature
@@ -11,7 +11,7 @@ Feature: Import XLSX products with numbers
       | number_family | number_in_stock,rate_sale |
     And I am logged in as "Julia"
 
-  @info If Excel opens a file containing numeric strings that match its locale config it will be transformed into real numbers
+  # @info If Excel opens a file containing numeric strings that match its locale config it will be transformed into real numbers
   Scenario: Successfully import an XLSX file of products with real integers
     Given I am on the "xlsx_footwear_product_import_fr" import job page
     When I upload and import the file "products_with_integers.xlsx"

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/apply_permissions_on_mass_edit_actions.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/apply_permissions_on_mass_edit_actions.feature
@@ -12,7 +12,7 @@ Feature: Apply ACL permissions on mass edit actions
       | hiking_shoes | sandals |
     And I am logged in as "Julia"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-5171
+  # @jira https://akeneo.atlassian.net/browse/PIM-5171
   Scenario: View only the mass edit operations I have permissions on
     Given I edit the "Catalog manager" Role
     And I visit the "Permissions" tab

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/edit_common_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/edit_common_attributes.feature
@@ -26,7 +26,7 @@ Feature: Edit common attributes of many products at once
       | blue_highheels | high_heels | blue  | 12 CENTIMETER |        |
     And I am logged in as "Julia"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6273
+  # @jira https://akeneo.atlassian.net/browse/PIM-6273
   Scenario: Successfully remove product attribute fields
     Given I am on the products grid
     And I select rows boots, sandals and sneakers

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/edit_common_attributes_scopable_localizable.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/edit_common_attributes_scopable_localizable.feature
@@ -14,7 +14,7 @@ Feature: Edit common attributes of many products at once
     And I am on the products grid
 
   @critical
-  @info https://akeneo.atlassian.net/browse/PIM-5351
+  # @info https://akeneo.atlassian.net/browse/PIM-5351
   Scenario: Successfully mass edit scoped product values
     Given I switch the scope to "Print"
     And I select rows black_jacket and white_jacket
@@ -30,8 +30,8 @@ Feature: Edit common attributes of many products at once
     And the unlocalized print customer_rating of "black_jacket" should be "5"
     And the unlocalized print customer_rating of "white_jacket" should be "5"
 
+  # @info https://akeneo.atlassian.net/browse/PIM-5351
   @critical
-  @info https://akeneo.atlassian.net/browse/PIM-5351
   Scenario: Successfully mass edit localized product values
     Given I switch the locale to "de_DE"
     When I switch the scope to "Ecommerce"

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_and_update_attribute_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_and_update_attribute_history.feature
@@ -1,9 +1,10 @@
-@javascript @jira https://akeneo.atlassian.net/browse/PIM-1920
+@javascript
 Feature: Update product history when mass editing products
   In order see what changes have been made to products in mass edit
   As a product manager
   I need to be able to see the changes made in mass edit in product history
 
+  # @jira https://akeneo.atlassian.net/browse/PIM-1920
   Background:
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"
@@ -35,6 +36,7 @@ Feature: Update product history when mass editing products
     And I select rows boots, sandals and sneakers
     And I press the "Bulk actions" button
 
+  # @jira https://akeneo.atlassian.net/browse/PIM-1920
   Scenario: Display history when editing product attributes
     Given I choose the "Edit attribute values" operation
     And I display the Name attribute

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_locale_specific_value.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_locale_specific_value.feature
@@ -14,7 +14,7 @@ Feature: Edit a locale specific value
       | tshirt | super_tshirts |
     And I am logged in as "Mary"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3298
+  # @jira https://akeneo.atlassian.net/browse/PIM-3298
   Scenario: Display the custom tax on the available locale
     Given I am on the "tshirt" product page
     And I visit the "Internal" group

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_product.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_product.feature
@@ -88,7 +88,7 @@ Feature: Edit a product
     Then I switch the scope to "channel_code"
     And I should see the text "The channel label"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6258
+  # @jira https://akeneo.atlassian.net/browse/PIM-6258
   Scenario: Successfully view a product even if permissions on locales channels and families are revoked
     Given I am logged in as "Peter"
     When I am on the "Catalog manager" role page

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_date_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_date_attributes.feature
@@ -29,28 +29,28 @@ Feature: Validate date attributes of a product
     Then I should see validation tooltip "The release attribute can not have the same value more than once. The 2013-01-01 value is already set on another product."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-4216
+  # @jira https://akeneo.atlassian.net/browse/PIM-4216
   Scenario: Validate the date min constraint of date attribute
     Given I change the Release to "01/01/2011"
     And I save the product
     Then I should see validation tooltip "The release attribute requires a date that should be 2013-01-01 or after."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-4216
+  # @jira https://akeneo.atlassian.net/browse/PIM-4216
   Scenario: Validate the date min constraint of scopable date attribute
     Given I change the Available to "01/01/2012"
     And I save the product
     Then I should see validation tooltip "The available attribute requires a date that should be 2013-01-01 or after."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-4216
+  # @jira https://akeneo.atlassian.net/browse/PIM-4216
   Scenario: Validate the date max constraint of date attribute
     Given I change the Release to "01/01/2016"
     And I save the product
     Then I should see validation tooltip "The release attribute requires a date that should be 2015-12-12 or before."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-4216
+  # @jira https://akeneo.atlassian.net/browse/PIM-4216
   Scenario: Validate the date max constraint of scopable date attribute
     Given I change the Available to "03/03/2017"
     And I save the product

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_file_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_file_attributes.feature
@@ -1,4 +1,5 @@
-@javascript @info More user-friendly validation to be done in the scope of @jira https://akeneo.atlassian.net/browse/PIM-2029
+# @info More user-friendly validation to be done in the scope of @jira https://akeneo.atlassian.net/browse/PIM-2029
+@javascript
 Feature: Validate file attributes of a product
   In order to keep my data consistent
   As a regular user

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_identifier_attribute.feature
@@ -33,7 +33,7 @@ Feature: Validate identifier attribute of a product
     Then I should see validation tooltip "The sku attribute must match the following regular expression: /^sku-\d*$/."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3447
+  # @jira https://akeneo.atlassian.net/browse/PIM-3447
   Scenario: Validate the max database value length of identifier attribute
     Given I am on the "bar" product page
     When I change the SKU to an invalid value

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_image_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_image_attributes.feature
@@ -1,4 +1,5 @@
-@javascript @info More user-friendly validation to be done in the scope of @jira https://akeneo.atlassian.net/browse/PIM-2029
+# @info More user-friendly validation to be done in the scope of @jira https://akeneo.atlassian.net/browse/PIM-2029
+@javascript
 Feature: Validate image attributes of a product
   In order to keep my data consistent
   As a regular user

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_text_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_text_attributes.feature
@@ -86,7 +86,7 @@ Feature: Validate text attributes of a product
     Then I should see validation tooltip "The manufacturer_number attribute must match the following regular expression: /^0\d*$/."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3447
+  # @jira https://akeneo.atlassian.net/browse/PIM-3447
   Scenario: Validate the max database value length of text attribute
     Given I change the Description to an invalid value
     And I save the product

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_textarea_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_textarea_attributes.feature
@@ -53,7 +53,8 @@ Feature: Validate textarea attributes of a product
     Then I should see validation tooltip "The long_description attribute must not contain more than 10 characters. The submitted value is too long."
     And there should be 1 error in the "Other" tab
 
-  @skip @info This generates an unresponsive script, should be checked on the backend @jira https://akeneo.atlassian.net/browse/PIM-3447
+  # @info This generates an unresponsive script, should be checked on the backend @jira https://akeneo.atlassian.net/browse/PIM-3447
+  @skip
   Scenario: Validate the max database value length of textarea attribute
     Given I change the Longtext to an invalid value
     And I save the product

--- a/tests/legacy/features/pim/enrichment/product/validation/validate_unique_attribute.feature
+++ b/tests/legacy/features/pim/enrichment/product/validation/validate_unique_attribute.feature
@@ -36,7 +36,7 @@ Feature: Validate unique attribute of a product
     Then I should see validation tooltip "The text attribute can not have the same value more than once. The my-text value is already set on another product."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3961
+  # @jira https://akeneo.atlassian.net/browse/PIM-3961
   Scenario: Validate the unique constraint of text attribute with an empty text
     Given I am on the "text1" product page
     And I change the Text to ""
@@ -46,7 +46,7 @@ Feature: Validate unique attribute of a product
     And I save the product
     Then I should not see validation tooltip "The text attribute can not have the same value more than once. The  value is already set on another product."
 
-  @jira https://akeneo.atlassian.net/browse/PIM-7323
+  # @jira https://akeneo.atlassian.net/browse/PIM-7323
   Scenario: Validate the unique constraint of text attribute with an removed value
     Given I am on the "text1" product page
     And I change the Text to "my-text"
@@ -69,7 +69,7 @@ Feature: Validate unique attribute of a product
     And I should see validation tooltip "The number attribute can not have the same value more than once. The 12 value is already set on another product."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3961
+  # @jira https://akeneo.atlassian.net/browse/PIM-3961
   Scenario: Validate the unique constraint of number attribute with an empty number
     Given I am on the "number1" product page
     And I change the Number to ""
@@ -79,7 +79,8 @@ Feature: Validate unique attribute of a product
     And I save the product
     Then I should not see validation tooltip "The number attribute can not have the same value more than once. The  value is already set on another product."
 
-  @skip @info date picker does not work properly on CI
+  # @info date picker does not work properly on CI
+  @skip
   Scenario: Validate the unique constraint of date attribute with a provided date
     Given the following product values:
       | product | attribute | value      |
@@ -90,7 +91,7 @@ Feature: Validate unique attribute of a product
     And I should see validation tooltip "The date attribute can not have the same value more than once. The 2015-01-01 value is already set on another product."
     And there should be 1 error in the "Other" tab
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3961
+  # @jira https://akeneo.atlassian.net/browse/PIM-3961
   Scenario: Validate the unique constraint of date attribute with an empty date
     Given I am on the "date1" product page
     And I save the product

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_history.feature
@@ -20,7 +20,7 @@ Feature: Display the product history
       | version | property | value       | date |
       | 1       | SKU      | sandals-001 | now  |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3628
+  # @jira https://akeneo.atlassian.net/browse/PIM-3628
   Scenario: Update product history when updating product metric
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
@@ -4,7 +4,7 @@ Feature: Display the product history
   As a product manager
   I need to have access to a product history
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3420
+  # @jira https://akeneo.atlassian.net/browse/PIM-3420
   Scenario: Update product history when multiple linked attributes are removed
     Given a "footwear" catalog configuration
     And I am logged in as "Julia"

--- a/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
+++ b/tests/legacy/features/pim/structure/attribute/delete_attribute.feature
@@ -4,8 +4,8 @@ Feature: Delete an attribute
   As a product manager
   I need to delete a text attribute
 
+  # @jira https://akeneo.atlassian.net/browse/PIM-7199
   @critical
-  @jira https://akeneo.atlassian.net/browse/PIM-7199
   Scenario: An identifier attribute cannot be deleted
     Given the "default" catalog configuration
     And I am logged in as "Julia"

--- a/tests/legacy/features/pim/structure/attribute/import/import_attributes.feature
+++ b/tests/legacy/features/pim/structure/attribute/import/import_attributes.feature
@@ -39,7 +39,7 @@ Feature: Import attributes
       | pim_catalog_metric           | lace_length  | Lace length  | info      | 0      | 0                      | 0           | 0        |                    | Length        | CENTIMETER          | 0          |               |
       | pim_catalog_boolean          | is_enabled   | Is enabled   | info      | 0      | 1                      | 1           | 0        |                    |               |                     | 0          | 1             |
 
-  @jira https://akeneo.atlassian.net/browse/PIM-3266
+  # @jira https://akeneo.atlassian.net/browse/PIM-3266
   @javascript
   Scenario: Skip new attributes with invalid data during an import
     Given the "footwear" catalog configuration

--- a/tests/legacy/features/pim/structure/family/add_attributes_to_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/add_attributes_to_a_family.feature
@@ -7,9 +7,9 @@ Feature: Add attribute to a family
   Background:
     Given a "footwear" catalog configuration
     And I am logged in as "Peter"
-    
+
+  # @info https://akeneo.atlassian.net/browse/PIM-355
   @critical
-  @info https://akeneo.atlassian.net/browse/PIM-355
   Scenario: Successfully display all grouped family's attributes
     Given I am on the "sneakers" family page
     And I visit the "Attributes" tab
@@ -19,8 +19,8 @@ Feature: Add attribute to a family
     And I should see attribute "Size" in group "Sizes"
     And I should see attributes "Color and Lace color" in group "Colors"
 
+  # @info https://akeneo.atlassian.net/browse/PIM-244
   @critical
-  @info https://akeneo.atlassian.net/browse/PIM-244
   Scenario: Successfully add an attribute to a family
     Given I am on the "sandals" family page
     And I visit the "Attributes" tab

--- a/tests/legacy/features/pim/structure/family/add_attributes_to_family_by_group.feature
+++ b/tests/legacy/features/pim/structure/family/add_attributes_to_family_by_group.feature
@@ -8,7 +8,7 @@ Feature: Add attributes by attribute groups to a family
     Given a "footwear" catalog configuration
     And I am logged in as "Peter"
 
-  @info https://akeneo.atlassian.net/browse/PIM-6095
+  # @info https://akeneo.atlassian.net/browse/PIM-6095
   Scenario: Successfully add attributes by attribute groups to a family
     Given I am on the "Sandals" family page
     And I visit the "Attributes" tab

--- a/tests/legacy/features/platform/acl/api.feature
+++ b/tests/legacy/features/platform/acl/api.feature
@@ -4,8 +4,8 @@ Feature: Define user rights on the web API
   As an administrator
   I need to be able to assign/remove rights
 
-  @info here we check only if ACLs on "Web API permissions" are saved. Check on access resources are done in integration tests
-    Scenario: Successfully edit and apply user rights on web API
+  # @info here we check only if ACLs on "Web API permissions" are saved. Check on access resources are done in integration tests
+  Scenario: Successfully edit and apply user rights on web API
     Given a "default" catalog configuration
     And I am logged in as "Peter"
     When I am on the "Administrator" role page

--- a/tests/legacy/features/platform/security/security.feature
+++ b/tests/legacy/features/platform/security/security.feature
@@ -3,7 +3,7 @@ Feature: Security
   As a developer
   I need to be able to execute shell commands without security issues
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6062
+  # @jira https://akeneo.atlassian.net/browse/PIM-6062
   Scenario: Fail when trying to inject command
     Given file "%tmp%/this_will_raise_an_error.txt" should not exist
     When I run '$(touch %tmp%/this_will_raise_an_error.txt)' in background

--- a/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
+++ b/tests/legacy/features/user-management/role/edit_user_role_assignations.feature
@@ -33,7 +33,7 @@ Feature: Edit a user groups and roles
     And I should not see the text "There are unsaved changes."
     Then the row "Sandra" should be checked
 
-  @jira https://akeneo.atlassian.net/browse/PIM-5201
+  # @jira https://akeneo.atlassian.net/browse/PIM-5201
   Scenario: Successfully remove a role from the group page
     Given I edit the "User" Role
     When I visit the "Permissions" tab

--- a/tests/legacy/features/user-management/user/edit_my_account.feature
+++ b/tests/legacy/features/user-management/user/edit_my_account.feature
@@ -8,7 +8,7 @@ Feature: Change my profile
     Given the "apparel" catalog configuration
     And I am logged in as "Peter"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-8286
+  # @jira https://akeneo.atlassian.net/browse/PIM-8286
   Scenario: I can edit my own profile even if I don't have the permission to edit users
     Given I am on the "Administrator" role page
     And I visit the "Permissions" tab
@@ -24,7 +24,7 @@ Feature: Change my profile
     Then I should not see the text "There are unsaved changes"
     And the "Middle name" field should contain "James"
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6914
+  # @jira https://akeneo.atlassian.net/browse/PIM-6914
   Scenario: Successfully display the UI locale of the user
     Given I edit the "Peter" user
     When I visit the "Interfaces" tab

--- a/tests/legacy/features/user-management/user/edit_user.feature
+++ b/tests/legacy/features/user-management/user/edit_user.feature
@@ -38,7 +38,7 @@ Feature: Edit a user
     And I should see the filters name, family and sku
     And I should not see the filter enabled
 
-  @jira https://akeneo.atlassian.net/browse/PIM-6901
+  # @jira https://akeneo.atlassian.net/browse/PIM-6901
   Scenario: Successfully edit a user with a new role
     Given I am on the role creation page
     And I fill in the following information:


### PR DESCRIPTION
Fixes deprecation warnings when using the `@jira` or `@info` annotations in a behat scenario
`PHP Deprecated: Whitespace in tags is deprecated, found "$tag" in /srv/pim/vendor/behat/gherkin/src/Behat/Gherkin/Parser.php on line 659`