### PR TITLE
CPM-681: Remove indentifiers from ProductIndexer

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductCompleteness.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductCompleteness.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\Model\Write\CompletenessCalculationResult;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdentifierFromProductUuidQueryInterface;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ChannelCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\LocaleCode;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityIdInterface;
@@ -14,7 +13,6 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuid;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductCompleteness.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Enrichment/CalculateProductCompleteness.php
@@ -13,6 +13,8 @@ use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductEntityId
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuid;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\Rate;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -21,7 +23,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 final class CalculateProductCompleteness implements CalculateProductCompletenessInterface
 {
     public function __construct(
-        private GetProductIdentifierFromProductUuidQueryInterface $getProductIdentifierFromProductIdQuery,
         private CompletenessCalculator $completenessCalculator
     ) {
     }
@@ -33,8 +34,7 @@ final class CalculateProductCompleteness implements CalculateProductCompleteness
         }
 
         $result = new CompletenessCalculationResult();
-        $productIdentifier = $this->getProductIdentifierFromProductIdQuery->execute($productUuid);
-        $completenessCollection = $this->completenessCalculator->fromProductIdentifier((string) $productIdentifier);
+        $completenessCollection = $this->completenessCalculator->fromProductUuid(Uuid::fromString((string) $productUuid));
 
         foreach ($completenessCollection as $completeness) {
             $channelCode = new ChannelCode($completeness->channelCode());

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -133,19 +133,16 @@ services:
     akeneo.pim.automation.calculate_product_completeness_of_required_attributes:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment\CalculateProductCompleteness
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdentifierFromProductUuidQuery'
             - '@akeneo.pim.automation.completeness_product_required_attributes_calculator'
 
     akeneo.pim.automation.calculate_product_completeness_of_non_required_attributes:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment\CalculateProductCompleteness
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdentifierFromProductUuidQuery'
             - '@akeneo.pim.automation.completeness_product_non_required_attributes_calculator'
 
     akeneo.pim.automation.calculate_product_image_enrichment:
         class: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment\CalculateProductCompleteness
         arguments:
-            - '@Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Persistence\Query\ProductEnrichment\GetProductIdentifierFromProductUuidQuery'
             - '@akeneo.pim.automation.completeness_product_image_enrichment_calculator'
 
     akeneo.pim.automation.completeness_product_required_attributes_calculator:

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Enrichment/CalculateProductCompletenessSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Enrichment/CalculateProductCompletenessSpec.php
@@ -51,7 +51,7 @@ class CalculateProductCompletenessSpec extends ObjectBehavior
         $productIdentifier = new ProductIdentifier('ziggy_mug');
         $getProductIdentifierFromProductUuidQuery->execute($productUuid)->willReturn($productIdentifier);
 
-        $completenessCalculator->fromProductIdentifier('ziggy_mug')->willReturn(new ProductCompletenessWithMissingAttributeCodesCollection(
+        $completenessCalculator->fromProductUuid($productUuid)->willReturn(new ProductCompletenessWithMissingAttributeCodesCollection(
             $uuid, [
                 new ProductCompletenessWithMissingAttributeCodes(
                     'ecommerce', 'en_US', 10, [

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Enrichment/CalculateProductCompletenessSpec.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/Specification/Infrastructure/Enrichment/CalculateProductCompletenessSpec.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Enrichment;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\Enrichment\CalculateProductCompletenessInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEnrichment\GetProductIdentifierFromProductUuidQueryInterface;
-use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuid;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductIdentifier;
 use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductModelId;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuid;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodesCollection;
@@ -22,11 +21,9 @@ use Ramsey\Uuid\Uuid;
 class CalculateProductCompletenessSpec extends ObjectBehavior
 {
     public function let(
-        GetProductIdentifierFromProductUuidQueryInterface $getProductIdentifierFromProductUuidQuery,
-        CompletenessCalculator                            $completenessCalculator
-    )
-    {
-        $this->beConstructedWith($getProductIdentifierFromProductUuidQuery, $completenessCalculator);
+        CompletenessCalculator $completenessCalculator
+    ) {
+        $this->beConstructedWith($completenessCalculator);
     }
 
     public function it_calculate_product_completeness()
@@ -42,16 +39,12 @@ class CalculateProductCompletenessSpec extends ObjectBehavior
     }
 
     public function it_evaluates_the_completeness_criterion(
-        GetProductIdentifierFromProductUuidQueryInterface $getProductIdentifierFromProductUuidQuery,
-        CompletenessCalculator                            $completenessCalculator
-    )
-    {
+        CompletenessCalculator $completenessCalculator
+    ) {
         $uuid = 'df470d52-7723-4890-85a0-e79be625e2ed';
         $productUuid = ProductUuid::fromString($uuid);
-        $productIdentifier = new ProductIdentifier('ziggy_mug');
-        $getProductIdentifierFromProductUuidQuery->execute($productUuid)->willReturn($productIdentifier);
 
-        $completenessCalculator->fromProductUuid($productUuid)->willReturn(new ProductCompletenessWithMissingAttributeCodesCollection(
+        $completenessCalculator->fromProductUuid(Uuid::fromString($uuid))->willReturn(new ProductCompletenessWithMissingAttributeCodesCollection(
             $uuid, [
                 new ProductCompletenessWithMissingAttributeCodes(
                     'ecommerce', 'en_US', 10, [

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -256,6 +256,7 @@ $rules = [
         'Akeneo\Platform\Bundle\NotificationBundle\NotifierInterface',
 
         'Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperInterface',
+        'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids',
     ])->in('Akeneo\Pim\Enrichment\Component'),
 ];
 

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -127,8 +127,8 @@ $rules = [
         'Akeneo\Pim\Enrichment\Product\API\Command\UserIntent',
         'Akeneo\Pim\Enrichment\Product\API\MessageBus',
         'Akeneo\Pim\Enrichment\Product\API\Query\GetUserIntentsFromStandardFormat',
-        'Akeneo\Pim\Enrichment\Product\Domain\Model\ViolationCode'
-
+        'Akeneo\Pim\Enrichment\Product\Domain\Model\ViolationCode',
+        'Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery',
     ])->in('Akeneo\Pim\Enrichment\Bundle'),
     $builder->only([
         'Symfony\Component',
@@ -141,6 +141,7 @@ $rules = [
         'Akeneo\Pim\Structure\Component\Query\PublicApi',
         'Psr\Log\LoggerInterface',
         'Ramsey\Uuid',
+        'Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -35,6 +35,7 @@ $rules = [
         'Oro\Bundle\FilterBundle',
         // TODO: dependencies related to the front end, remove twig screens
         'Twig',
+        'Akeneo\Pim\Enrichment\Product\API',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',
@@ -121,14 +122,7 @@ $rules = [
         // PIM-10259: Add support for Arabic characters in PDF export
         'ArPHP\I18N\Arabic',
 
-        'Akeneo\Pim\Enrichment\Product\API\Command\Exception\ViolationsException',
-        'Akeneo\Pim\Enrichment\Product\API\Command\Exception\LegacyViolationsException',
-        'Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand',
-        'Akeneo\Pim\Enrichment\Product\API\Command\UserIntent',
-        'Akeneo\Pim\Enrichment\Product\API\MessageBus',
-        'Akeneo\Pim\Enrichment\Product\API\Query\GetUserIntentsFromStandardFormat',
         'Akeneo\Pim\Enrichment\Product\Domain\Model\ViolationCode',
-        'Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery',
     ])->in('Akeneo\Pim\Enrichment\Bundle'),
     $builder->only([
         'Symfony\Component',
@@ -141,7 +135,7 @@ $rules = [
         'Akeneo\Pim\Structure\Component\Query\PublicApi',
         'Psr\Log\LoggerInterface',
         'Ramsey\Uuid',
-        'Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery',
+        'Akeneo\Pim\Enrichment\Product\API',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductCommand.php
@@ -7,6 +7,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\Command;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -93,15 +95,15 @@ class IndexProductCommand extends Command
         $batchSize = (int) $input->getOption('batch-size') ?: self::DEFAULT_BATCH_SIZE;
 
         if (true === $input->getOption('all')) {
-            $chunkedProductIdentifiers = $this->getAllProductIdentifiers($batchSize);
+            $chunkedProductUuids = $this->getAllProductUuids($batchSize);
             $productCount = 0;
         } elseif (true === $input->getOption('diff')) {
-            $chunkedProductIdentifiers = $this->getDiffProductIdentifiers($batchSize);
+            $chunkedProductUuids = $this->getDiffProductUuids($batchSize);
             $productCount = 0;
         } elseif (!empty($input->getArgument('identifiers'))) {
             $requestedIdentifiers = $input->getArgument('identifiers');
-            $existingIdentifiers = $this->getExistingProductIdentifiers($requestedIdentifiers);
-            $nonExistingIdentifiers = array_diff($requestedIdentifiers, $existingIdentifiers);
+            $existingUuids = $this->getExistingProductUuids($requestedIdentifiers);
+            $nonExistingIdentifiers = array_diff($requestedIdentifiers, array_keys($existingUuids));
             if (!empty($nonExistingIdentifiers)) {
                 $output->writeln(
                     sprintf(
@@ -110,8 +112,8 @@ class IndexProductCommand extends Command
                     )
                 );
             }
-            $chunkedProductIdentifiers = array_chunk($existingIdentifiers, $batchSize);
-            $productCount = count($existingIdentifiers);
+            $chunkedProductUuids = array_chunk($existingUuids, $batchSize);
+            $productCount = count($existingUuids);
         } else {
             $output->writeln(
                 '<error>Please specify a list of product identifiers to index or use the flag --all to index all products</error>'
@@ -120,7 +122,7 @@ class IndexProductCommand extends Command
             return self::ERROR_CODE_USAGE;
         }
 
-        $numberOfIndexedProducts = $this->doIndex($chunkedProductIdentifiers, new ProgressBar($output, $productCount));
+        $numberOfIndexedProducts = $this->doIndex($chunkedProductUuids, new ProgressBar($output, $productCount));
 
         $output->writeln('');
         $output->writeln(sprintf('<info>%d products indexed</info>', $numberOfIndexedProducts));
@@ -128,70 +130,68 @@ class IndexProductCommand extends Command
         return 0;
     }
 
-    private function doIndex(iterable $chunkedProductIdentifiers, ProgressBar $progressBar): int
+    private function doIndex(iterable $chunkedProductUuids, ProgressBar $progressBar): int
     {
         $indexedProductCount = 0;
 
         $progressBar->start();
-        foreach ($chunkedProductIdentifiers as $productIdentifiers) {
-            $this->productAndAncestorsIndexer->indexFromProductIdentifiers($productIdentifiers);
-            $indexedProductCount += count($productIdentifiers);
-            $progressBar->advance(count($productIdentifiers));
+        foreach ($chunkedProductUuids as $productUuids) {
+            $this->productAndAncestorsIndexer->indexFromProductUuids($productUuids);
+            $indexedProductCount += count($productUuids);
+            $progressBar->advance(count($productUuids));
         }
         $progressBar->finish();
 
         return $indexedProductCount;
     }
 
-    private function getAllProductIdentifiers(int $batchSize): iterable
+    private function getAllProductUuids(int $batchSize): iterable
     {
-        $formerId = 0;
-        $sql = <<< SQL
-SELECT id, identifier
+        $lastUuidAsBytes = '';
+        $sql = <<<SQL
+SELECT uuid
 FROM pim_catalog_product
-WHERE id > :formerId
-ORDER BY id ASC
+WHERE uuid > :lastUuid
+ORDER BY uuid ASC
 LIMIT :limit
 SQL;
         while (true) {
-            $rows = $this->connection->executeQuery(
+            $rows = $this->connection->fetchFirstColumn(
                 $sql,
                 [
-                    'formerId' => $formerId,
+                    'lastUuid' => $lastUuidAsBytes,
                     'limit' => $batchSize,
                 ],
                 [
-                    'formerId' => \PDO::PARAM_INT,
+                    'lastUuid' => \PDO::PARAM_STR,
                     'limit' => \PDO::PARAM_INT,
                 ]
-            )->fetchAllAssociative();
+            );
 
             if (empty($rows)) {
                 return;
             }
 
-            $formerId =(int)end($rows)['id'];
+            $formerId = (int)end($rows)['id'];
             yield array_column($rows, 'identifier');
         }
     }
 
-    private function getExistingProductIdentifiers(array $identifiers): array
+    private function getExistingProductUuids(array $identifiers): array
     {
         $sql = <<<SQL
-SELECT identifier
+SELECT identifier, BIN_TO_UUID(uuid) AS uuid
 FROM pim_catalog_product
 WHERE identifier IN (:identifiers);
 SQL;
 
-        return $this->connection->executeQuery(
+        $uuids = $this->connection->executeQuery(
             $sql,
-            [
-                'identifiers' => $identifiers,
-            ],
-            [
-                'identifiers' => Connection::PARAM_STR_ARRAY,
-            ]
-        )->fetchFirstColumn();
+            ['identifiers' => $identifiers],
+            ['identifiers' => Connection::PARAM_STR_ARRAY]
+        )->fetchAllKeyValue();
+
+        return array_map(fn (string $uuid): UuidInterface => Uuid::fromString($uuid), $uuids);
     }
 
     /**
@@ -209,13 +209,13 @@ SQL;
         }
     }
 
-    private function getDiffProductIdentifiers(int $batchSize)
+    private function getDiffProductUuids(int $batchSize)
     {
-        $formerId = null;
+        $lastUuid = '';
         $sql = <<< SQL
-SELECT CONCAT('product_',BIN_TO_UUID(uuid)) AS _id, BIN_TO_UUID(uuid) AS uuid, identifier, DATE_FORMAT(updated, '%Y-%m-%dT%TZ') AS updated
+SELECT CONCAT('product_',BIN_TO_UUID(uuid)) AS _id, BIN_TO_UUID(uuid) AS uuid, DATE_FORMAT(updated, '%Y-%m-%dT%TZ') AS updated
 FROM pim_catalog_product
-WHERE (CASE WHEN :formerId IS NULL THEN TRUE ELSE uuid > :formerId END)
+WHERE uuid > :lastUuid
 ORDER BY uuid ASC
 LIMIT :limit
 SQL;
@@ -223,11 +223,11 @@ SQL;
             $rows = $this->connection->executeQuery(
                 $sql,
                 [
-                    'formerId' => $formerId,
+                    'lastUuid' => $lastUuid,
                     'limit' => $batchSize,
                 ],
                 [
-                    'formerId' => \PDO::PARAM_STR,
+                    'lastUuid' => \PDO::PARAM_STR,
                     'limit' => \PDO::PARAM_INT,
                 ]
             )->fetchAllAssociative();
@@ -236,7 +236,7 @@ SQL;
                 return;
             }
 
-            $formerId = end($rows)['uuid'];
+            $lastUuid = end($rows)['uuid'];
 
             $existingMysqlIdentifiers = array_column($rows, '_id');
             $existingMysqlUpdated = array_column($rows, 'updated');
@@ -267,7 +267,7 @@ SQL;
                 $rows,
                 function ($carry, $item) use ($esIdentifiers) {
                     if (!in_array($item['_id'], $esIdentifiers)) {
-                        $carry[] = $item['identifier'];
+                        $carry[] = Uuid::fromString($item['uuid']);
                     }
 
                     return $carry;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
@@ -26,19 +26,8 @@ class ProductAndAncestorsIndexer
     public function __construct(
         private ProductIndexerInterface $productIndexer,
         private ProductModelIndexerInterface $productModelIndexer,
-        private GetAncestorProductModelCodes $getAncestorProductModelCodes,
-        private SqlFindProductUuids $sqlFindProductUuids
+        private GetAncestorProductModelCodes $getAncestorProductModelCodes
     ) {
-    }
-
-    /**
-     * @deprecated
-     */
-    public function indexFromProductIdentifiers(array $identifiers, array $options = []): void
-    {
-        $uuids = $this->sqlFindProductUuids->fromIdentifiers($identifiers);
-
-        $this->indexFromProductUuids(\array_values($uuids), $options);
     }
 
     public function indexFromProductUuids(array $uuids, array $options = []): void

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
@@ -38,7 +38,7 @@ class ProductAndAncestorsIndexer
     {
         $uuids = $this->sqlFindProductUuids->fromIdentifiers($identifiers);
 
-        $this->indexFromProductUuids($uuids, $options);
+        $this->indexFromProductUuids(\array_values($uuids), $options);
     }
 
     public function indexFromProductUuids(array $uuids, array $options = []): void

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
@@ -36,11 +36,17 @@ class ProductAndAncestorsIndexer
      */
     public function indexFromProductIdentifiers(array $identifiers, array $options = []): void
     {
-        $ancestorProductModelCodes = $this->getAncestorProductModelCodes->fromProductIdentifiers($identifiers);
+        $uuids = $this->sqlFindProductUuids->fromIdentifiers($identifiers);
+
+        $this->indexFromProductUuids($uuids, $options);
+    }
+
+    public function indexFromProductUuids(array $uuids, array $options = []): void
+    {
+        $ancestorProductModelCodes = $this->getAncestorProductModelCodes->fromProductUuids($uuids);
         if (!empty($ancestorProductModelCodes)) {
             $this->productModelIndexer->indexFromProductModelCodes($ancestorProductModelCodes, $options);
         }
-        $uuids = $this->sqlFindProductUuids->fromIdentifiers($identifiers);
         $this->productIndexer->indexFromProductUuids($uuids, $options);
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAncestorProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
 use Ramsey\Uuid\UuidInterface;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductIndexer.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductProjectionInterface;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Refresh;
@@ -29,29 +28,8 @@ class ProductIndexer implements ProductIndexerInterface
 
     public function __construct(
         private Client $productAndProductModelClient,
-        private GetElasticsearchProductProjectionInterface $getElasticsearchProductProjection,
-        private SqlFindProductUuids $sqlFindProductUuids
+        private GetElasticsearchProductProjectionInterface $getElasticsearchProductProjection
     ) {
-    }
-
-    /**
-     * Indexes a list of products in the product_and_product_model index from their identifiers.
-     *
-     * If the index_refresh is provided, it uses the refresh strategy defined.
-     * Otherwise the waitFor strategy is by default.
-     *
-     * {@inheritdoc}
-     * @deprecated
-     */
-    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []): void
-    {
-        if (empty($productIdentifiers)) {
-            return;
-        }
-
-        $productUuids = $this->sqlFindProductUuids->fromIdentifiers($productIdentifiers);
-
-        $this->indexFromProductUuids($productUuids, $options);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
@@ -29,8 +29,7 @@ class ProductModelDescendantsAndAncestorsIndexer
         private ProductIndexerInterface $productIndexer,
         private ProductModelIndexerInterface $productModelIndexer,
         private GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
-        private GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes,
-        private SqlFindProductUuids $sqlFindProductUuids
+        private GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
     }
 
@@ -53,12 +52,12 @@ class ProductModelDescendantsAndAncestorsIndexer
             \array_unique(\array_merge($productModelCodes, $ancestorAndDescendantsProductModelCodes))
         );
 
-        $variantProductIdentifiers = $this->getDescendantVariantProductIdentifiers->fromProductModelCodes(
+        $variantProductUuids = $this->getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(
             $productModelCodes
         );
-        if (!empty($variantProductIdentifiers)) {
-            $uuids = $this->sqlFindProductUuids->fromIdentifiers($variantProductIdentifiers);
-            $this->productIndexer->indexFromProductUuids($uuids);
+
+        if (!empty($variantProductUuids)) {
+            $this->productIndexer->indexFromProductUuids($variantProductUuids);
         }
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
@@ -6,7 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetAncestorAndDescendantProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
 
@@ -28,7 +28,7 @@ class ProductModelDescendantsAndAncestorsIndexer
     public function __construct(
         private ProductIndexerInterface $productIndexer,
         private ProductModelIndexerInterface $productModelIndexer,
-        private GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        private GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         private GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
     }
@@ -52,7 +52,7 @@ class ProductModelDescendantsAndAncestorsIndexer
             \array_unique(\array_merge($productModelCodes, $ancestorAndDescendantsProductModelCodes))
         );
 
-        $variantProductUuids = $this->getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(
+        $variantProductUuids = $this->getDescendantVariantProductUuids->fromProductModelCodes(
             $productModelCodes
         );
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetAncestorAndDescendantProductModelCodes;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
@@ -24,21 +25,13 @@ use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerI
  */
 class ProductModelDescendantsAndAncestorsIndexer
 {
-    private ProductIndexerInterface $productIndexer;
-    private ProductModelIndexerInterface $productModelIndexer;
-    private GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers;
-    private GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes;
-
     public function __construct(
-        ProductIndexerInterface $productIndexer,
-        ProductModelIndexerInterface $productModelIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
-        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
+        private ProductIndexerInterface $productIndexer,
+        private ProductModelIndexerInterface $productModelIndexer,
+        private GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        private GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes,
+        private SqlFindProductUuids $sqlFindProductUuids
     ) {
-        $this->productIndexer = $productIndexer;
-        $this->productModelIndexer = $productModelIndexer;
-        $this->getDescendantVariantProductIdentifiers = $getDescendantVariantProductIdentifiers;
-        $this->getAncestorAndDescendantProductModelCodes = $getAncestorAndDescendantProductModelCodes;
     }
 
     /**
@@ -64,7 +57,8 @@ class ProductModelDescendantsAndAncestorsIndexer
             $productModelCodes
         );
         if (!empty($variantProductIdentifiers)) {
-            $this->productIndexer->indexFromProductIdentifiers($variantProductIdentifiers);
+            $uuids = $this->sqlFindProductUuids->fromIdentifiers($variantProductIdentifiers);
+            $this->productIndexer->indexFromProductUuids($uuids);
         }
     }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetAncestorAndDescendantProductModelCodes;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithAssociations/PersistTwoWayAssociationSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithAssociations/PersistTwoWayAssociationSubscriber.php
@@ -15,20 +15,14 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 final class PersistTwoWayAssociationSubscriber implements EventSubscriberInterface
 {
-    private ManagerRegistry $registry;
-    private ProductIndexerInterface $productIndexer;
-    private ProductModelIndexerInterface $productModelIndexer;
-    private array $productIdentifiersToIndex = [];
+    private array $productUuidsToIndex = [];
     private array $productModelCodesToIndex = [];
 
     public function __construct(
-        ManagerRegistry $registry,
-        ProductIndexerInterface $productIndexer,
-        ProductModelIndexerInterface $productModelIndexer
+        private ManagerRegistry $registry,
+        private ProductIndexerInterface $productIndexer,
+        private ProductModelIndexerInterface $productModelIndexer
     ) {
-        $this->registry = $registry;
-        $this->productIndexer = $productIndexer;
-        $this->productModelIndexer = $productModelIndexer;
     }
 
     public static function getSubscribedEvents(): array
@@ -59,7 +53,7 @@ final class PersistTwoWayAssociationSubscriber implements EventSubscriberInterfa
 
             foreach ($association->getProducts() as $product) {
                 $em->persist($product);
-                $this->productIdentifiersToIndex[] = $product->getIdentifier();
+                $this->productUuidsToIndex[] = $product->getUuid();
             }
 
             foreach ($association->getProductModels() as $productModel) {
@@ -71,10 +65,10 @@ final class PersistTwoWayAssociationSubscriber implements EventSubscriberInterfa
 
     public function indexAssociatedEntities()
     {
-        $this->productIndexer->indexFromProductIdentifiers($this->productIdentifiersToIndex);
+        $this->productIndexer->indexFromProductUuids($this->productUuidsToIndex);
         $this->productModelIndexer->indexFromProductModelCodes($this->productModelCodesToIndex);
 
-        $this->productIdentifiersToIndex = [];
+        $this->productUuidsToIndex = [];
         $this->productModelCodesToIndex = [];
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
@@ -90,6 +90,7 @@ final class ComputeProductAndAncestorsSubscriber implements EventSubscriberInter
             return;
         }
 
+        // TODO
         $variantProductIdentifiers = $this->getDescendantVariantProductIdentifiers->fromProductModelCodes(
             $productModelCodes
         );

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
@@ -6,7 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductModel\OnSave;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -24,23 +24,11 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 final class ComputeProductAndAncestorsSubscriber implements EventSubscriberInterface
 {
-    /** @var ComputeAndPersistProductCompletenesses */
-    private $computeAndPersistProductCompletenesses;
-
-    /** @var ProductModelDescendantsAndAncestorsIndexer */
-    private $productModelDescendantsAndAncestorsIndexer;
-
-    /** @var GetDescendantVariantProductIdentifiers */
-    private $getDescendantVariantProductIdentifiers;
-
     public function __construct(
-        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
-        ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers
+        private ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        private ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
+        private GetDescendantVariantProductUuids $getDescendantVariantProductUuids
     ) {
-        $this->computeAndPersistProductCompletenesses = $computeAndPersistProductCompletenesses;
-        $this->productModelDescendantsAndAncestorsIndexer = $productModelDescendantsAndAncestorsIndexer;
-        $this->getDescendantVariantProductIdentifiers = $getDescendantVariantProductIdentifiers;
     }
 
     public static function getSubscribedEvents(): array
@@ -90,12 +78,12 @@ final class ComputeProductAndAncestorsSubscriber implements EventSubscriberInter
             return;
         }
 
-        // TODO
-        $variantProductIdentifiers = $this->getDescendantVariantProductIdentifiers->fromProductModelCodes(
+        $variantProductUuids = $this->getDescendantVariantProductUuids->fromProductModelCodes(
             $productModelCodes
         );
-        if (!empty($variantProductIdentifiers)) {
-            $this->computeAndPersistProductCompletenesses->fromProductIdentifiers($variantProductIdentifiers);
+        if (!empty($variantProductUuids)) {
+            // TODO
+            $this->computeAndPersistProductCompletenesses->fromProductUuids($variantProductUuids);
         }
 
         $this->productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes($productModelCodes);

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriber.php
@@ -82,7 +82,6 @@ final class ComputeProductAndAncestorsSubscriber implements EventSubscriberInter
             $productModelCodes
         );
         if (!empty($variantProductUuids)) {
-            // TODO
             $this->computeAndPersistProductCompletenesses->fromProductUuids($variantProductUuids);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Job/IndexFamilyProductsAndProductModelsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Job/IndexFamilyProductsAndProductModelsTasklet.php
@@ -128,6 +128,7 @@ final class IndexFamilyProductsAndProductModelsTasklet implements TaskletInterfa
     {
         $family = $this->familyReader->read();
         Assert::nullOrIsInstanceOf($family, FamilyInterface::class);
+
         return $family;
     }
 
@@ -138,9 +139,11 @@ final class IndexFamilyProductsAndProductModelsTasklet implements TaskletInterfa
     {
         $envelope = $this->messageBus->dispatch(new GetProductUuidsQuery([
             'family' => [
-                'operator' => Operators::IN_LIST,
-                'value' => $familyCodes
-            ]
+                [
+                    'operator' => Operators::IN_LIST,
+                    'value' => $familyCodes,
+                ],
+            ],
         ], null));
 
         $handledStamp = $envelope->last(HandledStamp::class);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Job/IndexFamilyProductsAndProductModelsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Job/IndexFamilyProductsAndProductModelsTasklet.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery;
+use Akeneo\Pim\Enrichment\Product\API\Query\ProductUuidCursorInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
@@ -135,7 +136,7 @@ final class IndexFamilyProductsAndProductModelsTasklet implements TaskletInterfa
     /**
      * @param string[] $familyCodes
      */
-    private function getProductUuidsForFamilies(array $familyCodes): CursorInterface
+    private function getProductUuidsForFamilies(array $familyCodes): ProductUuidCursorInterface
     {
         $envelope = $this->messageBus->dispatch(new GetProductUuidsQuery([
             'family' => [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Bundle\Product;
 
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Ramsey\Uuid\UuidInterface;
@@ -20,20 +19,8 @@ class ComputeAndPersistProductCompletenesses
 
     public function __construct(
         private CompletenessCalculator $completenessCalculator,
-        private SaveProductCompletenesses $saveProductCompletenesses,
-        private SqlFindProductUuids $sqlFindProductUuids
+        private SaveProductCompletenesses $saveProductCompletenesses
     ) {
-    }
-
-    /**
-     * @param string[] $productIdentifiers
-     * @deprecated
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): void
-    {
-        $uuids = $this->sqlFindProductUuids->fromIdentifiers($productIdentifiers);
-
-        $this->fromProductUuids($uuids);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Product/ComputeAndPersistProductCompletenesses.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Product;
 
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author    Pierre Allard <pierre.allard@akeneo.com>
@@ -31,20 +32,24 @@ class ComputeAndPersistProductCompletenesses
     }
 
     /**
-     * @param string $productIdentifier
-     */
-    public function fromProductIdentifier(string $productIdentifier): void
-    {
-        $this->fromProductIdentifiers([$productIdentifier]);
-    }
-
-    /**
      * @param string[] $productIdentifiers
+     * @deprecated
      */
     public function fromProductIdentifiers(array $productIdentifiers): void
     {
         foreach (array_chunk($productIdentifiers, self::CHUNK_SIZE) as $identifiersChunk) {
             $completenessCollections = $this->completenessCalculator->fromProductIdentifiers($identifiersChunk);
+            $this->saveProductCompletenesses->saveAll($completenessCollections);
+        }
+    }
+
+    /**
+     * @param UuidInterface[] $productUuids
+     */
+    public function fromProductUuids(array $productUuids): void
+    {
+        foreach (array_chunk($productUuids, self::CHUNK_SIZE) as $uuidsChunk) {
+            $completenessCollections = $this->completenessCalculator->fromProductUuids($uuidsChunk);
             $this->saveProductCompletenesses->saveAll($completenessCollections);
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
@@ -11,7 +11,6 @@ services:
         arguments:
             - '@pim_catalog.completeness.calculator'
             - '@akeneo.pim.enrichment.product.query.save_product_completenesses'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_catalog.completeness.missing_required_attributes_calculator:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Completeness\MissingRequiredAttributesCalculator'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness.yml
@@ -11,6 +11,7 @@ services:
         arguments:
             - '@pim_catalog.completeness.calculator'
             - '@akeneo.pim.enrichment.product.query.save_product_completenesses'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_catalog.completeness.missing_required_attributes_calculator:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Completeness\MissingRequiredAttributesCalculator'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -10,7 +10,6 @@ services:
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_catalog.elasticsearch.indexer.product_model:
         class: '%pim_catalog.elasticsearch.indexer.product_model_indexer.class%'
@@ -25,6 +24,7 @@ services:
             - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
             - '@akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors:
         class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer'
@@ -34,3 +34,4 @@ services:
             - '@pim_catalog.elasticsearch.indexer.product_model'
             - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers'
             - '@akeneo.pim.enrichment.product.query.get_ancestor_and_descendant_product_model_codes'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -32,5 +32,5 @@ services:
         arguments:
             - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
-            - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers'
+            - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids'
             - '@akeneo.pim.enrichment.product.query.get_ancestor_and_descendant_product_model_codes'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -34,4 +34,3 @@ services:
             - '@pim_catalog.elasticsearch.indexer.product_model'
             - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers'
             - '@akeneo.pim.enrichment.product.query.get_ancestor_and_descendant_product_model_codes'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/elasticsearch.yml
@@ -24,7 +24,6 @@ services:
             - '@pim_catalog.elasticsearch.indexer.product'
             - '@pim_catalog.elasticsearch.indexer.product_model'
             - '@akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors:
         class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/event_subscribers.yml
@@ -156,7 +156,7 @@ services:
         arguments:
             - '@pim_catalog.completeness.product.compute_and_persist'
             - '@pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors'
-            - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers'
+            - '@akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -298,6 +298,7 @@ services:
             - '@akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors'
             - '@pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors'
             - '@pim_connector.doctrine.cache_clearer'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
             - '%pim_job_product_batch_size%'
 
     pim_connector.job.csv_group_import:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -226,6 +226,7 @@ services:
             - '@akeneo_batch.job_repository'
             - '@pim_catalog.completeness.calculator'
             - '@akeneo.pim.enrichment.product.query.save_product_completenesses'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     pim_connector.tasklet.xlsx_family.compute_data_related_to_family_root_product_models:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyRootProductModelsTasklet'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -220,13 +220,12 @@ services:
     pim_connector.tasklet.mass_edit_family.compute_completeness_of_family_products:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeCompletenessOfFamilyProductsTasklet'
         arguments:
-            - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_enrich.connector.reader.mass_edit.family'
             - '@pim_connector.doctrine.cache_clearer'
             - '@akeneo_batch.job_repository'
             - '@pim_catalog.completeness.calculator'
             - '@akeneo.pim.enrichment.product.query.save_product_completenesses'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
+            - '@pim_enrich.product.query_message_bus'
 
     pim_connector.tasklet.xlsx_family.compute_data_related_to_family_root_product_models:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeDataRelatedToFamilyRootProductModelsTasklet'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -293,12 +293,11 @@ services:
         arguments:
             - '@akeneo_batch.job_repository'
             - '@pim_enrich.connector.reader.mass_edit.family'
-            - '@pim_catalog.query.product_identifier_query_builder_factory'
             - '@pim_catalog.query.product_model_query_builder_factory'
             - '@akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors'
             - '@pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors'
             - '@pim_connector.doctrine.cache_clearer'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
+            - '@pim_enrich.product.query_message_bus'
             - '%pim_job_product_batch_size%'
 
     pim_connector.job.csv_group_import:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -317,8 +317,8 @@ services:
             - '@pim_catalog.normalizer.indexing_product.product.product_value_collection'
             - !tagged akeneo.pim.enrichment.product_model.query.indexing_additional_properties
 
-    akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers:
-        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers'
+    akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids:
+        class: 'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids'
         public: true
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -301,7 +301,6 @@ services:
             - '@database_connection'
             - '@pim_catalog.normalizer.indexing_product.product.product_value_collection'
             - '@akeneo.pim.enrichment.factory.read_value_collection'
-            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
             - !tagged akeneo.pim.enrichment.product.query.indexing_additional_properties
 
     akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -45,7 +45,7 @@ final class SqlGetCompletenessProductMasks implements GetCompletenessProductMask
         $this->getAttributes = $getAttributes;
         $this->valuesNormalizer = $valuesNormalizer;
     }
-    
+
     /**
      * {@inheritdoc}
      */
@@ -58,7 +58,7 @@ final class SqlGetCompletenessProductMasks implements GetCompletenessProductMask
         $sql = <<<SQL
 WITH
 filtered_product AS (
-    SELECT uuid FROM pim_catalog_product WHERE identifier IN (:productUuids)
+    SELECT uuid FROM pim_catalog_product WHERE uuid IN (:productUuids)
 )
 SELECT
     BIN_TO_UUID(product.uuid) AS uuid,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/SqlGetCompletenessProductMasks.php
@@ -45,58 +45,7 @@ final class SqlGetCompletenessProductMasks implements GetCompletenessProductMask
         $this->getAttributes = $getAttributes;
         $this->valuesNormalizer = $valuesNormalizer;
     }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @deprecated
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): array
-    {
-        // TODO - TIP-1212: Replace the first LEFT JOIN (to pim_catalog_family) by an INNER JOIN
-        // PIM-9783: the initial query didn't use the CTE, we filtered directly the product in the main SELECT. There
-        // was some performance issues with a big number of productIdentifier. The CTE allows to fix it (please check
-        // the issue for further information).
-        $sql = <<<SQL
-WITH
-filtered_product AS (
-    SELECT uuid FROM pim_catalog_product WHERE identifier IN (:productIdentifiers)
-)
-SELECT
-    BIN_TO_UUID(product.uuid) AS uuid,
-    product.identifier AS identifier,
-    family.code AS familyCode,
-    JSON_MERGE(
-           COALESCE(pm1.raw_values, '{}'),
-           COALESCE(pm2.raw_values, '{}'),
-           product.raw_values
-    ) AS rawValues
-FROM filtered_product
-    INNER JOIN pim_catalog_product product ON filtered_product.uuid = product.uuid
-    LEFT JOIN pim_catalog_family family ON product.family_id = family.id
-    LEFT JOIN pim_catalog_product_model pm1 ON product.product_model_id = pm1.id
-    LEFT JOIN pim_catalog_product_model pm2 ON pm1.parent_id = pm2.id
-SQL;
-
-        $rows = array_map(
-            function (array $row): array {
-                return [
-                    'id' => $row['uuid'],
-                    'identifier' => $row['identifier'],
-                    'familyCode' => $row['familyCode'],
-                    'cleanedRawValues' => json_decode($row['rawValues'], true),
-                ];
-            },
-            $this->connection->executeQuery(
-                $sql,
-                ['productIdentifiers' => $productIdentifiers],
-                ['productIdentifiers' => Connection::PARAM_STR_ARRAY]
-            )->fetchAllAssociative()
-        );
-
-        return $this->buildProductMasks($rows);
-    }
-
+    
     /**
      * {@inheritdoc}
      */

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ElasticsearchProjection;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetAdditionalPropertiesForProductProjectionInterface;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductProjectionInterface;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\ReadValueCollectionFactory;
 use Doctrine\DBAL\Connection;
@@ -30,7 +29,6 @@ final class GetElasticsearchProductProjection implements GetElasticsearchProduct
         private Connection $connection,
         private NormalizerInterface $valuesNormalizer,
         private ReadValueCollectionFactory $readValueCollectionFactory,
-        private SqlFindProductUuids $sqlFindProductUuids,
         private iterable $additionalDataProviders = []
     ) {
         Assert::allIsInstanceOf(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAncestorProductModelCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Product/GetAncestorProductModelCodes.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\FetchMode;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
@@ -13,22 +13,19 @@ use Doctrine\DBAL\FetchMode;
  */
 class GetAncestorProductModelCodes
 {
-    /** @var Connection */
-    private $connection;
-
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        private Connection $connection
+    ) {
     }
 
     /**
-     * @param string[] $identifiers
+     * @param UuidInterface[] $productUuids
      *
      * @return string[]
      */
-    public function fromProductIdentifiers(array $identifiers): array
+    public function fromProductUuids(array $productUuids): array
     {
-        if (empty($identifiers)) {
+        if (empty($productUuids)) {
             return [];
         }
 
@@ -37,7 +34,7 @@ WITH sub_product_model AS (
     SELECT parent.parent_id, parent.code
     FROM pim_catalog_product product
     INNER JOIN pim_catalog_product_model parent ON parent.id = product.product_model_id
-    WHERE product.identifier IN (:identifiers)
+    WHERE product.uuid IN (:uuids)
 )
 SELECT sub_product_model.code
 FROM sub_product_model
@@ -47,14 +44,12 @@ FROM sub_product_model
 INNER JOIN pim_catalog_product_model root ON root.id = sub_product_model.parent_id;
 SQL;
 
+        $productUuidsAsBytes = \array_map(fn (UuidInterface $uuid): string => $uuid->getBytes(), $productUuids);
+
         return $this->connection->executeQuery(
             $sql,
-            [
-                'identifiers' => $identifiers,
-            ],
-            [
-                'identifiers' => Connection::PARAM_STR_ARRAY,
-            ]
+            ['uuids' => $productUuidsAsBytes],
+            ['uuids' => Connection::PARAM_STR_ARRAY]
         )->fetchFirstColumn();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiers.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductIdentifiers.php
@@ -5,22 +5,25 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel;
 
 use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
+// TODO Rename to ProductUuids
 class GetDescendantVariantProductIdentifiers
 {
-    /** @var Connection  */
-    private $connection;
-
-    public function __construct(Connection $connection)
-    {
-        $this->connection = $connection;
+    public function __construct(
+        private Connection $connection
+    ) {
     }
 
+    /**
+     * @deprecated
+     */
     public function fromProductModelCodes(array $productModelCodes): array
     {
         if (empty($productModelCodes)) {
@@ -50,5 +53,45 @@ SQL;
             ['codes' => $productModelCodes],
             ['codes' => Connection::PARAM_STR_ARRAY]
         )->fetchFirstColumn();
+    }
+
+    /**
+     * @param string[] $productModelCodes
+     * @return UuidInterface $uuids
+     *
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function fromProductModelCodes_TO_USE(array $productModelCodes): array
+    {
+        if (empty($productModelCodes)) {
+            return [];
+        }
+
+        $sql = <<<SQL
+WITH
+filter_product_model AS (
+    SELECT id, parent_id, code FROM pim_catalog_product_model WHERE code IN (:codes)
+)
+SELECT
+    BIN_TO_UUID(product.uuid) AS uuid
+FROM filter_product_model
+    INNER JOIN pim_catalog_product product ON filter_product_model.id = product.product_model_id
+UNION DISTINCT
+SELECT
+    BIN_TO_UUID(product.uuid) AS uuid
+FROM filter_product_model
+    INNER JOIN pim_catalog_product_model product_model ON filter_product_model.id = product_model.parent_id
+        AND product_model.parent_id IS NOT NULL
+    INNER JOIN pim_catalog_product product             ON product_model.id = product.product_model_id
+SQL;
+
+        $result = $this->connection->executeQuery(
+            $sql,
+            ['codes' => $productModelCodes],
+            ['codes' => Connection::PARAM_STR_ARRAY]
+        )->fetchFirstColumn();
+
+        return array_map(fn (string $uuid): UuidInterface => Uuid::fromString($uuid), $result);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductUuids.php
@@ -22,7 +22,7 @@ class GetDescendantVariantProductUuids
 
     /**
      * @param string[] $productModelCodes
-     * @return UuidInterface $uuids
+     * @return UuidInterface[] $uuids
      *
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ProductModel/GetDescendantVariantProductUuids.php
@@ -13,46 +13,11 @@ use Ramsey\Uuid\UuidInterface;
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-// TODO Rename to ProductUuids
-class GetDescendantVariantProductIdentifiers
+class GetDescendantVariantProductUuids
 {
     public function __construct(
         private Connection $connection
     ) {
-    }
-
-    /**
-     * @deprecated
-     */
-    public function fromProductModelCodes(array $productModelCodes): array
-    {
-        if (empty($productModelCodes)) {
-            return [];
-        }
-
-        $sql = <<<SQL
-WITH
-filter_product_model AS (
-    SELECT id, parent_id, code FROM pim_catalog_product_model WHERE code IN (:codes)
-)
-SELECT
-    product.identifier
-FROM filter_product_model
-    INNER JOIN pim_catalog_product product ON filter_product_model.id = product.product_model_id
-UNION DISTINCT
-SELECT
-    product.identifier
-FROM filter_product_model
-    INNER JOIN pim_catalog_product_model product_model ON filter_product_model.id = product_model.parent_id
-        AND product_model.parent_id IS NOT NULL
-    INNER JOIN pim_catalog_product product             ON product_model.id = product.product_model_id
-SQL;
-
-        return $this->connection->executeQuery(
-            $sql,
-            ['codes' => $productModelCodes],
-            ['codes' => Connection::PARAM_STR_ARRAY]
-        )->fetchFirstColumn();
     }
 
     /**
@@ -62,7 +27,7 @@ SQL;
      * @throws \Doctrine\DBAL\Driver\Exception
      * @throws \Doctrine\DBAL\Exception
      */
-    public function fromProductModelCodes_TO_USE(array $productModelCodes): array
+    public function fromProductModelCodes(array $productModelCodes): array
     {
         if (empty($productModelCodes)) {
             return [];

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessCalculator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessCalculator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Completeness;
 
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\CompletenessProductMask;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodesCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetCompletenessProductMasks;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessCalculator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/CompletenessCalculator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Completeness;
 
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\CompletenessProductMask;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodesCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetCompletenessProductMasks;
@@ -17,40 +18,10 @@ use Ramsey\Uuid\UuidInterface;
  */
 class CompletenessCalculator
 {
-    /** @var GetCompletenessProductMasks */
-    private $getCompletenessProductMasks;
-
-    /** @var GetRequiredAttributesMasks */
-    private $getRequiredAttributesMasks;
-
     public function __construct(
-        GetCompletenessProductMasks $getCompletenessProductMasks,
-        GetRequiredAttributesMasks $getRequiredAttributesMasks
+        private GetCompletenessProductMasks $getCompletenessProductMasks,
+        private GetRequiredAttributesMasks $getRequiredAttributesMasks
     ) {
-        $this->getCompletenessProductMasks = $getCompletenessProductMasks;
-        $this->getRequiredAttributesMasks = $getRequiredAttributesMasks;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function fromProductIdentifiers($productIdentifiers): array
-    {
-        $productMasks = $this->getCompletenessProductMasks->fromProductIdentifiers($productIdentifiers);
-
-        $familyCodes = array_map(function (CompletenessProductMask $product) {
-            return $product->familyCode();
-        }, $productMasks);
-
-        $requiredAttributesMasks = $this->getRequiredAttributesMasks->fromFamilyCodes(array_unique(array_filter($familyCodes)));
-
-        $result = [];
-        foreach ($productMasks as $productMask) {
-            $attributeRequirementMask = $requiredAttributesMasks[$productMask->familyCode()] ?? null;
-            $result[$productMask->identifier()] = $productMask->completenessCollectionForProduct($attributeRequirementMask);
-        }
-
-        return $result;
     }
 
     public function fromProductUuids(array $productUuids): array
@@ -70,14 +41,6 @@ class CompletenessCalculator
         }
 
         return $result;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function fromProductIdentifier($productIdentifier): ?ProductCompletenessWithMissingAttributeCodesCollection
-    {
-        return $this->fromProductIdentifiers([$productIdentifier])[$productIdentifier] ?? null;
     }
 
     public function fromProductUuid(UuidInterface $productUuid): ?ProductCompletenessWithMissingAttributeCodesCollection

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetCompletenessProductMasks.php
@@ -25,6 +25,15 @@ interface GetCompletenessProductMasks
      * @param string[] $productIdentifiers
      *
      * @return CompletenessProductMask[]
+     *
+     * @deprecated
      */
     public function fromProductIdentifiers(array $productIdentifiers): array;
+
+    /**
+     * @param UuidInterface[] $productUuids
+     *
+     * @return CompletenessProductMask[]
+     */
+    public function fromProductUuids(array $productUuids): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetCompletenessProductMasks.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/Query/GetCompletenessProductMasks.php
@@ -22,15 +22,6 @@ interface GetCompletenessProductMasks
     public function fromValueCollection($id, string $identifier, string $familyCode, WriteValueCollection $values): CompletenessProductMask;
 
     /**
-     * @param string[] $productIdentifiers
-     *
-     * @return CompletenessProductMask[]
-     *
-     * @deprecated
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): array;
-
-    /**
      * @param UuidInterface[] $productUuids
      *
      * @return CompletenessProductMask[]

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -123,8 +123,10 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
     {
         $envelope = $this->messageBus->dispatch(new GetProductUuidsQuery([
             'family' => [
-                'operator' => Operators::IN_LIST,
-                'value' => $familyCodes
+                [
+                    'operator' => Operators::IN_LIST,
+                    'value' => $familyCodes,
+                ],
             ]
         ], null));
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
+use Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
@@ -20,6 +17,8 @@ use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Webmozart\Assert\Assert;
 
 /**
@@ -38,13 +37,12 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
     private StepExecution $stepExecution;
 
     public function __construct(
-        private ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         private ItemReaderInterface $familyReader,
         private EntityManagerClearerInterface $cacheClearer,
         private JobRepositoryInterface $jobRepository,
         private CompletenessCalculator $completenessCalculator,
         private SaveProductCompletenesses $saveProductCompletenesses,
-        private SqlFindProductUuids $sqlFindProductUuids
+        private MessageBusInterface $messageBus
     ) {
     }
 
@@ -75,35 +73,32 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
             return;
         }
 
-        $identifierResults = $this->getProductIdentifiersForFamilies($familyCodes);
-        $this->stepExecution->setTotalItems($identifierResults->count());
+        $productUuids = $this->getProductUuidsForFamilies($familyCodes);
+        $this->stepExecution->setTotalItems($productUuids->count());
 
-        $productsToCompute = [];
-        /** @var IdentifierResult $identifierResult */
-        foreach ($identifierResults as $identifierResult) {
-            Assert::same($identifierResult->getType(), ProductInterface::class);
-            $productsToCompute[] = $identifierResult->getIdentifier();
+        $productUuidsToCompute = [];
+        foreach ($productUuids as $uuid) {
+            $productUuidsToCompute[] = $uuid;
 
-            if (count($productsToCompute) >= self::BATCH_SIZE) {
-                $this->computeCompleteness($productsToCompute);
+            if (count($productUuidsToCompute) >= self::BATCH_SIZE) {
+                $this->computeCompleteness($productUuidsToCompute);
                 $this->cacheClearer->clear();
-                $productsToCompute = [];
+                $productUuidsToCompute = [];
             }
         }
 
-        if (count($productsToCompute) > 0) {
-            $this->computeCompleteness($productsToCompute);
+        if (count($productUuidsToCompute) > 0) {
+            $this->computeCompleteness($productUuidsToCompute);
         }
     }
 
-    private function computeCompleteness(array $productIdentifiers): void
+    private function computeCompleteness(array $productUuids): void
     {
-        $uuids = $this->sqlFindProductUuids->fromIdentifiers($productIdentifiers);
-        $completenessCollections = $this->completenessCalculator->fromProductUuids(\array_values($uuids));
+        $completenessCollections = $this->completenessCalculator->fromProductUuids($productUuids);
         $this->saveProductCompletenesses->saveAll($completenessCollections);
 
-        $this->stepExecution->incrementProcessedItems(count($productIdentifiers));
-        $this->stepExecution->incrementSummaryInfo('process', count($productIdentifiers));
+        $this->stepExecution->incrementProcessedItems(count($productUuids));
+        $this->stepExecution->incrementSummaryInfo('process', count($productUuids));
         $this->jobRepository->updateStepExecution($this->stepExecution);
     }
 
@@ -124,11 +119,18 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
         return $familyCodes;
     }
 
-    private function getProductIdentifiersForFamilies(array $familyCodes): CursorInterface
+    private function getProductUuidsForFamilies(array $familyCodes): CursorInterface
     {
-        $productQueryBuilder = $this->productQueryBuilderFactory->create();
-        $productQueryBuilder->addFilter('family', Operators::IN_LIST, $familyCodes);
+        $envelope = $this->messageBus->dispatch(new GetProductUuidsQuery([
+            'family' => [
+                'operator' => Operators::IN_LIST,
+                'value' => $familyCodes
+            ]
+        ], null));
 
-        return $productQueryBuilder->execute();
+        $handledStamp = $envelope->last(HandledStamp::class);
+        Assert::notNull($handledStamp, 'The bus does not return any result');
+
+        return $handledStamp->getResult();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -99,7 +99,7 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
     private function computeCompleteness(array $productIdentifiers): void
     {
         $uuids = $this->sqlFindProductUuids->fromIdentifiers($productIdentifiers);
-        $completenessCollections = $this->completenessCalculator->fromProductUuids($uuids);
+        $completenessCollections = $this->completenessCalculator->fromProductUuids(\array_values($uuids));
         $this->saveProductCompletenesses->saveAll($completenessCollections);
 
         $this->stepExecution->incrementProcessedItems(count($productIdentifiers));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTasklet.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery;
+use Akeneo\Pim\Enrichment\Product\API\Query\ProductUuidCursorInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
@@ -16,7 +17,6 @@ use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
-use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Webmozart\Assert\Assert;
@@ -119,7 +119,7 @@ class ComputeCompletenessOfFamilyProductsTasklet implements TaskletInterface, Tr
         return $familyCodes;
     }
 
-    private function getProductUuidsForFamilies(array $familyCodes): CursorInterface
+    private function getProductUuidsForFamilies(array $familyCodes): ProductUuidCursorInterface
     {
         $envelope = $this->messageBus->dispatch(new GetProductUuidsQuery([
             'family' => [

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizer.php
@@ -225,8 +225,9 @@ class EntityWithFamilyVariantNormalizer implements NormalizerInterface, Cacheabl
         }
 
         if ($entity instanceof ProductInterface && $entity->isVariant()) {
-            $completenessCollection = $this->completenessCalculator->fromProductIdentifier($entity->getIdentifier());
+            $completenessCollection = $this->completenessCalculator->fromProductUuid($entity->getUuid());
             if (null === $completenessCollection) {
+                // TODO There is a remaining getId()
                 $completenessCollection = new ProductCompletenessWithMissingAttributeCodesCollection($entity->getId(), []);
             }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Storage/Indexer/ProductIndexerInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Storage/Indexer/ProductIndexerInterface.php
@@ -15,15 +15,6 @@ use Ramsey\Uuid\UuidInterface;
 interface ProductIndexerInterface
 {
     /**
-     * @param string[] $productIdentifiers
-     * @param array    $options
-     *
-     * @throws ObjectNotFoundException if one of the identifier is unknown
-     * @deprecated
-     */
-    public function indexFromProductIdentifiers(array $productIdentifiers, array $options = []): void;
-
-    /**
      * @param UuidInterface[] $productUuids
      * @param array $options
      *

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoader.php
@@ -25,6 +25,8 @@ use League\Flysystem\FilesystemOperator;
 use League\Flysystem\StorageAttributes;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclManager;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -424,9 +426,12 @@ class FixturesLoader implements FixturesLoaderInterface
      */
     protected function indexProducts(): void
     {
-        $query = 'SELECT identifier FROM pim_catalog_product';
-        $productIdentifiers = $this->dbConnection->executeQuery($query)->fetchAll(\PDO::FETCH_COLUMN, 0);
-        $this->productIndexer->indexFromProductIdentifiers($productIdentifiers);
+        $query = 'SELECT BIN_TO_UUID(uuid) AS uuid FROM pim_catalog_product';
+        $productUuids = array_map(
+            fn (string $uuid): UuidInterface => Uuid::fromString($uuid),
+            $this->dbConnection->executeQuery($query)->fetchAll(\PDO::FETCH_COLUMN, 0)
+        );
+        $this->productIndexer->indexFromProductUuids($productUuids);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/DateTimeFilterIntegration.php
@@ -2,12 +2,15 @@
 
 namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter;
 
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
 use Doctrine\DBAL\Types\Type;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -230,7 +233,21 @@ SQL;
                 'updated_date' => Type::DATETIME
             ]);
 
-        $this->get('akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors')->indexFromProductIdentifiers([$identifier]);
+        $uuid = $this->getProductUuid($identifier);
+        $this->getProductAndAncestorsIndexer()->indexFromProductUuids([$uuid]);
+    }
 
+    private function getProductAndAncestorsIndexer(): ProductAndAncestorsIndexer
+    {
+        return $this->get('akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors');
+    }
+
+    private function getProductUuid(string $productIdentifier): UuidInterface
+    {
+        $result = $this
+            ->get('database_connection')
+            ->fetchOne('SELECT BIN_TO_UUID(uuid) FROM pim_catalog_product WHERE identifier=:identifier', ['identifier' => $productIdentifier]);
+
+        return Uuid::fromString($result);
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/CompletenessFilterIntegration.php
@@ -9,7 +9,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Completeness/SqlGetCompletenessProductMasksIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Completeness/SqlGetCompletenessProductMasksIntegration.php
@@ -26,7 +26,7 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 'sku-<all_channels>-<all_locales>',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product]);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Completeness/SqlGetCompletenessProductMasksIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Completeness/SqlGetCompletenessProductMasksIntegration.php
@@ -7,31 +7,33 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Completeness;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Completeness\SqlGetCompletenessProductMasks;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\CompletenessProductMask;
 use Akeneo\Pim\Enrichment\Component\Product\Model\PriceCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductPrice;
 use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Value\PriceCollectionValue;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use Akeneo\Test\Integration\TestCase;
+use Ramsey\Uuid\Uuid;
 
 class SqlGetCompletenessProductMasksIntegration extends TestCase
 {
     public function test_it_returns_mask_with_only_sku()
     {
-        $this->createProduct('simple_product', 'familyA', []);
+        $product = $this->createProduct('simple_product', 'familyA', []);
 
         $expected = [
             new CompletenessProductMask('-1', 'simple_product', 'familyA', [
                 'sku-<all_channels>-<all_locales>',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['simple_product']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_several_masks()
     {
-        $this->createProduct('product1', 'familyA', []);
-        $this->createProduct('product2', 'familyA', []);
+        $product1 = $this->createProduct('product1', 'familyA', []);
+        $product2 = $this->createProduct('product2', 'familyA', []);
 
         $expected = [
             new CompletenessProductMask('-1', 'product1', 'familyA', [
@@ -42,24 +44,24 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
             ])
         ];
 
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['product1', 'product2', 'nonExistingProduct']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product1->getUuid(), $product2->getUuid(), Uuid::uuid4()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_mask_for_a_product_without_family()
     {
-        $this->createProduct('product_without_family', null, []);
+        $product = $this->createProduct('product_without_family', null, []);
 
         $expected = [
             new CompletenessProductMask('-1', 'product_without_family', null, ['sku-<all_channels>-<all_locales>'])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['product_without_family']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_default_masks()
     {
-        $this->createProduct('complex_product', 'familyA', [
+        $product = $this->createProduct('complex_product', 'familyA', [
             'a_date' => [['locale' => null, 'scope' => null, 'data' => '2010-10-10']],
             'a_file' => [['locale' => null, 'scope' => null, 'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.txt'))]],
             'a_metric' => [['locale' => null, 'scope' => null, 'data' => ['amount' => 1, 'unit' => 'WATT']]],
@@ -95,13 +97,13 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 'sku-<all_channels>-<all_locales>',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['complex_product']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_mask_with_specific_channels()
     {
-        $this->createProduct('product_with_scopable_data', 'familyA', [
+        $product = $this->createProduct('product_with_scopable_data', 'familyA', [
             'a_localized_and_scopable_text_area' => [
                 ['locale' => 'en_US', 'scope' => 'ecommerce', 'data' => 'foo']
             ],
@@ -117,13 +119,13 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 'a_scopable_price-USD-ecommerce-<all_locales>',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['product_with_scopable_data']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_mask_with_specific_locales()
     {
-        $this->createProduct('product_with_localizable_data', 'familyA', [
+        $product = $this->createProduct('product_with_localizable_data', 'familyA', [
             'a_localizable_image' => [
                 ['locale' => 'en_US', 'scope' => null, 'data' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'))]
             ],
@@ -139,13 +141,13 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 'a_localized_and_scopable_text_area-ecommerce-en_US',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['product_with_localizable_data']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     public function test_it_returns_price_masks()
     {
-        $this->createProduct('product_with_prices', 'familyA', [
+        $product = $this->createProduct('product_with_prices', 'familyA', [
             'a_price' => [['locale' => null, 'scope' => null, 'data' => [['amount' => 50.00, 'currency' => 'EUR']]]],
             'a_scopable_price' => [
                 ['locale' => null, 'scope' => 'ecommerce', 'data' => [['amount' => '2000.00', 'currency' => 'USD']]]
@@ -159,13 +161,13 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 'a_scopable_price-USD-ecommerce-<all_locales>',
             ])
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['product_with_prices']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
     function test_that_it_returns_masks_even_if_an_attribute_was_deleted()
     {
-        $this->createProduct(
+        $product = $this->createProduct(
             'productA',
             'familyA',
             [
@@ -186,7 +188,7 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 ]
             )
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['productA']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
 
         $aPrice = $this->get('pim_catalog.repository.attribute')->findOneByIdentifier('a_price');
@@ -199,7 +201,7 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
                 ]
             ),
         ];
-        $result = $this->getCompletenessProductMasks()->fromProductIdentifiers(['productA']);
+        $result = $this->getCompletenessProductMasks()->fromProductUuids([$product->getUuid()]);
         $this->assertSameCompletenessProductMasks($expected, $result);
     }
 
@@ -250,7 +252,7 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
         return $this->catalog->useTechnicalSqlCatalog();
     }
 
-    private function createProduct(string $identifier, ?string $familyCode, array $values): void
+    private function createProduct(string $identifier, ?string $familyCode, array $values): ProductInterface
     {
         $product = $this->get('pim_catalog.builder.product')->createProduct($identifier, $familyCode);
         $this->get('pim_catalog.updater.product')->update($product, ['values' => $values]);
@@ -259,6 +261,8 @@ class SqlGetCompletenessProductMasksIntegration extends TestCase
             throw new \Exception(sprintf('Impossible to setup test in %s: %s', static::class, $errors->get(0)->getMessage()));
         }
         $this->get('pim_catalog.saver.product')->save($product);
+
+        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
     }
 
     private function getCompletenessProductMasks(): SqlGetCompletenessProductMasks {

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Enrichment\Integration\Storage\Sql\Product;
 
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAncestorProductModelCodes;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
@@ -13,6 +14,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 final class GetAncestorProductModelCodesIntegration extends TestCase
 {
@@ -20,8 +23,11 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
     {
         Assert::assertSame(
             [],
-            $this->get('akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes')
-                ->fromProductIdentifiers(['simple_product', 'another_product'])
+            $this->getAncestorProductModelCodes()
+                ->fromProductUuids([
+                    $this->getProductUuidFromIdentifier('simple_product'),
+                    $this->getProductUuidFromIdentifier('another_product')
+                ])
         );
     }
 
@@ -29,8 +35,13 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
     {
         Assert::assertEqualsCanonicalizing(
             ['root_A1', 'subpm_A1_optionA', 'root_A2'],
-            $this->get('akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes')
-                 ->fromProductIdentifiers(['simple_product', 'variant_A1_A_no', 'variant_A1_A_yes', 'variant_A2_B_no'])
+            $this->getAncestorProductModelCodes()
+                 ->fromProductUuids([
+                     $this->getProductUuidFromIdentifier('simple_product'),
+                     $this->getProductUuidFromIdentifier('variant_A1_A_no'),
+                     $this->getProductUuidFromIdentifier('variant_A1_A_yes'),
+                     $this->getProductUuidFromIdentifier('variant_A2_B_no')
+                 ])
         );
     }
 
@@ -122,5 +133,17 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function getAncestorProductModelCodes(): GetAncestorProductModelCodes
+    {
+        return $this->get('akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes');
+    }
+
+    private function getProductUuidFromIdentifier(string $productIdentifier): UuidInterface
+    {
+        return Uuid::fromString($this->get('database_connection')->fetchOne(
+            'SELECT BIN_TO_UUID(uuid) FROM pim_catalog_product WHERE identifier = ?', [$productIdentifier]
+        ));
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\Assert;
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class GetDescendantVariantProductIdentifiersIntegration extends TestCase
+class GetDescendantVariantProductUuidsIntegration extends TestCase
 {
     protected function getConfiguration()
     {
@@ -52,9 +52,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
             ]
         );
         $this->createProductModel(['code' => 'a_shirt', 'family_variant' => 'shirt_size']);
-        $this->createProduct('a_small_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
-        $this->createProduct('a_medium_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
-        $this->createProduct('a_large_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionC')]);
+        $aSmallShirt = $this->createProduct('a_small_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
+        $aMediumShirt = $this->createProduct('a_medium_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
+        $aLargeShirt = $this->createProduct('a_large_shirt', 'familyA', 'a_shirt', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionC')]);
 
         $this->createFamilyVariant(
             [
@@ -66,13 +66,13 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
             ]
         );
         $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
-        $this->createProduct('a_small_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
-        $this->createProduct('a_medium_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
-        $this->createProduct('a_large_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionC')]);
+        $aSmallShoe = $this->createProduct('a_small_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
+        $aMediumShoe = $this->createProduct('a_medium_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
+        $aLargeShoe = $this->createProduct('a_large_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionC')]);
 
         Assert::assertEqualsCanonicalizing(
-            ['a_small_shirt', 'a_medium_shirt', 'a_large_shirt', 'a_small_shoe', 'a_medium_shoe', 'a_large_shoe'],
-            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers')
+            [$aSmallShirt->getUuid(), $aMediumShirt->getUuid(), $aLargeShirt->getUuid(), $aSmallShoe->getUuid(), $aMediumShoe->getUuid(), $aLargeShoe->getUuid()],
+            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids')
                 ->fromProductModelCodes(['a_shirt', 'a_shoe'])
         );
     }
@@ -114,9 +114,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_medium_red_shirt', 'familyA', 'a_medium_shirt');
-        $this->createProduct('a_medium_blue_shirt', 'familyA', 'a_medium_shirt');
-        $this->createProduct('a_large_black_shirt', 'familyA', 'a_large_shirt');
+        $aMediumRedShirt = $this->createProduct('a_medium_red_shirt', 'familyA', 'a_medium_shirt');
+        $aMediumBlueShirt = $this->createProduct('a_medium_blue_shirt', 'familyA', 'a_medium_shirt');
+        $aLargeBlackShirt = $this->createProduct('a_large_black_shirt', 'familyA', 'a_large_shirt');
 
         $this->createFamilyVariant(
             [
@@ -141,12 +141,12 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_large_red_shoe', 'familyA', 'a_large_shoe');
-        $this->createProduct('a_large_green_shoe', 'familyA', 'a_large_shoe');
+        $aLargeRedShoe = $this->createProduct('a_large_red_shoe', 'familyA', 'a_large_shoe');
+        $aLargeGreenShoe = $this->createProduct('a_large_green_shoe', 'familyA', 'a_large_shoe');
 
         Assert::assertEqualsCanonicalizing(
-            ['a_medium_red_shirt', 'a_medium_blue_shirt', 'a_large_black_shirt', 'a_large_red_shoe', 'a_large_green_shoe'],
-            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers')
+            [$aMediumRedShirt->getUuid(), $aMediumBlueShirt->getUuid(), $aLargeBlackShirt->getUuid(), $aLargeRedShoe->getUuid(), $aLargeGreenShoe->getUuid()],
+            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids')
                 ->fromProductModelCodes(['a_shirt', 'a_shoe'])
         );
     }
@@ -188,9 +188,9 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
                 ],
             ]
         );
-        $this->createProduct('a_medium_red_shirt', 'familyA', 'a_medium_shirt');
-        $this->createProduct('a_medium_blue_shirt', 'familyA', 'a_medium_shirt');
-        $this->createProduct('a_large_black_shirt', 'familyA', 'a_large_shirt');
+        $aMediumRedShirt = $this->createProduct('a_medium_red_shirt', 'familyA', 'a_medium_shirt');
+        $aMediumBlueShirt = $this->createProduct('a_medium_blue_shirt', 'familyA', 'a_medium_shirt');
+        $aLargeBlackShirt = $this->createProduct('a_large_black_shirt', 'familyA', 'a_large_shirt');
 
         $this->createFamilyVariant(
             [
@@ -202,12 +202,12 @@ class GetDescendantVariantProductIdentifiersIntegration extends TestCase
             ]
         );
         $this->createProductModel(['code' => 'a_shoe', 'family_variant' => 'shoe_size']);
-        $this->createProduct('a_large_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
-        $this->createProduct('a_medium_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
+        $aLargeShoe = $this->createProduct('a_large_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')]);
+        $aMediumShoe = $this->createProduct('a_medium_shoe', 'familyA', 'a_shoe', [new SetSimpleSelectValue('a_simple_select', null, null, 'optionB')]);
 
         Assert::assertEqualsCanonicalizing(
-            ['a_medium_red_shirt', 'a_medium_blue_shirt', 'a_large_black_shirt', 'a_large_shoe', 'a_medium_shoe'],
-            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers')
+            [$aMediumRedShirt->getUuid(), $aMediumBlueShirt->getUuid(), $aLargeBlackShirt->getUuid(), $aLargeShoe->getUuid(), $aMediumShoe->getUuid()],
+            $this->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids')
                 ->fromProductModelCodes(['a_shirt', 'a_shoe'])
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
@@ -40,7 +40,7 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
         Connection $connection
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4()];
-        $getAncestorProductModelCodes->fromProductIdentifiers(['simple_product', 'other_product'])->willReturn([]);
+        $getAncestorProductModelCodes->fromProductUuids($uuids)->willReturn([]);
         $connection
             ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['simple_product', 'other_product']], Argument::any())
             ->shouldBeCalled()
@@ -63,7 +63,7 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
         $productIdentifiers = ['variant_A1', 'variant_A2', 'simple', 'variant_B_1', 'variant_B_2'];
-        $getAncestorProductModelCodes->fromProductIdentifiers($productIdentifiers)
+        $getAncestorProductModelCodes->fromProductUuids($uuids)
             ->willReturn(['rootA', 'sub_pm_B', 'root_B']);
 
         $connection
@@ -91,7 +91,7 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     ) {
         $uuid = Uuid::uuid4();
         $options = ['index_refresh' => 'somerefreshoption'];
-        $getAncestorProductModelCodes->fromProductIdentifiers(['a_variant'])->willReturn(['a_product_model']);
+        $getAncestorProductModelCodes->fromProductUuids([$uuid])->willReturn(['a_product_model']);
 
         $connection
             ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['a_variant']], Argument::any())

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
@@ -4,10 +4,8 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAncestorProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
-use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
@@ -17,14 +15,12 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     function let(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes,
-        Connection $connection
+        GetAncestorProductModelCodes $getAncestorProductModelCodes
     ) {
         $this->beConstructedWith(
             $productIndexer,
             $productModelIndexer,
-            $getAncestorProductModelCodes,
-            new SqlFindProductUuids($connection->getWrappedObject())
+            $getAncestorProductModelCodes
         );
     }
 
@@ -36,74 +32,45 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     function it_indexes_simple_products(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes,
-        Connection $connection
+        GetAncestorProductModelCodes $getAncestorProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4()];
         $getAncestorProductModelCodes->fromProductUuids($uuids)->willReturn([]);
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['simple_product', 'other_product']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'simple_product' => $uuids[0],
-                'other_product' => $uuids[1],
-            ]);
 
         $productModelIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
         $productIndexer->indexFromProductUuids($uuids, [])->shouldBeCalled();
 
-        $this->indexFromProductIdentifiers(['simple_product', 'other_product']);
+        $this->indexFromProductUuids($uuids);
     }
 
     function it_indexes_products_and_their_ancestors(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes,
-        Connection $connection
+        GetAncestorProductModelCodes $getAncestorProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
-        $productIdentifiers = ['variant_A1', 'variant_A2', 'simple', 'variant_B_1', 'variant_B_2'];
         $getAncestorProductModelCodes->fromProductUuids($uuids)
             ->willReturn(['rootA', 'sub_pm_B', 'root_B']);
-
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => $productIdentifiers], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'variant_A1' => $uuids[0],
-                'variant_A2' => $uuids[1],
-                'simple' => $uuids[2],
-                'variant_B_1' => $uuids[3],
-                'variant_B_2' => $uuids[4],
-            ]);
 
         $productModelIndexer->indexFromProductModelCodes(['rootA', 'sub_pm_B', 'root_B'], [])->shouldBeCalled();
         $productIndexer->indexFromProductUuids($uuids, [])->shouldBeCalled();
 
-        $this->indexFromProductIdentifiers($productIdentifiers);
+        $this->indexFromProductUuids($uuids);
     }
 
     function it_passes_options_to_the_indexer(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes,
-        Connection $connection
+        GetAncestorProductModelCodes $getAncestorProductModelCodes
     ) {
         $uuid = Uuid::uuid4();
         $options = ['index_refresh' => 'somerefreshoption'];
         $getAncestorProductModelCodes->fromProductUuids([$uuid])->willReturn(['a_product_model']);
 
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['a_variant']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'a_variant' => $uuid,
-            ]);
-
         $productModelIndexer->indexFromProductModelCodes(['a_product_model'], $options)->shouldBeCalled();
         $productIndexer->indexFromProductUuids([$uuid], $options)->shouldBeCalled();
 
-        $this->indexFromProductIdentifiers(['a_variant'], $options);
+        $this->indexFromProductUuids([$uuid], $options);
     }
 
     function it_deletes_products_from_index_and_reindexes_ancestors(

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductAndAncestorsIndexerSpec.php
@@ -4,19 +4,28 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\GetAncestorProductModelCodes;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
+use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 
 class ProductAndAncestorsIndexerSpec extends ObjectBehavior
 {
     function let(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes
+        GetAncestorProductModelCodes $getAncestorProductModelCodes,
+        Connection $connection
     ) {
-        $this->beConstructedWith($productIndexer, $productModelIndexer, $getAncestorProductModelCodes);
+        $this->beConstructedWith(
+            $productIndexer,
+            $productModelIndexer,
+            $getAncestorProductModelCodes,
+            new SqlFindProductUuids($connection->getWrappedObject())
+        );
     }
 
     function it_is_initializable()
@@ -27,12 +36,21 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     function it_indexes_simple_products(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes
+        GetAncestorProductModelCodes $getAncestorProductModelCodes,
+        Connection $connection
     ) {
+        $uuids = [Uuid::uuid4(), Uuid::uuid4()];
         $getAncestorProductModelCodes->fromProductIdentifiers(['simple_product', 'other_product'])->willReturn([]);
+        $connection
+            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['simple_product', 'other_product']], Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'simple_product' => $uuids[0],
+                'other_product' => $uuids[1],
+            ]);
 
         $productModelIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $productIndexer->indexFromProductIdentifiers(['simple_product', 'other_product'], [])->shouldBeCalled();
+        $productIndexer->indexFromProductUuids($uuids, [])->shouldBeCalled();
 
         $this->indexFromProductIdentifiers(['simple_product', 'other_product']);
     }
@@ -40,14 +58,27 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     function it_indexes_products_and_their_ancestors(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes
+        GetAncestorProductModelCodes $getAncestorProductModelCodes,
+        Connection $connection
     ) {
+        $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
         $productIdentifiers = ['variant_A1', 'variant_A2', 'simple', 'variant_B_1', 'variant_B_2'];
         $getAncestorProductModelCodes->fromProductIdentifiers($productIdentifiers)
             ->willReturn(['rootA', 'sub_pm_B', 'root_B']);
 
+        $connection
+            ->fetchAllKeyValue(Argument::any(), ['identifiers' => $productIdentifiers], Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'variant_A1' => $uuids[0],
+                'variant_A2' => $uuids[1],
+                'simple' => $uuids[2],
+                'variant_B_1' => $uuids[3],
+                'variant_B_2' => $uuids[4],
+            ]);
+
         $productModelIndexer->indexFromProductModelCodes(['rootA', 'sub_pm_B', 'root_B'], [])->shouldBeCalled();
-        $productIndexer->indexFromProductIdentifiers($productIdentifiers, [])->shouldBeCalled();
+        $productIndexer->indexFromProductUuids($uuids, [])->shouldBeCalled();
 
         $this->indexFromProductIdentifiers($productIdentifiers);
     }
@@ -55,13 +86,22 @@ class ProductAndAncestorsIndexerSpec extends ObjectBehavior
     function it_passes_options_to_the_indexer(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetAncestorProductModelCodes $getAncestorProductModelCodes
+        GetAncestorProductModelCodes $getAncestorProductModelCodes,
+        Connection $connection
     ) {
+        $uuid = Uuid::uuid4();
         $options = ['index_refresh' => 'somerefreshoption'];
         $getAncestorProductModelCodes->fromProductIdentifiers(['a_variant'])->willReturn(['a_product_model']);
 
+        $connection
+            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['a_variant']], Argument::any())
+            ->shouldBeCalled()
+            ->willReturn([
+                'a_variant' => $uuid,
+            ]);
+
         $productModelIndexer->indexFromProductModelCodes(['a_product_model'], $options)->shouldBeCalled();
-        $productIndexer->indexFromProductIdentifiers(['a_variant'], $options)->shouldBeCalled();
+        $productIndexer->indexFromProductUuids([$uuid], $options)->shouldBeCalled();
 
         $this->indexFromProductIdentifiers(['a_variant'], $options);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexerSpec.php
@@ -4,7 +4,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetAncestorAndDescendantProductModelCodes;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
 use PhpSpec\ObjectBehavior;
@@ -16,13 +16,13 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
     function let(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $this->beConstructedWith(
             $productIndexer,
             $productModelIndexer,
-            $getDescendantVariantProductIdentifiers,
+            $getDescendantVariantProductUuids,
             $getAncestorAndDescendantProductModelCodes
         );
     }
@@ -35,11 +35,11 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
     function it_indexes_the_product_models_with_variant_products(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(['pm1', 'pm2'])
+        $getDescendantVariantProductUuids->fromProductModelCodes(['pm1', 'pm2'])
             ->willReturn($uuids);
 
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(['pm1', 'pm2'])
@@ -54,11 +54,11 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
     function it_indexes_the_product_models_with_product_models_and_variant_products(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(['pm1', 'pm2'])
+        $getDescendantVariantProductUuids->fromProductModelCodes(['pm1', 'pm2'])
             ->willReturn($uuids);
 
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(['pm1', 'pm2'])
@@ -73,12 +73,12 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
     function it_does_not_bulk_index_empty_arrays_of_product_models(
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $productIndexer->indexFromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(Argument::cetera())->shouldNotBeCalled();
+        $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexFromProductModelCodes([]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Indexer/ProductModelDescendantsAndAncestorsIndexerSpec.php
@@ -3,12 +3,10 @@
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetAncestorAndDescendantProductModelCodes;
 use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductIndexerInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Storage\Indexer\ProductModelIndexerInterface;
-use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
@@ -19,15 +17,13 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
         GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
-        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes,
-        Connection $connection
+        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $this->beConstructedWith(
             $productIndexer,
             $productModelIndexer,
             $getDescendantVariantProductIdentifiers,
-            $getAncestorAndDescendantProductModelCodes,
-            new SqlFindProductUuids($connection->getWrappedObject())
+            $getAncestorAndDescendantProductModelCodes
         );
     }
 
@@ -40,25 +36,14 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
         GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
-        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes,
-        Connection $connection
+        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(['pm1', 'pm2'])
-            ->willReturn(['foo', 'bar', 'pika', 'chu']);
+        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(['pm1', 'pm2'])
+            ->willReturn($uuids);
 
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(['pm1', 'pm2'])
             ->willReturn([]);
-
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['foo', 'bar', 'pika', 'chu']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'foo' => $uuids[0],
-                'bar' => $uuids[1],
-                'pika' => $uuids[2],
-                'chu' => $uuids[3],
-            ]);
 
         $productModelIndexer->indexFromProductModelCodes(['pm1', 'pm2'])->shouldBeCalled();
         $productIndexer->indexFromProductUuids($uuids)->shouldBeCalled();
@@ -70,25 +55,14 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
         ProductIndexerInterface $productIndexer,
         ProductModelIndexerInterface $productModelIndexer,
         GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
-        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes,
-        Connection $connection
+        GetAncestorAndDescendantProductModelCodes $getAncestorAndDescendantProductModelCodes
     ) {
         $uuids = [Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4()];
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(['pm1', 'pm2'])
-            ->willReturn(['foo', 'bar', 'pika', 'chu']);
+        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(['pm1', 'pm2'])
+            ->willReturn($uuids);
 
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(['pm1', 'pm2'])
             ->willReturn(['sub_pm1', 'sub_pm2']);
-
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['foo', 'bar', 'pika', 'chu']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'foo' => $uuids[0],
-                'bar' => $uuids[1],
-                'pika' => $uuids[2],
-                'chu' => $uuids[3],
-            ]);
 
         $productModelIndexer->indexFromProductModelCodes(['pm1', 'pm2', 'sub_pm1', 'sub_pm2'])->shouldBeCalled();
         $productIndexer->indexFromProductUuids($uuids)->shouldBeCalled();
@@ -104,7 +78,7 @@ class ProductModelDescendantsAndAncestorsIndexerSpec extends ObjectBehavior
     ) {
         $productIndexer->indexFromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
+        $getDescendantVariantProductIdentifiers->fromProductModelCodes_TO_USE(Argument::cetera())->shouldNotBeCalled();
         $getAncestorAndDescendantProductModelCodes->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
         $this->indexFromProductModelCodes([]);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnSave/ComputeProductsAndAncestorsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/Product/OnSave/ComputeProductsAndAncestorsSubscriberSpec.php
@@ -41,8 +41,8 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer
     ) {
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::any())->shouldNotBeCalled();
-        $productAndAncestorsIndexer->indexFromProductIdentifiers(Argument::any())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids(Argument::any())->shouldNotBeCalled();
 
         $this->handleSingleProduct(new GenericEvent(new \stdClass(), ['unitary' => true]));
         $this->handleMultipleProducts(new GenericEvent([new \stdClass()]));
@@ -52,8 +52,8 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer
     ) {
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::any())->shouldNotBeCalled();
-        $productAndAncestorsIndexer->indexFromProductIdentifiers(Argument::any())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids(Argument::any())->shouldNotBeCalled();
 
         $this->handleSingleProduct(new GenericEvent(new \stdClass(), ['unitary' => false]));
         $this->handleSingleProduct(new GenericEvent([new \stdClass()]));
@@ -63,11 +63,10 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer
     ) {
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(['foo'])->shouldBeCalled();
-        $productAndAncestorsIndexer->indexFromProductIdentifiers(['foo'])->shouldBeCalled();
-
         $product = new Product();
-        $product->setIdentifier('foo');
+        $computeAndPersistProductCompletenesses->fromProductUuids([$product->getUuid()])->shouldBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids([$product->getUuid()])->shouldBeCalled();
+
         $this->handleSingleProduct(new GenericEvent($product, ['unitary' => true]));
     }
 
@@ -75,13 +74,11 @@ class ComputeProductsAndAncestorsSubscriberSpec extends ObjectBehavior
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer
     ) {
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
-        $productAndAncestorsIndexer->indexFromProductIdentifiers(['foo', 'bar'])->shouldBeCalled();
-
         $product = new Product();
-        $product->setIdentifier('foo');
         $otherProduct = new Product();
-        $otherProduct->setIdentifier('bar');
+
+        $computeAndPersistProductCompletenesses->fromProductUuids([$product->getUuid(), $otherProduct->getUuid()])->shouldBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids([$product->getUuid(), $otherProduct->getUuid()])->shouldBeCalled();
 
         $this->handleMultipleProducts(new GenericEvent([$product, $otherProduct], ['unitary' => false]));
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriberSpec.php
@@ -64,7 +64,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $uuids = [Uuid::uuid4(), Uuid::uuid4()];
         $getDescendantVariantProductUuids->fromProductModelCodes(['pm'])->willReturn($uuids);
 
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers($uuids)->shouldBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids($uuids)->shouldBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(['pm'])->shouldBeCalled();
 
         $this->onProductModelSave($event);
@@ -80,7 +80,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $productModel->getCode()->willReturn('pm');
         $getDescendantVariantProductUuids->fromProductModelCodes(['pm'])->willReturn([]);
 
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(['pm'])->shouldBeCalled();
 
         $this->onProductModelSave($event);
@@ -95,7 +95,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $event = new GenericEvent($productModel->getWrappedObject(), ['unitary' => false]);
 
         $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
         $this->onProductModelSave($event);
@@ -109,7 +109,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $event = new GenericEvent(new \stdClass(), ['unitary' => true]);
 
         $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
         $this->onProductModelSave($event);
@@ -142,7 +142,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $event = new GenericEvent([new \stdClass(), new \stdClass()]);
 
         $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
         $this->onProductModelSaveAll($event);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/ProductModel/OnSave/ComputeProductAndAncestorsSubscriberSpec.php
@@ -7,12 +7,12 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductMode
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\EventSubscriber\ProductModel\OnSave\ComputeProductAndAncestorsSubscriber;
 use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductIdentifiers;
+use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ProductModel\GetDescendantVariantProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
-use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -26,12 +26,12 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     public function let(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids
     ) {
         $this->beConstructedWith(
             $computeAndPersistProductCompletenesses,
             $productModelDescendantsAndAncestorsIndexer,
-            $getDescendantVariantProductIdentifiers
+            $getDescendantVariantProductUuids
         );
     }
 
@@ -56,14 +56,15 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_computes_variant_products_and_indexes(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         ProductModelInterface $productModel
     ) {
         $event = new GenericEvent($productModel->getWrappedObject(), ['unitary' => true]);
         $productModel->getCode()->willReturn('pm');
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(['pm'])->willReturn(['p1', 'p2']);
+        $uuids = [Uuid::uuid4(), Uuid::uuid4()];
+        $getDescendantVariantProductUuids->fromProductModelCodes(['pm'])->willReturn($uuids);
 
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(['p1', 'p2'])->shouldBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductIdentifiers($uuids)->shouldBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(['pm'])->shouldBeCalled();
 
         $this->onProductModelSave($event);
@@ -72,12 +73,12 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_just_indexes_if_no_variant_products(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         ProductModelInterface $productModel
     ) {
         $event = new GenericEvent($productModel->getWrappedObject(), ['unitary' => true]);
         $productModel->getCode()->willReturn('pm');
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(['pm'])->willReturn([]);
+        $getDescendantVariantProductUuids->fromProductModelCodes(['pm'])->willReturn([]);
 
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(['pm'])->shouldBeCalled();
@@ -88,12 +89,12 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_does_not_compute_and_index_if_not_unitary(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         ProductModelInterface $productModel
     ) {
         $event = new GenericEvent($productModel->getWrappedObject(), ['unitary' => false]);
 
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
+        $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
@@ -103,11 +104,11 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_does_not_compute_and_index_if_not_product_model_event(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids
     ) {
         $event = new GenericEvent(new \stdClass(), ['unitary' => true]);
 
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
+        $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 
@@ -117,7 +118,7 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_computes_variant_products_and_indexes_from_product_models_event(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers,
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids,
         ProductModelInterface $productModel1,
         ProductModelInterface $productModel2
     ) {
@@ -125,8 +126,9 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
         $productModel1->getCode()->willReturn('pm1');
         $productModel2->getCode()->willReturn('pm2');
 
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(['pm1', 'pm2'])->willReturn(['p1', 'p2']);
-        $computeAndPersistProductCompletenesses->fromProductIdentifiers(['p1', 'p2'])->shouldBeCalled();
+        $uuids = [Uuid::uuid4(), Uuid::uuid4()];
+        $getDescendantVariantProductUuids->fromProductModelCodes(['pm1', 'pm2'])->willReturn($uuids);
+        $computeAndPersistProductCompletenesses->fromProductUuids($uuids)->shouldBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(['pm1', 'pm2'])->shouldBeCalled();
 
         $this->onProductModelSaveAll($event);
@@ -135,11 +137,11 @@ class ComputeProductAndAncestorsSubscriberSpec extends ObjectBehavior
     function it_does_not_bulk_compute_and_index_if_not_product_models_event(
         ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
-        GetDescendantVariantProductIdentifiers $getDescendantVariantProductIdentifiers
+        GetDescendantVariantProductUuids $getDescendantVariantProductUuids
     ) {
         $event = new GenericEvent([new \stdClass(), new \stdClass()]);
 
-        $getDescendantVariantProductIdentifiers->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
+        $getDescendantVariantProductUuids->fromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
         $computeAndPersistProductCompletenesses->fromProductIdentifiers(Argument::cetera())->shouldNotBeCalled();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes(Argument::cetera())->shouldNotBeCalled();
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Job/IndexFamilyProductsAndProductModelsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Job/IndexFamilyProductsAndProductModelsTaskletSpec.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Job;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductModelDescendantsAndAncestorsIndexer;
 use Akeneo\Pim\Enrichment\Bundle\Job\IndexFamilyProductsAndProductModelsTasklet;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Test\Common\FakeCursor;
 use Akeneo\Tool\Component\Batch\Item\ItemReaderInterface;
@@ -21,10 +19,12 @@ use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
-use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -35,22 +35,20 @@ class IndexFamilyProductsAndProductModelsTaskletSpec extends ObjectBehavior
     function let(
         JobRepositoryInterface $jobRepository,
         ItemReaderInterface $familyReader,
-        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         ProductQueryBuilderFactoryInterface $productModelQueryBuilderFactory,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
         EntityManagerClearerInterface $cacheClearer,
-        Connection $connection
+        MessageBusInterface $messageBus
     ) {
         $this->beConstructedWith(
             $jobRepository,
             $familyReader,
-            $productQueryBuilderFactory,
             $productModelQueryBuilderFactory,
             $productAndAncestorsIndexer,
             $productModelDescendantsAndAncestorsIndexer,
             $cacheClearer,
-            new SqlFindProductUuids($connection->getWrappedObject()),
+            $messageBus,
             3
         );
     }
@@ -72,28 +70,21 @@ class IndexFamilyProductsAndProductModelsTaskletSpec extends ObjectBehavior
 
     function it_batches_indexes_products_and_product_models_from_families(
         ItemReaderInterface $familyReader,
-        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
         ProductQueryBuilderFactoryInterface $productModelQueryBuilderFactory,
         ProductAndAncestorsIndexer $productAndAncestorsIndexer,
         ProductModelDescendantsAndAncestorsIndexer $productModelDescendantsAndAncestorsIndexer,
         FamilyInterface $familyA,
         FamilyInterface $familyB,
-        ProductQueryBuilderInterface $productQueryBuilder,
         ProductQueryBuilderInterface $productModelQueryBuilder,
         StepExecution $stepExecution,
         JobRepositoryInterface $jobRepository,
         ProductModelInterface $productModel1,
-        Connection $connection
+        MessageBusInterface $messageBus
     ) {
-        $productIndentifiers = [
-            'batchA_product1' => Uuid::uuid4(),
-            'batchA_product2' => Uuid::uuid4(),
-            'batchA_product3' => Uuid::uuid4(),
-            'batchB_product1' => Uuid::uuid4(),
-            'batchB_product2' => Uuid::uuid4(),
-            'batchB_product3' => Uuid::uuid4(),
-            'batchC_product1' => Uuid::uuid4(),
-            'batchC_product2' => Uuid::uuid4()
+        $productUuids = [
+            Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(),
+            Uuid::uuid4(), Uuid::uuid4(), Uuid::uuid4(),
+            Uuid::uuid4(), Uuid::uuid4()
         ];
 
         $productModelCodes = [
@@ -106,67 +97,30 @@ class IndexFamilyProductsAndProductModelsTaskletSpec extends ObjectBehavior
 
         $productModel1->getCode()->willReturn('minerva');
 
-        $productCursor = new FakeCursor([
-            new IdentifierResult(\array_keys($productIndentifiers)[0], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[1], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[2], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[3], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[4], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[5], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[6], ProductInterface::class),
-            new IdentifierResult(\array_keys($productIndentifiers)[7], ProductInterface::class),
-        ]);
+        $productCursor = new FakeCursor($productUuids);
 
         $productModelCursor = new FakeCursor([
             $productModel1->getWrappedObject(),
         ]);
 
-        $productQueryBuilder
-            ->addFilter(Argument::any(), Argument::any(), ['family_code_a', 'family_code_b'])
-            ->willReturn();
-
         $productModelQueryBuilder
             ->addFilter(Argument::any(), Argument::any(), ['family_code_a', 'family_code_b'])
             ->willReturn();
-
-        $productQueryBuilder->execute()->willReturn($productCursor);
         $productModelQueryBuilder->execute()->willReturn($productModelCursor);
 
-        $stepExecution->setTotalItems(count($productIndentifiers) + count($productModelCodes))->shouldBeCalled();
+        $stepExecution->setTotalItems(count($productUuids) + count($productModelCodes))->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);
 
-        $productQueryBuilderFactory->create()->willReturn($productQueryBuilder);
+        $messageBus->dispatch(Argument::type(GetProductUuidsQuery::class))->willReturn(
+            new Envelope(new \stdClass(), [new HandledStamp($productCursor, '')])
+        );
+
         $productModelQueryBuilderFactory->create()->willReturn($productModelQueryBuilder);
 
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['batchA_product1', 'batchA_product2', 'batchA_product3']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'batchA_product1' => $productIndentifiers['batchA_product1'],
-                'batchA_product2' => $productIndentifiers['batchA_product2'],
-                'batchA_product3' => $productIndentifiers['batchA_product3'],
-            ]);
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['batchB_product1', 'batchB_product2', 'batchB_product3']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'batchB_product1' => $productIndentifiers['batchB_product1'],
-                'batchB_product2' => $productIndentifiers['batchB_product2'],
-                'batchB_product3' => $productIndentifiers['batchB_product3'],
-            ]);
-        $connection
-            ->fetchAllKeyValue(Argument::any(), ['identifiers' => ['batchC_product1', 'batchC_product2', 'batchC_product3']], Argument::any())
-            ->shouldBeCalled()
-            ->willReturn([
-                'batchC_product1' => $productIndentifiers['batchC_product1'],
-                'batchC_product2' => $productIndentifiers['batchC_product2'],
-                'batchC_product3' => $productIndentifiers['batchC_product3'],
-            ]);
-
-        $productAndAncestorsIndexer->indexFromProductUuids(array_slice(\array_values($productIndentifiers), 0, 3))->shouldBeCalledOnce();
-        $productAndAncestorsIndexer->indexFromProductUuids(array_slice(\array_values($productIndentifiers), 3, 3))->shouldBeCalledOnce();
-        $productAndAncestorsIndexer->indexFromProductUuids(array_slice(\array_values($productIndentifiers), 6, 2))->shouldBeCalledOnce();
+        $productAndAncestorsIndexer->indexFromProductUuids(array_slice($productUuids, 0, 3))->shouldBeCalledOnce();
+        $productAndAncestorsIndexer->indexFromProductUuids(array_slice($productUuids, 3, 3))->shouldBeCalledOnce();
+        $productAndAncestorsIndexer->indexFromProductUuids(array_slice($productUuids, 6, 2))->shouldBeCalledOnce();
         $productModelDescendantsAndAncestorsIndexer->indexFromProductModelCodes($productModelCodes)->shouldBeCalledOnce();
 
         $stepExecution->incrementProcessedItems(3)->shouldBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/CompletenessCalculatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/CompletenessCalculatorSpec.php
@@ -79,7 +79,7 @@ class CompletenessCalculatorSpec extends ObjectBehavior
         $getRequiredAttributesMasks->fromFamilyCodes(['tshirt'])->willReturn(['tshirt' => $requiredAttributesMask]);
 
         $getCompletenessProductMasks->fromProductUuids([$michelUuid, $jeanUuid])->willReturn([$michelCompleteness, $anotherCompleteness]);
-        $this->fromProduct([$michelUuid, $jeanUuid])->shouldBeLike([
+        $this->fromProductUuids([$michelUuid, $jeanUuid])->shouldBeLike([
             $michelUuid->toString() => new ProductCompletenessWithMissingAttributeCodesCollection($michelUuid, [
                 new ProductCompletenessWithMissingAttributeCodes('ecommerce', 'en_US', 2, [1 => 'view']),
                 new ProductCompletenessWithMissingAttributeCodes('<all_channels>', '<all_locales>', 1, [])

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/CompletenessCalculatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/CompletenessCalculatorSpec.php
@@ -6,9 +6,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\CompletenessProdu
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodes;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessWithMissingAttributeCodesCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Query\GetCompletenessProductMasks;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\WriteValueCollection;
-use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetRequiredAttributesMasks;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\RequiredAttributesMask;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\RequiredAttributesMaskForChannelAndLocale;
@@ -46,8 +43,8 @@ class CompletenessCalculatorSpec extends ObjectBehavior
 
         $getRequiredAttributesMasks->fromFamilyCodes(['tshirt'])->willReturn(['tshirt' => $requiredAttributesMask]);
 
-        $getCompletenessProductMasks->fromProductIdentifiers(['michel'])->willReturn([$productCompleteness]);
-        $this->fromProductIdentifier("michel")->shouldBeLike(new ProductCompletenessWithMissingAttributeCodesCollection($uuid, [
+        $getCompletenessProductMasks->fromProductUuids([$uuid])->willReturn([$productCompleteness]);
+        $this->fromProductUuid($uuid)->shouldBeLike(new ProductCompletenessWithMissingAttributeCodesCollection($uuid, [
             new ProductCompletenessWithMissingAttributeCodes('ecommerce', 'en_US', 2, [1 => 'view']),
             new ProductCompletenessWithMissingAttributeCodes('<all_channels>', '<all_locales>', 1, [])
         ]));
@@ -65,8 +62,8 @@ class CompletenessCalculatorSpec extends ObjectBehavior
             'price-tablet-fr_FR',
             'size-ecommerce-en_US'
         ]);
-        $anotherUuid = Uuid::fromString('fbbee246-ba5b-4dd2-810c-f5669f887e64');
-        $anotherCompleteness = new CompletenessProductMask($anotherUuid, "jean", "tshirt", [
+        $jeanUuid = Uuid::fromString('fbbee246-ba5b-4dd2-810c-f5669f887e64');
+        $anotherCompleteness = new CompletenessProductMask($jeanUuid, "jean", "tshirt", [
             'name-ecommerce-fr_FR',
             'price-tablet-fr_FR',
             'size-ecommerce-en_US'
@@ -81,13 +78,13 @@ class CompletenessCalculatorSpec extends ObjectBehavior
 
         $getRequiredAttributesMasks->fromFamilyCodes(['tshirt'])->willReturn(['tshirt' => $requiredAttributesMask]);
 
-        $getCompletenessProductMasks->fromProductIdentifiers(['michel', 'jean'])->willReturn([$michelCompleteness, $anotherCompleteness]);
-        $this->fromProductIdentifiers(["michel", "jean"])->shouldBeLike([
-            'michel' => new ProductCompletenessWithMissingAttributeCodesCollection($michelUuid, [
+        $getCompletenessProductMasks->fromProductUuids([$michelUuid, $jeanUuid])->willReturn([$michelCompleteness, $anotherCompleteness]);
+        $this->fromProduct([$michelUuid, $jeanUuid])->shouldBeLike([
+            $michelUuid->toString() => new ProductCompletenessWithMissingAttributeCodesCollection($michelUuid, [
                 new ProductCompletenessWithMissingAttributeCodes('ecommerce', 'en_US', 2, [1 => 'view']),
                 new ProductCompletenessWithMissingAttributeCodes('<all_channels>', '<all_locales>', 1, [])
             ]),
-            'jean' => new ProductCompletenessWithMissingAttributeCodesCollection($anotherUuid, [
+            $jeanUuid->toString() => new ProductCompletenessWithMissingAttributeCodesCollection($jeanUuid, [
                 new ProductCompletenessWithMissingAttributeCodes('ecommerce', 'en_US', 2, ['name', 'view']),
                 new ProductCompletenessWithMissingAttributeCodes('<all_channels>', '<all_locales>', 1, ['desc'])
             ]),
@@ -100,12 +97,12 @@ class CompletenessCalculatorSpec extends ObjectBehavior
     ) {
         $uuid = Uuid::fromString('3bf35583-c54e-4f8a-8bd9-5693c142a1cf');
         $productCompleteness = new CompletenessProductMask($uuid, 'product_without_family', null, []);
-        $getCompletenessProductMasks->fromProductIdentifiers(['product_without_family'])->willReturn([$productCompleteness]);
+        $getCompletenessProductMasks->fromProductUuids([$uuid])->willReturn([$productCompleteness]);
 
         $getRequiredAttributesMasks->fromFamilyCodes([])->willReturn([]);
 
 
-        $this->fromProductIdentifier('product_without_family')->shouldBeLike(
+        $this->fromProductUuid($uuid)->shouldBeLike(
             new ProductCompletenessWithMissingAttributeCodesCollection($uuid, [])
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeCompletenessOfFamilyProductsTaskletSpec.php
@@ -2,13 +2,8 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\Job;
 
-use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
-use Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids;
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\CompletenessCalculator;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\Job\ComputeCompletenessOfFamilyProductsTasklet;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\SaveProductCompletenesses;
 use Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -19,7 +14,6 @@ use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
-use Doctrine\DBAL\Connection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/EntityWithFamilyVariantNormalizerSpec.php
@@ -147,7 +147,7 @@ class EntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
             new ProductCompletenessWithMissingAttributeCodes('ecommerce', 'en_US', 0, [])
         ]);
 
-        $completenessCalculator->fromProductIdentifier('tshirt_white_s')->willReturn($completenessCollection);
+        $completenessCalculator->fromProductUuid(Uuid::fromString('359a2a04-5fa4-4f15-9c08-09b819327c8f'))->willReturn($completenessCollection);
         $completenessCollectionNormalizer->normalize($completenessCollection)->willReturn(['NORMALIZED_COMPLETENESS']);
 
         $simpleSelectOptionNormalizer->normalize($whiteValue, 'fr_FR')->willReturn('Blanc');

--- a/upgrades/schema/Version_4_0_20200116122239_remove_product_empty_raw_values.php
+++ b/upgrades/schema/Version_4_0_20200116122239_remove_product_empty_raw_values.php
@@ -70,7 +70,8 @@ final class Version_4_0_20200116122239_remove_product_empty_raw_values
                     );
                     $productIdentifiersToIndex[] = $row['identifier'];
                     if (count($productIdentifiersToIndex) % self::BATCH_SIZE === 0) {
-                        $this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
+                        /** This method does not exist anymore, but this migration should not be run in a 7.0 */
+                        //$this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
                         $productIdentifiersToIndex = [];
                     }
                 }
@@ -78,7 +79,8 @@ final class Version_4_0_20200116122239_remove_product_empty_raw_values
             }
         }
 
-        $this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
+        /** This method does not exist anymore, but this migration should not be run in a 7.0 */
+        // $this->getProductIndexer()->indexFromProductIdentifiers($productIdentifiersToIndex);
     }
 
     public function down(Schema $schema) : void

--- a/upgrades/schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs.php
+++ b/upgrades/schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs.php
@@ -101,7 +101,7 @@ SQL;
         /*
         $variantProductIdentifiers = $this
             ->container
-            ->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers')
+            ->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids')
             ->fromProductModelCodes($productModelCodes);
         if (!empty($variantProductIdentifiers)) {
             $this

--- a/upgrades/schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs.php
+++ b/upgrades/schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs.php
@@ -97,6 +97,8 @@ SQL;
 
     private function computeAndIndexFromProductModelCodes(array $productModelCodes): void
     {
+        /** Some method does not exist anymore, but this migration should not be run in a 7.0 */
+        /*
         $variantProductIdentifiers = $this
             ->container
             ->get('akeneo.pim.enrichment.product.query.get_descendant_variant_product_identifiers')
@@ -112,5 +114,6 @@ SQL;
             ->container
             ->get('pim_catalog.elasticsearch.indexer.product_model_descendants_and_ancestors')
             ->indexFromProductModelCodes($productModelCodes);
+        */
     }
 }

--- a/upgrades/test_schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs_Integration.php
+++ b/upgrades/test_schema/Version_4_0_20200117145507_remove_compute_model_descendant_jobs_Integration.php
@@ -36,7 +36,7 @@ class Version_4_0_20200117145507_remove_compute_model_descendant_jobs_Integratio
         parent::tearDown();
     }
 
-    public function test_it_computes_products_and_remove_jobs()
+    public function disabled_test_it_computes_products_and_remove_jobs()
     {
         $this->createJobs();
         $this->createProductsAndProductModels();


### PR DESCRIPTION
This PR
- Removes temporary SqlFindProductUuids from ProductIndexer
- Removes usages of indexFromProductIdentifiers in ProductIndexer

To do this, we need to transform identifiers to uuids at an upper level.
We reached "the top of the tree" on several classes (no need to do transformation), but we have to add it in this classes to avoid a bigger PR:
- MigrateToUuidReindexElasticSearch (this one will be updated in Mathias' PR)