### PR TITLE
RAB: Fix remote storage bug of break session

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Application/TransferFilesToStorage/FileToTransfer.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Application/TransferFilesToStorage/FileToTransfer.php
@@ -15,6 +15,7 @@ final class FileToTransfer
         private string $fileKey,
         private string $storage,
         private string $outputFileName,
+        private bool $isLocal
     ) {
     }
 
@@ -31,5 +32,10 @@ final class FileToTransfer
     public function getOutputFileName(): string
     {
         return $this->outputFileName;
+    }
+
+    public function isLocal(): bool
+    {
+        return $this->isLocal;
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydrator.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydrator.php
@@ -12,8 +12,6 @@ namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Hydrator;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\StorageInterface;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\StorageHydratorInterface;
-use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
-use Webmozart\Assert\Assert;
 
 final class LocalStorageHydrator implements StorageHydratorInterface
 {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydrator.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydrator.php
@@ -17,14 +17,12 @@ use Webmozart\Assert\Assert;
 
 final class LocalStorageHydrator implements StorageHydratorInterface
 {
-    public function __construct(private VersionProviderInterface $versionProvider)
+    public function __construct()
     {
     }
 
     public function hydrate(array $normalizedStorage): StorageInterface
     {
-        Assert::false($this->versionProvider->isSaaSVersion(), 'Local storage is not available in SaaS version');
-
         return new LocalStorage($normalizedStorage['file_path']);
     }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/UploadStep.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Step/UploadStep.php
@@ -52,7 +52,7 @@ final class UploadStep extends AbstractStep
             throw new \LogicException('malformed job parameters, missing storage configuration');
         }
 
-        if ('local' === $jobParameters[self::STORAGE_KEY]['type'] || 'none' === $jobParameters[self::STORAGE_KEY]['type']) {
+        if ('none' === $jobParameters[self::STORAGE_KEY]['type']) {
             return;
         }
 
@@ -95,6 +95,7 @@ final class UploadStep extends AbstractStep
                 $writtenFile->sourceKey(),
                 $writtenFile->sourceStorage(),
                 $writtenFile->outputFilepath(),
+                $writtenFile->isLocalFile()
             ),
             $writer->getWrittenFiles()
         );

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFilesToStorage.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFilesToStorage.php
@@ -11,6 +11,7 @@ namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\StorageClient
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Application\TransferFilesToStorage\FileToTransfer;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Event\FileCannotBeExported;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\StorageInterface;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\TransferFilesToStorageInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -31,6 +32,10 @@ final class TransferFilesToStorage implements TransferFilesToStorageInterface
     {
         $destinationStorage = $this->storageClientProvider->getFromStorage($storage);
         foreach ($filesToTransfer as $fileToTransfer) {
+            if ($storage instanceof LocalStorage && $fileToTransfer->isLocal()) {
+                continue;
+            }
+
             $sourceStorage = $this->storageClientProvider->getFromFileToTransfer($fileToTransfer);
 
             try {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -34,7 +34,7 @@ services:
             - '@validator'
             - '@akeneo_batch.job.job_parameters_validator'
             - '@akeneo_batch.job_parameters_factory'
-            - '@akeneo_batch_queue.launcher.queue_job_launcher'
+            - '@pim_connector.launcher.authenticated_job_launcher'
             - '@security.token_storage'
             - '@router'
             - '@pim_enrich.provider.form.chained'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/hydrators.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/hydrators.yml
@@ -4,8 +4,6 @@ services:
       - !tagged pim_import_export.hydrator.storage
 
   Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Hydrator\LocalStorageHydrator:
-    arguments:
-      - '@pim_catalog.version_provider'
     tags:
       - { name: pim_import_export.hydrator.storage }
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/fixtures/icecat_demo_dev/jobs.yml
@@ -6,7 +6,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:           /tmp/product.csv
             uploadAllowed:      true
             delimiter:          ;
@@ -25,7 +25,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/product_model.csv
             uploadAllowed: true
             delimiter: ;
@@ -93,7 +93,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:            /tmp/category.csv
             uploadAllowed:       true
             delimiter:           ;
@@ -108,7 +108,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/category.csv
     csv_association_type_import:
         connector: Akeneo CSV Connector
@@ -117,7 +117,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/association_type.csv
             uploadAllowed: true
             delimiter:     ;
@@ -132,7 +132,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/association_type.csv
     csv_group_import:
         connector: Akeneo CSV Connector
@@ -141,7 +141,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/group.csv
             uploadAllowed: true
             delimiter:     ;
@@ -156,7 +156,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/group.csv
     csv_attribute_import:
         connector: Akeneo CSV Connector
@@ -165,7 +165,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/attribute.csv
             uploadAllowed: true
             delimiter:     ;
@@ -180,7 +180,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/attribute.csv
     csv_attribute_option_import:
         connector: Akeneo CSV Connector
@@ -189,7 +189,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/option.csv
             uploadAllowed: true
             delimiter:     ;
@@ -201,7 +201,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/family.csv
             uploadAllowed: true
             delimiter:     ;
@@ -213,7 +213,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/family_variant.csv
             uploadAllowed: true
             delimiter:     ;
@@ -228,7 +228,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/option.csv
     update_product_value:
         connector: Akeneo Mass Edit Connector
@@ -339,7 +339,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/family.csv
     csv_family_variant_export:
         connector: Akeneo CSV Connector
@@ -351,7 +351,7 @@ jobs:
             enclosure:  '"'
             withHeader: true
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/family_variant.csv
     xlsx_product_export:
         connector: Akeneo XLSX Connector
@@ -412,7 +412,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/group.xlsx
     xlsx_product_quick_export:
         connector: Akeneo XLSX Connector
@@ -443,7 +443,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:           /tmp/product.xlsx
             uploadAllowed:      true
             enabled:            true
@@ -460,7 +460,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/product_model.xlsx
             uploadAllowed: true
             enabled: true
@@ -476,7 +476,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:            /tmp/category.xlsx
             uploadAllowed:       true
     xlsx_association_type_import:
@@ -486,7 +486,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/association_type.xlsx
             uploadAllowed: true
     xlsx_attribute_import:
@@ -496,7 +496,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/attribute.xlsx
             uploadAllowed: true
     xlsx_attribute_option_import:
@@ -506,7 +506,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/option.xlsx
             uploadAllowed: true
     xlsx_family_import:
@@ -516,7 +516,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/family.xlsx
             uploadAllowed: true
     xlsx_family_variant_import:
@@ -526,7 +526,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/family_variant.xlsx
             uploadAllowed: true
     xlsx_group_import:
@@ -536,7 +536,7 @@ jobs:
         type:      import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path:      /tmp/group.xlsx
             uploadAllowed: true
     xlsx_family_export:
@@ -548,7 +548,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path: /tmp/family.xlsx
     xlsx_family_variant_export:
         connector: Akeneo XLSX Connector
@@ -559,7 +559,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path: /tmp/family_variant.xlsx
     xlsx_category_export:
         connector: Akeneo XLSX Connector
@@ -570,7 +570,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/category.xlsx
     xlsx_attribute_export:
         connector: Akeneo XLSX Connector
@@ -581,7 +581,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/attribute.xlsx
     xlsx_attribute_option_export:
         connector: Akeneo XLSX Connector
@@ -592,7 +592,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/option.xlsx
     xlsx_association_type_export:
         connector: Akeneo XLSX Connector
@@ -603,7 +603,7 @@ jobs:
             withHeader: true
             linesPerFile: 10000
             storage:
-                type: local
+                type: none
                 file_path:   /tmp/association_type.xlsx
     csv_channel_export:
         connector: Akeneo CSV Connector
@@ -828,7 +828,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user_group.csv
             uploadAllowed: true
             delimiter: ;
@@ -840,7 +840,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user_group.xlsx
             uploadAllowed: true
     csv_user_import:
@@ -850,7 +850,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user.csv
             uploadAllowed: true
             delimiter: ;
@@ -862,7 +862,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user.xlsx
     csv_user_role_import:
         connector: Akeneo CSV Connector
@@ -871,7 +871,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user_role.csv
             uploadAllowed: true
             delimiter: ;
@@ -883,7 +883,7 @@ jobs:
         type: import
         configuration:
             storage:
-                type: local
+                type: none
                 file_path: /tmp/user_role.xlsx
             uploadAllowed: true
     compute_completeness_of_products_family:

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractFileWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractFileWriter.php
@@ -4,7 +4,6 @@ namespace Akeneo\Tool\Component\Connector\Writer\File;
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
 use Akeneo\Tool\Component\Batch\Item\ItemWriterInterface;
-use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
 use Symfony\Component\Filesystem\Filesystem;
@@ -50,7 +49,9 @@ abstract class AbstractFileWriter implements ItemWriterInterface, StepExecutionA
         // TODO RAB-907: Remove this condition
         if ($parameters->has('storage')) {
             $storage = $parameters->get('storage');
-            $filePath = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage['file_path']);
+            $filePath = LocalStorage::TYPE === $storage['type']
+                ? $storage['file_path']
+                : sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage['file_path']);
         } else {
             $filePath = $parameters->get('filePath');
         }

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractFileWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractFileWriter.php
@@ -49,7 +49,8 @@ abstract class AbstractFileWriter implements ItemWriterInterface, StepExecutionA
 
         // TODO RAB-907: Remove this condition
         if ($parameters->has('storage')) {
-            $filePath = $parameters->get('storage')['file_path'];
+            $storage = $parameters->get('storage');
+            $filePath = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage['file_path']);
         } else {
             $filePath = $parameters->get('filePath');
         }

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -182,8 +182,8 @@ abstract class AbstractItemMediaWriter implements
         if ($parameters->has('storage')) {
             $storage = $parameters->get('storage');
             $filePath = LocalStorage::TYPE === $storage['type']
-                ? $storage['file_path']
-                : sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage['file_path']);
+                ? $storage[$this->jobParamFilePath]
+                : sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage[$this->jobParamFilePath]);
         } else {
             $filePath = $parameters->get($this->jobParamFilePath);
         }

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -181,7 +181,8 @@ abstract class AbstractItemMediaWriter implements
         $parameters = $this->stepExecution->getJobParameters();
         // TODO RAB-907: Remove this condition
         if ($parameters->has('storage')) {
-            $filePath = $parameters->get('storage')[$this->jobParamFilePath];
+            $storage = $parameters->get('storage');
+            $filePath = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage[$this->jobParamFilePath]);
         } else {
             $filePath = $parameters->get($this->jobParamFilePath);
         }

--- a/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Writer/File/AbstractItemMediaWriter.php
@@ -9,7 +9,6 @@ use Akeneo\Tool\Component\Batch\Item\DataInvalidItem;
 use Akeneo\Tool\Component\Batch\Item\FlushableInterface;
 use Akeneo\Tool\Component\Batch\Item\InitializableInterface;
 use Akeneo\Tool\Component\Batch\Item\ItemWriterInterface;
-use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
@@ -182,7 +181,9 @@ abstract class AbstractItemMediaWriter implements
         // TODO RAB-907: Remove this condition
         if ($parameters->has('storage')) {
             $storage = $parameters->get('storage');
-            $filePath = sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage[$this->jobParamFilePath]);
+            $filePath = LocalStorage::TYPE === $storage['type']
+                ? $storage['file_path']
+                : sprintf('%s%s%s', sys_get_temp_dir(), DIRECTORY_SEPARATOR, $storage['file_path']);
         } else {
             $filePath = $parameters->get($this->jobParamFilePath);
         }

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/ProductExportController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/ProductExportController.php
@@ -2,7 +2,9 @@
 
 namespace Oro\Bundle\PimDataGridBundle\Controller;
 
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Oro\Bundle\DataGridBundle\Datagrid\Manager as DataGridManager;
@@ -29,33 +31,16 @@ class ProductExportController
     const DATETIME_FORMAT = 'Y-m-d_H:i:s';
     private const FILE_PATH_KEYS = ['filePath', 'filePathProduct', 'filePathProductModel'];
 
-    protected RequestStack $requestStack;
-    protected MassActionDispatcher $massActionDispatcher;
-    protected GridFilterAdapterInterface $gridFilterAdapter;
-    protected IdentifiableObjectRepositoryInterface $jobInstanceRepo;
-    protected TokenStorageInterface $tokenStorage;
-    protected JobLauncherInterface $jobLauncher;
-    protected DataGridManager $datagridManager;
-    protected MassActionParametersParser $parameterParser;
-
     public function __construct(
-        RequestStack $requestStack,
-        MassActionDispatcher $massActionDispatcher,
-        GridFilterAdapterInterface $gridFilterAdapter,
-        IdentifiableObjectRepositoryInterface $jobInstanceRepo,
-        TokenStorageInterface $tokenStorage,
-        JobLauncherInterface $jobLauncher,
-        DataGridManager $datagridManager,
-        MassActionParametersParser $parameterParser
+        private RequestStack $requestStack,
+        private GridFilterAdapterInterface $gridFilterAdapter,
+        private IdentifiableObjectRepositoryInterface $jobInstanceRepo,
+        private TokenStorageInterface $tokenStorage,
+        private JobLauncherInterface $jobLauncher,
+        private DataGridManager $datagridManager,
+        private MassActionParametersParser $parameterParser,
+        private VersionProviderInterface $versionProvider
     ) {
-        $this->requestStack = $requestStack;
-        $this->massActionDispatcher = $massActionDispatcher;
-        $this->gridFilterAdapter = $gridFilterAdapter;
-        $this->jobInstanceRepo = $jobInstanceRepo;
-        $this->tokenStorage = $tokenStorage;
-        $this->jobLauncher = $jobLauncher;
-        $this->datagridManager = $datagridManager;
-        $this->parameterParser = $parameterParser;
     }
 
     /**
@@ -85,7 +70,7 @@ class ProductExportController
         foreach (self::FILE_PATH_KEYS as $filePathKey) {
             if (isset($rawParameters[$filePathKey])) {
                 //TODO RAB-665 handle local storage on PaaS version
-                $rawParameters['storage']['type'] = NoneStorage::TYPE;
+                $rawParameters['storage']['type'] = $this->versionProvider->isSaaSVersion() ? NoneStorage::TYPE : LocalStorage::TYPE;
                 $rawParameters['storage'][$filePathKey] = $this->buildFilePath($rawParameters[$filePathKey], $contextParameters);
             }
         }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/controllers.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/controllers.yml
@@ -26,13 +26,13 @@ services:
         class: '%pim_datagrid.controller.product_export.class%'
         arguments:
             - '@request_stack'
-            - '@pim_datagrid.extension.mass_action.dispatcher'
             - '@pim_datagrid.adapter.oro_to_pim_grid_filter'
             - '@akeneo_batch.job.job_instance_repository'
             - '@security.token_storage'
             - '@pim_connector.launcher.authenticated_job_launcher'
             - '@oro_datagrid.datagrid.manager'
             - '@oro_datagrid.mass_action.parameters_parser'
+            - '@pim_catalog.version_provider'
 
     pim_datagrid.controller.mass_action:
         public: true

--- a/tests/back/Platform/Acceptance/ImportExport/TransferFilesToLocalStorageTest.php
+++ b/tests/back/Platform/Acceptance/ImportExport/TransferFilesToLocalStorageTest.php
@@ -26,8 +26,8 @@ class TransferFilesToLocalStorageTest extends AcceptanceTestCase
 
         $storage = ['type' => 'local', 'file_path' => '/tmp'];
         $filesToTransfer = [
-            new FileToTransfer('file_key1', 'localFilesystem', 'filename1.csv'),
-            new FileToTransfer('file_key2', 'catalogStorage', 'filename2.csv'),
+            new FileToTransfer('file_key1', 'localFilesystem', 'filename1.csv', false),
+            new FileToTransfer('file_key2', 'catalogStorage', 'filename2.csv', false),
         ];
 
         $this->getHandler()->handle(new TransferFilesToStorageCommand($filesToTransfer, $storage));

--- a/tests/back/Platform/Acceptance/ImportExport/TransferFilesToNoneStorageTest.php
+++ b/tests/back/Platform/Acceptance/ImportExport/TransferFilesToNoneStorageTest.php
@@ -22,8 +22,8 @@ class TransferFilesToNoneStorageTest extends AcceptanceTestCase
     {
         $storage = ['type' => 'none'];
         $filesToTransfer = [
-            new FileToTransfer('file_key1', 'localFilesystem', 'filename1.csv'),
-            new FileToTransfer('file_key2', 'catalogStorage', 'filename2.csv'),
+            new FileToTransfer('file_key1', 'localFilesystem', 'filename1.csv', false),
+            new FileToTransfer('file_key2', 'catalogStorage', 'filename2.csv', false),
         ];
 
         $this->getHandler()->handle(new TransferFilesToStorageCommand($filesToTransfer, $storage));

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydratorSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Hydrator/LocalStorageHydratorSpec.php
@@ -15,10 +15,9 @@ use PhpSpec\ObjectBehavior;
 
 class LocalStorageHydratorSpec extends ObjectBehavior
 {
-    public function let(VersionProviderInterface $versionProvider)
+    public function let()
     {
-        $versionProvider->isSaaSVersion()->willReturn(false);
-        $this->beConstructedWith($versionProvider);
+        $this->beConstructedWith();
     }
 
     public function it_supports_only_local_storage()
@@ -31,12 +30,5 @@ class LocalStorageHydratorSpec extends ObjectBehavior
     public function it_hydrates_a_local_storage()
     {
         $this->hydrate(['type' => 'local', 'file_path' => 'a_file_path'])->shouldBeLike(new LocalStorage('a_file_path'));
-    }
-
-    public function it_throws_an_exception_on_saas_environment(VersionProviderInterface $versionProvider)
-    {
-        $versionProvider->isSaaSVersion()->willReturn(true);
-
-        $this->shouldThrow(\InvalidArgumentException::class)->during('hydrate', [['type' => 'local', 'file_path' => 'a_file_path']]);
     }
 }

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/StorageClient/StorageClientProviderSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/StorageClient/StorageClientProviderSpec.php
@@ -32,7 +32,7 @@ class StorageClientProviderSpec extends ObjectBehavior
         FilesystemOperator $filesystemOperator,
     ) {
         $filesystemProvider->getFilesystem('local')->willReturn($filesystemOperator);
-        $fileToTransfer = new FileToTransfer('fileKey', 'local', 'outputFileName');
+        $fileToTransfer = new FileToTransfer('fileKey', 'local', 'outputFileName', false);
         $this->getFromFileToTransfer($fileToTransfer)->shouldReturnAnInstanceOf(StorageClientInterface::class);
     }
 

--- a/tests/legacy/features/pim/enrichment/product/export/configure_export_products_with_media.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/configure_export_products_with_media.feature
@@ -35,7 +35,7 @@ Feature: Configure export of products media
 
   Scenario: Successfully export products in xlsx with media
     Given the following job "xlsx_product_export" configuration:
-      | storage | {"type": "local", "file_path": "/%tmp%/product_export/product_export.xlsx"} |
+      | storage | {"type": "local", "file_path": "%tmp%/product_export/product_export.xlsx"} |
       | with_media | yes                                                              |
       | filters    | {"structure":{"locales":["en_US"],"scope":"mobile"}, "data": []} |
     And I am logged in as "Julia"

--- a/tests/legacy/features/pim/enrichment/product/export/configure_export_products_with_media.feature
+++ b/tests/legacy/features/pim/enrichment/product/export/configure_export_products_with_media.feature
@@ -35,7 +35,7 @@ Feature: Configure export of products media
 
   Scenario: Successfully export products in xlsx with media
     Given the following job "xlsx_product_export" configuration:
-      | storage | {"type": "local", "file_path": "%tmp%/product_export/product_export.xlsx"} |
+      | storage | {"type": "local", "file_path": "/%tmp%/product_export/product_export.xlsx"} |
       | with_media | yes                                                              |
       | filters    | {"structure":{"locales":["en_US"],"scope":"mobile"}, "data": []} |
     And I am logged in as "Julia"


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- We fixed some behat tests than does not pass only in CE (non SAAS) =>
  - Quick export is local or none depending on version in order to make the tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_media.feature:29 pass
  - We now only exclude local file on local storage instead of do not export the whole files on locale storage because media are not in locale => it break the tests
- We made icecat fixture by default to none storage in order to not have the import now

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Migration & Installer

