### PR TITLE
fix(MW-383): Code challenge validation: Send json encoded body instead of querystring

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/WebMarketplaceApi.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/WebMarketplaceApi.php
@@ -96,7 +96,7 @@ class WebMarketplaceApi implements WebMarketplaceApiInterface
     {
         try {
             $response = $this->client->request('POST', \sprintf('/api/1.0/app/%s/challenge', $appId), [
-                'query' => [
+                'json' => [
                     'code_identifier' => $codeIdentifier,
                     'code_challenge' => $codeChallenge,
                 ],

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/WebMarketplaceApiSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/WebMarketplaceApiSpec.php
@@ -106,7 +106,7 @@ class WebMarketplaceApiSpec extends ObjectBehavior
         $codeChallenge = 'JN2eVHPP4F';
 
         $client->request('POST', '/api/1.0/app/90741597-54c5-48a1-98da-a68e7ee0a715/challenge', [
-            'query' => [
+            'json' => [
                 'code_identifier' => $codeIdentifier,
                 'code_challenge' => $codeChallenge,
             ],
@@ -128,7 +128,7 @@ class WebMarketplaceApiSpec extends ObjectBehavior
         $codeChallenge = 'JN2eVHPP4F';
 
         $client->request('POST', '/api/1.0/app/90741597-54c5-48a1-98da-a68e7ee0a715/challenge', [
-            'query' => [
+            'json' => [
                 'code_identifier' => $codeIdentifier,
                 'code_challenge' => $codeChallenge,
             ],
@@ -150,7 +150,7 @@ class WebMarketplaceApiSpec extends ObjectBehavior
         $codeChallenge = 'JN2eVHPP4F';
 
         $client->request('POST', '/api/1.0/app/90741597-54c5-48a1-98da-a68e7ee0a715/challenge', [
-            'query' => [
+            'json' => [
                 'code_identifier' => $codeIdentifier,
                 'code_challenge' => $codeChallenge,
             ],


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/MW-383

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
