### PR TITLE
PIM-10545 - Remove merge of non viewable categories on SetCategories userIntent

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -74,7 +74,7 @@ catalogs-integration-back:
 	APP_ENV=test $(PHP_RUN) vendor/bin/phpunit \
 		--configuration $(CATALOGS_PATH)/back/ \
 		--bootstrap $(CATALOGS_BOOTSTRAP_PATH) \
-		--testsuite Catalogs_Integration
+		--testsuite Catalogs_Integration ${O}
 
 .PHONY: catalogs-acceptance-back
 catalogs-acceptance-back:

--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/GetProductIdentifiersQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/GetProductIdentifiersQueryTest.php
@@ -30,7 +30,11 @@ class GetProductIdentifiersQueryTest extends IntegrationTestCase
 
     public function testItGetsPaginatedProductsUuids(): void
     {
-        $ownerId = $this->createUser('owner')->getId();
+        $owner = $this->createUser('owner');
+        $ownerId = $owner->getId();
+
+        $this->logAs($owner->getUserIdentifier());
+
         $this->createCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c', 'Store US', 'owner');
         $this->enableCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c');
         $this->createProduct('blue', [new SetEnabled(true)], $ownerId);

--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/GetProductUuidFromIdentifierQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/GetProductUuidFromIdentifierQueryTest.php
@@ -29,6 +29,9 @@ class GetProductUuidFromIdentifierQueryTest extends IntegrationTestCase
     public function testItGetsProductUuidFromIdentifier(): void
     {
         $user = $this->createUser('shopifi');
+
+        $this->logAs($user->getUserIdentifier());
+
         $product = $this->createProduct('green', [], $user->getId());
         $expected = $product->getUuid();
 

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -174,18 +174,13 @@ abstract class IntegrationTestCase extends WebTestCase
      */
     protected function createProduct(string $identifier, array $intents = [], ?int $userId = null): AbstractProduct
     {
-        if (null !== $userId) {
-            $user = self::getContainer()->get('pim_user.repository.user')->find($userId);
-        } else {
-            $user = self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('owner');
-            if (null === $user) {
-                $user = $this->createUser('owner');
-            }
+        $bus = self::getContainer()->get('pim_enrich.product.message_bus');
+
+        if (null === $userId) {
+            $user = self::getContainer()->get('security.token_storage')->getToken()?->getUser();
+            \assert($user instanceof UserInterface);
             $userId = $user->getId();
         }
-        $this->logAs($user->getUserIdentifier());
-
-        $bus = self::getContainer()->get('pim_enrich.product.message_bus');
 
         Assert::notNull($userId);
 

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -174,13 +174,18 @@ abstract class IntegrationTestCase extends WebTestCase
      */
     protected function createProduct(string $identifier, array $intents = [], ?int $userId = null): AbstractProduct
     {
-        $bus = self::getContainer()->get('pim_enrich.product.message_bus');
-
-        if (null === $userId) {
-            $user = self::getContainer()->get('security.token_storage')->getToken()?->getUser();
-            \assert($user instanceof UserInterface);
+        if (null !== $userId) {
+            $user = self::getContainer()->get('pim_user.repository.user')->find($userId);
+        } else {
+            $user = self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('owner');
+            if (null === $user) {
+                $user = $this->createUser('owner');
+            }
             $userId = $user->getId();
         }
+        $this->logAs($user->getUserIdentifier());
+
+        $bus = self::getContainer()->get('pim_enrich.product.message_bus');
 
         Assert::notNull($userId);
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/SetCategoriesApplier.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/SetCategoriesApplier.php
@@ -7,8 +7,6 @@ namespace Akeneo\Pim\Enrichment\Product\Application\Applier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
-use Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Webmozart\Assert\Assert;
 
@@ -18,10 +16,8 @@ use Webmozart\Assert\Assert;
  */
 class SetCategoriesApplier implements UserIntentApplier
 {
-    public function __construct(
-        private ObjectUpdaterInterface $productUpdater,
-        private GetNonViewableCategoryCodes $getNonViewableCategories
-    ) {
+    public function __construct(private ObjectUpdaterInterface $productUpdater)
+    {
     }
 
     /**
@@ -30,13 +26,10 @@ class SetCategoriesApplier implements UserIntentApplier
     public function apply(UserIntent $setCategories, ProductInterface $product, int $userId): void
     {
         Assert::isInstanceOf($setCategories, SetCategories::class);
-        $productIdentifier = ProductIdentifier::fromString($product->getIdentifier());
 
-        $nonViewableCategories = $this->getNonViewableCategories->fromProductIdentifiers([$productIdentifier], $userId);
-        $nonViewableCategoriesForProduct = $nonViewableCategories[$productIdentifier->asString()] ?? [];
-
+        // we only send categories viewed by user but they are later merged with non viewabled ones
         $this->productUpdater->update($product, [
-            'categories' => \array_merge($setCategories->categoryCodes(), $nonViewableCategoriesForProduct),
+            'categories' => $setCategories->categoryCodes(),
         ]);
     }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/appliers.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/appliers.yml
@@ -76,7 +76,6 @@ services:
     Akeneo\Pim\Enrichment\Product\Application\Applier\SetCategoriesApplier:
         arguments:
             - '@pim_catalog.updater.product'
-            - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes'
         tags:
             - { name: 'pim.enrichment.product.user_intent_applier' }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -8,6 +8,7 @@ services:
             - '@pim_catalog.validator.product'
             - '@event_dispatcher'
             - '@Akeneo\Pim\Enrichment\Product\Application\Applier\UserIntentApplierRegistry'
+            - '@security.token_storage'
         tags:
             - { name: 'akeneo.pim.enrichment.product.handler', command: 'Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand' }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
@@ -56,6 +56,7 @@ $rules = [
         'Akeneo\Pim\Structure\Component\AttributeTypes',
         'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface',
 
+        // TODO: remove when Upsert product does not use token interface
         'Akeneo\UserManagement\Component\Model\UserInterface',
         'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface',
     ])->in('Akeneo\Pim\Enrichment\Product\Application'),

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
@@ -54,7 +54,10 @@ $rules = [
 
         // Public APIs
         'Akeneo\Pim\Structure\Component\AttributeTypes',
-        'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface'
+        'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface',
+
+        'Akeneo\UserManagement\Component\Model\UserInterface',
+        'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface',
     ])->in('Akeneo\Pim\Enrichment\Product\Application'),
 
     $builder->only([

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -96,7 +96,7 @@ abstract class EnrichmentProductTestCase extends TestCase
 
     protected function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('peter'),
             productIdentifier: $identifier,
@@ -310,18 +310,5 @@ abstract class EnrichmentProductTestCase extends TestCase
     protected function refreshIndex(): void
     {
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -49,6 +49,7 @@ abstract class EnrichmentProductTestCase extends TestCase
         $this->createCategory(['code' => 'print']);
         $this->createCategory(['code' => 'suppliers']);
         $this->createCategory(['code' => 'sales']);
+        $this->createCategory(['code' => 'not_viewable_category']);
 
         if (FeatureHelper::isPermissionFeatureAvailable()) {
             $this->get('Akeneo\Pim\Permission\Bundle\Saver\UserGroupCategoryPermissionsSaver')->save('All', [
@@ -67,9 +68,9 @@ abstract class EnrichmentProductTestCase extends TestCase
                 'view' => ['all' => false, 'identifiers' => ['print', 'sales']],
             ]);
             $this->get('Akeneo\Pim\Permission\Bundle\Saver\UserGroupCategoryPermissionsSaver')->save('IT Support', [
-                'own' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales']],
-                'edit' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales']],
-                'view' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales']],
+                'own' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales', 'not_viewable_category']],
+                'edit' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales', 'not_viewable_category']],
+                'view' => ['all' => false, 'identifiers' => ['print', 'suppliers', 'sales', 'not_viewable_category']],
             ]);
         }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/PQB/GetProductUuidsHandlerIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/PQB/GetProductUuidsHandlerIntegration.php
@@ -37,7 +37,7 @@ final class GetProductUuidsHandlerIntegration extends EnrichmentProductTestCase
     {
         parent::setUp();
         $this->productRepository = $this->get('pim_catalog.repository.product');
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
 
         $this->commandMessageBus->dispatch(
             UpsertProductCommand::createFromCollection($this->getUserId('admin'), 'test1', [])

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/PQB/GetProductUuidsHandlerIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/PQB/GetProductUuidsHandlerIntegration.php
@@ -37,6 +37,7 @@ final class GetProductUuidsHandlerIntegration extends EnrichmentProductTestCase
     {
         parent::setUp();
         $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->logIn('admin');
 
         $this->commandMessageBus->dispatch(
             UpsertProductCommand::createFromCollection($this->getUserId('admin'), 'test1', [])

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
@@ -40,6 +40,7 @@ class UpsertProductAssociationsIntegration extends EnrichmentProductTestCase
         $this->loadEnrichmentProductFunctionalFixtures();
 
         $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->logIn('peter');
 
         $command = new UpsertProductCommand(userId: $this->getUserId('peter'), productIdentifier: 'identifier');
         $this->commandMessageBus->dispatch($command);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductAssociationsIntegration.php
@@ -6,7 +6,6 @@ namespace Akeneo\Pim\Enrichment\Product\Test\Integration\Handler;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\GroupInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\Exception\ViolationsException;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
@@ -40,7 +39,7 @@ class UpsertProductAssociationsIntegration extends EnrichmentProductTestCase
         $this->loadEnrichmentProductFunctionalFixtures();
 
         $this->productRepository = $this->get('pim_catalog.repository.product');
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
 
         $command = new UpsertProductCommand(userId: $this->getUserId('peter'), productIdentifier: 'identifier');
         $this->commandMessageBus->dispatch($command);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
@@ -55,6 +55,7 @@ use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 final class UpsertProductIntegration extends TestCase
 {
@@ -74,6 +75,7 @@ final class UpsertProductIntegration extends TestCase
 
         $this->messageBus = $this->get('pim_enrich.product.message_bus');
         $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->login('admin');
     }
 
     private function clearDoctrineUoW(): void
@@ -1509,5 +1511,18 @@ final class UpsertProductIntegration extends TestCase
             Assert::assertCount(0, $violations, \sprintf('The command is not valid: %s', $violations));
             ($this->get('akeneo_referenceentity.application.record.create_record_handler'))($createRecord);
         }
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
@@ -55,7 +55,6 @@ use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 final class UpsertProductIntegration extends TestCase
 {
@@ -75,7 +74,7 @@ final class UpsertProductIntegration extends TestCase
 
         $this->messageBus = $this->get('pim_enrich.product.message_bus');
         $this->productRepository = $this->get('pim_catalog.repository.product');
-        $this->login('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
     }
 
     private function clearDoctrineUoW(): void
@@ -1511,18 +1510,5 @@ final class UpsertProductIntegration extends TestCase
             Assert::assertCount(0, $violations, \sprintf('The command is not valid: %s', $violations));
             ($this->get('akeneo_referenceentity.application.record.create_record_handler'))($createRecord);
         }
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductVariantIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductVariantIntegration.php
@@ -14,7 +14,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Pim\Enrichment\Product\Integration\EnrichmentProductTestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Messenger\MessageBusInterface;
 
 final class UpsertProductVariantIntegration extends EnrichmentProductTestCase
 {
@@ -28,7 +27,7 @@ final class UpsertProductVariantIntegration extends EnrichmentProductTestCase
 
         $this->commandMessageBus = $this->get('pim_enrich.product.message_bus');
         $this->productRepository = $this->get('pim_catalog.repository.product');
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
     }
 
     /** @test */

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductVariantIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductVariantIntegration.php
@@ -28,6 +28,7 @@ final class UpsertProductVariantIntegration extends EnrichmentProductTestCase
 
         $this->commandMessageBus = $this->get('pim_enrich.product.message_bus');
         $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->logIn('peter');
     }
 
     /** @test */

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
@@ -24,8 +24,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
 use Akeneo\Test\Pim\Enrichment\Product\Integration\EnrichmentProductTestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\BrowserKit\Cookie;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 final class UpsertProductWithPermissionIntegration extends EnrichmentProductTestCase
 {

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
@@ -78,7 +78,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
     /** @test */
     public function it_creates_a_new_uncategorized_product(): void
     {
-        $this->logIn('mary');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('mary');
         $command = new UpsertProductCommand(userId: $this->getUserId('mary'), productIdentifier: 'new_product', valueUserIntents: [
             new SetTextValue('name', null, null, 'foo'),
         ]);
@@ -94,7 +94,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
     /** @test */
     public function it_creates_a_categorized_product(): void
     {
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -116,7 +116,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage('The "suppliers" category does not exist');
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -133,7 +133,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage('The "suppliers" category does not exist');
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -148,7 +148,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage("You should at least keep your product in one category on which you have an own permission");
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -165,7 +165,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage('You should at least keep your product in one category on which you have an own permission');
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -182,7 +182,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage('You should at least keep your product in one category on which you have an own permission');
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'identifier',
@@ -199,7 +199,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->expectException(ViolationsException::class);
         $this->expectExceptionMessage("You don't have access to products in any tree, please contact your administrator");
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'my_product',
@@ -213,7 +213,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
     {
         $this->createProduct('my_product', [new SetCategories(['print', 'suppliers', 'not_viewable_category'])]);
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = new UpsertProductCommand(
             userId: $this->getUserId('betty'),
             productIdentifier: 'my_product',
@@ -224,7 +224,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->clearDoctrineUoW();
 
         // we login as a user that access all categories to check they are still linked to product
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         $product = $this->productRepository->findOneByIdentifier('my_product');
 
         Assert::assertNotNull($product);
@@ -249,7 +249,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
             [new AssociateProducts('X_SELL', ['product_viewable_by_manager', 'product_non_viewable_by_manager'])]
         );
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = UpsertProductCommand::createFromCollection(
             $this->getUserId('betty'),
             'my_product',
@@ -262,7 +262,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->clearDoctrineUoW();
 
         // we relog as peter to have full permission on categories
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         $product = $this->productRepository->findOneByIdentifier('my_product');
 
         Assert::assertNotNull($product);
@@ -287,7 +287,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
             new AssociateProductModels('X_SELL', ['product_model_non_viewable_by_manager'])
         ]);
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = UpsertProductCommand::createFromCollection(
             $this->getUserId('betty'),
             'my_product',
@@ -300,7 +300,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->clearDoctrineUoW();
 
         // we relog as peter to have full permission on categories
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         $product = $this->productRepository->findOneByIdentifier('my_product');
 
         Assert::assertSame('my_product', $product->getIdentifier());
@@ -330,7 +330,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
             ])]
         );
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $this->commandMessageBus->dispatch(UpsertProductCommand::createFromCollection(
             $this->getUserId('betty'),
             'my_product',
@@ -340,7 +340,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         ));
 
         // we relog as peter to have full permission on viewable products
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         Assert::assertEqualsCanonicalizing(
             [
                 new QuantifiedEntity('product_viewable_by_manager', 7),
@@ -366,7 +366,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
             ]),
         ]);
 
-        $this->logIn('betty');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
         $command = UpsertProductCommand::createFromCollection(
             $this->getUserId('betty'),
             'my_product',
@@ -379,7 +379,7 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->commandMessageBus->dispatch($command);
 
         // we relog as peter to have full permission on viewable products
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
         Assert::assertEqualsCanonicalizing(
             [
                 new QuantifiedEntity('product_model_non_viewable_by_manager', 10),

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertQuantifiedAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertQuantifiedAssociationsIntegration.php
@@ -36,6 +36,7 @@ class UpsertQuantifiedAssociationsIntegration extends EnrichmentProductTestCase
         $this->loadEnrichmentProductFunctionalFixtures();
 
         $this->productRepository = $this->get('pim_catalog.repository.product');
+        $this->logIn('peter');
 
         $this->commandMessageBus->dispatch(new UpsertProductCommand(userId: $this->getUserId('peter'), productIdentifier: 'identifier'));
         Assert::assertNotNull($this->productRepository->findOneByIdentifier('identifier'));

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertQuantifiedAssociationsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertQuantifiedAssociationsIntegration.php
@@ -36,7 +36,7 @@ class UpsertQuantifiedAssociationsIntegration extends EnrichmentProductTestCase
         $this->loadEnrichmentProductFunctionalFixtures();
 
         $this->productRepository = $this->get('pim_catalog.repository.product');
-        $this->logIn('peter');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
 
         $this->commandMessageBus->dispatch(new UpsertProductCommand(userId: $this->getUserId('peter'), productIdentifier: 'identifier'));
         Assert::assertNotNull($this->productRepository->findOneByIdentifier('identifier'));

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
@@ -43,7 +43,7 @@ class SetCategoriesApplierSpec extends ObjectBehavior
         $this->apply($userIntent, $product, 10);
     }
 
-    function it_applies_a_set_categories_user_intent_when_all_product_categories_are_viewable(
+    /**function it_applies_a_set_categories_user_intent_when_all_product_categories_are_viewable(
         ObjectUpdaterInterface $productUpdater,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes
     ) {
@@ -57,9 +57,9 @@ class SetCategoriesApplierSpec extends ObjectBehavior
         $productUpdater->update($product, ['categories' => ['categoryA', 'categoryB']])->shouldBeCalledOnce();
 
         $this->apply($userIntent, $product, 10);
-    }
+    }*/
 
-    function it_merges_non_viewable_categories_when_applying_a_set_categories_user_intent(
+    /**function it_merges_non_viewable_categories_when_applying_a_set_categories_user_intent(
         ObjectUpdaterInterface $productUpdater,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes
     ) {
@@ -74,5 +74,5 @@ class SetCategoriesApplierSpec extends ObjectBehavior
             ->shouldBeCalledOnce();
 
         $this->apply($userIntent, $product, 10);
-    }
+    }*/
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
@@ -42,37 +42,4 @@ class SetCategoriesApplierSpec extends ObjectBehavior
 
         $this->apply($userIntent, $product, 10);
     }
-
-    /**function it_applies_a_set_categories_user_intent_when_all_product_categories_are_viewable(
-        ObjectUpdaterInterface $productUpdater,
-        GetNonViewableCategoryCodes $getNonViewableCategoryCodes
-    ) {
-        $userIntent = new SetCategories(['categoryA', 'categoryB']);
-        $product = new Product();
-        $product->setIdentifier('foo');
-
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)
-            ->willReturn(['foo' => []]);
-
-        $productUpdater->update($product, ['categories' => ['categoryA', 'categoryB']])->shouldBeCalledOnce();
-
-        $this->apply($userIntent, $product, 10);
-    }*/
-
-    /**function it_merges_non_viewable_categories_when_applying_a_set_categories_user_intent(
-        ObjectUpdaterInterface $productUpdater,
-        GetNonViewableCategoryCodes $getNonViewableCategoryCodes
-    ) {
-        $userIntent = new SetCategories(['categoryA', 'categoryB']);
-        $product = new Product();
-        $product->setIdentifier('foo');
-
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)
-            ->willReturn(['foo' => ['categoryD', 'categoryE']]);
-
-        $productUpdater->update($product, ['categories' => ['categoryA', 'categoryB', 'categoryD', 'categoryE']])
-            ->shouldBeCalledOnce();
-
-        $this->apply($userIntent, $product, 10);
-    }*/
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
@@ -77,8 +77,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn(null);
         $productBuilder->createProduct('identifier1')->shouldBeCalledOnce()->willReturn($product);
@@ -106,8 +106,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productBuilder->createProduct('identifier1')->shouldNotBeCalled();
@@ -136,8 +136,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->isDirty()->willReturn(false);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productBuilder->createProduct('identifier1')->shouldNotBeCalled();
@@ -165,8 +165,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ]);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn($violations);
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productSaver->save($product)->shouldNotBeCalled();
 
@@ -190,8 +190,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ]);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productValidator->validate($product)->shouldBeCalledOnce()->willReturn($violations);
@@ -217,8 +217,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $applierRegistry->getApplier($setTextUserIntent)->willReturn($userIntentApplier);
@@ -251,8 +251,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
 
@@ -305,8 +305,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier')->shouldBeCalledOnce()->willReturn($product);
 
@@ -332,8 +332,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
-        $currentToken = $tokenStorage->getToken()->willReturn($token);
-        $currentToken->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+        $token->getUser()->willReturn($user);
         $user->getId()->willReturn(2);
 
         $productUpdater->update($product, Argument::cetera())->shouldNotbeCalled();

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
@@ -22,9 +22,12 @@ use Akeneo\Pim\Enrichment\Product\Application\UpsertProductHandler;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -38,7 +41,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ValidatorInterface $productValidator,
         EventDispatcherInterface $eventDispatcher,
-        UserIntentApplierRegistry $applierRegistry
+        UserIntentApplierRegistry $applierRegistry,
+        TokenStorageInterface $tokenStorage
     ) {
         $this->beConstructedWith(
             $validator,
@@ -47,7 +51,8 @@ class UpsertProductHandlerSpec extends ObjectBehavior
             $productSaver,
             $productValidator,
             $eventDispatcher,
-            $applierRegistry
+            $applierRegistry,
+            $tokenStorage
         );
     }
 
@@ -63,12 +68,18 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ValidatorInterface $productValidator,
         EventDispatcherInterface $eventDispatcher,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn(null);
         $productBuilder->createProduct('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
@@ -86,12 +97,18 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ValidatorInterface $productValidator,
         EventDispatcherInterface $eventDispatcher,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productBuilder->createProduct('identifier1')->shouldNotBeCalled();
         $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
@@ -109,13 +126,19 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ValidatorInterface $productValidator,
         EventDispatcherInterface $eventDispatcher,
-        ProductInterface $product
+        ProductInterface $product,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product->getIdentifier()->willReturn('identifier1');
         $product->isDirty()->willReturn(false);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productBuilder->createProduct('identifier1')->shouldNotBeCalled();
         $productValidator->validate($product)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
@@ -129,7 +152,10 @@ class UpsertProductHandlerSpec extends ObjectBehavior
 
     function it_throws_an_exception_when_command_is_not_valid(
         ValidatorInterface $validator,
-        SaverInterface $productSaver
+        SaverInterface $productSaver,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
@@ -139,6 +165,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ]);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn($violations);
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productSaver->save($product)->shouldNotBeCalled();
 
         $this->shouldThrow(new ViolationsException($violations))->during('__invoke', [$command]);
@@ -148,7 +177,10 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ValidatorInterface $validator,
         ProductRepositoryInterface $productRepository,
         SaverInterface $productSaver,
-        ValidatorInterface $productValidator
+        ValidatorInterface $productValidator,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $command = new UpsertProductCommand(1, 'identifier1');
         $product = new Product();
@@ -158,6 +190,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         ]);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $productValidator->validate($product)->shouldBeCalledOnce()->willReturn($violations);
         $productSaver->save($product)->shouldNotBeCalled();
@@ -171,7 +206,10 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ValidatorInterface $productValidator,
         UserIntentApplierRegistry $applierRegistry,
-        UserIntentApplier $userIntentApplier
+        UserIntentApplier $userIntentApplier,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $setTextUserIntent = new SetTextValue('name', null, null, 'foo');
         $command = new UpsertProductCommand(1, 'identifier1', valueUserIntents: [$setTextUserIntent]);
@@ -179,6 +217,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
         $applierRegistry->getApplier($setTextUserIntent)->willReturn($userIntentApplier);
         $userIntentApplier->apply($setTextUserIntent, $product, 1)->willThrow(
@@ -198,7 +239,10 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         EventDispatcherInterface $eventDispatcher,
         UserIntentApplierRegistry $applierRegistry,
         UserIntentApplier $applier,
-        UserIntentApplier $applier2
+        UserIntentApplier $applier2,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $userIntent = new SetEnabled(true);
         $setTextUserIntent = new SetTextValue('name', null, null, 'Lorem Ipsum');
@@ -207,6 +251,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier1')->shouldBeCalledOnce()->willReturn($product);
 
         $applierRegistry->getApplier($userIntent)->shouldBeCalledOnce()->willReturn($applier);
@@ -228,6 +275,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         SaverInterface $productSaver,
         ObjectUpdaterInterface $productUpdater,
         ValidatorInterface $productValidator,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
     ) {
         $unknownUserIntent = new class implements ValueUserIntent {
             public function attributeCode(): string
@@ -255,6 +305,9 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(1);
         $productRepository->findOneByIdentifier('identifier')->shouldBeCalledOnce()->willReturn($product);
 
         $productUpdater->update($product, Argument::cetera())->shouldNotbeCalled();
@@ -262,5 +315,31 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $productSaver->save($product)->shouldNotBeCalled();
 
         $this->shouldThrow(\InvalidArgumentException::class)->during('__invoke', [$command]);
+    }
+
+    function it_throws_an_error_when_connected_user_is_different_from_user_id(
+        ValidatorInterface $validator,
+        SaverInterface $productSaver,
+        ObjectUpdaterInterface $productUpdater,
+        ValidatorInterface $productValidator,
+        TokenStorageInterface $tokenStorage,
+        TokenInterface $token,
+        UserInterface $user,
+    ) {
+        $command = new UpsertProductCommand(userId: 1, productIdentifier: 'identifier', valueUserIntents: []);
+
+        $product = new Product();
+        $product->setIdentifier('identifier1');
+
+        $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
+        $currentToken = $tokenStorage->getToken()->willReturn($token);
+        $currentToken->getUser()->willReturn($user);
+        $user->getId()->willReturn(2);
+
+        $productUpdater->update($product, Argument::cetera())->shouldNotbeCalled();
+        $productValidator->validate($product)->shouldNotBeCalled();
+        $productSaver->save($product)->shouldNotBeCalled();
+
+        $this->shouldThrow(\LogicException::class)->during('__invoke', [$command]);
     }
 }

--- a/src/Akeneo/Platform/Job/back/tests/Integration/ControllerIntegrationTestCase.php
+++ b/src/Akeneo/Platform/Job/back/tests/Integration/ControllerIntegrationTestCase.php
@@ -24,6 +24,6 @@ abstract class ControllerIntegrationTestCase extends IntegrationTestCase
 
     protected function logAs(string $username): void
     {
-        $this->get('akeneo_integration_tests.helper.authenticator')->logIn($this->client, $username);
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn($username, $this->client);
     }
 }

--- a/tests/back/Integration/IntegrationTestsBundle/Helper/AuthenticatorHelper.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Helper/AuthenticatorHelper.php
@@ -49,7 +49,7 @@ final class AuthenticatorHelper
         $this->session = $session;
     }
 
-    public function logIn(KernelBrowser $client, string $username): void
+    public function logIn(string $username, ?KernelBrowser $client = null): void
     {
         $user = $this->userRepository->findOneByIdentifier($username);
         if (null === $user) {
@@ -62,8 +62,10 @@ final class AuthenticatorHelper
         $this->session->set('_security_main', serialize($token));
         $this->session->save();
 
-        $cookie = new Cookie($this->session->getName(), $this->session->getId());
-        $client->getCookieJar()->set($cookie);
+        if (null !== $client) {
+            $cookie = new Cookie($this->session->getName(), $this->session->getId());
+            $client->getCookieJar()->set($cookie);
+        }
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
@@ -10,7 +10,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
@@ -48,7 +47,7 @@ abstract class InternalApiTestCase extends TestCase
      */
     protected function createProduct(string $identifier, ?string $familyCode, array $userIntents): ProductInterface
     {
-        $this->login('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -111,18 +110,5 @@ abstract class InternalApiTestCase extends TestCase
         }
 
         return \intval($id);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\HttpKernelBrowser;
@@ -47,6 +48,7 @@ abstract class InternalApiTestCase extends TestCase
      */
     protected function createProduct(string $identifier, ?string $familyCode, array $userIntents): ProductInterface
     {
+        $this->login('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -109,5 +111,18 @@ abstract class InternalApiTestCase extends TestCase
         }
 
         return \intval($id);
+    }
+
+    protected function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -10,7 +10,6 @@ use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -24,7 +23,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []): ProductInterface
     {
-        $this->login('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -40,7 +39,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
      */
     protected function createVariantProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -135,18 +134,5 @@ abstract class AbstractProductTestCase extends ApiTestCase
         }
 
         return \intval($id);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductMediaFileEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductMediaFileEndToEnd.php
@@ -8,10 +8,8 @@ use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Akeneo\Tool\Component\Api\Repository\ApiResourceRepositoryInterface;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use League\Flysystem\FilesystemOperator;
-use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class CreateProductMediaFileEndToEnd extends ApiTestCase
 {
@@ -311,7 +309,7 @@ JSON;
 
         $this->fileRepository = $this->get('pim_api.repository.media_file');
 
-        $this->login('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'foo',
@@ -353,18 +351,5 @@ JSON;
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductMediaFileEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/Media/CreateProductMediaFileEndToEnd.php
@@ -8,8 +8,10 @@ use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
 use Akeneo\Tool\Component\Api\Repository\ApiResourceRepositoryInterface;
 use Akeneo\Tool\Component\FileStorage\Model\FileInfoInterface;
 use League\Flysystem\FilesystemOperator;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class CreateProductMediaFileEndToEnd extends ApiTestCase
 {
@@ -309,6 +311,7 @@ JSON;
 
         $this->fileRepository = $this->get('pim_api.repository.media_file');
 
+        $this->login('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'foo',
@@ -350,5 +353,18 @@ JSON;
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
@@ -7,11 +7,14 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ClassifyProductIntegration extends TestCase
 {
     public function testClassify()
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'tee',
@@ -48,5 +51,18 @@ class ClassifyProductIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductIntegration.php
@@ -7,14 +7,12 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ClassifyProductIntegration extends TestCase
 {
     public function testClassify()
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'tee',
@@ -51,18 +49,5 @@ class ClassifyProductIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
@@ -7,8 +7,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ClassifyProductModelIntegration extends TestCase
 {
@@ -155,7 +153,7 @@ class ClassifyProductModelIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -178,18 +176,5 @@ class ClassifyProductModelIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Classification/ClassifyProductModelIntegration.php
@@ -7,6 +7,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ClassifyProductModelIntegration extends TestCase
 {
@@ -153,6 +155,7 @@ class ClassifyProductModelIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -175,5 +178,18 @@ class ClassifyProductModelIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
@@ -13,8 +13,6 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeRequirementInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Julien Janvier <j.janvier@gmail.com>
@@ -78,7 +76,7 @@ abstract class AbstractCompletenessTestCase extends TestCase
      */
     protected function createProductWithStandardValues(string $identifier, array $userIntents = []): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -214,18 +212,5 @@ abstract class AbstractCompletenessTestCase extends TestCase
         }
 
         return $attributeRequirementToRemove;
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/AbstractCompletenessTestCase.php
@@ -13,6 +13,8 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeRequirementInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Julien Janvier <j.janvier@gmail.com>
@@ -76,6 +78,7 @@ abstract class AbstractCompletenessTestCase extends TestCase
      */
     protected function createProductWithStandardValues(string $identifier, array $userIntents = []): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -211,5 +214,18 @@ abstract class AbstractCompletenessTestCase extends TestCase
         }
 
         return $attributeRequirementToRemove;
+    }
+
+    protected function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/CalculateCompletenessCommandIntegration.php
@@ -15,7 +15,6 @@ use Akeneo\Test\IntegrationTestsBundle\Launcher\CommandLauncher;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class CalculateCompletenessCommandIntegration extends TestCase
 {
@@ -126,7 +125,7 @@ class CalculateCompletenessCommandIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -150,19 +149,6 @@ class CalculateCompletenessCommandIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     private function createProductModel(array $data): void

--- a/tests/back/Pim/Enrichment/Integration/Completeness/RemoveCompletenessWhenDeletingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/RemoveCompletenessWhenDeletingProductIntegration.php
@@ -5,12 +5,9 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Completeness;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
-use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 
 class RemoveCompletenessWhenDeletingProductIntegration extends AbstractCompletenessTestCase
@@ -114,7 +111,7 @@ class RemoveCompletenessWhenDeletingProductIntegration extends AbstractCompleten
      */
     private function createProduct(string $identifier, array $userIntents, int $userId): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $userId,
             productIdentifier: $identifier,

--- a/tests/back/Pim/Enrichment/Integration/Completeness/RemoveCompletenessWhenDeletingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/RemoveCompletenessWhenDeletingProductIntegration.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 
 class RemoveCompletenessWhenDeletingProductIntegration extends AbstractCompletenessTestCase
@@ -113,6 +114,7 @@ class RemoveCompletenessWhenDeletingProductIntegration extends AbstractCompleten
      */
     private function createProduct(string $identifier, array $userIntents, int $userId): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $userId,
             productIdentifier: $identifier,

--- a/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
@@ -18,7 +18,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -90,7 +89,7 @@ class SqlGetProductCompletenessRatioIntegration extends TestCase
 
     private function createProduct(): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'test_completeness',
@@ -123,18 +122,5 @@ class SqlGetProductCompletenessRatioIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Completeness/SqlGetProductCompletenessRatioIntegration.php
@@ -18,6 +18,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -89,6 +90,7 @@ class SqlGetProductCompletenessRatioIntegration extends TestCase
 
     private function createProduct(): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'test_completeness',
@@ -121,5 +123,18 @@ class SqlGetProductCompletenessRatioIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ComputeDescendantProductCompletenessesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ComputeDescendantProductCompletenessesIntegration.php
@@ -158,6 +158,7 @@ class ComputeDescendantProductCompletenessesIntegration extends AbstractComplete
      * @param UserIntent[] $userIntents
      */
     private function createProduct(string $identifier, array $userIntents = []): ProductInterface {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ComputeDescendantProductCompletenessesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/ComputeDescendantProductCompletenessesIntegration.php
@@ -158,7 +158,7 @@ class ComputeDescendantProductCompletenessesIntegration extends AbstractComplete
      * @param UserIntent[] $userIntents
      */
     private function createProduct(string $identifier, array $userIntents = []): ProductInterface {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
@@ -7,9 +7,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
-use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Test products have been correctly removed from the index after a product has been removed.
@@ -99,7 +97,7 @@ class RemovingProductIntegration extends TestCase
 
     private function createProduct(string $identifier): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier, //'bat',
@@ -108,18 +106,5 @@ class RemovingProductIntegration extends TestCase
         $this->get('pim_enrich.product.message_bus')->dispatch($command);
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Common/Saver/RemovingProductIntegration.php
@@ -7,7 +7,9 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Elasticsearch\Common\Exceptions\Missing404Exception;
+use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Test products have been correctly removed from the index after a product has been removed.
@@ -97,6 +99,7 @@ class RemovingProductIntegration extends TestCase
 
     private function createProduct(string $identifier): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier, //'bat',
@@ -105,5 +108,18 @@ class RemovingProductIntegration extends TestCase
         $this->get('pim_enrich.product.message_bus')->dispatch($command);
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindNonExistingProductIdentifiersQueryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindNonExistingProductIdentifiersQueryIntegration.php
@@ -5,6 +5,8 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Query\FindNonExistingProductIdentifiersQueryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
 {
@@ -66,6 +68,7 @@ class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
 
     private function createProduct(string $productIdentifier): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $productIdentifier,
@@ -86,5 +89,18 @@ class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindNonExistingProductIdentifiersQueryIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Doctrine/Query/FindNonExistingProductIdentifiersQueryIntegration.php
@@ -5,8 +5,6 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Doctrine\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Query\FindNonExistingProductIdentifiersQueryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
 {
@@ -68,7 +66,7 @@ class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
 
     private function createProduct(string $productIdentifier): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $productIdentifier,
@@ -89,18 +87,5 @@ class FindNonExistingProductIdentifiersQueryIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
@@ -8,8 +8,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
@@ -127,7 +125,7 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
 
     public function testMoveAttributeUpRemovesValuesOnTwoLevels()
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'running-shoes-m-antique-white',
@@ -433,18 +431,5 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/ChangeVariantFamilyStructureIntegration.php
@@ -8,6 +8,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Adrien Pétremann <adrien.petremann@akeneo.com>
@@ -125,6 +127,7 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
 
     public function testMoveAttributeUpRemovesValuesOnTwoLevels()
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'running-shoes-m-antique-white',
@@ -430,5 +433,18 @@ class ChangeVariantFamilyStructureIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
@@ -11,8 +11,6 @@ use Akeneo\Pim\Structure\Component\Model\AttributeOption;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -37,7 +35,7 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         $attributeOption->setAttribute($this->get('pim_api.repository.attribute')->findOneByIdentifier('brand'));
         $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
 
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'hiking_shoes',
@@ -165,18 +163,5 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/EntityWithFamilyVariant/RemoveNonExistingProductValuesIntegration.php
@@ -11,6 +11,8 @@ use Akeneo\Pim\Structure\Component\Model\AttributeOption;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Jobs\JobExecutionObserver;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -35,6 +37,7 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         $attributeOption->setAttribute($this->get('pim_api.repository.attribute')->findOneByIdentifier('brand'));
         $this->get('pim_catalog.saver.attribute_option')->save($attributeOption);
 
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'hiking_shoes',
@@ -162,5 +165,18 @@ final class RemoveNonExistingProductValuesIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/AbstractProductQueryBuilderTestCase.php
@@ -10,7 +10,6 @@ use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -45,8 +44,7 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $this->logIn('admin');
-
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -196,18 +194,5 @@ abstract class AbstractProductQueryBuilderTestCase extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -23,7 +23,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Test attribute filters with the EMPTY operator for product and product models
@@ -252,7 +251,7 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -281,18 +280,5 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Attribute/EmptyFilterWithProductsAndProductModelsIntegration.php
@@ -23,6 +23,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Test attribute filters with the EMPTY operator for product and product models
@@ -251,6 +252,7 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -279,5 +281,18 @@ class EmptyFilterWithProductsAndProductModelsIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/Association/CreateTwoWayAssociationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Association/CreateTwoWayAssociationIntegration.php
@@ -16,7 +16,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateP
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class CreateTwoWayAssociationIntegration extends TestCase
 {
@@ -291,7 +290,7 @@ class CreateTwoWayAssociationIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -374,18 +373,5 @@ class CreateTwoWayAssociationIntegration extends TestCase
     private function clearUnitOfWork(): void
     {
         $this->get('pim_connector.doctrine.cache_clearer')->clear();
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/ConvertVariantToSimpleProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ConvertVariantToSimpleProductIntegration.php
@@ -26,7 +26,6 @@ use Akeneo\Pim\Structure\Component\Model\AssociationType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ConvertVariantToSimpleProductIntegration extends TestCase
 {
@@ -261,7 +260,7 @@ class ConvertVariantToSimpleProductIntegration extends TestCase
      */
     private function upsertProduct(string $identifier, array $userIntents = []): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -284,18 +283,5 @@ class ConvertVariantToSimpleProductIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/ConvertVariantToSimpleProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/ConvertVariantToSimpleProductIntegration.php
@@ -26,6 +26,7 @@ use Akeneo\Pim\Structure\Component\Model\AssociationType;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class ConvertVariantToSimpleProductIntegration extends TestCase
 {
@@ -260,6 +261,7 @@ class ConvertVariantToSimpleProductIntegration extends TestCase
      */
     private function upsertProduct(string $identifier, array $userIntents = []): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -282,5 +284,18 @@ class ConvertVariantToSimpleProductIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
@@ -10,7 +10,6 @@ use Akeneo\Test\Common\EntityBuilder;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * When deleting a value from a product that is unique, it should delete the row from the unique value table.
@@ -70,7 +69,7 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
      */
     private function createProductWithUniqueValue(array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'foo',
@@ -110,19 +109,6 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/DeleteUniqueValueInDatabaseIntegration.php
@@ -10,6 +10,7 @@ use Akeneo\Test\Common\EntityBuilder;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * When deleting a value from a product that is unique, it should delete the row from the unique value table.
@@ -69,6 +70,7 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
      */
     private function createProductWithUniqueValue(array $userIntents): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'foo',
@@ -108,6 +110,19 @@ class DeleteUniqueValueInDatabaseIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/AbstractExportTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/AbstractExportTestCase.php
@@ -14,6 +14,8 @@ use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 abstract class AbstractExportTestCase extends TestCase
 {
@@ -51,6 +53,7 @@ abstract class AbstractExportTestCase extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -75,6 +78,20 @@ abstract class AbstractExportTestCase extends TestCase
 
         return \intval($id);
     }
+
+    protected function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
+    }
+
     /**
      * @param array  $data
      *

--- a/tests/back/Pim/Enrichment/Integration/Product/Export/AbstractExportTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Export/AbstractExportTestCase.php
@@ -14,8 +14,6 @@ use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Launcher\JobLauncher;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 abstract class AbstractExportTestCase extends TestCase
 {
@@ -53,7 +51,7 @@ abstract class AbstractExportTestCase extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -77,19 +75,6 @@ abstract class AbstractExportTestCase extends TestCase
         }
 
         return \intval($id);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Product/LoadProductAndProductModelIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/LoadProductAndProductModelIntegration.php
@@ -19,7 +19,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -147,7 +146,7 @@ class LoadProductAndProductModelIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -179,18 +178,5 @@ class LoadProductAndProductModelIntegration extends TestCase
         Assert::assertCount(0, $violations, \sprintf('The product model is not valid: %s', (string)$violations));
         $this->get('pim_catalog.saver.product_model')->save($productModel);
         $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
@@ -35,6 +35,7 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SqlGetConnectorProductsIntegration extends TestCase
 {
@@ -619,6 +620,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
+        $this->logIn('admin');
         $this->get('pim_enrich.product.message_bus')->dispatch(UpsertProductCommand::createFromCollection(
             $this->adminUserId,
             $identifier,
@@ -626,6 +628,19 @@ class SqlGetConnectorProductsIntegration extends TestCase
         ));
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsIntegration.php
@@ -35,7 +35,6 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SqlGetConnectorProductsIntegration extends TestCase
 {
@@ -620,7 +619,7 @@ class SqlGetConnectorProductsIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $this->get('pim_enrich.product.message_bus')->dispatch(UpsertProductCommand::createFromCollection(
             $this->adminUserId,
             $identifier,
@@ -628,19 +627,6 @@ class SqlGetConnectorProductsIntegration extends TestCase
         ));
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
@@ -35,7 +35,6 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
 {
@@ -593,7 +592,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $this->get('pim_enrich.product.message_bus')->dispatch(UpsertProductCommand::createFromCollection(
             $this->adminUserId,
             $identifier,
@@ -601,19 +600,6 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
         ));
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Connector/SqlGetConnectorProductsWithOptionsIntegration.php
@@ -35,6 +35,7 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\EntityWithQuantifiedAssociations\
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
 {
@@ -592,6 +593,7 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents = []) : ProductInterface
     {
+        $this->logIn('admin');
         $this->get('pim_enrich.product.message_bus')->dispatch(UpsertProductCommand::createFromCollection(
             $this->adminUserId,
             $identifier,
@@ -599,6 +601,19 @@ class SqlGetConnectorProductsWithOptionsIntegration extends TestCase
         ));
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
@@ -16,7 +16,6 @@ use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 final class GetAncestorProductModelCodesIntegration extends TestCase
 {
@@ -114,7 +113,7 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -135,19 +134,6 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     private function getAncestorProductModelCodes(): GetAncestorProductModelCodes

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/GetAncestorProductModelCodesIntegration.php
@@ -16,6 +16,7 @@ use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 final class GetAncestorProductModelCodesIntegration extends TestCase
 {
@@ -113,6 +114,7 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -133,6 +135,19 @@ final class GetAncestorProductModelCodesIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     private function getAncestorProductModelCodes(): GetAncestorProductModelCodes

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlFindProductIdentifierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlFindProductIdentifierIntegration.php
@@ -8,7 +8,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -45,26 +44,13 @@ SQL;
         $dbalConnection->executeQuery($sqlInsert, ['localeId' => $localeId]);
         $userId = $this->createAdminUser()->getId();
 
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection((int) $userId, 'foo', []);
         $this->get('pim_enrich.product.message_bus')->dispatch($command);
         $this->get('pim_connector.doctrine.cache_clearer')->clear();
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
         Assert::assertNotNull($product);
         $this->fooUuid = $product->getUuid()->toString();
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     protected function getConfiguration()

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlGetValuesOfSiblingsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlGetValuesOfSiblingsIntegration.php
@@ -15,7 +15,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>
@@ -177,7 +176,7 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
      */
     private function createProduct($identifier, array $userIntents = []): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -186,19 +185,6 @@ class SqlGetValuesOfSiblingsIntegration extends TestCase
         $this->get('pim_enrich.product.message_bus')->dispatch($command);
 
         return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     private function createProductModel(array $data = [], bool $save = true): ProductModelInterface

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
@@ -14,6 +14,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Webmozart\Assert\Assert;
 
 class FetchProductModelRowsFromCodesIntegration extends TestCase
@@ -227,6 +228,7 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
 
     private function createVariantProduct(string $identifier, string $parentCode): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -250,6 +252,19 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        \PHPUnit\Framework\Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     private function getFetchProductRowsFromCodes(): FetchProductModelRowsFromCodes

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductModelRowsFromCodesIntegration.php
@@ -14,7 +14,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Webmozart\Assert\Assert;
 
 class FetchProductModelRowsFromCodesIntegration extends TestCase
@@ -228,7 +227,7 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
 
     private function createVariantProduct(string $identifier, string $parentCode): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -252,19 +251,6 @@ class FetchProductModelRowsFromCodesIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        \PHPUnit\Framework\Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     private function getFetchProductRowsFromCodes(): FetchProductModelRowsFromCodes

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
@@ -14,7 +14,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Webmozart\Assert\Assert;
 
 class FetchProductRowsFromIdentifiersIntegration extends TestCase
@@ -177,7 +176,7 @@ class FetchProductRowsFromIdentifiersIntegration extends TestCase
 
     private function createVariantProduct(string $identifier, string $parentCode): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -201,19 +200,6 @@ class FetchProductRowsFromIdentifiersIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        \PHPUnit\Framework\Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/FetchProductRowsFromIdentifiersIntegration.php
@@ -14,6 +14,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Webmozart\Assert\Assert;
 
 class FetchProductRowsFromIdentifiersIntegration extends TestCase
@@ -176,6 +177,7 @@ class FetchProductRowsFromIdentifiersIntegration extends TestCase
 
     private function createVariantProduct(string $identifier, string $parentCode): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -199,6 +201,19 @@ class FetchProductRowsFromIdentifiersIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    protected function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        \PHPUnit\Framework\Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
@@ -15,6 +15,7 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
@@ -140,6 +141,7 @@ class ProductModelImagesFromCodesIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -160,6 +162,19 @@ class ProductModelImagesFromCodesIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductGrid/ProductModelImagesFromCodesIntegration.php
@@ -15,7 +15,6 @@ use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
@@ -141,7 +140,7 @@ class ProductModelImagesFromCodesIntegration extends TestCase
      */
     private function createProduct(string $identifier, array $userIntents): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -162,19 +161,6 @@ class ProductModelImagesFromCodesIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountVariantProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountVariantProductsIntegration.php
@@ -14,8 +14,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Product models / variant products available for the tests:
@@ -212,7 +210,7 @@ class CountVariantProductsIntegration extends TestCase
      */
     private function createVariantProduct($identifier, array $userIntents = []): void
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -233,18 +231,5 @@ class CountVariantProductsIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountVariantProductsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/CountVariantProductsIntegration.php
@@ -14,6 +14,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * Product models / variant products available for the tests:
@@ -210,6 +212,7 @@ class CountVariantProductsIntegration extends TestCase
      */
     private function createVariantProduct($identifier, array $userIntents = []): void
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -230,5 +233,18 @@ class CountVariantProductsIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
@@ -14,7 +14,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>
@@ -248,7 +247,7 @@ class GetDescendantVariantProductUuidsIntegration extends TestCase
      * @param UserIntent[] $userIntents
      */
     private function createProduct(string $identifier, string $familyCode, string $parentCode, array $userIntents = []): ProductInterface {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -277,19 +276,6 @@ class GetDescendantVariantProductUuidsIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ProductModel/GetDescendantVariantProductUuidsIntegration.php
@@ -14,6 +14,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Mathias METAYER <mathias.metayer@akeneo.com>
@@ -247,6 +248,7 @@ class GetDescendantVariantProductUuidsIntegration extends TestCase
      * @param UserIntent[] $userIntents
      */
     private function createProduct(string $identifier, string $familyCode, string $parentCode, array $userIntents = []): ProductInterface {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -275,6 +277,19 @@ class GetDescendantVariantProductUuidsIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Integration/Updater/Copier/AbstractCopierTestCase.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Copier/AbstractCopierTestCase.php
@@ -6,8 +6,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Damien Carcel (damien.carcel@akeneo.com)
@@ -29,7 +27,7 @@ class AbstractCopierTestCase extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -53,18 +51,5 @@ class AbstractCopierTestCase extends TestCase
         }
 
         return \intval($id);
-    }
-
-    protected function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -18,6 +18,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -157,6 +159,7 @@ class PropertyClearerIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -192,5 +195,18 @@ class PropertyClearerIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/PropertyClearerIntegration.php
@@ -18,8 +18,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
@@ -159,7 +157,7 @@ class PropertyClearerIntegration extends TestCase
      */
     protected function createProduct(string $identifier, array $userIntents): ProductInterface
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
@@ -195,18 +193,5 @@ class PropertyClearerIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -7,6 +7,8 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
@@ -122,6 +124,7 @@ class MediaAttributeSetterIntegration extends TestCase
      */
     protected function assertCommandMedia(array $userIntents, array $result, string $attributeName)
     {
+        $this->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'product_media',
@@ -166,5 +169,18 @@ class MediaAttributeSetterIntegration extends TestCase
         }
 
         return \intval($id);
+    }
+
+    private function logIn(string $username): void
+    {
+        $session = $this->get('session');
+        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
+        Assert::assertNotNull($user);
+
+        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
+        $this->get('security.token_storage')->setToken($token);
+
+        $session->set('_security_main', serialize($token));
+        $session->save();
     }
 }

--- a/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Updater/Setter/MediaAttributeSetterIntegration.php
@@ -7,8 +7,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\IntegrationTestsBundle\Sanitizer\MediaSanitizer;
-use PHPUnit\Framework\Assert;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 /**
  * @author    Alexandre Hocquard <alexandre.hocquard@akeneo.com>
@@ -124,7 +122,7 @@ class MediaAttributeSetterIntegration extends TestCase
      */
     protected function assertCommandMedia(array $userIntents, array $result, string $attributeName)
     {
-        $this->logIn('admin');
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: 'product_media',
@@ -169,18 +167,5 @@ class MediaAttributeSetterIntegration extends TestCase
         }
 
         return \intval($id);
-    }
-
-    private function logIn(string $username): void
-    {
-        $session = $this->get('session');
-        $user = $this->get('pim_user.repository.user')->findOneByIdentifier($username);
-        Assert::assertNotNull($user);
-
-        $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
-        $this->get('security.token_storage')->setToken($token);
-
-        $session->set('_security_main', serialize($token));
-        $session->save();
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Remove merge of non viewable categories in user intent
- Check that the user passed in the UpsertProductCommand is the same as the one connected

Before, we merged non viewable categories with the one passed in the userIntent.
But there was a check afterwards on the GrantedProductUpdater for categories passed in the update.

The merge is already done in `NotGrantedCategoryMerger`

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
