### PR TITLE
PIM-10504: Add possibility to launch rule without passing throught queue

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/JobLauncherInterface.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/JobLauncherInterface.php
@@ -19,12 +19,6 @@ interface JobLauncherInterface
 {
     /**
      * Launch a job with command
-     *
-     * @param JobInstance   $jobInstance
-     * @param UserInterface $user
-     * @param array         $configuration
-     *
-     * @return JobExecution
      */
-    public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution;
+    public function launch(JobInstance $jobInstance, ?UserInterface $user, array $configuration = []) : JobExecution;
 }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -83,10 +83,10 @@ class SimpleJobLauncher implements JobLauncherInterface
     /**
      * {@inheritdoc}
      */
-    public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
+    public function launch(JobInstance $jobInstance, ?UserInterface $user, array $configuration = []) : JobExecution
     {
         $emailParameter = '';
-        if (isset($configuration['send_email']) && method_exists($user, 'getEmail')) {
+        if (isset($configuration['send_email']) && $user && method_exists($user, 'getEmail')) {
             $emailParameter = sprintf('--email=%s', escapeshellarg($user->getEmail()));
             unset($configuration['send_email']);
         }
@@ -128,17 +128,9 @@ class SimpleJobLauncher implements JobLauncherInterface
     }
 
     /**
-     * Create a jobExecution
-     *
-     * @param JobInstance   $jobInstance
-     * @param UserInterface $user
-     * @param array         $configuration
-     *
      * @throws \RuntimeException
-     *
-     * @return JobExecution
      */
-    protected function createJobExecution(JobInstance $jobInstance, UserInterface $user, array $configuration) : JobExecution
+    protected function createJobExecution(JobInstance $jobInstance, ?UserInterface $user, array $configuration) : JobExecution
     {
         $job = $this->jobRegistry->get($jobInstance->getJobName());
         $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
@@ -160,7 +152,9 @@ class SimpleJobLauncher implements JobLauncherInterface
         }
 
         $jobExecution = $this->jobRepository->createJobExecution($job, $jobInstance, $jobParameters);
-        $jobExecution->setUser($user->getUsername());
+        if ($user) {
+            $jobExecution->setUser($user->getUsername());
+        }
         $this->jobRepository->updateJobExecution($jobExecution);
 
         $this->dispatchJobExecutionEvent(EventInterface::JOB_EXECUTION_CREATED, $jobExecution);

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SynchronousJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SynchronousJobLauncher.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\Launcher;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Repository\InternalApi\JobExecutionRepository;
+use Akeneo\Tool\Bundle\BatchQueueBundle\Manager\JobExecutionManager;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
+use Akeneo\Tool\Component\Batch\Job\JobRegistry;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class SynchronousJobLauncher implements JobLauncherInterface
+{
+    /**
+     * Interval in seconds before checking if the process is still running.
+     */
+    private const RUNNING_PROCESS_CHECK_INTERVAL = 5;
+
+    public function __construct(
+        private JobExecutionManager $executionManager,
+        private JobRepositoryInterface $jobRepository,
+        private JobExecutionRepository $jobExecutionRepository,
+        private LoggerInterface $logger,
+        private JobRegistry $jobRegistry,
+        private string $projectDir
+    ) {
+    }
+
+    public function launch(JobInstance $jobInstance, ?UserInterface $user, array $configuration = []): JobExecution
+    {
+        $jobExecution = $this->createJobExecution($jobInstance, $user, $configuration);
+        $jobExecutionId = $jobExecution->getId();
+
+        try {
+            $this->executionManager->updateHealthCheck($jobExecutionId);
+            $process = $this->initializeProcess($jobInstance, $jobExecution);
+            $process->start();
+
+            while ($process->isRunning()) {
+                sleep(self::RUNNING_PROCESS_CHECK_INTERVAL);
+                $this->executionManager->updateHealthCheck($jobExecutionId);
+                $this->writeProcessOutput($process);
+            }
+        } catch (\Throwable $e) {
+            $this->logger->error('Job execution failed, an error occurred', [
+                'error_message' => $e->getMessage(),
+                'error_trace' => $e->getTraceAsString()
+            ]);
+        } finally {
+            $exitStatus = $this->executionManager->getExitStatus($jobExecutionId);
+            if ($exitStatus->isRunning()) {
+                $this->executionManager->markAsFailed($jobExecutionId);
+            }
+        }
+
+        $this->logger->info('Job execution is finished', ['job_id' => $jobExecutionId]);
+
+        return $this->jobExecutionRepository->find($jobExecutionId);
+    }
+
+    private function initializeProcess(JobInstance $jobInstance, JobExecution $jobExecution): Process
+    {
+        $pathFinder = new PhpExecutableFinder();
+        $console = sprintf('%s%sbin%sconsole', $this->projectDir, DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR);
+
+        $process = new Process([
+            $pathFinder->find(),
+            $console,
+            'akeneo:batch:job',
+            $jobInstance->getCode(),
+            $jobExecution->getId()
+        ]);
+
+        $process->setTimeout(null);
+
+        return $process;
+    }
+
+    private function writeProcessOutput(Process $process): void
+    {
+        $this->logger->info($process->getIncrementalOutput());
+
+        $errors = $process->getIncrementalErrorOutput();
+        if ($errors) {
+            $this->logger->error($errors);
+        }
+    }
+
+    private function createJobExecution(JobInstance $jobInstance, ?UserInterface $user, array $jobParameters): JobExecution
+    {
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $jobExecution = $this->jobRepository->createJobExecution($job, $jobInstance, new JobParameters($jobParameters));
+        if ($user) {
+            $jobExecution->setUser($user->getUserIdentifier());
+        }
+
+        $this->jobRepository->updateJobExecution($jobExecution);
+
+        return $jobExecution;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -81,6 +81,16 @@ services:
             - '%kernel.environment%'
             - '%kernel.logs_dir%'
 
+    akeneo_batch.launcher.synchronous_job_launcher:
+        class: Akeneo\Tool\Bundle\BatchBundle\Launcher\SynchronousJobLauncher
+        arguments:
+            - '@akeneo_batch_queue.manager.job_execution_manager'
+            - '@akeneo_batch.job_repository'
+            - '@pim_enrich.repository.job_execution'
+            - '@logger'
+            - '@akeneo_batch.job.job_registry'
+            - '%kernel.project_dir%'
+
     akeneo_batch.entity_manager.persisted_connection_entity_manager:
         class: '%akeneo_batch.entity_manager.persisted_connection_entity_manager.class%'
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/Launcher/SynchronousJobLauncherIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/Launcher/SynchronousJobLauncherIntegration.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\BatchBundle\tests\Integration\Launcher;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Tool\Bundle\BatchBundle\Launcher\SynchronousJobLauncher;
+
+class SynchronousJobLauncherIntegration extends TestCase
+{
+    private SynchronousJobLauncher $jobLauncher;
+    private JobInstanceRepository $jobInstanceRepository;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->jobLauncher = $this->get('akeneo_batch.launcher.synchronous_job_launcher');
+        $this->jobInstanceRepository = $this->get('akeneo_batch.job.job_instance_repository');
+    }
+
+    /**
+     * @test
+     */
+    public function it_run_a_job_and_update_health_check_time_in_same_time()
+    {
+        $jobInstance = $this->jobInstanceRepository->findOneByIdentifier('clean_removed_attribute_job');
+
+        $jobExecution = $this->jobLauncher->launch($jobInstance, null, ['attribute_codes' => []]);
+
+        $this->assertEquals('COMPLETED', $jobExecution->getStatus());
+        $this->assertNotNull($jobExecution->getHealthCheckTime());
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
@@ -65,10 +65,10 @@ class QueueJobLauncher implements JobLauncherInterface
     /**
      * {@inheritdoc}
      */
-    public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
+    public function launch(JobInstance $jobInstance, ?UserInterface $user, array $configuration = []) : JobExecution
     {
         $options = ['env' => $this->environment];
-        if (isset($configuration['send_email']) && method_exists($user, 'getEmail')) {
+        if (isset($configuration['send_email']) && $user && method_exists($user, 'getEmail')) {
             $options['email'] = $user->getEmail();
             unset($configuration['send_email']);
         }
@@ -96,7 +96,7 @@ class QueueJobLauncher implements JobLauncherInterface
      *
      * @return JobExecution
      */
-    private function createJobExecution(JobInstance $jobInstance, UserInterface $user, array $configuration) : JobExecution
+    private function createJobExecution(JobInstance $jobInstance, ?UserInterface $user, array $configuration) : JobExecution
     {
         $job = $this->jobRegistry->get($jobInstance->getJobName());
         $configuration = array_merge($jobInstance->getRawParameters(), $configuration);
@@ -118,7 +118,10 @@ class QueueJobLauncher implements JobLauncherInterface
         }
 
         $jobExecution = $this->jobRepository->createJobExecution($job, $jobInstance, $jobParameters);
-        $jobExecution->setUser($user->getUsername());
+        if ($user) {
+            $jobExecution->setUser($user->getUsername());
+        }
+
         $this->jobRepository->updateJobExecution($jobExecution);
 
         $this->batchLogHandler->setSubDirectory($jobExecution->getId());

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/Launcher/AuthenticatedJobLauncher.php
@@ -29,7 +29,7 @@ class AuthenticatedJobLauncher implements JobLauncherInterface
     /**
      * {@inheritdoc}
      */
-    public function launch(JobInstance $jobInstance, UserInterface $user, array $configuration = []) : JobExecution
+    public function launch(JobInstance $jobInstance, ?UserInterface $user, array $configuration = []) : JobExecution
     {
         $configuration['is_user_authenticated'] = true;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- I added a new JobLauncher called SynchronousJobLauncher this launcher will not queue job but instead directly run the job. In order to sure that process killed is managed, the launcher run job in another process and the master process update the health_check_time during the process. 
- I made the user nullable because rule are actually launched without user

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
