### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,33 @@ updates:
     allow:
       - dependency-type: "production"
 
+  #6.0
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "6.0"
+    allow:
+      - dependency-type: "production"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "/front-packages/akeneo-design-system"
+    schedule:
+      interval: "daily"
+    target-branch: "6.0"
+    allow:
+      - dependency-type: "production"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "6.0"
+    allow:
+      - dependency-type: "production"
+
   #5.0
   - package-ecosystem: "npm"
     directory: "/"
@@ -64,23 +91,5 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "5.0"
-    allow:
-      - dependency-type: "production"
-
-  #4.0
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "4.0"
-    allow:
-      - dependency-type: "production"
-    open-pull-requests-limit: 0
-
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    target-branch: "4.0"
     allow:
       - dependency-type: "production"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
 
   #6.0
   - package-ecosystem: "npm"
@@ -66,6 +69,9 @@ updates:
     target-branch: "6.0"
     allow:
       - dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]
 
   #5.0
   - package-ecosystem: "npm"
@@ -93,3 +99,6 @@ updates:
     target-branch: "5.0"
     allow:
       - dependency-type: "production"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
4.0 is not supported anymore.
6.0 was forgotten.

Also ignore major versions for Composer realm because we will mange them manually.
see https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore