### PR TITLE
OCT-93: Hide test app internal endpoints from the public endpoint list

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/routing.yml
@@ -35,11 +35,13 @@ akeneo_connectivity_connection_marketplace_api_test_apps_create:
     path: '/api/rest/v1/test-apps'
     controller: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\TestApps\Controller\External\CreateTestAppAction
     methods: [POST]
+    defaults: { _list_in_root_endpoint: false }
 
 akeneo_connectivity_connection_marketplace_api_test_apps_delete:
     path: '/api/rest/v1/test-apps/{clientId}'
     controller: Akeneo\Connectivity\Connection\Infrastructure\Marketplace\TestApps\Controller\External\DeleteTestAppAction
     methods: [DELETE]
+    defaults: { _list_in_root_endpoint: false }
 
 # Front API
 akeneo_connectivity_connection_connect_marketplace:


### PR DESCRIPTION
Endpoints for Test App creation and deletion are listed when fetching the list of available endpoints using `/api/rest/v1/`

This fix effectively removes these two endpoints from the list