### PR TITLE
OCT-76: On CE v6, when you connect an App and you are redirected to the PIM, you lose your authentication

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- OCT-76: Fixed redundant authentication prompt during App activation
+
 # 6.0.36 (2022-07-21)
 
 ## Bug fixes

--- a/config/packages/framework.yml
+++ b/config/packages/framework.yml
@@ -14,7 +14,7 @@ framework:
         name: BAPID
         handler_id: session.handler.pdo
         gc_maxlifetime: 3600
-        cookie_samesite: 'strict'
+        cookie_samesite: 'lax' # needed to not be strict for SSO and Apps oAuth2 workflows
     serializer:
         enabled: true
     http_method_override: true

--- a/config/packages/security.yml
+++ b/config/packages/security.yml
@@ -69,7 +69,7 @@ security:
                 secret:                     "%env(APP_SECRET)%"
                 name:                       BAPRM
                 lifetime:                   1209600   # stay logged for two weeks
-                samesite:                   'strict'
+                samesite:                   'lax'
             anonymous:                      false
 
     access_control:


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

`strict` mode samesite cookies was implemented [here](https://github.com/akeneo/pim-community-dev/pull/16099/files) and backport to v6 [here](https://github.com/akeneo/pim-community-dev/pull/16520).

It was the [rollback](https://github.com/akeneo/pim-enterprise-dev/pull/12679) and [change to](https://github.com/akeneo/pim-enterprise-dev/pull/12684) `lax` mode but only on EE.

In this PR we correct it on CE. It cannot be in `strict` mode for SSO and Apps oAuth2 workflows.

**Note**: we cannot test it with behat because Cookie creation in `friendsofbehat/mink` only manages `name` and `value`: https://github.com/FriendsOfBehat/Mink/blob/master/src/Driver/DriverInterface.php#L203

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
