### PR TITLE
PIM-10515: Fix 'add associations' button visibility for quantified associations & category permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-10515: Fix 'add associations' button visibility for quantified associations & category permissions
 - PIM-10487: Fix import of very tiny measurement values (e.g. 0.000075 GRAM)
 - PIM-10215: Fixed last operation widget job type translation key
 - PIM-10233: Fix the saved value by an empty wysiwyg

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
@@ -156,11 +156,13 @@ define([
     },
 
     renderQuantifiedAssociations: function (quantifiedAssociations) {
+      const isUserOwner = this.getFormData().meta.is_owner ?? true;
       const props = {
         quantifiedAssociations,
         parentQuantifiedAssociations: {products: [], product_models: []},
         errors: [],
         isCompact: true,
+        isUserOwner,
         onAssociationsChange: updatedAssociations => {
           const currentAssociationTypeCode = this.getCurrentAssociationTypeCode();
           this.setValue({[currentAssociationTypeCode]: updatedAssociations}, true);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
@@ -315,11 +315,13 @@ define([
         `quantifiedAssociations.${associationTypeCode}`
       );
 
+      const isUserOwner = this.getFormData().meta.is_owner ?? true;
       const props = {
         quantifiedAssociations,
         parentQuantifiedAssociations,
         errors,
         isCompact: false,
+        isUserOwner,
         onAssociationsChange: updatedAssociations => {
           const formData = this.getFormData();
           formData.quantified_associations = {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
@@ -95,6 +95,7 @@ const RowAction = styled.div`
 type QuantifiedAssociationRowProps = {
   row: Row;
   parentQuantifiedLink: QuantifiedLink | undefined;
+  isUserOwner?: boolean;
   isCompact?: boolean;
   onChange: (row: Row) => void;
   onRemove: (row: Row) => void;
@@ -104,6 +105,7 @@ const QuantifiedAssociationRow = ({
   row,
   parentQuantifiedLink,
   isCompact = false,
+  isUserOwner = true,
   onChange,
   onRemove,
 }: QuantifiedAssociationRowProps) => {
@@ -113,8 +115,10 @@ const QuantifiedAssociationRow = ({
   const productEditUrl = useRoute(`pim_enrich_${row.productType}_edit`, {id: row.product?.id.toString() || ''});
   const thumbnailUrl = useProductThumbnail(row.product);
   const blueColor = useTheme().color.blue100;
-  const canRemoveAssociation = isGranted('pim_enrich_associations_remove') && undefined === parentQuantifiedLink;
-  const canUpdateQuantity = isGranted('pim_enrich_associations_edit') && isGranted('pim_enrich_associations_remove');
+  const canRemoveAssociation =
+    isGranted('pim_enrich_associations_remove') && undefined === parentQuantifiedLink && isUserOwner;
+  const canUpdateQuantity =
+    isGranted('pim_enrich_associations_edit') && isGranted('pim_enrich_associations_remove') && isUserOwner;
 
   const handleQuantityChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!canUpdateQuantity) return;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociations.tsx
@@ -66,6 +66,7 @@ type QuantifiedAssociationsProps = {
   quantifiedAssociations: QuantifiedAssociation;
   parentQuantifiedAssociations: QuantifiedAssociation;
   errors: ValidationError[];
+  isUserOwner?: boolean;
   isCompact?: boolean;
   onAssociationsChange: (quantifiedAssociations: QuantifiedAssociation) => void;
   onOpenPicker: () => Promise<Row[]>;
@@ -76,6 +77,7 @@ const QuantifiedAssociations = ({
   parentQuantifiedAssociations,
   errors,
   isCompact = false,
+  isUserOwner = true,
   onOpenPicker,
   onAssociationsChange,
 }: QuantifiedAssociationsProps) => {
@@ -98,7 +100,7 @@ const QuantifiedAssociations = ({
   );
   const filteredCollectionWithProducts = collectionWithProducts.filter(filterOnLabelOrIdentifier(searchValue));
   const inputRef = useRef<HTMLInputElement>(null);
-  const canAddAssociation = isGranted('pim_enrich_associations_edit');
+  const canAddAssociation = isGranted('pim_enrich_associations_edit') && isUserOwner;
 
   useAutoFocus(inputRef);
 
@@ -209,6 +211,7 @@ const QuantifiedAssociations = ({
               <QuantifiedAssociationRow
                 key={index}
                 row={row}
+                isUserOwner={isUserOwner}
                 isCompact={isCompact}
                 parentQuantifiedLink={parentQuantifiedAssociations[getProductsType(row.productType)].find(
                   quantifiedAssociation => quantifiedAssociation.identifier === row.quantifiedLink.identifier

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociationRow.unit.tsx
@@ -259,9 +259,38 @@ test('It cannot remove an association when user did not have the ACL', () => {
             errors: [],
           }}
           isCompact={true}
+          isUserOwner={true}
           parentQuantifiedLink={undefined}
           onChange={jest.fn()}
           onRemove={jest.fn()}
+        />
+      </tbody>
+    </table>
+  );
+
+  const removeButton = screen.queryByTitle('pim_enrich.entity.product.module.associations.remove');
+  expect(removeButton).not.toBeInTheDocument();
+});
+
+test('It cannot remove an association when user does not own the product', () => {
+  mockedGrantedAcl = ['pim_enrich_associations_remove'];
+  const handleChange = jest.fn();
+
+  renderWithProviders(
+    <table>
+      <tbody>
+        <QuantifiedAssociationRow
+          row={{
+            productType: ProductType.ProductModel,
+            quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+            product: productModel,
+            errors: [],
+          }}
+          isCompact={true}
+          parentQuantifiedLink={undefined}
+          onChange={handleChange}
+          onRemove={jest.fn()}
+          isUserOwner={false}
         />
       </tbody>
     </table>
@@ -286,6 +315,36 @@ test('It cannot update the quantity of an association when user did not have the
             errors: [],
           }}
           isCompact={true}
+          parentQuantifiedLink={undefined}
+          onChange={handleChange}
+          onRemove={jest.fn()}
+        />
+      </tbody>
+    </table>
+  );
+
+  const quantityInput = screen.getByTitle('pim_enrich.entity.product.module.associations.quantified.quantity');
+  fireEvent.change(quantityInput, {target: {value: '16'}});
+
+  expect(handleChange).not.toBeCalled();
+});
+
+test('It cannot update the quantity of an association when user does not own the product', () => {
+  mockedGrantedAcl = ['pim_enrich_associations_edit'];
+  const handleChange = jest.fn();
+
+  renderWithProviders(
+    <table>
+      <tbody>
+        <QuantifiedAssociationRow
+          row={{
+            productType: ProductType.ProductModel,
+            quantifiedLink: {quantity: 15, identifier: 'braided-hat'},
+            product: productModel,
+            errors: [],
+          }}
+          isCompact={true}
+          isUserOwner={false}
           parentQuantifiedLink={undefined}
           onChange={handleChange}
           onRemove={jest.fn()}

--- a/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociations.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/tests/front/unit/components/QuantifiedAssociations.unit.tsx
@@ -298,3 +298,28 @@ test('It notifies when a product model error is detected', async () => {
 
   expect(dependencies.notify).toBeCalledWith('error', 'a.product.model.error.occured');
 });
+
+/**
+ * @see https://akeneo.atlassian.net/browse/PIM-10515
+ */
+test('It does not display the add association button if the user is not owner of the product', async () => {
+  jest.mock('pim/security-context', () => {}, {virtual: true});
+
+  await act(async () => {
+    renderDOMWithProviders(
+      <QuantifiedAssociations
+        quantifiedAssociations={quantifiedAssociationCollection}
+        parentQuantifiedAssociations={{products: [{identifier: 'bag', quantity: 1}], product_models: []}}
+        errors={[]}
+        isUserOwner={false}
+        onAssociationsChange={jest.fn()}
+        onOpenPicker={jest.fn()}
+      />,
+      container
+    );
+  });
+
+  expect(
+    queryByText(container, 'pim_enrich.entity.product.module.associations.add_associations')
+  ).not.toBeInTheDocument();
+});


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

There was a behavior mismatch concerning the "Add associations" button visibility for simple associations and quantified associations.
This button should be displayed if: (see [here](https://github.com/akeneo/pim-enterprise-dev/blob/8c2201079b376273c501d6c04e395a2c3a186b05/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js#L19-L18))
1. The user is owner of the product
2. The user has the permission to add associations (ACL)

The problem comes from the fact that there was a missing check for rule #1 when displaying the quantified association grid.

The fix consists in drilling down the "isOwner" information (from backbone getFormData().meta.is_user_owner) through a new optional React prop "isUserOwner"

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
