### PR TITLE
RAB-873: Migrate existing job instances (JobConfiguration[storage][file_path] and JobConfiguration[filePath])

### DIFF
--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -22,7 +22,6 @@ final class Version_7_0_20220704141138_update_job_instance_parameter_path extend
     public function up(Schema $schema): void
     {
         $jobInstances = $this->getJobInstances();
-        $this->skipIf(empty($jobInstances), 'No job instance to migrate.');
 
         foreach ($jobInstances as $jobInstance) {
             $rawParameters = unserialize($jobInstance['raw_parameters']);

--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -42,7 +42,15 @@ final class Version_7_0_20220704141138_update_job_instance_parameter_path extend
         $sql = <<<SQL
 SELECT id, raw_parameters
 FROM akeneo_batch_job_instance
-WHERE connector IN ('Akeneo CSV Connector', 'Akeneo XLSX Connector', 'Akeneo Rule Engine Connector', 'Akeneo Tailored Export', 'Akeneo Tailored Import')
+WHERE connector IN (
+    'Akeneo CSV Connector', 
+    'Akeneo XLSX Connector', 
+    'Akeneo Rule Engine Connector', 
+    'Akeneo Tailored Export', 
+    'Akeneo Tailored Import', 
+    'Akeneo Onboarder CSV Connector', 
+    'Akeneo Onboarder XLSX Connector'
+)
 AND type IN ('import', 'export')
 SQL;
 

--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
@@ -60,7 +58,7 @@ SQL;
             return $rawParameters;
         }
 
-        $rawParameters['storage']['type'] = $this->isSaaSVersion() ? NoneStorage::TYPE : LocalStorage::TYPE;
+        $rawParameters['storage']['type'] = $this->isSaaSVersion() ? 'none' : 'local';
         $rawParameters['storage']['file_path'] = $rawParameters['filePath'];
 
         unset($rawParameters['filePath']);

--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -12,11 +12,6 @@ use Doctrine\Migrations\AbstractMigration;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * TODO
- *
- *
- */
 final class Version_7_0_20220704141138_update_job_instance_parameter_path extends AbstractMigration implements ContainerAwareInterface
 {
     private ?ContainerInterface $container;

--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * TODO
+ *
+ *
+ */
+final class Version_7_0_20220704141138_update_job_instance_parameter_path extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $jobInstances = $this->getJobInstances();
+        $this->skipIf(empty($jobInstances), 'No job instance to migrate.');
+
+        foreach ($jobInstances as $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            $migratedRawParameters = $this->migrateRawParameters($rawParameters);
+
+            $this->updateJobInstance($jobInstance['id'], serialize($migratedRawParameters));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function getJobInstances(): array
+    {
+        $connection = $this->container->get('database_connection');
+        $sql = <<<SQL
+SELECT id, raw_parameters
+FROM akeneo_batch_job_instance
+WHERE connector IN ('Akeneo CSV Connector', 'Akeneo XLSX Connector', 'Akeneo Rule Engine Connector')
+AND type IN ('import', 'export')
+SQL;
+
+        $stmt = $connection->executeQuery($sql);
+
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    private function migrateRawParameters(array $rawParameters): array
+    {
+        if (!array_key_exists('filePath', $rawParameters)) {
+            return $rawParameters;
+        }
+
+        $rawParameters['storage']['type'] = $this->isSaaSVersion() ? NoneStorage::TYPE : LocalStorage::TYPE;
+        $rawParameters['storage']['file_path'] = $rawParameters['filePath'];
+
+        unset($rawParameters['filePath']);
+
+        return $rawParameters;
+    }
+
+    private function updateJobInstance(string $jobInstanceId, string $serializedRawParameters)
+    {
+        $sql = <<<SQL
+UPDATE akeneo_batch_job_instance
+SET raw_parameters = :raw_parameters
+WHERE id = :job_instance_id
+SQL;
+
+        $this->addSql($sql, ['job_instance_id' => $jobInstanceId, 'raw_parameters' => $serializedRawParameters]);
+    }
+
+    private function isSaaSVersion(): bool
+    {
+        /** @var VersionProviderInterface $versionProvider */
+        $versionProvider = $this->container->get('pim_catalog.version_provider');
+
+        return $versionProvider->isSaaSVersion();
+    }
+}

--- a/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
+++ b/upgrades/schema/Version_7_0_20220704141138_update_job_instance_parameter_path.php
@@ -45,7 +45,7 @@ final class Version_7_0_20220704141138_update_job_instance_parameter_path extend
         $sql = <<<SQL
 SELECT id, raw_parameters
 FROM akeneo_batch_job_instance
-WHERE connector IN ('Akeneo CSV Connector', 'Akeneo XLSX Connector', 'Akeneo Rule Engine Connector')
+WHERE connector IN ('Akeneo CSV Connector', 'Akeneo XLSX Connector', 'Akeneo Rule Engine Connector', 'Akeneo Tailored Export', 'Akeneo Tailored Import')
 AND type IN ('import', 'export')
 SQL;
 

--- a/upgrades/test_schema/Version_7_0_20220704141138_update_job_instance_parameter_path_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220704141138_update_job_instance_parameter_path_Integration.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Doctrine\DBAL\Connection;
+
+final class Version_7_0_20220704141138_update_job_instance_parameter_path_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220704141138_update_job_instance_parameter_path';
+
+    private Connection $connection;
+    private JobInstanceRepository $jobInstanceRepository;
+    private VersionProviderInterface $versionProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+        $this->jobInstanceRepository = $this->get('akeneo_batch.job.job_instance_repository');
+        $this->versionProvider = $this->get('pim_catalog.version_provider');
+    }
+
+    public function test_it_changes_storage_path_for_import_job_instance(): void
+    {
+        $this->createProductImport();
+
+        $this->assertTrue($this->jobContainsOldFilepath('xlsx_product_import'));
+        $this->assertFalse($this->jobContainsStorage('xlsx_product_import', '/tmp/product.xlsx'));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertFalse($this->jobContainsOldFilepath('xlsx_product_import'));
+        $this->assertTrue($this->jobContainsStorage('xlsx_product_import', '/tmp/product.xlsx'));
+    }
+
+    public function test_it_changes_storage_path_for_export_job_instance(): void
+    {
+        $this->createProductExport();
+
+        $this->assertTrue($this->jobContainsOldFilepath('csv_product_export'));
+        $this->assertFalse($this->jobContainsStorage('csv_product_export', '/tmp/export_%job_label%_%datetime%.csv'));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertFalse($this->jobContainsOldFilepath('csv_product_export'));
+        $this->assertTrue($this->jobContainsStorage('csv_product_export', '/tmp/export_%job_label%_%datetime%.csv'));
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createProductImport()
+    {
+        $rawParameters = [
+            "filePath" => "/tmp/product.xlsx",
+            "withHeader" => true,
+            "uploadAllowed" => true,
+            "invalid_items_file_format" => "xlsx",
+            "user_to_notify" => null,
+            "is_user_authenticated" => false,
+            "decimalSeparator" => ".",
+            "dateFormat" => "yyyy-MM-dd",
+            "enabled" => true,
+            "categoriesColumn" => "categories",
+            "familyColumn" => "family",
+            "groupsColumn" => "groups",
+            "enabledComparison" => true,
+            "realTimeVersioning" => true,
+            "convertVariantToSimple" => false,
+        ];
+
+        $this->connection->executeStatement("DELETE FROM akeneo_batch_job_instance WHERE code = 'xlsx_product_import'");
+
+        $sql = <<<SQL
+INSERT INTO `akeneo_batch_job_instance` (`code`, `label`, `job_name`, `status`, `connector`, `raw_parameters`, `type`)
+VALUES
+	('xlsx_product_import', 'Demo XLSX product import', 'xlsx_product_import', 0, 'Akeneo XLSX Connector', :raw_parameters, 'import');
+SQL;
+
+        $this->connection->executeStatement($sql, [
+            'raw_parameters' => serialize($rawParameters)
+        ]);
+    }
+
+    private function createProductExport()
+    {
+        $rawParameters = [
+            'filePath' => '/tmp/export_%job_label%_%datetime%.csv',
+            'delimiter' => ';',
+            'enclosure' => '"',
+            'withHeader' => true,
+            'user_to_notify' => null,
+            'is_user_authenticated' => false,
+            'decimalSeparator' => '.',
+            'dateFormat' => 'yyyy-MM-dd',
+            'with_media' => true,
+            'with_label' => false,
+            'header_with_label' => false,
+            'file_locale' => null,
+            'filters' =>
+                [
+                    'data' =>
+                        [
+                            [
+                                'field' => 'enabled',
+                                'operator' => '=',
+                                'value' => true,
+                            ],
+                            [
+                                'field' => 'categories',
+                                'operator' => 'IN CHILDREN',
+                                'value' =>
+                                    [
+                                        'master',
+                                    ],
+                            ],
+                            [
+                                'field' => 'completeness',
+                                'operator' => '>=',
+                                'value' => 100,
+                                'context' =>
+                                    [
+                                        'locales' =>
+                                            [
+                                                'fr_FR',
+                                                'en_US',
+                                                'de_DE',
+                                            ],
+                                    ],
+                            ],
+                        ],
+                    'structure' =>
+                        [
+                            'scope' => 'ecommerce',
+                            'locales' =>
+                                [
+                                    'fr_FR',
+                                    'en_US',
+                                    'de_DE',
+                                ],
+                        ],
+                ],
+        ];
+
+        $this->connection->executeStatement("DELETE FROM akeneo_batch_job_instance WHERE code = 'csv_product_export'");
+
+        $sql = <<<SQL
+INSERT INTO `akeneo_batch_job_instance` (`code`, `label`, `job_name`, `status`, `connector`, `raw_parameters`, `type`)
+VALUES
+	('csv_product_export', 'Demo CSV product export', 'csv_product_export', 0, 'Akeneo CSV Connector', :raw_parameters, 'export');
+SQL;
+
+        $this->connection->executeStatement($sql, [
+            'raw_parameters' => serialize($rawParameters)
+        ]);
+    }
+
+    private function jobContainsStorage(string $jobCode, string $storageFilePath): bool
+    {
+        $this->jobInstanceRepository->clear();
+
+        /** @var JobInstance $jobInstance */
+        $jobInstance = $this->jobInstanceRepository->findOneByCode($jobCode);
+        $rawParameters = $jobInstance->getRawParameters();
+
+        if (!isset($rawParameters['storage'])) return false;
+
+        $expectedStorage = [
+            'file_path' => $storageFilePath,
+            'type' => $this->isSaaSVersion() ? NoneStorage::TYPE : LocalStorage::TYPE
+        ];
+
+        return $rawParameters['storage'] == $expectedStorage;
+    }
+
+    private function jobContainsOldFilepath(string $jobCode): bool
+    {
+        $this->jobInstanceRepository->clear();
+
+        /** @var JobInstance $jobInstance */
+        $jobInstance = $this->jobInstanceRepository->findOneByCode($jobCode);
+        $rawParameters = $jobInstance->getRawParameters();
+
+        return isset($rawParameters['filePath']);
+    }
+
+    private function isSaaSVersion(): bool
+    {
+        return $this->versionProvider->isSaaSVersion();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- In this PR, we **don't migrate quick export** job instances as they have a dedicated type (`quick_export`).

**Performances impact on customers** :zap:  
This query only updates job instances filtered by `types` and `connector`. 
The maximum in production is **243** (`srnt-alfuttain`), so this won't be a problem.

**Remaining work:**
- [x] Wait for RAB-753 to be **merged** to ensure we can test the migration

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer