### PR TITLE
PIM-10530: Fix case issue when querying products with attribute options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - PIM-10543: Fix selected categories sent to listCategories
 - PIM-10561: Fix associationUserIntentFactory to cast int to string
 - PIM-10557: Fix notifications not displayed for obsolete route parameters
+- PIM-10530: Fix case issue when querying products with attribute options
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ReadModel/ConnectorProduct.php
@@ -241,6 +241,10 @@ final class ConnectorProduct
     {
         $values = $this->values->map(function (ValueInterface $value) use ($optionLabels) {
             if ($value instanceof OptionValue) {
+                $optionCodes = \array_keys($optionLabels[$value->getAttributeCode()] ?? []);
+                $index = \array_search(\strtolower($value->getData()), \array_map('strtolower', $optionCodes));
+                $optionCodeWithRightCase = false !== $index ? $optionCodes[$index] : $value->getData();
+
                 return new OptionValueWithLinkedData(
                     $value->getAttributeCode(),
                     $value->getData(),
@@ -248,17 +252,21 @@ final class ConnectorProduct
                     $value->getLocaleCode(),
                     [
                         'attribute' => $value->getAttributeCode(),
-                        'code' => $value->getData(),
-                        'labels' => $optionLabels[$value->getAttributeCode()][$value->getData()] ?? []
+                        'code' => $optionCodeWithRightCase,
+                        'labels' => $optionLabels[$value->getAttributeCode()][$optionCodeWithRightCase] ?? []
                     ],
                 );
             } elseif ($value instanceof OptionsValue) {
                 $linkedData = [];
+                $optionCodes = \array_keys($optionLabels[$value->getAttributeCode()] ?? []);
                 foreach ($value->getData() as $optionCode) {
+                    $index = \array_search(\strtolower($optionCode), \array_map('strtolower', $optionCodes));
+                    $optionCodeWithRightCase = false !== $index ? $optionCodes[$index] : $optionCode;
+
                     $linkedData[$optionCode] = [
                         'attribute' => $value->getAttributeCode(),
-                        'code' => $optionCode,
-                        'labels' => $optionLabels[$value->getAttributeCode()][$optionCode] ?? [],
+                        'code' => $optionCodeWithRightCase,
+                        'labels' => $optionLabels[$value->getAttributeCode()][$optionCodeWithRightCase] ?? [],
                     ];
                 }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -130,6 +130,65 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $this->assertResponse($response, $expectedProduct);
     }
 
+    public function test_it_gets_a_product_with_attribute_options_multi_select_with_wrong_case()
+    {
+        $this->createProduct('product', [
+            new SetFamily('familyA'),
+            new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'OptiONB'])
+        ]);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
+
+        $expectedProduct = [
+            'identifier' => 'product',
+            'family' => 'familyA',
+            'parent' => null,
+            'groups' => [],
+            'categories' => [],
+            'enabled' => true,
+            'values' => [
+                'a_multi_select' => [
+                    [
+                        'data' => ['OptiONB', 'optionA'],
+                        'locale' => null,
+                        'scope' => null,
+                        'linked_data' => [
+                            'optionA' => [
+                                'attribute' => 'a_multi_select',
+                                'code' => 'optionA',
+                                'labels' => [
+                                    'en_US' => 'Option A',
+                                ],
+                            ],
+                            'OptiONB' => [
+                                'attribute' => 'a_multi_select',
+                                'code' => 'optionB',
+                                'labels' => [
+                                    'en_US' => 'Option B',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'created' => '2016-06-14T13:12:50+02:00',
+            'updated' => '2016-06-14T13:12:50+02:00',
+            'associations' => [
+                'PACK' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'SUBSTITUTION' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'UPSELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+                'X_SELL' => ['groups' => [], 'products' => [], 'product_models' => []],
+            ],
+            'quantified_associations' => [],
+        ];
+
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponse($response, $expectedProduct);
+    }
+
     /**
      * @group critical
      */

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ReadModel/ConnectorProductSpec.php
@@ -8,6 +8,10 @@ use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletene
 use Akeneo\Pim\Enrichment\Component\Product\Completeness\Model\ProductCompletenessCollection;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ReadValueCollection;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionsValueWithLinkedData;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValue;
+use Akeneo\Pim\Enrichment\Component\Product\Value\OptionValueWithLinkedData;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
 use PhpSpec\ObjectBehavior;
 use Ramsey\Uuid\Uuid;
@@ -69,7 +73,9 @@ class ConnectorProductSpec extends ObjectBehavior
             new ReadValueCollection([
                 ScalarValue::value('attribute_code_1', 'data'),
                 ScalarValue::localizableValue('attribute_code_2', 'data', 'en_US'),
-                ScalarValue::localizableValue('attribute_code_2', 'data', 'fr_FR')
+                ScalarValue::localizableValue('attribute_code_2', 'data', 'fr_FR'),
+                OptionValue::value('simple_select', 'Option_1'),
+                OptionsValue::value('multi_select', ['Option1', 'OPTION2']),
             ]),
             null,
             null
@@ -307,5 +313,74 @@ class ConnectorProductSpec extends ObjectBehavior
         $connectorProduct = $this->buildWithCompletenesses($completenessCollection);
 
         $connectorProduct->completenesses()->shouldReturn($completenessCollection);
+    }
+
+    function it_returns_the_option_labels()
+    {
+        $connectorProductWithLinkedData = $this->buildLinkedData([
+            'simple_select' => [
+                'option_1' => [
+                    'en_US' => 'Code 1',
+                    'fr_FR' => 'Option 1',
+                ],
+            ],
+            'multi_select' => [
+                'option1' => [
+                    'en_US' => 'OPTION NUMBER ONE',
+                    'fr_FR' => null,
+                ],
+                'Option2' => [
+                    'en_US' => null,
+                    'fr_FR' => null,
+                ]
+            ]
+        ]);
+        $connectorProductWithLinkedData->shouldBeAnInstanceOf(ConnectorProduct::class);
+        /** @var ReadValueCollection $values */
+        $connectorProductWithLinkedData->values()->toArray()->shouldBeLike(
+            [
+                ScalarValue::value('attribute_code_1', 'data'),
+                ScalarValue::localizableValue('attribute_code_2', 'data', 'en_US'),
+                ScalarValue::localizableValue('attribute_code_2', 'data', 'fr_FR'),
+                new OptionValueWithLinkedData(
+                    'simple_select',
+                    'Option_1',
+                    null,
+                    null,
+                    [
+                        'attribute' => 'simple_select',
+                        'code' => 'option_1',
+                        'labels' => [
+                            'en_US' => 'Code 1',
+                            'fr_FR' => 'Option 1',
+                        ]
+                    ]
+                ),
+                new OptionsValueWithLinkedData(
+                    'multi_select',
+                    ['Option1', 'OPTION2'],
+                    null,
+                    null,
+                    [
+                        'Option1' => [
+                            'attribute' => 'multi_select',
+                            'code' => 'option1',
+                            'labels' => [
+                                'en_US' => 'OPTION NUMBER ONE',
+                                'fr_FR' => null,
+                            ],
+                        ],
+                        'OPTION2' => [
+                            'attribute' => 'multi_select',
+                            'code' => 'Option2',
+                            'labels' => [
+                                'en_US' => null,
+                                'fr_FR' => null,
+                            ]
+                        ]
+                    ]
+                )
+            ]
+        );
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

Fixes an issue where attribute option labels were not displayed in the Get/List products endpoints, when the value in DB does not have the same case as the option code

TODO:
- [x] write an end-to-end test (or an integration test)
- [x] add the changeleog 
