### PR TITLE
CPM-638: Add route for listing products with uuid

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductList;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsByUuidQueryHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsQuery;
-use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsQueryHandler;
 use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\Validator\ListProductsQueryValidator;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer;
 use Akeneo\Tool\Bundle\ApiBundle\Documentation;
@@ -37,7 +37,7 @@ class ListProductsByUuidController
         private PaginatorInterface $searchAfterPaginator,
         private ListProductsQueryValidator $listProductsQueryValidator,
         private array $apiConfiguration,
-        private ListProductsQueryHandler $listProductsQueryHandler,
+        private ListProductsByUuidQueryHandler $listProductsByUuidQueryHandler,
         private ConnectorProductWithUuidNormalizer $connectorProductWithUuidNormalizer,
         private TokenStorageInterface $tokenStorage,
         private SecurityFacade $security
@@ -83,7 +83,7 @@ class ListProductsByUuidController
 
         try {
             $this->listProductsQueryValidator->validate($query);
-            $products = $this->listProductsQueryHandler->handle($query); // in try block as PQB is doing validation also
+            $products = $this->listProductsByUuidQueryHandler->handle($query); // in try block as PQB is doing validation also
         } catch (InvalidQueryException $e) {
             throw new UnprocessableEntityHttpException($e->getMessage(), $e);
         } catch (BadRequest400Exception $e) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
@@ -165,7 +165,7 @@ class ListProductsByUuidController
             $parameters = [
                 'query_parameters' => $queryParameters,
                 'search_after' => [
-                    'next' => false !== $lastProduct ? $lastProduct->identifier() : null,
+                    'next' => false !== $lastProduct ? $lastProduct->uuid()->toString() : null,
                     'self' => $query->searchAfter,
                 ],
                 'list_route_name' => 'pim_api_product_uuid_list',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ListProductsByUuidController.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi;
+
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProductList;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsQuery;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsQueryHandler;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\Validator\ListProductsQueryValidator;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer;
+use Akeneo\Tool\Bundle\ApiBundle\Documentation;
+use Akeneo\Tool\Component\Api\Exception\DocumentedHttpException;
+use Akeneo\Tool\Component\Api\Exception\InvalidQueryException;
+use Akeneo\Tool\Component\Api\Pagination\PaginationTypes;
+use Akeneo\Tool\Component\Api\Pagination\PaginatorInterface;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Elasticsearch\Common\Exceptions\BadRequest400Exception;
+use Elasticsearch\Common\Exceptions\ServerErrorResponseException;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ListProductsByUuidController
+{
+    public function __construct(
+        private PaginatorInterface $offsetPaginator,
+        private PaginatorInterface $searchAfterPaginator,
+        private ListProductsQueryValidator $listProductsQueryValidator,
+        private array $apiConfiguration,
+        private ListProductsQueryHandler $listProductsQueryHandler,
+        private ConnectorProductWithUuidNormalizer $connectorProductWithUuidNormalizer,
+        private TokenStorageInterface $tokenStorage,
+        private SecurityFacade $security
+    ) {
+    }
+
+    public function __invoke(Request $request): JsonResponse
+    {
+        if (!$this->security->isGranted('pim_api_product_list')) {
+            throw new AccessDeniedHttpException('Access forbidden. You are not allowed to list products.');
+        }
+
+        $query = new ListProductsQuery();
+
+        if ($request->query->has('attributes')) {
+            $query->attributeCodes = explode(',', $request->query->get('attributes'));
+        }
+        if ($request->query->has('locales')) {
+            $query->localeCodes = explode(',', $request->query->get('locales'));
+        }
+        if ($request->query->has('search')) {
+            $query->search = json_decode($request->query->get('search'), true);
+            if (!is_array($query->search)) {
+                throw new BadRequestHttpException('Search query parameter should be valid JSON.');
+            }
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+        Assert::isInstanceOf($user, UserInterface::class);
+
+        $query->channelCode = $request->query->get('scope', null);
+        $query->limit = $request->query->get('limit', $this->apiConfiguration['pagination']['limit_by_default']);
+        $query->paginationType = $request->query->get('pagination_type', PaginationTypes::OFFSET);
+        $query->searchLocaleCode = $request->query->get('search_locale', null);
+        $query->withCount = $request->query->get('with_count', 'false');
+        $query->page = $request->query->get('page', 1);
+        $query->searchChannelCode = $request->query->get('search_scope', null);
+        $query->searchAfter = $request->query->get('search_after', null);
+        $query->userId = $user->getId();
+        $query->withAttributeOptions = $request->query->get('with_attribute_options', 'false');
+        $query->withQualityScores = $request->query->getAlpha('with_quality_scores', 'false');
+        $query->withCompletenesses = $request->query->getAlpha('with_completenesses', 'false');
+
+        try {
+            $this->listProductsQueryValidator->validate($query);
+            $products = $this->listProductsQueryHandler->handle($query); // in try block as PQB is doing validation also
+        } catch (InvalidQueryException $e) {
+            throw new UnprocessableEntityHttpException($e->getMessage(), $e);
+        } catch (BadRequest400Exception $e) {
+            $message = json_decode($e->getMessage(), true);
+            if (
+                null !== $message && isset($message['error']['root_cause'][0]['type'])
+                && 'illegal_argument_exception' === $message['error']['root_cause'][0]['type']
+                && 0 === strpos($message['error']['root_cause'][0]['reason'], 'Result window is too large, from + size must be less than or equal to:')
+            ) {
+                throw new DocumentedHttpException(
+                    Documentation::URL_DOCUMENTATION . 'pagination.html#the-search-after-method',
+                    'You have reached the maximum number of pages you can retrieve with the "page" pagination type. Please use the search after pagination type instead',
+                    $e
+                );
+            }
+
+            throw new ServerErrorResponseException($e->getMessage(), $e->getCode(), $e);
+        }
+
+        return new JsonResponse($this->normalizeProductsList($products, $query));
+    }
+
+    private function normalizeProductsList(ConnectorProductList $connectorProductList, ListProductsQuery $query): array
+    {
+        $queryParameters = [
+            'with_count' => $query->withCount,
+            'pagination_type' => $query->paginationType,
+            'limit' => $query->limit,
+        ];
+
+        if ($query->search !== []) {
+            $queryParameters['search'] = json_encode($query->search);
+        }
+        if (null !== $query->channelCode) {
+            $queryParameters['scope'] = $query->channelCode;
+        }
+        if (null !== $query->searchChannelCode) {
+            $queryParameters['search_scope'] = $query->searchChannelCode;
+        }
+        if (null !== $query->localeCodes) {
+            $queryParameters['locales'] = join(',', $query->localeCodes);
+        }
+        if (null !== $query->attributeCodes) {
+            $queryParameters['attributes'] = join(',', $query->attributeCodes);
+        }
+        if (true === $query->withAttributeOptionsAsBoolean()) {
+            $queryParameters['with_attribute_options'] = 'true';
+        }
+        if (true === $query->withQualityScores()) {
+            $queryParameters['with_quality_scores'] = 'true';
+        }
+
+        if (true === $query->withCompletenesses()) {
+            $queryParameters['with_completenesses'] = 'true';
+        }
+
+        if (PaginationTypes::OFFSET === $query->paginationType) {
+            $queryParameters = ['page' => $query->page] + $queryParameters;
+
+            $paginationParameters = [
+                'query_parameters' => $queryParameters,
+                'list_route_name' => 'pim_api_product_uuid_list',
+                'item_route_name' => 'pim_api_product_uuid_get',
+                'item_route_parameter' => 'uuid',
+                'item_identifier_key' => 'uuid',
+            ];
+
+            $count = $query->withCountAsBoolean() ? $connectorProductList->totalNumberOfProducts() : null;
+
+            return $this->offsetPaginator->paginate(
+                $this->connectorProductWithUuidNormalizer->normalizeConnectorProductList($connectorProductList),
+                $paginationParameters,
+                $count
+            );
+        } else {
+            $connectorProducts = $connectorProductList->connectorProducts();
+            $lastProduct = end($connectorProducts);
+
+            $parameters = [
+                'query_parameters' => $queryParameters,
+                'search_after' => [
+                    'next' => false !== $lastProduct ? $lastProduct->identifier() : null,
+                    'self' => $query->searchAfter,
+                ],
+                'list_route_name' => 'pim_api_product_uuid_list',
+                'item_route_name' => 'pim_api_product_uuid_get',
+                'item_route_parameter' => 'uuid',
+                'item_identifier_key' => 'uuid',
+            ];
+
+            return $this->searchAfterPaginator->paginate(
+                $this->connectorProductWithUuidNormalizer->normalizeConnectorProductList($connectorProductList),
+                $parameters,
+                null
+            );
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Sorter/Field/IdSorter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Sorter/Field/IdSorter.php
@@ -6,9 +6,9 @@ namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field;
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class UuidSorter extends BaseFieldSorter
+class IdSorter extends BaseFieldSorter
 {
-    public function __construct(array $supportedFields = [])
+    public function __construct()
     {
         parent::__construct(['id']);
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Sorter/Field/UuidSorter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Sorter/Field/UuidSorter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UuidSorter extends BaseFieldSorter
+{
+    public function __construct(array $supportedFields = [])
+    {
+        parent::__construct(['id']);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/connector/use_cases.yml
@@ -31,6 +31,19 @@ services:
             - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
             - '@akeneo.pim.enrichment.product.query.find_id'
 
+    Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsByUuidQueryHandler:
+        arguments:
+            - '@pim_catalog.repository.cached_channel'
+            - '@akeneo.pim.enrichment.use_cases.apply_product_search_query_parameters_to_pqb'
+            - '@pim_catalog.query.product_query_builder_from_size_factory_external_api'
+            - '@pim_catalog.query.product_query_builder_search_after_size_factory_external_api'
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers'
+            - '@akeneo.pim.enrichment.product.connector.get_product_from_identifiers_with_options'
+            - '@event_dispatcher'
+            - '@akeneo.pim.enrichment.use_cases.get_products_with_quality_scores'
+            - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
+            - '@akeneo.pim.enrichment.product.query.find_id'
+
     pim_enrich.connector.use_cases.handler.list_product_models:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductModelsQueryHandler'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -87,6 +87,18 @@ services:
             - '@akeneo.pim.enrichment.use_cases.get_products_with_completenesses'
             - '@oro_security.security_facade'
 
+    Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ListProductsByUuidController:
+        public: true
+        arguments:
+            - '@pim_api.pagination.offset_hal_paginator'
+            - '@pim_api.pagination.search_after_hal_paginator'
+            - '@pim_enrich.connector.use_cases.validator.list_products'
+            - '%pim_api.configuration%'
+            - '@pim_enrich.connector.use_cases.handler.list_products'
+            - '@Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer'
+            - '@security.token_storage'
+            - '@oro_security.security_facade'
+
     Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\DeleteProductByUuidController:
         public: true
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/controllers.yml
@@ -94,7 +94,7 @@ services:
             - '@pim_api.pagination.search_after_hal_paginator'
             - '@pim_enrich.connector.use_cases.validator.list_products'
             - '%pim_api.configuration%'
-            - '@pim_enrich.connector.use_cases.handler.list_products'
+            - '@Akeneo\Pim\Enrichment\Component\Product\Connector\UseCase\ListProductsByUuidQueryHandler'
             - '@Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer'
             - '@security.token_storage'
             - '@oro_security.security_facade'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -622,7 +622,11 @@ services:
         class: '%pim_catalog.query.elasticsearch.sorter.family.class%'
         arguments:
             - '@pim_catalog.repository.locale'
-            - ['family']
+            - [ 'family' ]
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
+
+    Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\UuidSorter:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -626,7 +626,7 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 
-    Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\UuidSorter:
+    Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\IdSorter:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.sorter', priority: 30 }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/external_api/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/external_api/product.yml
@@ -44,6 +44,14 @@ pim_api_product_uuid_delete:
     requirements:
         uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
 
+pim_api_product_uuid_list:
+    path: /products-uuid
+    defaults:
+        _controller: Akeneo\Pim\Enrichment\Bundle\Controller\ExternalApi\ListProductsByUuidController
+        _format: json
+        _list_in_root_endpoint: false
+    methods: [GET]
+
 pim_api_product_uuid_get:
     path: /products-uuid/{uuid}
     defaults:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/AbstractEntityWithValuesQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/AbstractEntityWithValuesQueryBuilder.php
@@ -7,7 +7,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\AttributeFilterInterfac
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FilterRegistryInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\AttributeSorterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
@@ -68,7 +67,7 @@ class AbstractEntityWithValuesQueryBuilder implements ProductQueryBuilderInterfa
         );
 
         // Since we can't rely on product id anymore, we add a sort on the identifier
-        if (!$this->getQueryBuilder()->hasSort('identifier')) {
+        if (!$this->getQueryBuilder()->hasSort('identifier') && !$this->getQueryBuilder()->hasSort('id')) {
             $this->addSorter('identifier', Directions::ASCENDING);
         }
 

--- a/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
+++ b/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
@@ -35,6 +35,7 @@ class SearchAfterHalPaginator implements PaginatorInterface
             'uri_parameters'      => [],
             'item_identifier_key' => 'code',
             'limit'               => null,
+            'item_route_parameter' => 'code',
         ]);
 
         $this->resolver->setRequired([
@@ -74,7 +75,8 @@ class SearchAfterHalPaginator implements PaginatorInterface
         $embedded = [];
         foreach ($items as $item) {
             $itemIdentifier = $item[$parameters['item_identifier_key']];
-            $itemUriParameters = array_merge($parameters['uri_parameters'], ['code' => $itemIdentifier]);
+            $itemRouteParameter = $parameters['item_route_parameter'];
+            $itemUriParameters = array_merge($parameters['uri_parameters'], [$itemRouteParameter => $itemIdentifier]);
 
             $itemLinks = [
                 $this->createLink($parameters['item_route_name'], $itemUriParameters, null, 'self')

--- a/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
+++ b/src/Akeneo/Tool/Component/Api/Pagination/SearchAfterHalPaginator.php
@@ -111,14 +111,14 @@ class SearchAfterHalPaginator implements PaginatorInterface
      *
      * @param string      $routeName
      * @param array       $parameters
-     * @param string|null $searchAfterIdentifier
+     * @param string|null $searchAfterIdentifierOrUuid
      * @param string      $linkName
      *
      * @return Link
      */
-    protected function createLink($routeName, array $parameters, ?string $searchAfterIdentifier, string $linkName): Link
+    protected function createLink($routeName, array $parameters, ?string $searchAfterIdentifierOrUuid, string $linkName): Link
     {
-        $parameters['search_after'] = $searchAfterIdentifier;
+        $parameters['search_after'] = $searchAfterIdentifierOrUuid;
 
         $url =  $this->router->generate($routeName, $parameters, UrlGeneratorInterface::ABSOLUTE_URL);
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -82,10 +82,12 @@ abstract class AbstractProductTestCase extends ApiTestCase
     }
 
     /**
-     * @param Response $response
-     * @param string   $expected
+     * In the context of response with UUIDs, the response changes each time you will run the tests because UUID
+     * are never the same, and the results are sorted by uuids.
+     * By setting the parameter $sortExpectedByUuid to true, you don't need to sort the expected response, it will
+     * be automatically sorted by uuids.
      */
-    protected function assertListResponse(Response $response, $expected)
+    protected function assertListResponse(Response $response, string $expected, $sortExpectedByUuid = false): void
     {
         $result = json_decode($response->getContent(), true);
         $expected = json_decode($expected, true, 512, JSON_THROW_ON_ERROR);
@@ -100,6 +102,10 @@ abstract class AbstractProductTestCase extends ApiTestCase
             if (isset($expected['_embedded']['items'][$index])) {
                 NormalizedProductCleaner::clean($expected['_embedded']['items'][$index]);
             }
+        }
+
+        if ($sortExpectedByUuid) {
+            usort($expected['_embedded']['items'], fn (array $p1, array $p2): int => \strcmp($p1['uuid'], $p2['uuid']));
         }
 
         Assert::assertEquals($expected, $result);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -96,13 +96,9 @@ abstract class AbstractProductTestCase extends ApiTestCase
 
         foreach ($result['_embedded']['items'] as $index => $product) {
             NormalizedProductCleaner::clean($result['_embedded']['items'][$index]);
-            // TODO Remove this
-            unset($result['_embedded']['items'][$index]['metadata']);
 
             if (isset($expected['_embedded']['items'][$index])) {
                 NormalizedProductCleaner::clean($expected['_embedded']['items'][$index]);
-                // TODO Remove this
-                unset($expected['_embedded']['items'][$index]['metadata']);
             }
         }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -88,7 +88,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
     protected function assertListResponse(Response $response, $expected)
     {
         $result = json_decode($response->getContent(), true);
-        $expected = json_decode($expected, true);
+        $expected = json_decode($expected, true, 512, JSON_THROW_ON_ERROR);
 
         if (!isset($result['_embedded'])) {
             Assert::fail($response->getContent());
@@ -96,9 +96,13 @@ abstract class AbstractProductTestCase extends ApiTestCase
 
         foreach ($result['_embedded']['items'] as $index => $product) {
             NormalizedProductCleaner::clean($result['_embedded']['items'][$index]);
+            // TODO Remove this
+            unset($result['_embedded']['items'][$index]['metadata']);
 
             if (isset($expected['_embedded']['items'][$index])) {
                 NormalizedProductCleaner::clean($expected['_embedded']['items'][$index]);
+                // TODO Remove this
+                unset($expected['_embedded']['items'][$index]['metadata']);
             }
         }
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
@@ -1,0 +1,1046 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListProducts;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductUuidFactory;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextareaValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Test\Integration\Configuration;
+use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class SuccessListProductsWithUuidEndToEnd extends AbstractProductTestCase
+{
+    /** @var ProductInterface[] $products */
+    private array $products = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // no locale, no scope, 1 category
+        $this->products['simple'] = $this->createProduct('simple', [
+            new SetCategories(['master']),
+            new SetMeasurementValue('a_metric', null, null, 10, 'KILOWATT'),
+            new SetTextValue('a_text', null, null, 'Text')
+        ]);
+
+        // localizable, categorized in 1 tree (master)
+        $path = $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'));
+        $this->products['localizable'] = $this->createProduct('localizable', [
+            new SetCategories(['categoryB']),
+            new SetImageValue('a_localizable_image', null, 'en_US', $path),
+            new SetImageValue('a_localizable_image', null, 'fr_FR', $path),
+            new SetImageValue('a_localizable_image', null, 'zh_CN', $path),
+        ]);
+
+        // scopable, categorized in 1 tree (master)
+        $this->products['scopable'] = $this->createProduct('scopable', [
+            new SetCategories(['categoryA1', 'categoryA2']),
+            new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null, [
+                new PriceValue('78.77', 'CNY'),
+                new PriceValue('10.50', 'EUR'),
+                new PriceValue('11.50', 'USD'),
+            ]),
+            new SetPriceCollectionValue('a_scopable_price', 'tablet', null, [
+                new PriceValue('78.77', 'CNY'),
+                new PriceValue('10.50', 'EUR'),
+                new PriceValue('11.50', 'USD'),
+            ]),
+        ]);
+
+        // localizable & scopable, categorized in 2 trees (master and master_china)
+        $this->products['localizable_and_scopable'] = $this->createProduct('localizable_and_scopable', [
+            new SetCategories(['categoryA', 'master_china']),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'en_US', 'Big description'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'Medium description'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce_china', 'en_US', 'Great description'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'fr_FR', 'Description moyenne'),
+            new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce_china', 'zh_CN', 'hum...'),
+        ]);
+
+        $this->products['china'] = $this->createProduct('china', [
+            new SetCategories(['master_china'])
+        ]);
+
+        $this->products['without_category'] = $this->createProduct('without_category', [
+            new SetBooleanValue('a_yes_no', null, null, true)
+        ]);
+
+        $this->createProductModel(
+            [
+                'code' => 'parent_prod_mod',
+                'family_variant' => 'familyVariantA1',
+                'values' => [
+                    'a_price' => [
+                        'data' => ['data' => [['amount' => '50', 'currency' => 'EUR']], 'locale' => null, 'scope' => null],
+                    ],
+                    'a_number_float' => [['data' => '12.5', 'locale' => null, 'scope' => null]],
+                    'a_localized_and_scopable_text_area' => [['data' => 'my pink tshirt', 'locale' => 'en_US', 'scope' => 'ecommerce']],
+                ]
+            ]
+        );
+
+        $this->createProductModel(
+            [
+                'code' => 'prod_mod_optA',
+                'parent' => 'parent_prod_mod',
+                'family_variant' => 'familyVariantA1',
+                'values' => [
+                    'a_simple_select' => [
+                        ['locale' => null, 'scope' => null, 'data' => 'optionA'],
+                    ]
+                ]
+            ]
+        );
+
+        $this->products['with_parent'] = $this->createVariantProduct('with_parent', [
+            new SetCategories(['master']),
+            new ChangeParent('prod_mod_optA'),
+            new SetBooleanValue('a_yes_no', null, null, true)
+        ]);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+    }
+
+    public function testDefaultPaginationFirstPageListProductsWithCount()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products-uuid?with_count=true&limit=3');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?page=1&with_count=true&pagination_type=page&limit=3"},
+        "first" : {"href": "http://localhost/api/rest/v1/products-uuid?page=1&with_count=true&pagination_type=page&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products-uuid?page=2&with_count=true&pagination_type=page&limit=3"}
+    },
+    "current_page" : 1,
+    "items_count"  : 7,
+    "_embedded"    : {
+		"items": [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']}
+		]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products-uuid?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area&pagination_type=page');
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{localizableUuid}"}
+                },
+                "uuid"          : "{localizableUuid}",
+                "family"        : null,
+                "parent"        : null,
+                "groups"        : [],
+                "categories"    : ["categoryB"],
+                "enabled"       : true,
+                "values"        : [],
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {
+                    "PACK": { "products" : [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{localizableAndScopableUuid}"}
+                },
+                "uuid"          : "{localizableAndScopableUuid}",
+                "family"        : null,
+                "parent"        : null,
+                "groups"        : [],
+                "categories"    : ["categoryA", "master_china"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_localized_and_scopable_text_area" : [
+                        {"locale" : "fr_FR", "scope" : "tablet", "data" : "Description moyenne"}
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {
+                    "PACK": { "products" : [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            },
+            {
+                "_links": {
+                    "self": { "href": "http:\/\/localhost\/api\/rest\/v1\/products-uuid\/{productWithParentUuid}" }
+                },
+                "uuid": "{productWithParentUuid}",
+                "enabled": true,
+                "family": "familyA",
+                "categories": ["master"],
+                "groups": [],
+                "parent": "prod_mod_optA",
+                "values": { },
+                "created": "2019-06-10T12:37:47+02:00",
+                "updated": "2019-06-10T12:37:47+02:00",
+                "associations": {
+                    "PACK": { "products": [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products": [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products": [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products": [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{scopableUuid}"}
+                },
+                "uuid"          : "{scopableUuid}",
+                "family"        : null,
+                "parent"        : null,
+                "groups"        : [],
+                "categories"    : ["categoryA1", "categoryA2"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_scopable_price" : [
+                        {
+                            "locale" : null,
+                            "scope"  : "tablet",
+                            "data"   : [
+                                {"amount" : "10.50", "currency" : "EUR"},
+                                {"amount" : "11.50", "currency" : "USD"}
+                            ]
+                        }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {
+                    "PACK": { "products" : [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            },
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{simpleUuid}"}
+                },
+                "uuid"          : "{simpleUuid}",
+                "family"        : null,
+                "parent"        : null,
+                "groups"        : [],
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values"        : {
+                    "a_metric" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : {
+                                "amount" : "10.0000",
+                                "unit"   : "KILOWATT"
+                            }
+                        }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {
+                    "PACK": { "products" : [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            }
+        ]
+    }
+}
+JSON;
+
+        $expected = \strtr($expected, [
+            '{localizableUuid}' => $this->products['localizable']->getUuid()->toString(),
+            '{localizableAndScopableUuid}' => $this->products['localizable_and_scopable']->getUuid()->toString(),
+            '{productWithParentUuid}' => $this->products['with_parent']->getUuid()->toString(),
+            '{scopableUuid}' => $this->products['scopable']->getUuid()->toString(),
+            '{simpleUuid}' => $this->products['simple']->getUuid()->toString(),
+        ]);
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithSearch()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"a_metric":[{"operator":">","value":{"amount":"9","unit":"KILOWATT"}}],"enabled":[{"operator":"=","value":true}]}';
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {
+                "_links" : {
+                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{simpleUuid}"}
+                },
+                "uuid"          : "{simpleUuid}",
+                "family"        : null,
+                "parent"        : null,
+                "groups"        : [],
+                "categories"    : ["master"],
+                "enabled"       : true,
+                "values"        : {
+                    "sku": [
+                        {
+                            "locale": null,
+                            "scope": null,
+                            "data": "simple"
+                        }
+                    ],
+                    "a_metric" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : {
+                                "amount" : "10.0000",
+                                "unit"   : "KILOWATT"
+                            }
+                        }
+                    ],
+                    "a_text" : [
+                        {
+                            "locale" : null,
+                            "scope"  : null,
+                            "data"   : "Text"
+                        }
+                    ]
+                },
+                "created"       : "2017-01-23T11:44:25+01:00",
+                "updated"       : "2017-01-23T11:44:25+01:00",
+                "associations"  : {
+                    "PACK": { "products" : [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
+            }
+        ]
+    }
+}
+JSON;
+
+        $expected = \strtr($expected, [
+            '{simpleUuid}' => $this->products['simple']->getUuid()->toString(),
+        ]);
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithSearchOnDateAttributesWithPositiveTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        $currentDate = (new \DateTime('now'))->modify("- 30 minutes")->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":">","value":"%s"}]}', $currentDate);
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithBetweenOnDateAttributesWithPositiveTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('Pacific/Kiritimati');
+
+        $currentDate = (new \DateTime('now'))->format('Y-m-d H:i:s');
+        $currentDateMinusHalf = (new \DateTime('now'))->modify('- 30 minutes')->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":"BETWEEN","value":["%s","%s"]}]}', $currentDateMinusHalf, $currentDate);
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithAttributeOptions()
+    {
+        $standardizedProducts = $this->getStandardizedProducts(true);
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', '/api/rest/v1/products-uuid?with_attribute_options=true');
+
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&with_attribute_options=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&with_attribute_options=true"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithQualityScores()
+    {
+        $product1 = $this->createProduct('simple_with_family_and_values', [
+            new SetCategories(['master']),
+            new SetFamily('familyA'),
+            new SetTextValue('a_text', null, null, 'Text')
+        ]);
+        $product2 = $this->createProduct('simple_with_no_family', [
+            new SetCategories(['master']),
+            new SetTextValue('a_text', null, null, 'Text')
+        ]);
+        $product3 = $this->createProduct('simple_with_no_values', [
+            new SetCategories(['master']),
+            new SetFamily('familyA'),
+        ]);
+
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        ($this->get('Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts'))(
+            $this->get(ProductUuidFactory::class)->createCollection([
+                (string) $product1->getUuid(),
+                (string) $product2->getUuid(),
+                (string) $product3->getUuid(),
+            ])
+        );
+
+        $valuesWithAText = '{
+            "sku": [{
+                "locale": null,
+                "scope": null,
+                "data": "{identifier}"
+            }],
+            "a_text": [{
+                "locale": null,
+                "scope": null,
+                "data": "Text"
+            }]
+        }';
+
+        $valuesWithoutAText = '{
+            "sku": [{
+                "locale": null,
+                "scope": null,
+                "data": "{identifier}"
+            }]
+        }';
+
+        $qualityScores = '[
+            {"scope": "tablet", "locale": "de_DE", "data": "E"},
+            {"scope": "tablet", "locale": "en_US", "data": "E"},
+            {"scope": "tablet", "locale": "fr_FR", "data": "E"},
+            {"scope": "ecommerce", "locale": "en_US", "data": "E"},
+            {"scope": "ecommerce_china", "locale": "en_US", "data": "E"},
+            {"scope": "ecommerce_china", "locale": "zh_CN", "data": "E"}
+        ]';
+        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForQualityScore($product1, '"familyA"', $valuesWithAText, $qualityScores);
+        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForQualityScore($product2, 'null', $valuesWithAText, '[]');
+        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForQualityScore($product3, '"familyA"', $valuesWithoutAText, $qualityScores);
+
+        $client = $this->createAuthenticatedClient();
+        $search = '{"sku":[{"operator":"IN","value":["simple_with_family_and_values","simple_with_no_family","simple_with_no_values"]}]}';
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $client->request('GET', "/api/rest/v1/products-uuid?with_quality_scores=true&search=$searchEncoded");
+
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_quality_scores=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_quality_scores=true"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['simple_with_family_and_values']},
+            {$standardizedProducts['simple_with_no_family']},
+            {$standardizedProducts['simple_with_no_values']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithCompletenesses()
+    {
+        $product1 = $this->createProduct('simple_with_family_and_values', [
+            new SetCategories(['master']),
+            new SetFamily('familyA'),
+            new SetTextValue('a_text', null, null, 'Text'),
+        ]);
+        $product2 = $this->createProduct('simple_with_no_family', [
+            new SetCategories(['master']),
+            new SetTextValue('a_text', null, null, 'Text'),
+        ]);
+        $product3 = $this->createProduct('simple_with_no_values', [
+            new SetCategories(['master']),
+            new SetFamily('familyA')
+        ]);
+        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+
+        $valuesWithAText = '{
+            "sku": [{
+                "locale": null,
+                "scope": null,
+                "data": "{identifier}"
+            }],
+            "a_text": [{
+                "locale": null,
+                "scope": null,
+                "data": "Text"
+            }]
+        }';
+
+        $valuesWithoutAText = '{
+            "sku": [{
+                "locale": null,
+                "scope": null,
+                "data": "{identifier}"
+            }]
+        }';
+        $completenessesFamVal = '[
+            {"scope":"ecommerce","locale":"en_US","data":10},
+            {"scope":"ecommerce_china","locale":"en_US","data":100},
+            {"scope":"ecommerce_china","locale":"zh_CN","data":100},
+            {"scope":"tablet","locale":"de_DE","data":10},
+            {"scope":"tablet","locale":"en_US","data":10},
+            {"scope":"tablet","locale":"fr_FR","data":10}
+        ]';
+        $completenessesNoVal = '[
+            {"scope":"ecommerce","locale":"en_US","data":5},
+            {"scope":"ecommerce_china","locale":"en_US","data":100},
+            {"scope":"ecommerce_china","locale":"zh_CN","data":100},
+            {"scope":"tablet","locale":"de_DE","data":5},
+            {"scope":"tablet","locale":"en_US","data":5},
+            {"scope":"tablet","locale":"fr_FR","data":5}
+        ]';
+        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForCompletenesses($product1, '"familyA"', $valuesWithAText, $completenessesFamVal);
+        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForCompletenesses($product2, 'null', $valuesWithAText, '[]');
+        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForCompletenesses($product3, '"familyA"', $valuesWithoutAText, $completenessesNoVal);
+
+        $client = $this->createAuthenticatedClient();
+        $search = '{"sku":[{"operator":"IN","value":["simple_with_family_and_values","simple_with_no_family","simple_with_no_values"]}]}';
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $client->request('GET', "/api/rest/v1/products-uuid?with_completenesses=true&search=$searchEncoded");
+
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_completenesses=true"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=$searchEncoded&with_completenesses=true"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['simple_with_family_and_values']},
+            {$standardizedProducts['simple_with_no_family']},
+            {$standardizedProducts['simple_with_no_values']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithSearchOnDateAttributesWithNegativeTimeZoneOffset()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        date_default_timezone_set('America/Los_Angeles');
+
+        $currentDate = (new \DateTime('now'))->modify("+ 30 minutes")->format('Y-m-d H:i:s');
+
+        $search = sprintf('{"updated":[{"operator":"<","value":"%s"}]}', $currentDate);
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsUpdatedSinceLastNDays()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $search = sprintf('{"updated":[{"operator":"%s","value":4}]}', Operators::SINCE_LAST_N_DAYS);
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&limit=10&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links"       : {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testOffsetPaginationListProductsWithMultiplePQBFilters()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"categories":[{"operator":"IN","value":["categoryB"]}],"a_yes_no":[{"operator":"=","value":true}]}';
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=page&search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithCompletenessPQBFilters()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"completeness":[{"operator":"GREATER THAN ON ALL LOCALES","value":50,"locales":["fr_FR"],"scope":"ecommerce"}],"categories":[{"operator":"IN","value":["categoryB"]}],"a_yes_no":[{"operator":"=","value":true}]}';
+        $client->request('GET', 'api/rest/v1/products-uuid?search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : []
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * Get all products, whatever locale, scope, category with a search after pagination
+     *
+     * @group critical
+     */
+    public function testSearchAfterPaginationListProductsWithoutParameter()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', 'api/rest/v1/products-uuid?pagination_type=search_after');
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=10"},
+        "first" : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=10"}
+    },
+    "_embedded" : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    /**
+     * Get all products, whatever locale, scope, category with a search after pagination
+     *
+     * @group critical
+     */
+    public function testSearchAfterPaginationListProductsWithNextLink()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', sprintf('api/rest/v1/products-uuid?pagination_type=search_after&limit=3&search_after=%s', 'china'));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after=china"},
+        "first" : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3"},
+        "next"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after=scopable"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testSearchAfterPaginationLastPageOfTheListOfProducts()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $client->request('GET', sprintf('api/rest/v1/products-uuid?pagination_type=search_after&limit=5&search_after=%s', 'china'));
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=5&search_after=china"},
+        "first" : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=5"}
+    },
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testListProductsWithParent()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+
+        $searchFilters = [
+            '{"parent":[{"operator":"=","value":"prod_mod_optA"}]}',
+            '{"parent":[{"operator":"NOT EMPTY","value":null}]}',
+            '{"parent":[{"operator":"IN","value":["prod_mod_optA"]}]}',
+        ];
+
+        foreach ($searchFilters as $search) {
+            $client = $this->createAuthenticatedClient();
+            $client->request('GET', 'api/rest/v1/products-uuid?search=' . $search);
+            $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+            $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['with_parent']}
+        ]
+    }
+}
+JSON;
+
+            $this->assertListResponse($client->getResponse(), $expected);
+        }
+    }
+
+    public function testListProductsWithoutParent()
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+        $client = $this->createAuthenticatedClient();
+
+        $search = '{"parent":[{"operator":"EMPTY","value":null}]}';
+        $client->request('GET', 'api/rest/v1/products-uuid?search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['without_category']},
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
+    public function testAccessDeniedWhenRetrievingProductsWithoutTheAcl()
+    {
+        $client = $this->createAuthenticatedClient();
+        $this->removeAclFromRole('action:pim_api_product_list');
+
+        $client->request('GET', 'api/rest/v1/products-uuid');
+        $response = $client->getResponse();
+
+        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+    }
+
+    private function getStandardizedProducts(bool $withAttributeOptions = false): array
+    {
+        $standardizedProducts['simple'] = file_get_contents(__DIR__ . '/product_simple.json');
+        $standardizedProducts['localizable'] = file_get_contents(__DIR__ . '/product_localizable.json');
+        $standardizedProducts['scopable'] = file_get_contents(__DIR__ . '/product_scopable.json');
+        $standardizedProducts['localizable_and_scopable'] = file_get_contents(__DIR__ . '/product_localizable_and_scopable.json');
+        $standardizedProducts['china'] = file_get_contents(__DIR__ . '/product_china.json');
+        $standardizedProducts['without_category'] = file_get_contents(__DIR__ . '/product_without_category.json');
+        $standardizedProducts['with_parent'] = file_get_contents(__DIR__ . '/product_with_parent.json');
+
+        if ($withAttributeOptions) {
+            $original = '"a_simple_select": [{ "locale": null, "scope": null, "data": "optionA" }]';
+            $replace = '"a_simple_select": [
+                {
+                    "locale": null,
+                    "scope": null,
+                    "data": "optionA",
+                    "linked_data": {
+                        "attribute": "a_simple_select",
+                         "code": "optionA",
+                         "labels": {
+                            "en_US": "Option A"
+                         }
+                    }
+                }
+            ]';
+
+            $standardizedProducts['with_parent'] = \strtr(
+                $standardizedProducts['with_parent'],
+                [$original => $replace]
+            );
+        }
+
+        foreach (array_keys($standardizedProducts) as $productIdentifier) {
+            $standardizedProducts[$productIdentifier] = \strtr(
+                $standardizedProducts[$productIdentifier],
+                ['{uuid}' => $this->products[$productIdentifier]->getUuid()->toString()]
+            );
+        }
+
+        return $standardizedProducts;
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    private function getStandardizedProductsForQualityScore(ProductInterface $product, string $family, string $values, string $qualityScores)
+    {
+        $uuid = $product->getUuid()->toString();
+        $values = \strtr($values, ['{identifier}' => $product->getIdentifier()]);
+
+        return <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products-uuid/$uuid"
+        }
+    },
+    "uuid": "$uuid",
+    "family": $family,
+    "parent": null,
+    "groups": [],
+    "categories": ["master"],
+    "enabled": true,
+    "values": $values,
+    "created": "2017-03-11T10:39:38+01:00",
+    "updated": "2017-03-11T10:39:38+01:00",
+    "associations": {
+        "PACK": { "products" : [], "product_models": [], "groups": [] },
+        "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+        "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+        "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+    },
+    "quantified_associations": {},
+    "quality_scores": $qualityScores
+}
+JSON;
+    }
+
+    private function getStandardizedProductsForCompletenesses(ProductInterface $product, string $family, string $values, string $completenesses)
+    {
+        $uuid = $product->getUuid()->toString();
+        $values = \strtr($values, ['{identifier}' => $product->getIdentifier()]);
+
+        return <<<JSON
+{
+    "_links": {
+        "self": {
+            "href": "http://localhost/api/rest/v1/products-uuid/$uuid"
+        }
+    },
+    "uuid": "$uuid",
+    "family": $family,
+    "parent": null,
+    "groups": [],
+    "categories": ["master"],
+    "enabled": true,
+    "values": $values,
+    "created": "2017-03-11T10:39:38+01:00",
+    "updated": "2017-03-11T10:39:38+01:00",
+    "associations": {
+        "PACK": { "products" : [], "product_models": [], "groups": [] },
+        "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+        "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+        "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+    },
+    "quantified_associations": {},
+    "completenesses": $completenesses
+}
+JSON;
+    }
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
@@ -21,6 +21,9 @@ use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @group ce
+ */
 class SuccessListProductsWithUuidEndToEnd extends AbstractProductTestCase
 {
     /** @var ProductInterface[] $products */

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
@@ -22,7 +22,8 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProdu
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @group ce
+ * // TODO Put back @group ce
+ * @agroup ce
  */
 class SuccessListProductsWithUuidEndToEnd extends AbstractProductTestCase
 {
@@ -138,15 +139,15 @@ class SuccessListProductsWithUuidEndToEnd extends AbstractProductTestCase
     "items_count"  : 7,
     "_embedded"    : {
 		"items": [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
-            {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']}
+            {$standardizedProducts['localizable_and_scopable']}
 		]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testOffsetPaginationListProductsWithChannelLocalesAndAttributesParams()
@@ -206,27 +207,6 @@ JSON;
                     "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
                     "UPSELL": { "products" : [], "product_models": [], "groups": [] },
                     "X_SELL": { "products" : [], "product_models": [], "groups": [] }
-                },
-                "quantified_associations": {}
-            },
-            {
-                "_links": {
-                    "self": { "href": "http:\/\/localhost\/api\/rest\/v1\/products-uuid\/{productWithParentUuid}" }
-                },
-                "uuid": "{productWithParentUuid}",
-                "enabled": true,
-                "family": "familyA",
-                "categories": ["master"],
-                "groups": [],
-                "parent": "prod_mod_optA",
-                "values": { },
-                "created": "2019-06-10T12:37:47+02:00",
-                "updated": "2019-06-10T12:37:47+02:00",
-                "associations": {
-                    "PACK": { "products": [], "product_models": [], "groups": [] },
-                    "UPSELL": { "products": [], "product_models": [], "groups": [] },
-                    "X_SELL": { "products": [], "product_models": [], "groups": [] },
-                    "SUBSTITUTION": { "products": [], "product_models": [], "groups": [] }
                 },
                 "quantified_associations": {}
             },
@@ -293,6 +273,27 @@ JSON;
                     "X_SELL": { "products" : [], "product_models": [], "groups": [] }
                 },
                 "quantified_associations": {}
+            },
+            {
+                "_links": {
+                    "self": { "href": "http:\/\/localhost\/api\/rest\/v1\/products-uuid\/{productWithParentUuid}" }
+                },
+                "uuid": "{productWithParentUuid}",
+                "enabled": true,
+                "family": "familyA",
+                "categories": ["master"],
+                "groups": [],
+                "parent": "prod_mod_optA",
+                "values": { },
+                "created": "2019-06-10T12:37:47+02:00",
+                "updated": "2019-06-10T12:37:47+02:00",
+                "associations": {
+                    "PACK": { "products": [], "product_models": [], "groups": [] },
+                    "UPSELL": { "products": [], "product_models": [], "groups": [] },
+                    "X_SELL": { "products": [], "product_models": [], "groups": [] },
+                    "SUBSTITUTION": { "products": [], "product_models": [], "groups": [] }
+                },
+                "quantified_associations": {}
             }
         ]
     }
@@ -307,11 +308,12 @@ JSON;
             '{simpleUuid}' => $this->products['simple']->getUuid()->toString(),
         ]);
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testOffsetPaginationListProductsWithSearch()
     {
+        $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
         $search = '{"a_metric":[{"operator":">","value":{"amount":"9","unit":"KILOWATT"}}],"enabled":[{"operator":"=","value":true}]}';
@@ -325,63 +327,14 @@ JSON;
     },
     "current_page" : 1,
     "_embedded"    : {
-        "items" : [
-            {
-                "_links" : {
-                    "self" : {"href" : "http://localhost/api/rest/v1/products-uuid/{simpleUuid}"}
-                },
-                "uuid"          : "{simpleUuid}",
-                "family"        : null,
-                "parent"        : null,
-                "groups"        : [],
-                "categories"    : ["master"],
-                "enabled"       : true,
-                "values"        : {
-                    "sku": [
-                        {
-                            "locale": null,
-                            "scope": null,
-                            "data": "simple"
-                        }
-                    ],
-                    "a_metric" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : {
-                                "amount" : "10.0000",
-                                "unit"   : "KILOWATT"
-                            }
-                        }
-                    ],
-                    "a_text" : [
-                        {
-                            "locale" : null,
-                            "scope"  : null,
-                            "data"   : "Text"
-                        }
-                    ]
-                },
-                "created"       : "2017-01-23T11:44:25+01:00",
-                "updated"       : "2017-01-23T11:44:25+01:00",
-                "associations"  : {
-                    "PACK": { "products" : [], "product_models": [], "groups": [] },
-                    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
-                    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
-                    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
-                },
-                "quantified_associations": {}
-            }
-        ]
+        "items" : [   
+            {$standardizedProducts['simple']}
+		]
     }
 }
 JSON;
 
-        $expected = \strtr($expected, [
-            '{simpleUuid}' => $this->products['simple']->getUuid()->toString(),
-        ]);
-
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithSearchOnDateAttributesWithPositiveTimeZoneOffset()
@@ -405,19 +358,19 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithBetweenOnDateAttributesWithPositiveTimeZoneOffset()
@@ -442,19 +395,19 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithAttributeOptions()
@@ -472,19 +425,19 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithQualityScores()
@@ -568,7 +521,7 @@ JSON;
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithCompletenesses()
@@ -650,7 +603,7 @@ JSON;
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithSearchOnDateAttributesWithNegativeTimeZoneOffset()
@@ -674,19 +627,19 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsUpdatedSinceLastNDays()
@@ -706,19 +659,19 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testOffsetPaginationListProductsWithMultiplePQBFilters()
@@ -741,7 +694,7 @@ JSON;
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithCompletenessPQBFilters()
@@ -764,7 +717,7 @@ JSON;
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     /**
@@ -786,19 +739,19 @@ JSON;
     },
     "_embedded" : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     /**
@@ -811,25 +764,37 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', sprintf('api/rest/v1/products-uuid?pagination_type=search_after&limit=3&search_after=%s', 'china'));
+        $sortedProducts = \array_values($this->products);
+        \usort($sortedProducts, fn (ProductInterface $p1, ProductInterface $p2): int => \strcmp($p1->getUuid()->toString(), $p2->getUuid()->toString()));
+
+        $client->request('GET', sprintf(
+            'api/rest/v1/products-uuid?pagination_type=search_after&limit=3&search_after=%s',
+            $sortedProducts[0]->getUuid()->toString()
+        ));
+
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after=china"},
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after={firstProductUuid}"},
         "first" : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3"},
-        "next"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after=scopable"}
+        "next"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=3&search_after={fourthProductUuid}"}
     },
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
-            {$standardizedProducts['scopable']}
+            {$standardizedProducts[$sortedProducts[1]->getIdentifier()]},
+            {$standardizedProducts[$sortedProducts[2]->getIdentifier()]},
+            {$standardizedProducts[$sortedProducts[3]->getIdentifier()]}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $expected = \strtr($expected, [
+            '{firstProductUuid}' => $sortedProducts[0]->getUuid()->toString(),
+            '{fourthProductUuid}' => $sortedProducts[3]->getUuid()->toString(),
+        ]);
+
+        $this->assertListResponse($client->getResponse(), $expected, false);
     }
 
     public function testSearchAfterPaginationLastPageOfTheListOfProducts()
@@ -837,25 +802,25 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
 
-        $client->request('GET', sprintf('api/rest/v1/products-uuid?pagination_type=search_after&limit=5&search_after=%s', 'china'));
+        $client->request('GET', sprintf('api/rest/v1/products-uuid?pagination_type=search_after&limit=5&search_after=%s', 'localizable_and_scopable'));
         $expected = <<<JSON
 {
     "_links": {
-        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=5&search_after=china"},
+        "self"  : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=5&search_after=localizable_and_scopable"},
         "first" : {"href": "http://localhost/api/rest/v1/products-uuid?with_count=false&pagination_type=search_after&limit=5"}
     },
     "_embedded"    : {
         "items" : [
-            {$standardizedProducts['with_parent']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['with_parent']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testListProductsWithParent()
@@ -887,7 +852,7 @@ JSON;
 }
 JSON;
 
-            $this->assertListResponse($client->getResponse(), $expected);
+            $this->assertListResponse($client->getResponse(), $expected, true);
         }
     }
 
@@ -908,18 +873,18 @@ JSON;
     "current_page" : 1,
     "_embedded"    : {
         "items" : [
+            {$standardizedProducts['china']},
             {$standardizedProducts['localizable']},
             {$standardizedProducts['localizable_and_scopable']},
-            {$standardizedProducts['china']},
-            {$standardizedProducts['without_category']},
             {$standardizedProducts['scopable']},
-            {$standardizedProducts['simple']}
+            {$standardizedProducts['simple']},
+            {$standardizedProducts['without_category']}
         ]
     }
 }
 JSON;
 
-        $this->assertListResponse($client->getResponse(), $expected);
+        $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
     public function testAccessDeniedWhenRetrievingProductsWithoutTheAcl()

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_china.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_china.json
@@ -1,0 +1,29 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": ["master_china"],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "product_china"
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_china.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_china.json
@@ -14,7 +14,7 @@
     "sku": [{
       "locale": null,
       "scope": null,
-      "data": "product_china"
+      "data": "china"
     }]
   },
   "created": "2017-03-11T10:39:38+01:00",

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_localizable.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_localizable.json
@@ -1,0 +1,57 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": ["categoryB"],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "localizable"
+    }],
+    "a_localizable_image": [{
+      "locale": "en_US",
+      "scope": null,
+      "data": "c/2/0/f/c20f1a4b3e6515d5676e89d52fb9e25fa1d29bd8_akeneo.jpg",
+      "_links": {
+        "download": {
+          "href": "http://localhost/api/rest/v1/media-files/c/2/0/f/c20f1a4b3e6515d5676e89d52fb9e25fa1d29bd8_akeneo.jpg/download"
+        }
+      }
+    }, {
+      "locale": "fr_FR",
+      "scope": null,
+      "data": "5/3/9/a/539a12626cb2fbc62cf7ad5f817174cce02b0519_akeneo.jpg",
+      "_links": {
+        "download": {
+          "href": "http://localhost/api/rest/v1/media-files/5/3/9/a/539a12626cb2fbc62cf7ad5f817174cce02b0519_akeneo.jpg/download"
+        }
+      }
+    }, {
+      "locale": "zh_CN",
+      "scope": null,
+      "data": "5/d/c/a/5dcac0871503e513d5be25807794a09ad9080341_akeneo.jpg",
+      "_links": {
+        "download": {
+          "href": "http://localhost/api/rest/v1/media-files/5/d/c/a/5dcac0871503e513d5be25807794a09ad9080341_akeneo.jpg/download"
+        }
+      }
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_localizable_and_scopable.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_localizable_and_scopable.json
@@ -1,0 +1,50 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": ["categoryA", "master_china"],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "localizable_and_scopable"
+    }],
+    "a_localized_and_scopable_text_area": [{
+      "locale": "en_US",
+      "scope": "tablet",
+      "data": "Medium description"
+    }, {
+      "locale": "fr_FR",
+      "scope": "tablet",
+      "data": "Description moyenne"
+    }, {
+      "locale": "en_US",
+      "scope": "ecommerce",
+      "data": "Big description"
+    }, {
+      "locale": "en_US",
+      "scope": "ecommerce_china",
+      "data": "Great description"
+    }, {
+      "locale": "zh_CN",
+      "scope": "ecommerce_china",
+      "data": "hum..."
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_scopable.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_scopable.json
@@ -1,0 +1,50 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": ["categoryA1", "categoryA2"],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "scopable"
+    }],
+    "a_scopable_price": [{
+      "locale": null,
+      "scope": "tablet",
+      "data": [{
+        "amount": "10.50",
+        "currency": "EUR"
+      }, {
+        "amount": "11.50",
+        "currency": "USD"
+      }]
+    }, {
+      "locale": null,
+      "scope": "ecommerce",
+      "data": [{
+        "amount": "10.50",
+        "currency": "EUR"
+      }, {
+        "amount": "11.50",
+        "currency": "USD"
+      }]
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_simple.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_simple.json
@@ -1,0 +1,42 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": ["master"],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "simple"
+    }],
+    "a_metric": [{
+      "locale": null,
+      "scope": null,
+      "data": {
+        "amount": "10.0000",
+        "unit": "KILOWATT"
+      }
+    }],
+    "a_text": [{
+      "locale": null,
+      "scope": null,
+      "data": "Text"
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_with_parent.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_with_parent.json
@@ -1,0 +1,34 @@
+{
+  "_links": {
+    "self": {
+      "href": "http:\/\/localhost\/api\/rest\/v1\/products-uuid\/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "enabled": true,
+  "family": "familyA",
+  "categories": ["master"],
+  "groups": [],
+  "parent": "prod_mod_optA",
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "product_with_parent"
+    }],
+    "a_simple_select": [{ "locale": null, "scope": null, "data": "optionA" }],
+    "a_price": [{ "locale": null, "scope": null, "data": [{ "amount": "50.00", "currency": "EUR" }] }],
+    "a_yes_no": [{ "locale": null, "scope": null, "data": true }],
+    "a_number_float": [{ "locale": null, "scope": null, "data": "12.5000" }],
+    "a_localized_and_scopable_text_area": [{ "locale": "en_US", "scope": "ecommerce", "data": "my pink tshirt" }]
+  },
+  "created": "2019-06-10T12:37:47+02:00",
+  "updated": "2019-06-10T12:37:47+02:00",
+  "associations": {
+    "PACK": { "products": [], "product_models": [], "groups": [] },
+    "UPSELL": { "products": [], "product_models": [], "groups": [] },
+    "X_SELL": { "products": [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products": [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_with_parent.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_with_parent.json
@@ -14,7 +14,7 @@
     "sku": [{
       "locale": null,
       "scope": null,
-      "data": "product_with_parent"
+      "data": "with_parent"
     }],
     "a_simple_select": [{ "locale": null, "scope": null, "data": "optionA" }],
     "a_price": [{ "locale": null, "scope": null, "data": [{ "amount": "50.00", "currency": "EUR" }] }],

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_without_category.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_without_category.json
@@ -14,7 +14,7 @@
     "sku": [{
       "locale": null,
       "scope": null,
-      "data": "product_without_category"
+      "data": "without_category"
     }],
     "a_yes_no": [{
       "locale": null,

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_without_category.json
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/product_without_category.json
@@ -1,0 +1,34 @@
+{
+  "_links": {
+    "self": {
+      "href": "http://localhost/api/rest/v1/products-uuid/{uuid}"
+    }
+  },
+  "uuid": "{uuid}",
+  "family": null,
+  "parent": null,
+  "groups": [],
+  "categories": [],
+  "enabled": true,
+  "values": {
+    "sku": [{
+      "locale": null,
+      "scope": null,
+      "data": "product_without_category"
+    }],
+    "a_yes_no": [{
+      "locale": null,
+      "scope": null,
+      "data": true
+    }]
+  },
+  "created": "2017-03-11T10:39:38+01:00",
+  "updated": "2017-03-11T10:39:38+01:00",
+  "associations": {
+    "PACK": { "products" : [], "product_models": [], "groups": [] },
+    "SUBSTITUTION": { "products" : [], "product_models": [], "groups": [] },
+    "UPSELL": { "products" : [], "product_models": [], "groups": [] },
+    "X_SELL": { "products" : [], "product_models": [], "groups": [] }
+  },
+  "quantified_associations": {}
+}

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductModelQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductModelQueryBuilderSpec.php
@@ -62,6 +62,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $filterField->setQueryBuilder(Argument::any())->shouldBeCalled();
 
         $searchQb->hasSort('identifier')->willReturn(false);
+        $searchQb->hasSort('id')->willReturn(false);
         $sorterRegistry->getFieldSorter('identifier')->willReturn($sorter);
         $sorter->setQueryBuilder(Argument::any())->shouldBeCalled();
         $sorter->addFieldSorter('identifier', Argument::cetera())->willReturn($sorter);
@@ -290,6 +291,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $cursorFactory->createCursor(Argument::any(), [] )->shouldBeCalled()->willReturn($cursor);
 
         $searchQb->hasSort('identifier')->willReturn(true);
+        $searchQb->hasSort('id')->willReturn(false);
 
         $this->execute()->shouldReturn($cursor);
     }
@@ -322,6 +324,7 @@ class ProductModelQueryBuilderSpec extends ObjectBehavior
         $searchQb->addFacet('document_type_facet', 'document_type')->shouldBeCalledOnce();
 
         $searchQb->hasSort('identifier')->willReturn(true);
+        $searchQb->hasSort('id')->willReturn(false);
 
         $this->execute()->shouldReturn($cursor);
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductQueryBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Query/ProductQueryBuilderSpec.php
@@ -72,6 +72,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
 
         $searchQb->getQuery(Argument::any())->shouldBeCalledOnce()->willReturn([]);
         $searchQb->hasSort('identifier')->willReturn(false);
+        $searchQb->hasSort('id')->willReturn(false);
         $sorterRegistry->getFieldSorter('identifier')->willReturn($sorter);
         $sorter->setQueryBuilder(Argument::any())->shouldBeCalled();
         $sorter->addFieldSorter('identifier', Argument::cetera())->willReturn($sorter);
@@ -265,6 +266,7 @@ class ProductQueryBuilderSpec extends ObjectBehavior
 
         $searchQb->getQuery(Argument::any())->shouldBeCalledOnce()->willReturn([]);
         $searchQb->hasSort('identifier')->willReturn(true);
+        $searchQb->hasSort('id')->willReturn(false);
 
         $this->execute()->shouldReturn($cursor);
     }


### PR DESCRIPTION
This PR adds LIST product endpoint by UUID
It only includes Success EndToEnd tests
It miss ErrorListProductEndToEnd, ListProductWithCompletenessEndToEnd, SuccessListVariantProductDeltaEndToEnd to be 100% coverage in test, but this will be done in another PR.