### PR TITLE
PIM-10491: add gridName in column-selector configuration

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -148,6 +148,7 @@ extensions:
         position: 10
         config:
             route: pim_datagrid_productgrid_available_columns
+            gridName: product-grid
 
     pim-product-index-display-selector:
         module: pim/datagrid/display-selector

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/column-selector.ts
@@ -88,7 +88,7 @@ class ColumnSelector extends BaseView {
   getLocale(): string {
     const url = (<string>this.datagridCollection.url).split('?')[1];
     const urlParams = this.datagridCollection.decodeStateData(url);
-    const datagridParams = urlParams['product-grid'] || {};
+    const datagridParams = urlParams[this.config.gridName] || {};
 
     return urlParams['dataLocale'] || datagridParams['dataLocale'];
   }
@@ -476,7 +476,7 @@ class ColumnSelector extends BaseView {
       return;
     }
 
-    DatagridState.set('product-grid', 'columns', selected);
+    DatagridState.set(this.config.gridName, 'columns', selected);
     this.modal.close();
 
     var url = window.location.hash;


### PR DESCRIPTION
Allow using column-selector for different grids

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
