### PR TITLE
PH-20: UCS - Do not persist tenant ID in JobMessage

### DIFF
--- a/src/Akeneo/Channel/back/tests/phpstan.neon.dist
+++ b/src/Akeneo/Channel/back/tests/phpstan.neon.dist
@@ -2,6 +2,6 @@ parameters:
   level: 6
   paths:
     - %rootDir%/../../../src/Akeneo/Channel
-  excludes_analyse:
+  excludePaths:
     - %rootDir%/../../../src/Akeneo/Channel/back/tests/Specification
     - %rootDir%/../../../src/Akeneo/Channel/back/Infrastructure

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobExecutionMessageHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobExecutionMessageHandler.php
@@ -38,8 +38,8 @@ final class JobExecutionMessageHandler implements MessageHandlerInterface
             $env = [
                 'SYMFONY_DOTENV_VARS' => false,
             ];
-            if (null !== $jobExecutionMessage->tenantId()) {
-                $env['APP_TENANT_ID'] = $jobExecutionMessage->tenantId();
+            if (null !== $jobExecutionMessage->getTenantId()) {
+                $env['APP_TENANT_ID'] = $jobExecutionMessage->getTenantId();
             };
 
             $process = new Process($arguments, null, $env);

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Factory/JobExecutionMessageFactoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Factory/JobExecutionMessageFactoryIntegration.php
@@ -30,7 +30,6 @@ final class JobExecutionMessageFactoryIntegration extends TestCase
             [
                 'id' => '215ee791-1c40-4c60-82fb-cb017d6bcb90',
                 'job_execution_id' => $jobExecution->getId(),
-                'tenant_id' => 'foo_tenant_id',
                 'created_time' => '2021-03-08T15:37:23+01:00',
                 'updated_time' => null,
                 'options' => ['option1' => 'value1'],
@@ -43,7 +42,6 @@ final class JobExecutionMessageFactoryIntegration extends TestCase
         self::assertEquals(new \DateTime('2021-03-08T15:37:23+01:00'), $jobExecutionMessage->getCreateTime());
         self::assertNull($jobExecutionMessage->getUpdatedTime());
         self::assertEquals(['option1' => 'value1'], $jobExecutionMessage->getOptions());
-        self::assertEquals('foo_tenant_id', $jobExecutionMessage->tenantId());
     }
 
     public function test_it_returns_an_import_job_message(): void
@@ -65,7 +63,6 @@ final class JobExecutionMessageFactoryIntegration extends TestCase
         self::assertEquals(new \DateTime('2021-03-08T15:37:23+01:00'), $jobExecutionMessage->getCreateTime());
         self::assertEquals(new \DateTime('2021-03-10T15:37:23+01:00'), $jobExecutionMessage->getUpdatedTime());
         self::assertEquals(['option1' => 'value1', 'option2' => 'value2'], $jobExecutionMessage->getOptions());
-        self::assertNull($jobExecutionMessage->tenantId());
     }
 
     public function test_it_returns_an_export_job_message(): void

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -10,6 +10,10 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
 
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
 class UcsMiddleware implements MiddlewareInterface
 {
     public function __construct(private ?string $pimTenantId)

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -19,7 +19,7 @@ class UcsMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         // No tenant ID in the env, but existing in the received message
-        // We are in a daemon long running process
+        // We are in a daemon long-running process
         if (null === $this->pimTenantId && null !== $envelope->last(TenantIdStamp::class)) {
             /** @var TenantIdStamp $stamp */
             $stamp = $envelope->last(TenantIdStamp::class);

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -19,6 +19,7 @@ class UcsMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         // No tenant ID in the env, but existing in the received message
+        // We are in a daemon long running process
         if (null === $this->pimTenantId && null !== $envelope->last(TenantIdStamp::class)) {
             /** @var TenantIdStamp $stamp */
             $stamp = $envelope->last(TenantIdStamp::class);
@@ -26,10 +27,12 @@ class UcsMiddleware implements MiddlewareInterface
         }
 
         // Tenant ID exists in this env
+        // We are in a contextualized process
         if ($this->pimTenantId && null === $envelope->last(TenantIdStamp::class)) {
             $envelope = $envelope->with(new TenantIdStamp($this->pimTenantId));
         }
 
+        // Enrich the message with the tenant ID
         if ($this->pimTenantId && $envelope->getMessage() instanceof TenantAwareInterface) {
             $envelope->getMessage()->setTenantId($this->pimTenantId);
         }

--- a/src/Akeneo/Tool/Component/BatchQueue/Factory/JobExecutionMessageFactory.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Factory/JobExecutionMessageFactory.php
@@ -29,8 +29,7 @@ class JobExecutionMessageFactory
 
     public function __construct(
         array $mappingJobMessageTypes,
-        string $jobMessageTypeFallback,
-        private ?string $tenantId
+        string $jobMessageTypeFallback
     ) {
         Assert::classExists($jobMessageTypeFallback);
         Assert::subclassOf($jobMessageTypeFallback, JobExecutionMessageInterface::class);
@@ -49,11 +48,12 @@ class JobExecutionMessageFactory
         /** @var string|JobExecutionMessageInterface $class */
         $class = $this->getJobMessageClass($jobInstance->getType() ?? '');
 
-        return $class::createJobExecutionMessage($jobExecutionId, $options, $this->tenantId);
+        return $class::createJobExecutionMessage($jobExecutionId, $options);
     }
 
     public function buildFromNormalized(array $normalized, ?string $jobMessageClass): JobExecutionMessageInterface
     {
+        /** @var string|JobExecutionMessageInterface $class */
         $class = $jobMessageClass ?? $this->jobMessageTypeFallback;
 
         Assert::classExists($class);

--- a/src/Akeneo/Tool/Component/BatchQueue/Normalizer/JobExecutionMessageNormalizer.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Normalizer/JobExecutionMessageNormalizer.php
@@ -36,7 +36,6 @@ final class JobExecutionMessageNormalizer implements NormalizerInterface, Denorm
         return [
             'id' => $jobExecutionMessage->getId()->toString(),
             'job_execution_id' => $jobExecutionMessage->getJobExecutionId(),
-            'tenant_id' => $jobExecutionMessage->tenantId(),
             'created_time' => $jobExecutionMessage->getCreateTime()->format('c'),
             'updated_time' => null !== $jobExecutionMessage->getUpdatedTime() ?
                 $jobExecutionMessage->getUpdatedTime()->format('c')

--- a/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionMessage.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionMessage.php
@@ -16,13 +16,14 @@ use Ramsey\Uuid\UuidInterface;
  */
 abstract class JobExecutionMessage implements JobExecutionMessageInterface
 {
+    private ?string $tenantId = null;
+
     private function __construct(
         private UuidInterface $id,
         private int $jobExecutionId,
         private \DateTime $createTime,
         private ?\DateTime $updatedTime,
-        private array $options,
-        private ?string $tenantId
+        private array $options
     ) {
     }
 
@@ -31,12 +32,11 @@ abstract class JobExecutionMessage implements JobExecutionMessageInterface
      */
     public static function createJobExecutionMessage(
         int $jobExecutionId,
-        array $options,
-        ?string $tenantId = null
+        array $options
     ): JobExecutionMessageInterface {
         $createTime = new \DateTime('now', new \DateTimeZone('UTC'));
 
-        return new static(Uuid::uuid4(), $jobExecutionId, $createTime, null, $options, $tenantId);
+        return new static(Uuid::uuid4(), $jobExecutionId, $createTime, null, $options);
     }
 
     public static function createJobExecutionMessageFromNormalized(array $normalized): JobExecutionMessageInterface
@@ -48,8 +48,7 @@ abstract class JobExecutionMessage implements JobExecutionMessageInterface
             null !== $normalized['updated_time']
                 ? new \DateTime($normalized['updated_time'], new \DateTimeZone('UTC'))
                 : null,
-            $normalized['options'] ?? [],
-            $normalized['tenant_id'] ?? null,
+            $normalized['options'] ?? []
         );
     }
 
@@ -78,8 +77,13 @@ abstract class JobExecutionMessage implements JobExecutionMessageInterface
         return $this->options;
     }
 
-    public function tenantId(): ?string
+    public function getTenantId(): ?string
     {
         return $this->tenantId;
+    }
+
+    public function setTenantId(string $tenantId): void
+    {
+        $this->tenantId = $tenantId;
     }
 }

--- a/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionMessageInterface.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Queue/JobExecutionMessageInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Component\BatchQueue\Queue;
 
+use Akeneo\Tool\Component\Messenger\Tenant\TenantAwareInterface;
 use Ramsey\Uuid\UuidInterface;
 
 /**
@@ -11,12 +12,11 @@ use Ramsey\Uuid\UuidInterface;
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
-interface JobExecutionMessageInterface
+interface JobExecutionMessageInterface extends TenantAwareInterface
 {
     public static function createJobExecutionMessage(
         int $jobExecutionId,
-        array $options,
-        ?string $tenantId = null
+        array $options
     ): JobExecutionMessageInterface;
 
     public static function createJobExecutionMessageFromNormalized(array $normalized): JobExecutionMessageInterface;
@@ -30,6 +30,4 @@ interface JobExecutionMessageInterface
     public function getUpdatedTime(): ?\DateTime;
 
     public function getOptions(): array;
-
-    public function tenantId(): ?string;
 }

--- a/src/Akeneo/Tool/Component/BatchQueue/spec/Factory/JobExecutionMessageFactorySpec.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/spec/Factory/JobExecutionMessageFactorySpec.php
@@ -24,8 +24,7 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
                 ImportJobExecutionMessage::class => ['import'],
                 ExportJobExecutionMessage::class => ['export', 'quick_export'],
             ],
-            DataMaintenanceJobExecutionMessage::class,
-            'my_tenant_id'
+            DataMaintenanceJobExecutionMessage::class
         );
     }
 
@@ -41,7 +40,7 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
         $jobExecutionMessage = $this->buildFromJobInstance($jobInstance, 1, []);
         $jobExecutionMessage->shouldBeAnInstanceOf(UiJobExecutionMessage::class);
         $jobExecutionMessage->getJobExecutionId()->shouldBe(1);
-        $jobExecutionMessage->tenantId()->shouldBe('my_tenant_id');
+        $jobExecutionMessage->getTenantId()->shouldBe(null);
     }
 
     function it_builds_an_export_job_execution_message(JobInstance $jobInstance)
@@ -68,7 +67,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
             [
                 'id' => '30e8008d-48dc-4430-97e1-6f67a5c420e9',
                 'job_execution_id' => 10,
-                'tenant_id' => 'foo_tenant_id',
                 'created_time' => '2021-03-08T15:37:23+01:00',
                 'updated_time' => null,
                 'options' => ['option1' => 'value1'],
@@ -78,7 +76,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
         $jobExecutionMessage->shouldBeAnInstanceOf(UiJobExecutionMessage::class);
         $jobExecutionMessage->getId()->shouldBeLike(Uuid::fromString('30e8008d-48dc-4430-97e1-6f67a5c420e9'));
         $jobExecutionMessage->getJobExecutionId()->shouldBe(10);
-        $jobExecutionMessage->tenantId()->shouldBe('foo_tenant_id');
         $jobExecutionMessage->getCreateTime()->shouldBeLike(new \DateTime('2021-03-08T15:37:23+01:00'));
         $jobExecutionMessage->getUpdatedTime()->shouldBeNull();
         $jobExecutionMessage->getOptions()->shouldBe(['option1' => 'value1']);
@@ -90,7 +87,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
             [
                 'id' => 'a57380fc-ee3b-4bd2-94e6-c3ead13c32a7',
                 'job_execution_id' => 10,
-                'tenant_id' => 'foo_tenant_id',
                 'created_time' => '2021-03-08T15:37:23+01:00',
                 'updated_time' => '2021-03-09T15:37:23+01:00',
                 'options' => ['option1' => 'value1'],
@@ -100,7 +96,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
         $jobExecutionMessage->shouldBeAnInstanceOf(ImportJobExecutionMessage::class);
         $jobExecutionMessage->getId()->shouldBeLike(Uuid::fromString('a57380fc-ee3b-4bd2-94e6-c3ead13c32a7'));
         $jobExecutionMessage->getJobExecutionId()->shouldBe(10);
-        $jobExecutionMessage->tenantId()->shouldBe('foo_tenant_id');
         $jobExecutionMessage->getCreateTime()->shouldBeLike(new \DateTime('2021-03-08T15:37:23+01:00'));
         $jobExecutionMessage->getUpdatedTime()->shouldBeLike(new \DateTime('2021-03-09T15:37:23+01:00'));
         $jobExecutionMessage->getOptions()->shouldBe(['option1' => 'value1']);
@@ -117,7 +112,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
             [
                 'id' => 'a57380fc-ee3b-4bd2-94e6-c3ead13c32a7',
                 'job_execution_id' => 10,
-                'tenant_id' => 'foo_tenant_id',
                 'created_time' => '2021-03-08T15:37:23+01:00',
                 'updated_time' => '2021-03-09T15:37:23+01:00',
                 'options' => [],
@@ -127,7 +121,6 @@ class JobExecutionMessageFactorySpec extends ObjectBehavior
         $jobExecutionMessage->shouldBeAnInstanceOf(DataMaintenanceJobExecutionMessage::class);
         $jobExecutionMessage->getId()->shouldBeLike(Uuid::fromString('a57380fc-ee3b-4bd2-94e6-c3ead13c32a7'));
         $jobExecutionMessage->getJobExecutionId()->shouldBe(10);
-        $jobExecutionMessage->tenantId()->shouldBe('foo_tenant_id');
         $jobExecutionMessage->getCreateTime()->shouldBeLike(new \DateTime('2021-03-08T15:37:23+01:00'));
         $jobExecutionMessage->getUpdatedTime()->shouldBeLike(new \DateTime('2021-03-09T15:37:23+01:00'));
         $jobExecutionMessage->getOptions()->shouldBe([]);

--- a/src/Akeneo/Tool/Component/BatchQueue/spec/Normalizer/JobExecutionMessageNormalizerSpec.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/spec/Normalizer/JobExecutionMessageNormalizerSpec.php
@@ -65,7 +65,6 @@ class JobExecutionMessageNormalizerSpec extends ObjectBehavior
         $jobMessenger = ImportJobExecutionMessage::createJobExecutionMessageFromNormalized([
             'id' => '215ee791-1c40-4c60-82fb-cb017d6bcb90',
             'job_execution_id' => 2,
-            'tenant_id' => 'foo_tenant_id',
             'created_time' => '2020-01-01',
             'updated_time' => '2020-02-01',
             'options' => ['option1' => 'value1']
@@ -75,7 +74,6 @@ class JobExecutionMessageNormalizerSpec extends ObjectBehavior
         $normalized->shouldBeArray();
         $normalized['id']->shouldBeLike(Uuid::fromString('215ee791-1c40-4c60-82fb-cb017d6bcb90'));
         $normalized['job_execution_id']->shouldBe(2);
-        $normalized['tenant_id']->shouldBe('foo_tenant_id');
         $normalized['created_time']->shouldBe((new \DateTime('2020-01-01'))->format('c'));
         $normalized['updated_time']->shouldBe((new \DateTime('2020-02-01'))->format('c'));
         $normalized['options']->shouldBe(['option1' => 'value1']);


### PR DESCRIPTION
Tenant ID information is transported by the Doctrine transport and injected in messages at runtime.