### PR TITLE
PIM-10518: Normalize simple select option value like multi select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - PIM-10508: Fix attribute creation when label contains an '&' character
 - PIM-10501: Fix identifier validation for product and product model imports to disallow line breaks
 - PIM-10527: Fix associated groups grid
+- PIM-10518: Normalize simple select option value like multi select
 - PIM-10528: Fix escaped special characters in page titles
 
 ## Improvements

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/Versioning/Product/ValueNormalizer.php
@@ -62,13 +62,15 @@ class ValueNormalizer implements NormalizerInterface, NormalizerAwareInterface, 
 
         $result = null;
 
-        if (is_array($data)) {
-            $data = new ArrayCollection($data);
-        }
-
-
         $type = $attribute->getType();
         $backendType = $attribute->getBackendType();
+
+        if (is_array($data)) {
+            $data = new ArrayCollection($data);
+        } elseif (AttributeTypes::OPTION_SIMPLE_SELECT === $type) {
+            // PIM-10518: Transform the string value of the option to have the same behaviour as multiselect
+            $data = new ArrayCollection([$data]);
+        }
 
         if (AttributeTypes::BOOLEAN === $type) {
             $result = [$fieldName => (string) (int) $data];
@@ -87,7 +89,7 @@ class ValueNormalizer implements NormalizerInterface, NormalizerAwareInterface, 
             // even when an empty collection is passed
             if ('prices' === $backendType && $data instanceof Collection && $data->isEmpty()) {
                 $result = [];
-            } elseif ('options' === $backendType && $data instanceof Collection && $data->isEmpty() === false) {
+            } elseif (in_array($backendType, ['option', 'options']) && $data instanceof Collection && $data->isEmpty() === false) {
                 $data = $this->sortOptions($data, $attribute);
                 $context['field_name'] = $fieldName;
                 $result = $this->normalizer->normalize($data, $format, $context);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

https://akeneo.atlassian.net/browse/PIM-10518?atlOrigin=eyJpIjoiYmIxNmY4YTgwZDA1NDJhZmE5MTE5OWRmOTNjNjI3MGEiLCJwIjoiaiJ9

**What's the issue ?**

The normalization behavior for simple and multi select option is not the same. For multi, the normalizer gets the saved attribute code. For simple, the normalizer gets the saved product value. We want to have the same behavior for simple and multi.

After a product import with these values : 
![Screenshot from 2022-07-12 16-22-42](https://user-images.githubusercontent.com/35272857/178513124-fa3c5268-62bf-4b26-a170-f61b28f36b0b.png)

Versioning before fix : 
![Screenshot from 2022-07-12 16-20-15](https://user-images.githubusercontent.com/35272857/178512686-79522b35-6c84-4bcd-9b8e-b601beb74d64.png)
Versioning after fix : 
![Screenshot from 2022-07-12 16-26-12](https://user-images.githubusercontent.com/35272857/178513951-629b227b-d4c3-428e-891c-e49423478905.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
