### PR TITLE
PIM-10508: Fix attribute creation form when label contains an '&' character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - PIM-10503: Fix Wrong regex on channel deletion
 - PIM-10514: Fix associations normalization for published products
 - PIM-10516: Fix remove completeness job when deactivating and reactivating a locale
+- PIM-10508: Fix attribute creation when label contains an '&' character
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute/create.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute/create.js
@@ -89,7 +89,7 @@ define([
 
       const value = objectParams[paramName] ?? '';
 
-      return decodeURI(value);
+      return decodeURIComponent(value);
     },
 
     /**


### PR DESCRIPTION
Fixes the attribute creation form when the label from the creation modal contains an `&`

```javascript
decodeURI('%26')
'%26'
decodeURIComponent('%26')
'&'
```