### PR TITLE
PIM-10527: Fix associated groups grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PIM-10516: Fix remove completeness job when deactivating and reactivating a locale
 - PIM-10508: Fix attribute creation when label contains an '&' character
 - PIM-10501: Fix identifier validation for product and product model imports to disallow line breaks
+- PIM-10527: Fix associated groups grid
 
 ## Improvements
 

--- a/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToGridListener.php
+++ b/src/Oro/Bundle/PimDataGridBundle/EventListener/AddParametersToGridListener.php
@@ -80,7 +80,7 @@ class AddParametersToGridListener
              * #proudOfThis
              */
             $value = $this->requestParams->get($paramName, null);
-            if (Uuid::isValid($value)) {
+            if (\is_string($value) && Uuid::isValid($value)) {
                 $value = Uuid::fromString($value)->getBytes();
             }
             $queryParameters[($this->isQueryParam ? ':' : '') . $paramName] = $value;


### PR DESCRIPTION
This used to throw a type error if $value was an array (e.g assiciatedIds in `association-group-grid`)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
