### PR TITLE
RAB-837: Add min-width on remove tag icon

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TagInput/TagInput.tsx
@@ -6,6 +6,7 @@ import {arrayUnique, Key, Override} from '../../../shared';
 import {InputProps} from '../common';
 
 const RemoveTagIcon = styled(CloseIcon)<AkeneoThemedProps>`
+  min-width: 12px;
   width: 12px;
   height: 12px;
   color: ${getColor('grey', 120)};


### PR DESCRIPTION
Before:
<img width="477" alt="Screenshot 2022-07-20 at 17 16 34" src="https://user-images.githubusercontent.com/3492179/180019536-7c3aa05b-1258-4245-a8e6-261a245b524b.png">

After:
<img width="471" alt="Screenshot 2022-07-20 at 17 16 28" src="https://user-images.githubusercontent.com/3492179/180019560-df94f21a-0864-4c75-9cd1-2e01106daa81.png">
