### PR TITLE
PIM-10528: Fix escaped special characters in page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - PIM-10508: Fix attribute creation when label contains an '&' character
 - PIM-10501: Fix identifier validation for product and product model imports to disallow line breaks
 - PIM-10527: Fix associated groups grid
+- PIM-10528: Fix escaped special characters in page titles
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/association-type.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/association-type.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -10,7 +9,7 @@ define([
   'pim/dialog',
   'pim/page-title',
   'pim/i18n',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -23,11 +22,13 @@ define([
             return;
           }
 
-          var label = _.escape(
-            i18n.getLabel(associationType.labels, UserContext.get('catalogLocale'), associationType.code)
-          );
-
-          PageTitle.set({'association type.label': _.escape(label)});
+          PageTitle.set({
+            'association type.label': i18n.getLabel(
+              associationType.labels,
+              UserContext.get('catalogLocale'),
+              associationType.code
+            ),
+          });
 
           return FormBuilder.build(associationType.meta.form).then(form => {
             this.on('pim:controller:can-leave', function (event) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute-group/edit.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute-group/edit.js
@@ -8,7 +8,6 @@
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -16,7 +15,8 @@ define([
   'pim/user-context',
   'pim/dialog',
   'pim/page-title',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle) {
+  'pim/i18n',
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -30,7 +30,7 @@ define([
           }
 
           PageTitle.set({
-            'group.label': _.escape(attributeGroup.labels[UserContext.get('catalogLocale')]),
+            'group.label': i18n.getLabel(attributeGroup.labels, UserContext.get('catalogLocale'), attributeGroup.code),
           });
 
           return FormBuilder.build('pim-attribute-group-edit-form').then(form => {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute/edit.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/attribute/edit.js
@@ -6,14 +6,13 @@
 'use strict';
 
 define([
-  'underscore',
   'pim/controller/front',
   'pim/form-builder',
   'pim/fetcher-registry',
   'pim/user-context',
   'pim/page-title',
   'pim/i18n',
-], function (_, BaseController, FormBuilder, fetcherRegistry, UserContext, PageTitle, i18n) {
+], function (BaseController, FormBuilder, fetcherRegistry, UserContext, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -34,7 +33,7 @@ define([
           apply_filters: false,
         })
         .then(attribute => {
-          var label = _.escape(i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code));
+          var label = i18n.getLabel(attribute.labels, UserContext.get('catalogLocale'), attribute.code);
 
           PageTitle.set({'attribute.label': label});
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/channel/edit.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/channel/edit.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -10,7 +9,7 @@ define([
   'pim/dialog',
   'pim/page-title',
   'pim/i18n',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -39,14 +38,14 @@ define([
         return FetcherRegistry.getFetcher('channel')
           .fetch(route.params.code, {cached: false, filter_locales: 0})
           .then(channel => {
-            const label = _.escape(i18n.getLabel(channel.labels, UserContext.get('catalogLocale'), channel.code));
+            const label = i18n.getLabel(channel.labels, UserContext.get('catalogLocale'), channel.code);
 
             return createForm.call(this, this.$el, channel, label, channel.meta.form);
           });
       }
 
       function createForm(domElement, channel, label, formExtension) {
-        PageTitle.set({'channel.label': _.escape(label)});
+        PageTitle.set({'channel.label': label});
 
         return FormBuilder.build(formExtension).then(form => {
           this.on('pim:controller:can-leave', function (event) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/family.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -10,7 +9,7 @@ define([
   'pim/dialog',
   'pim/page-title',
   'pim/i18n',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -23,9 +22,7 @@ define([
             return;
           }
 
-          var label = _.escape(i18n.getLabel(family.labels, UserContext.get('catalogLocale'), family.code));
-
-          PageTitle.set({'family.label': _.escape(label)});
+          PageTitle.set({'family.label': i18n.getLabel(family.labels, UserContext.get('catalogLocale'), family.code)});
 
           return FormBuilder.build(family.meta.form).then(form => {
             this.on('pim:controller:can-leave', function (event) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/group-type.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/group-type.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -10,7 +9,7 @@ define([
   'pim/dialog',
   'pim/page-title',
   'pim/i18n',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -23,9 +22,9 @@ define([
             return;
           }
 
-          var label = _.escape(i18n.getLabel(groupType.labels, UserContext.get('catalogLocale'), groupType.code));
-
-          PageTitle.set({'group type.label': _.escape(label)});
+          PageTitle.set({
+            'group type.label': i18n.getLabel(groupType.labels, UserContext.get('catalogLocale'), groupType.code),
+          });
 
           return FormBuilder.build('pim-group-type-edit-form').then(form => {
             this.on('pim:controller:can-leave', event => {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/group.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/group.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -10,7 +9,7 @@ define([
   'pim/dialog',
   'pim/page-title',
   'pim/i18n',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle, i18n) {
   return BaseController.extend({
     initialize: function () {
       this.config = __moduleConfig;
@@ -27,9 +26,7 @@ define([
             return;
           }
 
-          var label = _.escape(i18n.getLabel(group.labels, UserContext.get('catalogLocale'), group.code));
-
-          PageTitle.set({'group.label': label});
+          PageTitle.set({'group.label': i18n.getLabel(group.labels, UserContext.get('catalogLocale'), group.code)});
 
           return FormBuilder.build(group.meta.form).then(form => {
             this.on('pim:controller:can-leave', function (event) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/job-instance.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/job-instance.js
@@ -1,7 +1,6 @@
 'use strict';
 
 define([
-  'underscore',
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
@@ -9,7 +8,7 @@ define([
   'pim/user-context',
   'pim/dialog',
   'pim/page-title',
-], function (_, __, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle) {
+], function (__, BaseController, FormBuilder, FetcherRegistry, UserContext, Dialog, PageTitle) {
   return BaseController.extend({
     /**
      * {@inheritdoc}
@@ -25,7 +24,7 @@ define([
             return;
           }
 
-          PageTitle.set({'job.label': _.escape(jobInstance.label)});
+          PageTitle.set({'job.label': jobInstance.label});
 
           return FormBuilder.build(jobInstance.meta.form + '-' + mode).then(form => {
             this.on('pim:controller:can-leave', event => {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/mass-edit.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/mass-edit.js
@@ -6,10 +6,9 @@ define([
   'oro/translator',
   'pim/controller/front',
   'pim/form-builder',
-  'pim/page-title',
   'routing',
   'pim/analytics',
-], function ($, _, __, BaseController, FormBuilder, PageTitle, Routing, analytics) {
+], function ($, _, __, BaseController, FormBuilder, Routing, analytics) {
   const ACTION_PRODUCT_GRID = 'product-edit';
 
   return BaseController.extend({

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/product/index.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/product/index.js
@@ -5,7 +5,6 @@ define([
   'pim/form-builder',
   'pim/user-context',
   'oro/mediator',
-  'pim/page-title',
   'routing',
   'pim/fetcher-registry',
   'pim/provider/sequential-edit-provider',
@@ -16,7 +15,6 @@ define([
   FormBuilder,
   UserContext,
   mediator,
-  PageTitle,
   Routing,
   fetcherRegistry,
   sequentialEditProvider

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/system.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/system.js
@@ -1,14 +1,13 @@
 'use strict';
 
-define([
-  'jquery',
-  'underscore',
-  'oro/translator',
-  'pim/controller/front',
-  'pim/form-builder',
-  'pim/page-title',
-  'routing',
-], function ($, _, __, BaseController, FormBuilder, PageTitle, Routing) {
+define(['jquery', 'underscore', 'oro/translator', 'pim/controller/front', 'pim/form-builder', 'routing'], function (
+  $,
+  _,
+  __,
+  BaseController,
+  FormBuilder,
+  Routing
+) {
   return BaseController.extend({
     /**
      * {@inheritdoc}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/controller/user.js
@@ -1,7 +1,6 @@
 'use strict';
 
-define(['underscore', 'pim/controller/front', 'pim/fetcher-registry', 'pim/page-title', 'pim/form-builder'], function (
-  _,
+define(['pim/controller/front', 'pim/fetcher-registry', 'pim/page-title', 'pim/form-builder'], function (
   BaseController,
   FetcherRegistry,
   PageTitle,
@@ -19,7 +18,7 @@ define(['underscore', 'pim/controller/front', 'pim/fetcher-registry', 'pim/page-
             return;
           }
 
-          PageTitle.set({username: _.escape(user.username)});
+          PageTitle.set({username: user.username});
 
           return FormBuilder.build(user.meta.form).then(form => {
             this.on('pim:controller:can-leave', function (event) {


### PR DESCRIPTION
Page titles are set through the [pim/page-title](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/page-title.js) component in javascript, we don't need to escape special characters here (as opposite as if they were included in a HTML template)
Also, in some pages, labels were escaped twice (eg `&` would become `&amp;amp;`)

before:
![before](https://user-images.githubusercontent.com/5301298/178489566-6c2bba68-fd7c-47e5-80a3-c3a052c3d58b.png)

after:
![after](https://user-images.githubusercontent.com/5301298/178489613-313f20f0-15f4-4b3b-9702-147e5482da6a.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
