### PR TITLE
PIM-10478: Disable compute_family_variant_structure_changes on familySave

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -38,6 +38,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         ];
     }
 
+    // TODO change explanation text
     /**
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
@@ -61,13 +62,15 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
             return;
         }
 
+        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
+
         $validationResponse = $this->validateFamilyVariants($subject);
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
-            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true,
+            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges,
         ]);
 
         if (!empty($allViolations)) {
@@ -102,9 +105,11 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
+        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
+
         $this->bulkFamilyVariantSaver->saveAll(
             $validFamilyVariants,
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges]
         );
 
         if (!empty($allViolations)) {

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -38,14 +38,11 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         ];
     }
 
-    // TODO change explanation text
     /**
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
      * As we are not in an import context, the `compute_family_variant_structure_changes` job is triggered
-     * by the bulkFamilyVariantSaver->saveAll(). We force the launch of this job because if an attribute
-     * at the common level is removed, the family variant stays unchanged but we need to recompute the root/sub
-     * product models.
+     * by the bulkFamilyVariantSaver->saveAll() only when the family variant structure has been updated.
      *
      * hence, updating the catalog asynchronously.
      *

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -64,6 +64,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
+        // This is an optimization to not trigger two times the jobs. Yet, it's not an ideal design because it means the
+        // caller know who are the listener. It means it introduced accidental coupling between the two components that
+        // should not know each other.
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
             ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true,
         ]);
@@ -100,6 +103,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
+        // This is an optimization to not trigger two times the jobs. Yet, it's not an ideal design because it means the
+        // caller knows who are the listeners. It means it introduced accidental coupling between the two components that
+        // should not know each other.
         $this->bulkFamilyVariantSaver->saveAll(
             $validFamilyVariants,
             [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]

--- a/src/Akeneo/Pim/Structure/Component/Model/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/Family.php
@@ -55,9 +55,6 @@ class Family implements FamilyInterface
     /** @var Collection */
     protected $familyVariants;
 
-    /** @var string[] */
-    private array $events = [];
-
     /**
      * Constructor
      */
@@ -482,8 +479,6 @@ class Family implements FamilyInterface
         sort($newAttributeCodes);
 
         if ($formerAttributeCodes !== $newAttributeCodes) {
-            $this->events[] = FamilyInterface::ATTRIBUTES_WERE_UPDATED;
-
             $attributeCodesToRemove = array_diff($formerAttributeCodes, $newAttributeCodes);
             $attributeCodesToAdd = array_diff($newAttributeCodes, $formerAttributeCodes);
 
@@ -503,16 +498,5 @@ class Family implements FamilyInterface
                 }
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function releaseEvents(): array
-    {
-        $events = $this->events;
-        $this->events = [];
-
-        return $events;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
@@ -22,11 +22,6 @@ interface FamilyInterface extends
     TimestampableInterface
 {
     /**
-     * For now the events are a list of strings, but they can be converted to object when needed.
-     */
-    public const ATTRIBUTES_WERE_UPDATED = 'ATTRIBUTES_WERE_UPDATED';
-
-    /**
      * Get id
      *
      * @return int
@@ -204,9 +199,4 @@ interface FamilyInterface extends
      * @param AttributeInterface[] $attributes
      */
     public function updateAttributes(array $attributes): void;
-
-    /**
-     * @return string[]
-     */
-    public function releaseEvents(): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
@@ -22,6 +22,11 @@ interface FamilyInterface extends
     TimestampableInterface
 {
     /**
+     * For now the events are a list of strings, but they can be converted to object when needed.
+     */
+    public const ATTRIBUTES_WERE_UPDATED = 'ATTRIBUTES_WERE_UPDATED';
+
+    /**
      * Get id
      *
      * @return int
@@ -194,4 +199,14 @@ interface FamilyInterface extends
      * @param Collection $familyVariants
      */
     public function setFamilyVariants(Collection $familyVariants): void;
+
+    /**
+     * @param AttributeInterface[] $attributes
+     */
+    public function updateAttributes(array $attributes): void;
+
+    /**
+     * @return string[]
+     */
+    public function releaseEvents(): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
@@ -15,8 +15,8 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * For now the events are a list of strings, but they can be converted to object when needed.
      */
-    public const AXES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
-    public const ATTRIBUTES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
+    public const AXES_WERE_UPDATED_ON_LEVEL = 'AXES_WERE_UPDATED_ON_LEVEL';
+    public const ATTRIBUTES_WERE_UPDATED_ON_LEVEL = 'ATTRIBUTES_WERE_UPDATED_ON_LEVEL';
 
     /**
      * @return null|int

--- a/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
@@ -336,27 +336,10 @@ class FamilyUpdater implements ObjectUpdaterInterface
      */
     protected function addAttributes(FamilyInterface $family, array $data)
     {
-        $currentAttributeCodes = [];
-        $wantedAttributeCodes = array_values($data);
-
-        foreach ($family->getAttributes() as $attribute) {
-            $currentAttributeCodes[] = $attribute->getCode();
-        }
-
-        $attributeCodesToRemove = array_diff($currentAttributeCodes, $wantedAttributeCodes);
-        $attributeCodesToAdd = array_diff($wantedAttributeCodes, $currentAttributeCodes);
-
-        foreach ($family->getAttributes() as $attribute) {
-            if (in_array($attribute->getCode(), $attributeCodesToRemove)) {
-                if (AttributeTypes::IDENTIFIER !== $attribute->getType()) {
-                    $family->removeAttribute($attribute);
-                }
-            }
-        }
-
-        foreach ($attributeCodesToAdd as $attributeCode) {
+        $newAttributes = [];
+        foreach ($data as $attributeCode) {
             if (null !== $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode)) {
-                $family->addAttribute($attribute);
+                $newAttributes[] = $attribute;
             } else {
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'attributes',
@@ -367,6 +350,8 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 );
             }
         }
+
+        $family->updateAttributes($newAttributes);
     }
 
     /**

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -4,11 +4,14 @@ namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber;
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
+use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariant;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -57,20 +60,12 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
-        $familyVariantsIterator->valid()->willReturn(true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants2 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2]));
 
         $validator->validate($familyVariants1)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
@@ -79,7 +74,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -92,23 +87,14 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        FamilyVariantInterface $familyVariants3
     ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
-        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
-
-        $familyVariants1->getCode()->willReturn('family_variant_1');
-        $familyVariants2->getCode()->willReturn('family_variant_2');
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants1->setCode('family_variant_1');
+        $familyVariants2 = new FamilyVariant();
+        $familyVariants2->setCode('family_variant_2');
+        $familyVariants3 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2, $familyVariants3]));
 
         $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
         $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
@@ -123,7 +109,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants3],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -249,23 +235,16 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         ValidatorInterface $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        ConstraintViolationList $constraintViolationList
+        ConstraintViolationList $constraintViolationList,
     ) {
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants2 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2]));
+
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(true);
-
-        $family->getFamilyVariants()->willReturn($familyVariants);
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
-        $familyVariantsIterator->valid()->willReturn(true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
 
         $validator->validate($familyVariants1)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
@@ -273,7 +252,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => false]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $this->onUnitarySave($event);

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -3,15 +3,14 @@
 namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber;
-use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
-use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
-use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
-use Akeneo\Tool\Component\StorageUtils\StorageEvents;
-use Doctrine\Common\Collections\Collection;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -65,7 +64,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -101,7 +99,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         FamilyVariantInterface $familyVariants3
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -163,7 +160,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -199,7 +195,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         FamilyVariantInterface $familyVariants3
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -264,8 +259,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(true);
-
-        $family->releaseEvents()->willReturn([]);
 
         $family->getFamilyVariants()->willReturn($familyVariants);
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Structure\Component\Model;
 
+use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
@@ -56,5 +57,44 @@ class FamilySpec extends ObjectBehavior
         $name->getCode()->willReturn('pim_catalog_text');
         $this->getAttributeAsLabel()->shouldReturn(null);
         $this->setAttributeAsLabel($name)->shouldReturn($this);
+    }
+
+    function it_updates_a_family_by_adding_an_attribute(
+        AttributeInterface $skuAttribute,
+        AttributeInterface $nameAttribute,
+        AttributeInterface $descAttribute,
+    ) {
+        $skuAttribute->getCode()->willReturn('sku');
+        $nameAttribute->getCode()->willReturn('name');
+        $descAttribute->getCode()->willReturn('description');
+        $descAttribute->getType()->willReturn(AttributeTypes::TEXTAREA);
+
+        $this->addAttribute($skuAttribute);
+        $this->addAttribute($nameAttribute);
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name']);
+
+        $this->updateAttributes([$skuAttribute, $nameAttribute, $descAttribute]);
+
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name', 'description']);
+    }
+
+    function it_updates_a_family_by_removing_an_attribute(
+        AttributeInterface $skuAttribute,
+        AttributeInterface $nameAttribute,
+        AttributeInterface $descAttribute,
+    ) {
+        $skuAttribute->getCode()->willReturn('sku');
+        $nameAttribute->getCode()->willReturn('name');
+        $descAttribute->getCode()->willReturn('description');
+        $descAttribute->getType()->willReturn(AttributeTypes::TEXTAREA);
+
+        $this->addAttribute($skuAttribute);
+        $this->addAttribute($nameAttribute);
+        $this->addAttribute($descAttribute);
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name', 'description']);
+
+        $this->updateAttributes([$skuAttribute, $nameAttribute]);
+
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name']);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
@@ -2,26 +2,26 @@
 
 namespace Specification\Akeneo\Pim\Structure\Component\Updater;
 
+use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
 use Akeneo\Channel\Infrastructure\Component\Model\Locale;
+use Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Factory\AttributeRequirementFactory;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeRequirementInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
+use Akeneo\Pim\Structure\Component\Repository\AttributeRequirementRepositoryInterface;
+use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
 use Akeneo\Pim\Structure\Component\Updater\FamilyUpdater;
-use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
-use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\Tool\Component\Localization\TranslatableUpdater;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\AttributeTypes;
-use Akeneo\Pim\Structure\Component\Factory\AttributeRequirementFactory;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Structure\Component\Model\AttributeRequirementInterface;
-use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
-use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
-use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
-use Akeneo\Pim\Structure\Component\Repository\AttributeRequirementRepositoryInterface;
-use Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface;
-use Akeneo\Pim\Structure\Component\Repository\FamilyRepositoryInterface;
 use Prophecy\Argument;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
@@ -135,6 +135,8 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
         $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
 
+        $family->updateAttributes([$skuAttribute, $nameAttribute, $descAttribute, $pictureAttribute]);
+
         $channelRepository->findOneByIdentifier('mobile')->willReturn($mobileChannel);
         $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
 
@@ -178,6 +180,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
     }
 
     function it_updates_a_family_without_changing_attributes_when_they_are_the_same(
+        AttributeRepositoryInterface $attributeRepository,
         FamilyInterface $family,
         AttributeInterface $skuAttribute,
         AttributeInterface $nameAttribute,
@@ -193,13 +196,17 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $nameAttribute->getCode()->willReturn('name');
         $descAttribute->getCode()->willReturn('description');
 
-        $family->removeAttribute(Argument::any())->shouldNotBeCalled();
-        $family->addAttribute(Argument::any())->shouldNotBeCalled();
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
+        $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
+        $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
+
+        $family->updateAttributes([$skuAttribute, $nameAttribute, $descAttribute])->shouldBeCalled();
 
         $this->update($family, $values, []);
     }
 
     function it_updates_a_family_by_removing_an_attribute(
+        AttributeRepositoryInterface $attributeRepository,
         FamilyInterface $family,
         AttributeInterface $skuAttribute,
         AttributeInterface $nameAttribute,
@@ -216,32 +223,11 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $descAttribute->getCode()->willReturn('description');
         $descAttribute->getType()->willReturn(AttributeTypes::TEXTAREA);
 
-        $family->removeAttribute($descAttribute)->shouldBeCalled();
-        $family->addAttribute(Argument::any())->shouldNotBeCalled();
-
-        $this->update($family, $values, []);
-    }
-
-    function it_updates_a_family_by_adding_an_attribute(
-        FamilyInterface $family,
-        AttributeInterface $skuAttribute,
-        AttributeInterface $nameAttribute,
-        AttributeInterface $descAttribute,
-        AttributeRepositoryInterface $attributeRepository
-    ) {
-        $values = [
-            'attributes' => ['sku', 'name', 'description']
-        ];
-
-        $family->getAttributes()->willReturn([$skuAttribute, $nameAttribute]);
-
-        $skuAttribute->getCode()->willReturn('sku');
-        $nameAttribute->getCode()->willReturn('name');
-
-        $family->removeAttribute(Argument::any())->shouldNotBeCalled();
-        $family->addAttribute($descAttribute)->shouldBeCalled();
-
+        $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
+        $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
         $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
+
+        $family->updateAttributes([$skuAttribute, $nameAttribute])->shouldBeCalled();
 
         $this->update($family, $values, []);
     }
@@ -419,7 +405,6 @@ class FamilyUpdaterSpec extends ObjectBehavior
 
         $family->setCode('mycode')->shouldBeCalled();
         $family->getAttributes()->willReturn([$priceAttribute]);
-        $family->removeAttribute($priceAttribute)->shouldBeCalled();
 
         $attributeRepository->findOneByIdentifier('sku')->willReturn(null);
 

--- a/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
@@ -29,14 +29,12 @@ Feature: Remove attribute from a family
     And I save the family
     Then I should not see the text "There are unsaved changes."
     And I should see the flash message "Attribute successfully removed from the family"
-    And I wait for the "compute_family_variant_structure_changes" job to finish
+    And I wait for the "compute_completeness_of_products_family" job to finish
     And I am on the "model-braided-hat" product model page
     Then I should see the text "Supplier"
     But I should not see the text "Material"
     And I am on the "braided-hat-m" product page
-    Then I should not see the Material field
-    And 0 event of type "product.updated" should have been raised
-    And 1 event of type "product_model.updated" should have been raised
+    Then I should not see the text "Material"
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
     Given I am on the "shoes" family page


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Disable `compute_family_variant_structure_changes` launch on simple and bulk family save subscriber because it is already done in the `ComputeCompletenessOfProductsFamilyTasklet` with the `saveAll` function.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
