### PR TITLE
OCT-81: fix tsconfig

### DIFF
--- a/components/catalogs/front/tsconfig.build.json
+++ b/components/catalogs/front/tsconfig.build.json
@@ -1,15 +1,18 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions":
-  {
+  "compilerOptions": {
     "tsBuildInfoFile": "tsconfig.build.tsbuildinfo",
     "module": "commonjs",
     "noEmit": false
   },
+  "include": [
+    "src/components",
+    "src/hooks",
+    "src/exports.ts"
+  ],
   "exclude": [
-    "src/**/*.test.ts",
-    "src/**/*.test.tsx",
-    "**/__mocks__/*",
-    "tests/**"
+    "**/*.unit.*",
+    "**/*.integration.*",
+    "**/__mocks__/*"
   ]
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Recent changes in catalogs broke how it's imported in Connectivity. Fixing the tsconfig resolve the issue.

What happened?
We changed the extensions of our frontend tests from `.test.ts` to `.unit.ts` and `.integration.ts` to better differentiate them.
We didn't notice that the tests were no longer ignored by tsconfig and were exported in the `lib` directory, changing its directory structure and making it unusable outside catalogs.

The CI for catalogs was green when we did that change and this is something that we need to prevent from happening again.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
