### PR TITLE
PIM-10516: Do not run the remove completeness job when there is no need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - PIM-10500: Fix API not returning quantified associations for products when association type code is numeric
 - PIM-10503: Fix Wrong regex on channel deletion
 - PIM-10514: Fix associations normalization for published products
+- PIM-10516: Fix remove completeness job when deactivating and reactivating a locale
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -130,8 +130,6 @@ services:
             - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_catalog.repository.product'
             - '@pim_catalog.repository.channel'
-            - '@pim_catalog.repository.locale'
-            - '@pim_catalog.saver.locale'
             - '@pim_catalog.saver.product'
             - '%pim_job_product_batch_size%'
         public: false


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When removing a locale from a channel, and re-adding it before the remove_completeness_for_channel_and_locale, the job would re-remove it, possibly deactivating the locale if it's not bound to another channel
This PR:
- ensures the job does nothing if the provided locales are still in the channel
- and moreover, ensures the job DOES NOT update the locales, as it's not its role (it's only here to clean product values, recompute completeness and reindex products)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
