### PR TITLE
Do not use v3.9.1 of friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -151,7 +151,7 @@
         "friends-of-behat/mink-extension": "^2.5.0",
         "friends-of-behat/symfony-extension": "^2.2.1",
         "friends-of-phpspec/phpspec-code-coverage": "^6.1.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
+        "friendsofphp/php-cs-fixer": "^3.0,<3.9.1",
         "instaclick/php-webdriver": "1.4.7",
         "league/flysystem-aws-s3-v3": "^2.0",
         "liuggio/fastest": "1.8.*",


### PR DESCRIPTION
Do not use v.3.9.1 of php-cs-fixer (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6470)

Note: This PR should be reverted when a fix comes for the mentioned issue