### PR TITLE
PIM-10542: Fix int attribute code breaks ValueUserIntentFactoryRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - PIM-10501: Fix identifier validation for product and product model imports to disallow line breaks
 - PIM-10527: Fix associated groups grid
 - PIM-10518: Normalize simple select option value like multi select
+- PIM-10542: Fix int attribute code breaks ValueUserIntentFactoryRegistry
 - PIM-10528: Fix escaped special characters in page titles
 - PIM-10541: Fix SetTableValue userIntent to allow null data in enrichment Service Api
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/ValueUserIntentFactoryRegistry.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/ValueUserIntentFactoryRegistry.php
@@ -44,20 +44,29 @@ class ValueUserIntentFactoryRegistry implements UserIntentFactory
     {
         Assert::isArray($data);
 
-        $attributeTypesByCode = \array_change_key_case($this->getAttributeTypes->fromAttributeCodes(\array_keys($data)), \CASE_LOWER);
+        $attributeTypesByCode = $this->getAttributeTypesByCode($data);
         $valueUserIntents = [];
         foreach ($data as $attributeCode => $values) {
-            $attributeType = $attributeTypesByCode[\strtolower($attributeCode)] ?? null;
+            $attributeType = $attributeTypesByCode[\strtolower((string) $attributeCode)] ?? null;
             Assert::notNull($attributeType, \sprintf('Could not find the %s attribute', $attributeCode));
             $factory = $this->valueUserIntentFactoriesByAttributeType[$attributeType] ?? null;
             if (null === $factory) {
                 throw new \InvalidArgumentException(\sprintf('There is no value factory linked to the attribute type %s', $attributeType));
             }
             foreach ($values as $value) {
-                $valueUserIntents[] = $factory->create($attributeType, $attributeCode, $value);
+                $valueUserIntents[] = $factory->create($attributeType, (string) $attributeCode, $value);
             }
         }
 
         return $valueUserIntents;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAttributeTypesByCode(mixed $data): array
+    {
+        $attributeCodes = \array_map(static fn ($attributeCode) => (string) $attributeCode, \array_keys($data));
+        return \array_change_key_case($this->getAttributeTypes->fromAttributeCodes($attributeCodes), \CASE_LOWER);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/ValueUserIntentFactoryRegistrySpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/ValueUserIntentFactoryRegistrySpec.php
@@ -38,17 +38,19 @@ class ValueUserIntentFactoryRegistrySpec extends ObjectBehavior
         ValueUserIntent $valueUserIntent1,
         ValueUserIntent $valueUserIntent2,
         ValueUserIntent $valueUserIntent3,
+        ValueUserIntent $valueUserIntent4,
     ) {
         $valueUserIntentFactory1->getSupportedAttributeTypes()->willReturn(['pim_catalog_text']);
         $valueUserIntentFactory2->getSupportedAttributeTypes()->willReturn(['pim_catalog_identifier']);
         $valueUserIntentFactory3->getSupportedAttributeTypes()->willReturn(['pim_catalog_textarea']);
 
-        $getAttributeTypes->fromAttributeCodes(['a_text', 'sku', 'A_TExtAreA'])
+        $getAttributeTypes->fromAttributeCodes(['a_text', 'sku', 'A_TExtAreA', '1234'])
             ->shouldBeCalledOnce()
             ->willReturn([
                 'a_text' => 'pim_catalog_text',
                 'sku' => 'pim_catalog_identifier',
                 'A_TExtAreA' => 'pim_catalog_textarea',
+                '1234' => 'pim_catalog_textarea',
             ]);
 
         $valueUserIntentFactory1->create('pim_catalog_text', 'a_text', ['data' => 'bonjour', 'locale' => null, 'scope' => null])
@@ -58,13 +60,17 @@ class ValueUserIntentFactoryRegistrySpec extends ObjectBehavior
             ->shouldBeCalledOnce()
             ->willReturn($valueUserIntent2);
         $valueUserIntentFactory3->create('pim_catalog_textarea', 'A_TExtAreA', ['data' => '<p>bonjour</p>', 'locale' => null, 'scope' => null])
-            ->shouldBeCalledOnce()
+            ->shouldBeCalled()
             ->willReturn($valueUserIntent3);
+        $valueUserIntentFactory3->create('pim_catalog_textarea', '1234', ['data' => 'some content', 'locale' => null, 'scope' => null])
+            ->shouldBeCalled()
+            ->willReturn($valueUserIntent4);
 
         $this->create('values', [
             'a_text' => [['data' => 'bonjour', 'locale' => null, 'scope' => null]],
             'sku' => [['data' => 'my_sku']],
             'A_TExtAreA' => [['data' => '<p>bonjour</p>', 'locale' => null, 'scope' => null]],
-        ])->shouldReturn([$valueUserIntent1, $valueUserIntent2, $valueUserIntent3]);
+            1234 => [['data' => 'some content', 'locale' => null, 'scope' => null]],
+        ])->shouldReturn([$valueUserIntent1, $valueUserIntent2, $valueUserIntent3, $valueUserIntent4]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Attribute codes containing only numeric chars are typed as int by PHP, we need to cast them to string.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
