### PR TITLE
CPM-629: Fix ZddMigration command

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/MigrateZddCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/MigrateZddCommand.php
@@ -49,7 +49,10 @@ final class MigrateZddCommand extends Command
             $this->logger->warning('%s - skip - Table pim_one_time_task does not exist', [
                 'action' => 'skip',
             ]);
+
+            return Command::SUCCESS;
         }
+
         $this->logger->info(sprintf('%s - start_command', self::$defaultName), [
             'action' => 'start_command'
         ]);


### PR DESCRIPTION
This PR fixes the command
- The "notices" are dropped from datadog and we can't see migrations, we replaced by "info"
- The command raised a 500 when the table does not exist, now it raises a warning
- The logged messages were too hard to find, we introduced a new format with "name - action - message" and add more context.