### PR TITLE
OCT-71: Add infection for mutation testing

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -138,5 +138,8 @@ catalogs-lint-back_fix:
 # BINARIES
 
 var/infection.phar:
-	$(DOCKER_COMPOSE) run -u www-data -w /srv/pim/var --rm php sh -c "wget https://github.com/infection/infection/releases/download/0.26.0/infection.phar && chmod +x infection.phar"
-	$(DOCKER_COMPOSE) run -u www-data -w /srv/pim/var --rm php sh -c "wget https://github.com/infection/infection/releases/download/0.26.0/infection.phar.asc"
+	wget -q https://github.com/infection/infection/releases/download/0.26.0/infection.phar -O var/infection.phar
+	wget -q https://github.com/infection/infection/releases/download/0.26.0/infection.phar.asc -O var/infection.phar.asc
+	echo "80b26af31585cf98f6a898c34aa961c0bd4289ad135fa6771831bcd1d47aa5cc  var/infection.phar" | sha256sum --check
+	echo "5052975aaf68cc4010b9726bd00ac2ec3c0cf0123f94044ae37aa3d892cf02c8  var/infection.phar.asc" | sha256sum --check
+	chmod +x var/infection.phar

--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -19,6 +19,7 @@ catalogs-fixtures:
 catalogs-tests:
 	$(MAKE) catalogs-lint-back
 	$(MAKE) catalogs-coupling-back
+	$(MAKE) catalogs-mutation-unit-back
 	$(MAKE) catalogs-coverage-back
 	$(MAKE) catalogs-acceptance-back
 	$(MAKE) catalogs-lint-front
@@ -81,6 +82,30 @@ catalogs-coverage-back:
 		--coverage-html coverage/Catalogs/Back/Global/ \
 		--coverage-filter $(CATALOGS_PATH)/back/src/
 
+.PHONY: catalogs-mutation-back
+catalogs-mutation-back: var/infection.phar
+	XDEBUG_MODE=coverage APP_ENV=test $(PHP_RUN) var/infection.phar \
+		--configuration=$(CATALOGS_PATH)/back/infection.json \
+		--only-covered \
+		--show-mutations
+
+.PHONY: catalogs-mutation-unit-back
+catalogs-mutation-unit-back: var/infection.phar
+	XDEBUG_MODE=coverage APP_ENV=test $(PHP_RUN) var/infection.phar \
+		--configuration=$(CATALOGS_PATH)/back/infection.json \
+		--only-covered \
+		--show-mutations \
+		--test-framework-options="--testsuite=Catalogs_Unit" \
+		--min-covered-msi=100
+
+.PHONY: catalogs-mutation-integration-back
+catalogs-mutation-integration-back: var/infection.phar
+	XDEBUG_MODE=coverage APP_ENV=test $(PHP_RUN) var/infection.phar \
+		--configuration=$(CATALOGS_PATH)/back/infection.json \
+		--only-covered \
+		--show-mutations \
+		--test-framework-options="--testsuite=Catalogs_Integration"
+
 # TESTS FRONT
 
 .PHONY: catalogs-lint-front
@@ -109,3 +134,9 @@ catalogs-lint-front_fix:
 .PHONY: catalogs-lint-back_fix
 catalogs-lint-back_fix:
 	$(PHP_RUN) vendor/bin/php-cs-fixer fix --config=$(CATALOGS_PATH)/back/.php_cs.php
+
+# BINARIES
+
+var/infection.phar:
+	$(DOCKER_COMPOSE) run -u www-data -w /srv/pim/var --rm php sh -c "wget https://github.com/infection/infection/releases/download/0.26.0/infection.phar && chmod +x infection.phar"
+	$(DOCKER_COMPOSE) run -u www-data -w /srv/pim/var --rm php sh -c "wget https://github.com/infection/infection/releases/download/0.26.0/infection.phar.asc"

--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -77,26 +77,9 @@ catalogs-coverage-back:
 	XDEBUG_MODE=coverage APP_ENV=test $(PHP_RUN) vendor/bin/phpunit \
 		--configuration $(CATALOGS_PATH)/back/ \
 		--bootstrap $(CATALOGS_BOOTSTRAP_PATH) \
-		--testsuite Catalogs_Unit \
-		--log-junit var/tests/phpunit/phpunit_catalogs_unit.xml \
-		--coverage-php coverage/Catalogs/Back/Global/unit.cov \
-		--coverage-html coverage/Catalogs/Back/Unit/ \
+		--log-junit var/tests/phpunit/phpunit_catalogs_global.xml \
+		--coverage-html coverage/Catalogs/Back/Global/ \
 		--coverage-filter $(CATALOGS_PATH)/back/src/
-	XDEBUG_MODE=coverage APP_ENV=test $(PHP_RUN) vendor/bin/phpunit \
-		--configuration $(CATALOGS_PATH)/back/ \
-		--bootstrap $(CATALOGS_BOOTSTRAP_PATH) \
-		--testsuite Catalogs_Integration \
-		--log-junit var/tests/phpunit/phpunit_catalogs_integration.xml \
-		--coverage-php coverage/Catalogs/Back/Global/integration.cov \
-		--coverage-html coverage/Catalogs/Back/Integration/ \
-		--coverage-filter $(CATALOGS_PATH)/back/src/
-
-	# download phpcov binary
-	$(DOCKER_COMPOSE) run -u www-data -w /srv/pim/var --rm php sh -c "test -e phpcov.phar || wget https://phar.phpunit.de/phpcov.phar && php phpcov.phar --version"
-	# Merge code coverages
-	$(PHP_RUN) -d memory_limit=-1 var/phpcov.phar merge \
-		--html coverage/Catalogs/Back/Global/ \
-		coverage/Catalogs/Back/Global/
 
 # TESTS FRONT
 

--- a/components/catalogs/back/infection.json
+++ b/components/catalogs/back/infection.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.26.0/resources/schema.json",
+    "source": {
+        "directories": [
+            "components/catalogs/back/src"
+        ]
+    },
+    "mutators": {
+        "@default": true
+    },
+    "phpUnit": {
+        "configDir": ""
+    }
+}

--- a/components/catalogs/back/phpunit.xml.dist
+++ b/components/catalogs/back/phpunit.xml.dist
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
     backupGlobals="false"
     backupStaticAttributes="false"
     colors="true"
@@ -12,7 +14,7 @@
     bootstrap="../../../config/bootstrap.php">
 
     <php>
-        <ini name="date.timezone" value="Europe/Paris"/>
+        <ini name="date.timezone" value="UTC"/>
         <ini name="intl.default_locale" value="en"/>
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
@@ -35,4 +37,9 @@
             <directory suffix="Test.php">tests/Integration</directory>
         </testsuite>
     </testsuites>
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/components/catalogs/back/tests/Unit/Infrastructure/Validation/MaxNumberOfCatalogsPerUserValidatorTest.php
+++ b/components/catalogs/back/tests/Unit/Infrastructure/Validation/MaxNumberOfCatalogsPerUserValidatorTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Catalogs\Test\Unit\Application\Validation;
+namespace Akeneo\Catalogs\Test\Unit\Infrastructure\Validation;
 
 use Akeneo\Catalogs\Application\Persistence\IsCatalogsNumberLimitReachedQueryInterface;
 use Akeneo\Catalogs\Infrastructure\Validation\MaxNumberOfCatalogsPerUser;
 use Akeneo\Catalogs\Infrastructure\Validation\MaxNumberOfCatalogsPerUserValidator;
 use Akeneo\Catalogs\ServiceAPI\Command\CreateCatalogCommand;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -72,5 +74,18 @@ class MaxNumberOfCatalogsPerUserValidatorTest extends ConstraintValidatorTestCas
         ));
 
         $this->validator->validate(new \stdClass(), new MaxNumberOfCatalogsPerUser());
+    }
+
+    public function testItThrowsAnExceptionIfInvalidConstraint(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $command = new CreateCatalogCommand(
+            id: '43c74e94-0074-4316-ac66-93cd0ca71a6b',
+            name: 'foo',
+            ownerUsername: 'shopifi',
+        );
+
+        $this->validator->validate($command, new NotBlank());
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

3 new makefile targets:
```
make catalogs-mutation-back
make catalogs-mutation-unit-back
make catalogs-mutation-integration-back
```

Since `catalogs-mutation-unit-back` is fast enough for the moment, I've added it to `catalogs-tests`.

On the contrary, `catalogs-mutation-integration-back` is quit slow (~7min) but can be useful, for example, it discovered that all tests are passing when you remove the following line, which is yet already covered by tests:
![Screenshot_2022-06-23_13-23-17](https://user-images.githubusercontent.com/1421130/175295980-b1fbcd29-2d4e-48e6-adc9-318ad92a3471.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
