### PR TITLE
CPM-682: Fix reindexation step

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -62,6 +62,7 @@ services:
             - '@monolog.logger'
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.elasticsearch.indexer.product'
+            - '@Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids'
 
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCommand:
         arguments:


### PR DESCRIPTION
Now that we don't delete legacy product documents (with mysql id) during indexation anymore, we need to manually delete them during the migration reindexation step to avoid an infinite loop.