### PR TITLE
CPM-674: Add uuid on webhook messages

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/EventNormalizer/ProductEventNormalizer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/EventNormalizer/ProductEventNormalizer.php
@@ -32,7 +32,8 @@ final class ProductEventNormalizer implements EventNormalizerInterface
         $normalizer = new EventNormalizer();
 
         return $normalizer->normalize($event) + [
-            'product_identifier' => $event->getIdentifier()
+            'product_identifier' => $event->getIdentifier(),
+            'product_uuid' => $event->getProductUuid()->toString(),
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\Connection as DbalConnection;
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -103,13 +104,19 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
             [
                 new ProductCreated(
                     $this->referenceAuthor,
-                    ['identifier' => $this->tshirtProduct->getIdentifier()],
+                    [
+                        'identifier' => $this->tshirtProduct->getIdentifier(),
+                        'uuid' => $this->tshirtProduct->getUuid(),
+                    ],
                     1607094167,
                     '0d931d13-8eae-4f4a-bf37-33d3a932b8c9'
                 ),
                 new ProductCreated(
                     $this->referenceAuthor,
-                    ['identifier' => $this->pantProduct->getIdentifier()],
+                    [
+                        'identifier' => $this->pantProduct->getIdentifier(),
+                        'uuid' => $this->pantProduct->getUuid(),
+                    ],
                     1607094167,
                     '0d932313-8eae-4f4a-bf37-33d3a932b8c9'
                 ),
@@ -141,7 +148,10 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
             [
                 new ProductUpdated(
                     $this->referenceAuthor,
-                    ['identifier' => $this->tshirtProduct->getIdentifier()],
+                    [
+                        'identifier' => $this->tshirtProduct->getIdentifier(),
+                        'uuid' => Uuid::uuid4(),
+                    ],
                     1607094167,
                     '0d931d13-8eae-4f4a-bf37-33d3a932b8c9'
                 ),
@@ -174,6 +184,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
                     $this->referenceAuthor,
                     [
                         'identifier' => $this->tshirtProduct->getIdentifier(),
+                        'uuid' => Uuid::uuid4(),
                         'category_codes' => $this->tshirtProduct->getCategoryCodes(),
                     ],
                     1607094167,

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
@@ -150,7 +150,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
                     $this->referenceAuthor,
                     [
                         'identifier' => $this->tshirtProduct->getIdentifier(),
-                        'uuid' => Uuid::uuid4(),
+                        'uuid' => $this->tshirtProduct->getUuid(),
                     ],
                     1607094167,
                     '0d931d13-8eae-4f4a-bf37-33d3a932b8c9'
@@ -184,7 +184,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
                     $this->referenceAuthor,
                     [
                         'identifier' => $this->tshirtProduct->getIdentifier(),
-                        'uuid' => Uuid::uuid4(),
+                        'uuid' => $this->tshirtProduct->getUuid(),
                         'category_codes' => $this->tshirtProduct->getCategoryCodes(),
                     ],
                     1607094167,
@@ -278,6 +278,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
             'data' => [
                 'resource' => [
                     'identifier' => $product->getIdentifier(),
+                    'uuid' => $product->getUuid(),
                 ],
             ],
         ];

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
@@ -67,7 +67,10 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
             [
                 new ProductCreated(
                     $this->referenceAuthor,
-                    ['identifier' => $this->referenceProduct->getIdentifier()],
+                    [
+                        'identifier' => $this->referenceProduct->getIdentifier(),
+                        'uuid' => $this->referenceProduct->getUuid(),
+                    ],
                     1607094167,
                     '0d931d13-8eae-4f4a-bf37-33d3a932b8c9'
                 ),

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/EventNormalizer/ProductEventNormalizerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/EventNormalizer/ProductEventNormalizerSpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Platform\Component\EventQueue\Author;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -39,9 +40,13 @@ class ProductEventNormalizerSpec extends ObjectBehavior
 
     public function it_normalizes_a_product_created_event(): void
     {
+        $uuid = Uuid::uuid4();
         $event = new ProductCreated(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'blue_sneakers'],
+            [
+                'identifier' => 'blue_sneakers',
+                'uuid' => $uuid,
+            ],
             0,
             '9979c367-595d-42ad-9070-05f62f31f49b'
         );
@@ -53,14 +58,19 @@ class ProductEventNormalizerSpec extends ObjectBehavior
             'author' => 'julia',
             'author_type' => 'ui',
             'product_identifier' => 'blue_sneakers',
+            'product_uuid' => $uuid->toString()
         ]);
     }
 
     public function it_normalizes_a_product_updated_event(): void
     {
+        $uuid = Uuid::uuid4();
         $event = new ProductUpdated(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'blue_sneakers'],
+            [
+                'identifier' => 'blue_sneakers',
+                'uuid' => $uuid,
+            ],
             0,
             '9979c367-595d-42ad-9070-05f62f31f49b'
         );
@@ -72,14 +82,20 @@ class ProductEventNormalizerSpec extends ObjectBehavior
             'author' => 'julia',
             'author_type' => 'ui',
             'product_identifier' => 'blue_sneakers',
+            'product_uuid' => $uuid->toString(),
         ]);
     }
 
     public function it_normalizes_a_product_removed_event(): void
     {
+        $uuid = Uuid::uuid4();
         $event = new ProductRemoved(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'blue_sneakers', 'category_codes' => []],
+            [
+                'identifier' => 'blue_sneakers',
+                'uuid' => $uuid,
+                'category_codes' => [],
+            ],
             0,
             '9979c367-595d-42ad-9070-05f62f31f49b'
         );
@@ -91,6 +107,7 @@ class ProductEventNormalizerSpec extends ObjectBehavior
             'author' => 'julia',
             'author_type' => 'ui',
             'product_identifier' => 'blue_sneakers',
+            'product_uuid' => $uuid->toString(),
         ]);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriber.php
@@ -72,6 +72,7 @@ final class DispatchProductCreatedAndUpdatedEventSubscriber implements DispatchB
         $author = Author::fromUser($user);
         $data = [
             'identifier' => $product->getIdentifier(),
+            'uuid' => $product->getUuid(),
         ];
 
         if ($postSaveEvent->hasArgument('is_new') && true === $postSaveEvent->getArgument('is_new')) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriber.php
@@ -67,6 +67,7 @@ final class DispatchProductRemovedEventSubscriber implements DispatchBufferedPim
         $author = Author::fromUser($user);
         $data = [
             'identifier' => $product->getIdentifier(),
+            'uuid' => $product->getUuid(),
             'category_codes' => $product->getCategoryCodes(),
         ];
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductCreated.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductCreated.php
@@ -6,7 +6,8 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Message;
 
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\Event;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -21,7 +22,9 @@ class ProductCreated extends Event
     public function __construct(Author $author, array $data, int $timestamp = null, string $uuid = null)
     {
         Assert::keyExists($data, 'identifier');
-        Assert::stringNotEmpty($data['identifier']);
+        Assert::nullOrString($data['identifier']);
+        Assert::keyExists($data, 'uuid');
+        Assert::true(Uuid::isValid($data['uuid']));
 
         parent::__construct($author, $data, $timestamp, $uuid);
     }
@@ -31,8 +34,13 @@ class ProductCreated extends Event
         return 'product.created';
     }
 
-    public function getIdentifier(): string
+    public function getIdentifier(): ?string
     {
         return $this->data['identifier'];
+    }
+
+    public function getProductUuid(): UuidInterface
+    {
+        return $this->data['uuid'];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductRemoved.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductRemoved.php
@@ -6,6 +6,8 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Message;
 
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\Event;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -20,7 +22,9 @@ class ProductRemoved extends Event
     public function __construct(Author $author, array $data, int $timestamp = null, string $uuid = null)
     {
         Assert::keyExists($data, 'identifier');
-        Assert::stringNotEmpty($data['identifier']);
+        Assert::nullOrString($data['identifier']);
+        Assert::keyExists($data, 'uuid');
+        Assert::true(Uuid::isValid($data['uuid']));
 
         Assert::keyExists($data, 'category_codes');
         Assert::allStringNotEmpty($data['category_codes']);
@@ -33,7 +37,7 @@ class ProductRemoved extends Event
         return 'product.removed';
     }
 
-    public function getIdentifier(): string
+    public function getIdentifier(): ?string
     {
         return $this->data['identifier'];
     }
@@ -44,5 +48,10 @@ class ProductRemoved extends Event
     public function getCategoryCodes(): array
     {
         return $this->data['category_codes'];
+    }
+
+    public function getProductUuid(): UuidInterface
+    {
+        return $this->data['uuid'];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductUpdated.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Message/ProductUpdated.php
@@ -6,6 +6,8 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Message;
 
 use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\Event;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -20,7 +22,9 @@ class ProductUpdated extends Event
     public function __construct(Author $author, array $data, int $timestamp = null, string $uuid = null)
     {
         Assert::keyExists($data, 'identifier');
-        Assert::stringNotEmpty($data['identifier']);
+        Assert::nullOrString($data['identifier']);
+        Assert::keyExists($data, 'uuid');
+        Assert::true(Uuid::isValid($data['uuid']));
 
         parent::__construct($author, $data, $timestamp, $uuid);
     }
@@ -30,8 +34,13 @@ class ProductUpdated extends Event
         return 'product.updated';
     }
 
-    public function getIdentifier(): string
+    public function getIdentifier(): ?string
     {
         return $this->data['identifier'];
+    }
+
+    public function getProductUuid(): UuidInterface
+    {
+        return $this->data['uuid'];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/Exception/ProductNotFoundException.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/Exception/ProductNotFoundException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception;
 
 use Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -12,8 +13,8 @@ use Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface;
  */
 class ProductNotFoundException extends \RuntimeException implements EventBuildingExceptionInterface
 {
-    public function __construct(string $identifier)
+    public function __construct(UuidInterface $uuid)
     {
-        parent::__construct(sprintf('Product "%s" not found', $identifier));
+        parent::__construct(sprintf('Product "%s" not found', $uuid->toString()));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Webhook;
 
-use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductNormalizer;
@@ -50,6 +49,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
 
     public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
+        // TODO Change this once GetConnectorProduct is done by Uuids
         $products = $this->getConnectorProducts(
             $this->getProductIdentifiers($bulkEvent->getEvents()),
             $context->getUserId()
@@ -59,10 +59,10 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
 
         /** @var ProductCreated|ProductUpdated $event */
         foreach ($bulkEvent->getEvents() as $event) {
-            $product = $products[$event->getIdentifier()] ?? null;
+            $product = $products[$event->getProductUuid()->toString()] ?? null;
 
             if (null === $product) {
-                $collection->setEventDataError($event, new ProductNotFoundException($event->getIdentifier()));
+                $collection->setEventDataError($event, new ProductNotFoundException($event->getProductUuid()));
 
                 continue;
             }
@@ -104,7 +104,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
 
         $products = array_fill_keys($identifiers, null);
         foreach ($result as $product) {
-            $products[$product->identifier()] = $product;
+            $products[$product->uuid()->toString()] = $product;
         }
 
         return $products;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Webhook;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductNormalizer;
@@ -49,7 +50,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
 
     public function build(BulkEventInterface $bulkEvent, Context $context): EventDataCollection
     {
-        // TODO Change this once GetConnectorProduct is done by Uuids
+        // TODO CPM-676 Change this once GetConnectorProduct is done by Uuids
         $products = $this->getConnectorProducts(
             $this->getProductIdentifiers($bulkEvent->getEvents()),
             $context->getUserId()
@@ -94,7 +95,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
     /**
      * @param string[] $identifiers
      *
-     * @return array<string, (ConnectorProduct|null)>
+     * @return array<string, ConnectorProduct>
      */
     private function getConnectorProducts(array $identifiers, int $userId): array
     {
@@ -102,7 +103,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
             ->fromProductIdentifiers($identifiers, $userId, null, null, null)
             ->connectorProducts();
 
-        $products = array_fill_keys($identifiers, null);
+        $products = [];
         foreach ($result as $product) {
             $products[$product->uuid()->toString()] = $product;
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductRemovedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductRemovedEventDataBuilder.php
@@ -39,7 +39,8 @@ class ProductRemovedEventDataBuilder implements EventDataBuilderInterface
         foreach ($bulkEvent->getEvents() as $event) {
             $data = [
                 'resource' => [
-                    'identifier' => $event->getIdentifier()
+                    'identifier' => $event->getIdentifier(),
+                    'uuid' => $event->getProductUuid(),
                 ],
             ];
             $collection->setEventData($event, $data);

--- a/src/Akeneo/Platform/Component/EventQueue/EventNormalizer.php
+++ b/src/Akeneo/Platform/Component/EventQueue/EventNormalizer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Component\EventQueue;
 
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -54,11 +55,15 @@ class EventNormalizer implements NormalizerInterface, DenormalizerInterface
             throw new RuntimeException(sprintf('The class "%s" is not defined.', $type));
         }
 
+        $eventData = $data['data'];
+        if (array_key_exists('uuid', $eventData)) {
+            $eventData = array_merge($eventData, ['uuid' => Uuid::fromString($eventData['uuid'])]);
+        }
         // /!\ Do not change to a new format for event without a strategy to
         // support the previous/old format of the events already in the queue (before the migration).
         return new $type(
             Author::fromNameAndType($data['author'], $data['author_type'] ?? Author::TYPE_API),
-            $data['data'],
+            $eventData,
             $data['timestamp'],
             $data['uuid']
         );

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductCreatedAndUpdatedEventSubscriberSpec.php
@@ -72,7 +72,10 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $event = $events[0];
         Assert::assertInstanceOf(ProductCreated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier',
+            'uuid' => $product->getUuid(),
+        ], $event->getData());
     }
 
     function it_dispatches_a_single_product_updated_event($security)
@@ -100,7 +103,10 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $event = $events[0];
         Assert::assertInstanceOf(ProductUpdated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier',
+            'uuid' => $product->getUuid(),
+        ], $event->getData());
     }
 
     function it_dispatches_multiple_product_events_in_bulk($security)
@@ -132,12 +138,18 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $event = $events[0];
         Assert::assertInstanceOf(ProductCreated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier_1'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier_1',
+            'uuid' => $product1->getUuid(),
+        ], $event->getData());
 
         $event = $events[1];
         Assert::assertInstanceOf(ProductUpdated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier_2'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier_2',
+            'uuid' => $product2->getUuid(),
+        ], $event->getData());
     }
 
     function it_dispatches_a_batch_of_product_events_once_the_max_bulk_size_is_reached($security)
@@ -172,12 +184,18 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $event = $events[0];
         Assert::assertInstanceOf(ProductCreated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier_1'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier_1',
+            'uuid' => $product1->getUuid(),
+        ], $event->getData());
 
         $event = $events[1];
         Assert::assertInstanceOf(ProductUpdated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier_2'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier_2',
+            'uuid' => $product2->getUuid(),
+        ], $event->getData());
 
         /** @var EventInterface[] */
         $events = $messageBus->messages[1]->getEvents();
@@ -186,7 +204,10 @@ class DispatchProductCreatedAndUpdatedEventSubscriberSpec extends ObjectBehavior
         $event = $events[0];
         Assert::assertInstanceOf(ProductCreated::class, $event);
         Assert::assertEquals(Author::fromUser($user), $event->getAuthor());
-        Assert::assertEquals(['identifier' => 'product_identifier_3'], $event->getData());
+        Assert::assertEquals([
+            'identifier' => 'product_identifier_3',
+            'uuid' => $product3->getUuid(),
+        ], $event->getData());
     }
 
     function it_only_supports_product_event($security)

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/BusinessEvent/DispatchProductRemovedEventSubscriberSpec.php
@@ -76,7 +76,8 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         Assert::assertEquals(
             [
                 'identifier' => 'blue_jean',
-                'category_codes' => []
+                'uuid' => $product->getUuid(),
+                'category_codes' => [],
             ],
             $event->getData()
         );
@@ -114,7 +115,8 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         Assert::assertEquals(
             [
                 'identifier' => 'product_identifier_1',
-                'category_codes' => []
+                'uuid' => $product1->getUuid(),
+                'category_codes' => [],
             ],
             $event->getData()
         );
@@ -125,7 +127,8 @@ class DispatchProductRemovedEventSubscriberSpec extends ObjectBehavior
         Assert::assertEquals(
             [
                 'identifier' => 'product_identifier_2',
-                'category_codes' => []
+                'uuid' => $product2->getUuid(),
+                'category_codes' => [],
             ],
             $event->getData()
         );

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductCreatedSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductCreatedSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Platform\Component\EventQueue\Event;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -19,7 +20,10 @@ class ProductCreatedSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'product_identifier'],
+            [
+                'identifier' => 'product_identifier',
+                'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'),
+            ],
             1598968800,
             '523e4557-e89b-12d3-a456-426614174000',
         );
@@ -49,6 +53,22 @@ class ProductCreatedSpec extends ObjectBehavior
         )->duringInstantiation();
     }
 
+    public function it_validates_the_product_uuid(): void
+    {
+        $this->beConstructedWith(
+            Author::fromNameAndType('julia', Author::TYPE_UI),
+            [
+                'identifier' => 'product_identifier'
+            ],
+            1598968800,
+            '523e4557-e89b-12d3-a456-426614174000',
+        );
+
+        $this->shouldThrow(
+            new \InvalidArgumentException('Expected the key "uuid" to exist.'),
+        )->duringInstantiation();
+    }
+
     public function it_returns_the_name(): void
     {
         $this->getName()->shouldReturn('product.created');
@@ -61,7 +81,10 @@ class ProductCreatedSpec extends ObjectBehavior
 
     public function it_returns_the_data(): void
     {
-        $this->getData()->shouldReturn(['identifier' => 'product_identifier']);
+        $this->getData()->shouldBeLike([
+            'identifier' => 'product_identifier',
+            'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'),
+        ]);
     }
 
     public function it_returns_the_timestamp(): void
@@ -72,6 +95,11 @@ class ProductCreatedSpec extends ObjectBehavior
     public function it_returns_the_uuid(): void
     {
         $this->getUuid()->shouldReturn('523e4557-e89b-12d3-a456-426614174000');
+    }
+
+    public function it_returns_the_product_uuid(): void
+    {
+        $this->getProductUuid()->shouldBeLike(Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'));
     }
 
     public function it_returns_the_product_identifier(): void

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductRemovedSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductRemovedSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductRemoved;
 use Akeneo\Platform\Component\EventQueue\Event;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -19,7 +20,11 @@ class ProductRemovedSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'product_identifier', 'category_codes' => ['category_code_1', 'category_code_2']],
+            [
+                'identifier' => 'product_identifier',
+                'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'),
+                'category_codes' => ['category_code_1', 'category_code_2'],
+            ],
             1598968800,
             '523e4557-e89b-12d3-a456-426614174000',
         );
@@ -49,11 +54,31 @@ class ProductRemovedSpec extends ObjectBehavior
         )->duringInstantiation();
     }
 
+    public function it_validates_the_product_uuid(): void
+    {
+        $this->beConstructedWith(
+            Author::fromNameAndType('julia', Author::TYPE_UI),
+            [
+                'identifier' => 'product_identifier',
+                'category_codes' => ['category_code_1', 'category_code_2'],
+            ],
+            1598968800,
+            '523e4557-e89b-12d3-a456-426614174000',
+        );
+
+        $this->shouldThrow(
+            new \InvalidArgumentException('Expected the key "uuid" to exist.'),
+        )->duringInstantiation();
+    }
+
     public function it_validates_the_category_codes(): void
     {
         $this->beConstructedWith(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'product_identifier'],
+            [
+                'identifier' => 'product_identifier',
+                'uuid' => Uuid::uuid4(),
+            ],
             1598968800,
             '523e4557-e89b-12d3-a456-426614174000',
         );
@@ -75,8 +100,9 @@ class ProductRemovedSpec extends ObjectBehavior
 
     public function it_returns_the_data(): void
     {
-        $this->getData()->shouldReturn([
+        $this->getData()->shouldBeLike([
             'identifier' => 'product_identifier',
+            'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'),
             'category_codes' => ['category_code_1', 'category_code_2'],
         ]);
     }
@@ -89,6 +115,11 @@ class ProductRemovedSpec extends ObjectBehavior
     public function it_returns_the_uuid(): void
     {
         $this->getUuid()->shouldReturn('523e4557-e89b-12d3-a456-426614174000');
+    }
+
+    public function it_returns_the_product_uuid(): void
+    {
+        $this->getProductUuid()->shouldBeLike(Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'));
     }
 
     public function it_returns_the_product_identifier(): void

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductUpdatedSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Message/ProductUpdatedSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Platform\Component\EventQueue\Event;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -19,7 +20,10 @@ class ProductUpdatedSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             Author::fromNameAndType('julia', Author::TYPE_UI),
-            ['identifier' => 'product_identifier'],
+            [
+                'identifier' => 'product_identifier',
+                'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'),
+            ],
             1598968800,
             '523e4557-e89b-12d3-a456-426614174000',
         );
@@ -49,6 +53,22 @@ class ProductUpdatedSpec extends ObjectBehavior
         )->duringInstantiation();
     }
 
+    public function it_validates_the_product_uuid(): void
+    {
+        $this->beConstructedWith(
+            Author::fromNameAndType('julia', Author::TYPE_UI),
+            [
+                'identifier' => 'product_identifier'
+            ],
+            1598968800,
+            '523e4557-e89b-12d3-a456-426614174000',
+        );
+
+        $this->shouldThrow(
+            new \InvalidArgumentException('Expected the key "uuid" to exist.'),
+        )->duringInstantiation();
+    }
+
     public function it_returns_the_name(): void
     {
         $this->getName()->shouldReturn('product.updated');
@@ -61,7 +81,10 @@ class ProductUpdatedSpec extends ObjectBehavior
 
     public function it_returns_the_data(): void
     {
-        $this->getData()->shouldReturn(['identifier' => 'product_identifier']);
+        $this->getData()->shouldBeLike([
+            'identifier' => 'product_identifier',
+            'uuid' => Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d')
+        ]);
     }
 
     public function it_returns_the_timestamp(): void
@@ -72,6 +95,11 @@ class ProductUpdatedSpec extends ObjectBehavior
     public function it_returns_the_uuid(): void
     {
         $this->getUuid()->shouldReturn('523e4557-e89b-12d3-a456-426614174000');
+    }
+
+    public function it_returns_the_product_uuid(): void
+    {
+        $this->getProductUuid()->shouldBeLike(Uuid::fromString('5dd9eb8b-261f-4e76-bf1d-f407063f931d'));
     }
 
     public function it_returns_the_product_identifier(): void

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/Exception/ProductNotFoundExceptionSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/Exception/ProductNotFoundExceptionSpec.php
@@ -6,6 +6,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Webhook\Exceptio
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductNotFoundException;
 use Akeneo\Platform\Component\Webhook\EventBuildingExceptionInterface;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author    Thomas Galvaing <thomas.galvaing@akeneo.com>
@@ -16,7 +17,7 @@ class ProductNotFoundExceptionSpec extends ObjectBehavior
 {
     function let()
     {
-        $this->beConstructedWith("identifier");
+        $this->beConstructedWith(Uuid::fromString('f496b00a-7d44-4fb0-9e0b-a77b7fdea342'));
     }
 
     function it_is_initializable()
@@ -36,6 +37,6 @@ class ProductNotFoundExceptionSpec extends ObjectBehavior
 
     function it_returns_a_message()
     {
-        $this->getMessage()->shouldReturn('Product "identifier" not found');
+        $this->getMessage()->shouldReturn('Product "f496b00a-7d44-4fb0-9e0b-a77b7fdea342" not found');
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
@@ -54,8 +54,14 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_supports_a_bulk_event_of_product_created_and_updated_events(): void
     {
         $bulkEvent = new BulkEvent([
-            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1']),
-            new ProductUpdated(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '2']),
+            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+            ]),
+            new ProductUpdated(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '2',
+                'uuid' => Uuid::uuid4(),
+            ]),
         ]);
 
         $this->supports($bulkEvent)->shouldReturn(true);
@@ -64,9 +70,13 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     public function it_does_not_support_a_bulk_event_of_unsupported_product_events(): void
     {
         $bulkEvent = new BulkEvent([
-            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1']),
+            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+            ]),
             new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
                 'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
                 'category_codes' => [],
             ]),
         ]);
@@ -79,17 +89,21 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     ): void {
         $context = new Context('ecommerce_0000', 10);
 
+        $blueJeanUuid = Uuid::uuid4();
         $blueJeanEvent = new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',
+            'uuid' => $blueJeanUuid,
         ]);
+        $redJeanUuid = Uuid::uuid4();
         $redJeanEvent = new ProductUpdated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'red_jean',
+            'uuid' => $redJeanUuid,
         ]);
         $bulkEvent = new BulkEvent([$blueJeanEvent, $redJeanEvent]);
 
         $productList = new ConnectorProductList(2, [
-            $this->buildConnectorProduct(Uuid::fromString('54162e35-ff81-48f1-96d5-5febd3f00fd5'), 'blue_jean'),
-            $this->buildConnectorProduct(Uuid::fromString('d9f573cc-8905-4949-8151-baf9d5328f26'), 'red_jean'),
+            $this->buildConnectorProduct($blueJeanUuid, 'blue_jean'),
+            $this->buildConnectorProduct($redJeanUuid, 'red_jean'),
         ]);
 
         $getConnectorProductsQuery
@@ -138,8 +152,9 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
     ): void {
         $context = new Context('ecommerce_0000', 10);
 
+        $blueJeanUuid = Uuid::uuid4();
         $productList = new ConnectorProductList(1, [
-            $this->buildConnectorProduct(Uuid::fromString('54162e35-ff81-48f1-96d5-5febd3f00fd5'), 'blue_jean')
+            $this->buildConnectorProduct($blueJeanUuid, 'blue_jean')
         ]);
 
         $getConnectorProductsQuery
@@ -148,9 +163,12 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
 
         $blueJeanEvent = new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',
+            'uuid' => $blueJeanUuid,
         ]);
+        $redJeanUuid = Uuid::uuid4();
         $redJeanEvent = new ProductUpdated(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'red_jean',
+            'uuid' => $redJeanUuid,
         ]);
         $bulkEvent = new BulkEvent([$blueJeanEvent, $redJeanEvent]);
 
@@ -170,7 +188,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
                 'quantified_associations' => (object) [],
             ],
         ]);
-        $expectedCollection->setEventDataError($redJeanEvent, new ProductNotFoundException('red_jean'));
+        $expectedCollection->setEventDataError($redJeanEvent, new ProductNotFoundException($redJeanUuid));
 
         $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductModelRemovedEventDataBuilderSpec.php
@@ -14,6 +14,7 @@ use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
 {
@@ -42,7 +43,11 @@ class ProductModelRemovedEventDataBuilderSpec extends ObjectBehavior
     {
         $bulkEvent = new BulkEvent([
             new ProductModelRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), ['code' => '1', 'category_codes' => []]),
-            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1', 'category_codes' => []]),
+            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+                'category_codes' => [],
+            ]),
         ]);
 
         $this->supports($bulkEvent)->shouldReturn(false);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductRemovedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductRemovedEventDataBuilderSpec.php
@@ -14,6 +14,7 @@ use Akeneo\Platform\Component\Webhook\EventDataBuilderInterface;
 use Akeneo\Platform\Component\Webhook\EventDataCollection;
 use PhpSpec\ObjectBehavior;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
 {
@@ -31,8 +32,16 @@ class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
     public function it_supports_a_bulk_event_of_product_removed_events(): void
     {
         $bulkEvent = new BulkEvent([
-            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1', 'category_codes' => []]),
-            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '2', 'category_codes' => []]),
+            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+                'category_codes' => [],
+            ]),
+            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '2',
+                'uuid' => Uuid::uuid4(),
+                'category_codes' => [],
+            ]),
         ]);
 
         $this->supports($bulkEvent)->shouldReturn(true);
@@ -41,8 +50,15 @@ class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
     public function it_does_not_support_a_bulk_event_of_unsupported_product_events(): void
     {
         $bulkEvent = new BulkEvent([
-            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1']),
-            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), ['identifier' => '1', 'category_codes' => []]),
+            new ProductCreated(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+            ]),
+            new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
+                'identifier' => '1',
+                'uuid' => Uuid::uuid4(),
+                'category_codes' => [],
+            ]),
         ]);
 
         $this->supports($bulkEvent)->shouldReturn(false);
@@ -52,19 +68,29 @@ class ProductRemovedEventDataBuilderSpec extends ObjectBehavior
     {
         $context = new Context('ecommerce_0000', 10);
 
+        $uuidBlueJean = Uuid::uuid4();
         $blueJeanEvent = new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'blue_jean',
+            'uuid' => $uuidBlueJean,
             'category_codes' => [],
         ]);
+        $uuidRedJean = Uuid::uuid4();
         $redJeanEvent = new ProductRemoved(Author::fromNameAndType('julia', Author::TYPE_UI), [
             'identifier' => 'red_jean',
+            'uuid' => $uuidRedJean,
             'category_codes' => [],
         ]);
         $bulkEvent = new BulkEvent([$blueJeanEvent, $redJeanEvent]);
 
         $expectedCollection = new EventDataCollection();
-        $expectedCollection->setEventData($blueJeanEvent, ['resource' => ['identifier' => 'blue_jean']]);
-        $expectedCollection->setEventData($redJeanEvent, ['resource' => ['identifier' => 'red_jean']]);
+        $expectedCollection->setEventData($blueJeanEvent, ['resource' => [
+            'identifier' => 'blue_jean',
+            'uuid' => $uuidBlueJean
+        ]]);
+        $expectedCollection->setEventData($redJeanEvent, ['resource' => [
+            'identifier' => 'red_jean',
+            'uuid' => $uuidRedJean
+        ]]);
 
         $collection = $this->build($bulkEvent, $context)->getWrappedObject();
 


### PR DESCRIPTION
As identifier will be optional, we need to create webhook messages with uuid instead of identifiers.