### PR TITLE
RAB-916: Fix error in console when we upload file template

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/MediaFileInput/MediaFileInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MediaFileInput/MediaFileInput.tsx
@@ -205,13 +205,14 @@ const MediaFileInput = React.forwardRef<HTMLInputElement, MediaFileInputProps>(
       try {
         const uploadedFile = await uploader(file, setProgress);
         uploadSucceeded();
-        onChange?.(uploadedFile);
-      } catch (error) {
-        uploadFailed();
-        console.error(error);
-      } finally {
         setProgress(0);
         stopUploading();
+        onChange?.(uploadedFile);
+      } catch (error) {
+        setProgress(0);
+        stopUploading();
+        uploadFailed();
+        console.error(error);
       }
     };
 

--- a/front-packages/akeneo-design-system/src/components/Input/MediaFileInput/MediaFileInput.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/MediaFileInput/MediaFileInput.unit.tsx
@@ -212,6 +212,32 @@ test('it displays the default picture when the image previewer fails', () => {
   expect(thumbnail).toHaveAttribute('src', 'FALLBACK_IMAGE');
 });
 
+
+test('it does not throw an error when component is hidden after upload', async () => {
+  const uploader = jest.fn().mockResolvedValue(fileInfo);
+  const mockedConsole = jest.spyOn(console, "error");
+
+  const {unmount} = render(
+    <MediaFileInput
+      {...defaultProps}
+      value={null}
+      onChange={() => unmount()}
+      uploader={uploader}
+      thumbnailUrl={null}
+    />
+  );
+
+  const fileInput = screen.getByPlaceholderText(/Upload your file here/i);
+
+  await act(async () => {
+    userEvent.upload(fileInput, imageFile);
+    await flushPromises();
+  });
+
+  expect(mockedConsole).not.toHaveBeenCalled();
+  mockedConsole.mockRestore();
+});
+
 test('MediaFileInput supports forwardRef', () => {
   const handleChange = jest.fn();
   const uploader = jest.fn().mockResolvedValue(fileInfo);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
I removed the error that we have when we upload the file template. 

![Screenshot from 2022-07-20 16-58-18](https://user-images.githubusercontent.com/7239572/180014895-825d2b1b-5ecb-464a-863e-5875e96805da.png)

Why we have this error ? 
Because we remove the element when onChange is called but the component made some state update after

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
