### PR TITLE
CXP-1240: add support to find families by code

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -25,8 +25,8 @@ catalogs-fixtures:
 catalogs-tests:
 	$(MAKE) catalogs-lint-back
 	$(MAKE) catalogs-coupling-back
-	$(MAKE) catalogs-mutation-unit-back
 	$(MAKE) catalogs-coverage-back
+	$(MAKE) catalogs-mutation-unit-back
 	$(MAKE) catalogs-acceptance-back
 	$(MAKE) catalogs-lint-front
 	$(MAKE) catalogs-unit-front

--- a/components/catalogs/back/src/Infrastructure/Persistence/GetFamiliesByCodeQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/GetFamiliesByCodeQuery.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Infrastructure\Persistence;
+
+use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\SearchableRepositoryInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class GetFamiliesByCodeQuery
+{
+    public function __construct(
+        private SearchableRepositoryInterface $searchableFamilyRepository,
+    ) {
+    }
+
+    /**
+     * @param array<string> $codes
+     * @return array<array{code: string, label: string}>
+     */
+    public function execute(array $codes, int $page = 1, int $limit = 20): array
+    {
+        $families = $this->searchableFamilyRepository->findBySearch(
+            null,
+            [
+                'identifiers' => $codes,
+                'limit' => $limit,
+                'page' => $page,
+            ],
+        );
+
+        return \array_map(
+            static fn (FamilyInterface $family) => ['code' => $family->getCode(), 'label' => $family->getLabel()],
+            $families
+        );
+    }
+}

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
@@ -71,3 +71,7 @@ services:
     Akeneo\Catalogs\Infrastructure\Persistence\SearchFamilyQuery:
         arguments:
             - '@pim_enrich.repository.family.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\GetFamiliesByCodeQuery:
+        arguments:
+            - '@pim_enrich.repository.family.search'

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Internal/GetFamiliesActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Internal/GetFamiliesActionTest.php
@@ -49,6 +49,30 @@ class GetFamiliesActionTest extends IntegrationTestCase
         Assert::assertArrayHasKey('label', $families[0]);
     }
 
+    public function testItGetsFamiliesByCodes(): void
+    {
+        $client = $this->getAuthenticatedInternalApiClient('admin');
+        $this->insertFamilies(['tshirt', 'pants', 'guitare']);
+
+        $client->request(
+            'GET',
+            '/rest/catalogs/families',
+            ['codes' => 'tshirt,guitare'],
+            [],
+            [
+                'HTTP_X-Requested-With' => 'XMLHttpRequest',
+            ],
+        );
+
+        $response = $client->getResponse();
+        Assert::assertEquals(200, $response->getStatusCode());
+
+        $families = \json_decode($response->getContent(), true);
+        Assert::assertCount(2, $families);
+        Assert::assertArrayHasKey('code', $families[0]);
+        Assert::assertArrayHasKey('label', $families[0]);
+    }
+
     public function testItPaginatesAndSearchesForFamilies(): void
     {
         $client = $this->getAuthenticatedInternalApiClient('admin');


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The frontend needs to be able to find families by code.
When the multi select is rendered, if there is values in it, we need to fetch the families of those codes to display the label.
We cannot wait for the infinite scroll to find them.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
