### PR TITLE
CPM-634: Add Uuids in IdentifierResult from PQB

### DIFF
--- a/components/catalogs/back/src/Infrastructure/TemporaryEnrichmentBridge/SearchAfterSizeUuidResultCursorFactory.php
+++ b/components/catalogs/back/src/Infrastructure/TemporaryEnrichmentBridge/SearchAfterSizeUuidResultCursorFactory.php
@@ -42,7 +42,7 @@ class SearchAfterSizeUuidResultCursorFactory implements CursorFactoryInterface
         $options = $this->resolveOptions($options);
         $sort = ['_id' => 'asc'];
 
-        $queryBuilder['_source'] = \array_merge($queryBuilder['_source'], ['document_type']);
+        $queryBuilder['_source'] = \array_merge($queryBuilder['_source'], ['document_type', 'id']);
         $queryBuilder['sort'] = isset($queryBuilder['sort']) ? \array_merge($queryBuilder['sort'], $sort) : $sort;
         $queryBuilder['size'] = $options['limit'];
         if (0 !== \count($options['search_after'])) {
@@ -54,7 +54,7 @@ class SearchAfterSizeUuidResultCursorFactory implements CursorFactoryInterface
 
         $identifiers = [];
         foreach ($response['hits']['hits'] as $hit) {
-            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $hit['_source']['document_type']);
+            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);
         }
 
         return new IdentifierResultCursor($identifiers, $totalCount, new ElasticsearchResult($response));

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Cursor.php
@@ -103,7 +103,7 @@ class Cursor extends AbstractCursor implements CursorInterface, ResultAwareInter
         $this->count = $response['hits']['total']['value'];
 
         foreach ($response['hits']['hits'] as $hit) {
-            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);
         }
 
         $lastResult = end($response['hits']['hits']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/CursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/CursorFactory.php
@@ -13,21 +13,6 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
  */
 class CursorFactory implements CursorFactoryInterface
 {
-    /** @var Client */
-    protected $searchEngine;
-
-    /** @var CursorableRepositoryInterface */
-    private $productRepository;
-
-    /** @var CursorableRepositoryInterface */
-    private $productModelRepository;
-
-    /** @var string */
-    protected $cursorClassName;
-
-    /** @var int */
-    protected $pageSize;
-
     /**
      * @param Client                        $searchEngine
      * @param CursorableRepositoryInterface $productRepository
@@ -35,15 +20,11 @@ class CursorFactory implements CursorFactoryInterface
      * @param int                           $pageSize
      */
     public function __construct(
-        Client $searchEngine,
-        CursorableRepositoryInterface $productRepository,
-        CursorableRepositoryInterface $productModelRepository,
-        int $pageSize
+        protected Client $searchEngine,
+        private CursorableRepositoryInterface $productRepository,
+        private CursorableRepositoryInterface $productModelRepository,
+        protected int $pageSize
     ) {
-        $this->searchEngine = $searchEngine;
-        $this->productRepository = $productRepository;
-        $this->productModelRepository = $productModelRepository;
-        $this->pageSize = $pageSize;
     }
 
     /**
@@ -53,7 +34,7 @@ class CursorFactory implements CursorFactoryInterface
     {
         $pageSize = !isset($options['page_size']) ? $this->pageSize : $options['page_size'];
 
-        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type']);
+        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type', 'id']);
 
         return new Cursor(
             $this->searchEngine,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursor.php
@@ -122,7 +122,7 @@ class FromSizeCursor extends AbstractCursor implements CursorInterface
         $this->count = $response['hits']['total']['value'];
 
         foreach ($response['hits']['hits'] as $hit) {
-            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);
         }
 
         return $identifiers;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeCursorFactory.php
@@ -14,34 +14,12 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class FromSizeCursorFactory implements CursorFactoryInterface
 {
-    /** @var Client */
-    private $searchEngine;
-
-    /** @var int */
-    private $pageSize;
-
-    /** @var CursorableRepositoryInterface */
-    private $productRepository;
-
-    /** @var CursorableRepositoryInterface */
-    private $productModelRepository;
-
-    /**
-     * @param Client                        $searchEngine
-     * @param CursorableRepositoryInterface $productRepository
-     * @param CursorableRepositoryInterface $productModelRepository
-     * @param int                           $pageSize
-     */
     public function __construct(
-        Client $searchEngine,
-        CursorableRepositoryInterface $productRepository,
-        CursorableRepositoryInterface $productModelRepository,
-        $pageSize
+        private Client $searchEngine,
+        private CursorableRepositoryInterface $productRepository,
+        private CursorableRepositoryInterface $productModelRepository,
+        private int $pageSize
     ) {
-        $this->searchEngine = $searchEngine;
-        $this->productRepository = $productRepository;
-        $this->productModelRepository = $productModelRepository;
-        $this->pageSize = $pageSize;
     }
 
     /**
@@ -51,7 +29,7 @@ class FromSizeCursorFactory implements CursorFactoryInterface
     {
         $options = $this->resolveOptions($options);
 
-        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type']);
+        $queryBuilder['_source'] = array_merge($queryBuilder['_source'], ['document_type', 'id']);
 
         return new FromSizeCursor(
             $this->searchEngine,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactory.php
@@ -32,7 +32,7 @@ class FromSizeIdentifierResultCursorFactory implements CursorFactoryInterface
         $sort = ['_id' => 'asc'];
 
         $esQuery['track_total_hits'] = true;
-        $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type']);
+        $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type', 'id']);
         $esQuery['sort'] = isset($esQuery['sort']) ? array_merge($esQuery['sort'], $sort) : $sort;
         $esQuery['size'] = $options['limit'];
         $esQuery['from'] = $options['from'];
@@ -44,7 +44,7 @@ class FromSizeIdentifierResultCursorFactory implements CursorFactoryInterface
         foreach ($response['hits']['hits'] as $hit) {
             // TODO: remove default type when TIP-1151 and TIP 1150 are done, as the document type will always exist
             $documentType = $hit['_source']['document_type'] ?? ProductInterface::class;
-            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $documentType);
+            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $documentType, $hit['_source']['id']);
         }
 
         return new IdentifierResultCursor($identifiers, $totalCount, new ElasticsearchResult($response));

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursor.php
@@ -126,7 +126,7 @@ final class IdentifierCursor implements CursorInterface, ResultAwareInterface
         $this->count = $response['hits']['total']['value'];
 
         foreach ($response['hits']['hits'] as $hit) {
-            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type']);
+            $identifiers->add($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);
         }
 
         $lastResult = \end($response['hits']['hits']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierCursorFactory.php
@@ -24,7 +24,7 @@ class IdentifierCursorFactory implements CursorFactoryInterface
     public function createCursor($queryBuilder, array $options = []): CursorInterface
     {
         $pageSize = $options['page_size'] ?? $this->pageSize;
-        $queryBuilder['_source'] = ['identifier', 'document_type'];
+        $queryBuilder['_source'] = ['identifier', 'document_type', 'id'];
 
         return new IdentifierCursor($this->searchEngine, $queryBuilder, $pageSize);
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
@@ -6,6 +6,7 @@ namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Ramsey\Uuid\Uuid;
 
 /**
  * Simple data holder for the results of an Elasticsearch search about products and product models.
@@ -22,6 +23,8 @@ class IdentifierResult
     /** @var string */
     private $identifier;
 
+    private string $id;
+
     /** @var string */
     private $type;
 
@@ -29,7 +32,7 @@ class IdentifierResult
      * @param string $identifier
      * @param string $type
      */
-    public function __construct(string $identifier, string $type)
+    public function __construct(string $identifier, string $type, string $id)
     {
         if ($type !== ProductInterface::class && $type !== ProductModelInterface::class) {
             throw new \InvalidArgumentException(
@@ -42,8 +45,13 @@ class IdentifierResult
             );
         }
 
+        if($type === ProductInterface::class && !Uuid::isValid($id)) {
+            throw new \InvalidArgumentException(\sprintf("Product has an invalid uuid : %s", $id));
+        }
+
         $this->identifier = (string) $identifier;
         $this->type = $type;
+        $this->id = $id;
     }
 
     /**
@@ -60,6 +68,11 @@ class IdentifierResult
     public function getType(): string
     {
         return $this->type;
+    }
+
+    public function getId(): string
+    {
+        return $this->getId();
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
@@ -72,7 +72,7 @@ class IdentifierResult
 
     public function getId(): string
     {
-        return $this->getId();
+        return $this->id;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
@@ -45,7 +45,7 @@ class IdentifierResult
             );
         }
 
-        if($type === ProductInterface::class && !Uuid::isValid($id)) {
+        if ($type === ProductInterface::class && !Uuid::isValid(\str_replace('product_', '', $id))) {
             throw new \InvalidArgumentException(\sprintf("Product has an invalid uuid : %s", $id));
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResults.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResults.php
@@ -20,15 +20,11 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 class IdentifierResults
 {
     /** @var IdentifierResult[] */
-    private $identifierResults = [];
+    private array $identifierResults = [];
 
-    /**
-     * @param string $identifier
-     * @param string $type
-     */
-    public function add(string $identifier, string $type)
+    public function add(string $identifier, string $type, string $id): void
     {
-        $this->identifierResults[] = new IdentifierResult($identifier, $type);
+        $this->identifierResults[] = new IdentifierResult($identifier, $type, $id);
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactory.php
@@ -30,7 +30,7 @@ class SearchAfterSizeIdentifierResultCursorFactory implements CursorFactoryInter
         $options = $this->resolveOptions($options);
         $sort = ['_id' => 'asc'];
 
-        $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type']);
+        $esQuery['_source'] = array_merge($esQuery['_source'], ['document_type', 'id']);
         $esQuery['sort'] = isset($esQuery['sort']) ? array_merge($esQuery['sort'], $sort) : $sort;
         $esQuery['size'] = $options['limit'];
 
@@ -46,7 +46,7 @@ class SearchAfterSizeIdentifierResultCursorFactory implements CursorFactoryInter
 
         $identifiers = [];
         foreach ($response['hits']['hits'] as $hit) {
-            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $hit['_source']['document_type']);
+            $identifiers[] = new IdentifierResult($hit['_source']['identifier'], $hit['_source']['document_type'], $hit['_source']['id']);
         }
 
         return new IdentifierResultCursor($identifiers, $totalCount, new ElasticsearchResult($response));

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeCursorSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
@@ -16,10 +17,10 @@ class FromSizeCursorSpec extends ObjectBehavior
         Client $esClient,
         CursorableRepositoryInterface $productRepository,
         CursorableRepositoryInterface $productModelRepository,
-        ProductInterface $variantProduct,
         ProductModelInterface $subProductModel
     ) {
-        $variantProduct->getIdentifier()->willReturn('a-variant-product');
+        $variantProduct = new Product();
+        $variantProduct->setIdentifier('a-variant-product');
         $productRepository->getItemsFromIdentifiers(['a-variant-product'])->willReturn([$variantProduct]);
 
         $subProductModel->getCode()->willReturn('a-sub-product-model');
@@ -36,11 +37,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => ['value' => 4, 'relation' => 'eq'],
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-variant-product', 'document_type' => ProductInterface::class],
+                            '_source' => ['identifier' => 'a-variant-product', 'document_type' => ProductInterface::class, 'id' => 'product_' . $variantProduct->getUuid()->toString()],
                             'sort' => ['#a-variant-product']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-sub-product-model', 'document_type' => ProductModelInterface::class],
+                            '_source' => ['identifier' => 'a-sub-product-model', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_a-sub-product-model'],
                             'sort' => ['#a-sub-product-model']
                         ],
                     ]
@@ -72,14 +73,17 @@ class FromSizeCursorSpec extends ObjectBehavior
 
     function it_is_iterable(
         $esClient,
-        $variantProduct,
         $subProductModel,
         $productRepository,
         $productModelRepository,
-        ProductInterface $product,
         ProductModelInterface $rootProductModel
     ) {
-        $product->getIdentifier()->willReturn('a-product');
+        $variantProduct = new Product();
+        $variantProduct->setIdentifier('a-variant-product');
+        $productRepository->getItemsFromIdentifiers(['a-variant-product'])->willReturn([$variantProduct]);
+
+        $product = new Product();
+        $product->setIdentifier('a-product');
         $productRepository->getItemsFromIdentifiers(['a-product'])->willReturn([$product]);
 
         $rootProductModel->getCode()->willReturn('a-root-product-model');
@@ -96,11 +100,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'a-root-product-model', 'document_type' => ProductModelInterface::class],
+                            '_source' => ['identifier' => 'a-root-product-model', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_a-root-product-model'],
                             'sort' => ['#a-root-product-model']
                         ],
                         [
-                            '_source' => ['identifier' => 'a-product', 'document_type' => ProductInterface::class],
+                            '_source' => ['identifier' => 'a-product', 'document_type' => ProductInterface::class, 'id' => 'product_' . $product->getUuid()->toString()],
                             'sort' => ['#a-product']
                         ],
                     ]
@@ -145,14 +149,18 @@ class FromSizeCursorSpec extends ObjectBehavior
 
     function it_is_iterable_with_products_and_product_models_having_the_same_identifiers(
         $esClient,
-        $variantProduct,
         $subProductModel,
         $productRepository,
         $productModelRepository,
         ProductInterface $product,
         ProductModelInterface $rootProductModel
     ) {
-        $product->getIdentifier()->willReturn('foo');
+        $variantProduct = new Product();
+        $variantProduct->setIdentifier('a-variant-product');
+        $productRepository->getItemsFromIdentifiers(['a-variant-product'])->willReturn([$variantProduct]);
+
+        $product = new Product();
+        $product->setIdentifier('foo');
         $productRepository->getItemsFromIdentifiers(['foo'])->willReturn([$product]);
 
         $rootProductModel->getCode()->willReturn('foo');
@@ -169,11 +177,11 @@ class FromSizeCursorSpec extends ObjectBehavior
                     'total' => 4,
                     'hits' => [
                         [
-                            '_source' => ['identifier' => 'foo', 'document_type' => ProductModelInterface::class],
+                            '_source' => ['identifier' => 'foo', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_foo'],
                             'sort' => ['#foo']
                         ],
                         [
-                            '_source' => ['identifier' => 'foo', 'document_type' => ProductInterface::class],
+                            '_source' => ['identifier' => 'foo', 'document_type' => ProductInterface::class, 'id' => 'product_' . $product->getUuid()->toString()],
                             'sort' => ['#foo']
                         ],
                     ]

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
@@ -43,7 +43,7 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
             'total' => ['value' => 42, 'relation' => 'eq'],
             'hits'  => [
                 ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class, 'id' => 'product_' . $uuid->toString()]],
-                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_2']],
+                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_product_model_2']],
             ]
         ]];
 
@@ -61,7 +61,7 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
         $this->createCursor($esQuery, $options)->shouldBeLike(new IdentifierResultCursor(
             [
                 new IdentifierResult('product_1', ProductInterface::class, 'product_' . $uuid->toString()),
-                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_2'),
+                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_product_model_2'),
             ],
             42,
             new ElasticsearchResult($result)

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/FromSizeIdentifierResultCursorFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 {
@@ -25,6 +26,8 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
     function it_creates_a_product_identifier_cursor($esClient)
     {
+        $uuid = Uuid::uuid4();
+
         $esQuery = [
             'sort'  => [],
             'query' => [],
@@ -39,8 +42,8 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
         $result = ['hits' => [
             'total' => ['value' => 42, 'relation' => 'eq'],
             'hits'  => [
-                ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class]],
-                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class]],
+                ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class, 'id' => 'product_' . $uuid->toString()]],
+                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_2']],
             ]
         ]];
 
@@ -48,7 +51,7 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
             [
                 'sort' => ['_id' => 'asc'],
                 'query' => [],
-                '_source' => ['identifier', 'document_type'],
+                '_source' => ['identifier', 'document_type', 'id'],
                 "track_total_hits" => true,
                 'size' => 25,
                 'from' => 0
@@ -57,8 +60,8 @@ class FromSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
         $this->createCursor($esQuery, $options)->shouldBeLike(new IdentifierResultCursor(
             [
-                new IdentifierResult('product_1', ProductInterface::class),
-                new IdentifierResult('product_model_2', ProductModelInterface::class),
+                new IdentifierResult('product_1', ProductInterface::class, 'product_' . $uuid->toString()),
+                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_2'),
             ],
             42,
             new ElasticsearchResult($result)

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierCursorFactorySpec.php
@@ -31,12 +31,12 @@ final class IdentifierCursorFactorySpec extends ObjectBehavior
     {
         $this->createCursor([], [])->shouldBeLike(new IdentifierCursor(
             $searchEngine->getWrappedObject(),
-            ['_source' => ['identifier', 'document_type']],
+            ['_source' => ['identifier', 'document_type', 'id']],
             100
         ));
         $this->createCursor(['_source' => 'values', 'foo' => 'bar'], ['page_size' => 62])->shouldBeLike(new IdentifierCursor(
             $searchEngine->getWrappedObject(),
-            ['_source' => ['identifier', 'document_type'], 'foo' => 'bar'],
+            ['_source' => ['identifier', 'document_type', 'id'], 'foo' => 'bar'],
             62
         ));
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierResultSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierResultSpec.php
@@ -5,42 +5,50 @@ namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Ramsey\Uuid\Uuid;
 
 class IdentifierResultSpec extends ObjectBehavior
 {
     function it_gets_the_identifier()
     {
-        $this->beConstructedWith('foo', ProductInterface::class);
+        $this->beConstructedWith('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
         $this->getIdentifier()->shouldReturn('foo');
     }
 
     function it_gets_the_type()
     {
-        $this->beConstructedWith('foo', ProductInterface::class);
+        $this->beConstructedWith('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
         $this->getType()->shouldReturn(ProductInterface::class);
+    }
+
+    function it_gets_the_id()
+    {
+        $uuidAsString = 'product_' . Uuid::uuid4()->toString();
+        $this->beConstructedWith('foo', ProductInterface::class, $uuidAsString);
+        $this->getId()->shouldReturn($uuidAsString);
     }
 
     function it_determines_if_equals_to_a_product_identifier()
     {
-        $this->beConstructedWith('foo', ProductInterface::class);
+        $this->beConstructedWith('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
         $this->isProductIdentifierEquals('foo')->shouldReturn(true);
     }
 
     function it_determines_if_not_equals_to_a_product_identifier()
     {
-        $this->beConstructedWith('foo', ProductModelInterface::class);
+        $this->beConstructedWith('foo', ProductModelInterface::class, 'product_model_foo');
         $this->isProductIdentifierEquals('foo')->shouldReturn(false);
     }
 
     function it_determines_if_equals_to_a_product_model_identifier()
     {
-        $this->beConstructedWith('foo', ProductModelInterface::class);
+        $this->beConstructedWith('foo', ProductModelInterface::class, 'product_model_foo');
         $this->isProductModelIdentifierEquals('foo')->shouldReturn(true);
     }
 
     function it_determines_if_not_equals_to_a_product_model_identifier()
     {
-        $this->beConstructedWith('foo', ProductInterface::class);
+        $this->beConstructedWith('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
         $this->isProductModelIdentifierEquals('foo')->shouldReturn(false);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierResultsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/IdentifierResultsSpec.php
@@ -6,12 +6,14 @@ use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Ramsey\Uuid\Uuid;
 
 class IdentifierResultsSpec extends ObjectBehavior
 {
     function it_adds_a_result_identifier()
     {
-        $this->add('foo', ProductInterface::class);
+        $uuidAsString = 'product_' .Uuid::uuid4()->toString();
+        $this->add('foo', ProductInterface::class, $uuidAsString);
 
         $all = $this->all();
         $all->shouldHaveCount(1);
@@ -19,6 +21,7 @@ class IdentifierResultsSpec extends ObjectBehavior
         $all[0]->shouldBeAnInstanceOf(IdentifierResult::class);
         $all[0]->getIdentifier()->shouldReturn('foo');
         $all[0]->getType()->shouldReturn(ProductInterface::class);
+        $all[0]->getId()->shouldReturn($uuidAsString);
     }
 
     function it_checks_if_empty()
@@ -28,7 +31,8 @@ class IdentifierResultsSpec extends ObjectBehavior
 
     function it_checks_if_not_empty()
     {
-        $this->add('foo', ProductInterface::class);
+        $uuidAsString = 'product_' .Uuid::uuid4()->toString();
+        $this->add('foo', ProductInterface::class, $uuidAsString);
         $this->isEmpty()->shouldReturn(false);
     }
 
@@ -39,9 +43,9 @@ class IdentifierResultsSpec extends ObjectBehavior
 
     function it_returns_all_elements()
     {
-        $this->add('foo', ProductInterface::class);
-        $this->add('bar', ProductInterface::class);
-        $this->add('baz', ProductInterface::class);
+        $this->add('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
+        $this->add('bar', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
+        $this->add('baz', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
 
         $all = $this->all();
         $all->shouldHaveCount(3);
@@ -53,20 +57,20 @@ class IdentifierResultsSpec extends ObjectBehavior
 
     function it_returns_product_identifiers()
     {
-        $this->add('foo', ProductInterface::class);
-        $this->add('bar', ProductModelInterface::class);
-        $this->add('baz', ProductModelInterface::class);
-        $this->add('qux', ProductInterface::class);
+        $this->add('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
+        $this->add('bar', ProductModelInterface::class, 'product_model_bar');
+        $this->add('baz', ProductModelInterface::class, 'product_model_baz');
+        $this->add('qux', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
 
         $this->getProductIdentifiers()->shouldReturn(['foo', 'qux']);
     }
 
     function it_returns_product_model_identifiers()
     {
-        $this->add('foo', ProductInterface::class);
-        $this->add('bar', ProductModelInterface::class);
-        $this->add('baz', ProductModelInterface::class);
-        $this->add('qux', ProductInterface::class);
+        $this->add('foo', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
+        $this->add('bar', ProductModelInterface::class, 'product_model_bar');
+        $this->add('baz', ProductModelInterface::class, 'product_model_bar');
+        $this->add('qux', ProductInterface::class, 'product_' . Uuid::uuid4()->toString());
 
         $this->getProductModelIdentifiers()->shouldReturn(['bar', 'baz']);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 {
@@ -25,6 +26,8 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
     function it_creates_a_product_identifier_cursor($esClient)
     {
+        $uuid = Uuid::uuid4();
+
         $esQuery = [
             'sort'  => [],
             'query' => [],
@@ -40,8 +43,8 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
         $result = ['hits' => [
             'total' => ['value' => 42, 'relation' => 'eq'],
             'hits'  => [
-                ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class]],
-                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class]],
+                ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class, 'id' => 'product_' . $uuid->toString()]],
+                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_2']],
             ]
         ]];
 
@@ -49,7 +52,7 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
             [
                 'sort'    => ['_id' => 'asc'],
                 'query'   => [],
-                '_source' => ['identifier', 'document_type'],
+                '_source' => ['identifier', 'document_type', 'id'],
                 'size'    => 25,
                 'search_after'    => ['123', '123']
             ]
@@ -57,8 +60,8 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
 
         $this->createCursor($esQuery, $options)->shouldBeLike(new IdentifierResultCursor(
             [
-                new IdentifierResult('product_1', ProductInterface::class),
-                new IdentifierResult('product_model_2', ProductModelInterface::class),
+                new IdentifierResult('product_1', ProductInterface::class, 'product_' . $uuid->toString()),
+                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_2'),
             ],
             42,
             new ElasticsearchResult($result)

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/SearchAfterSizeIdentifierResultCursorFactorySpec.php
@@ -44,7 +44,7 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
             'total' => ['value' => 42, 'relation' => 'eq'],
             'hits'  => [
                 ['_source' => ['identifier' => 'product_1', 'document_type' => ProductInterface::class, 'id' => 'product_' . $uuid->toString()]],
-                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_2']],
+                ['_source' => ['identifier' => 'product_model_2', 'document_type' => ProductModelInterface::class, 'id' => 'product_model_product_model_2']],
             ]
         ]];
 
@@ -61,7 +61,7 @@ class SearchAfterSizeIdentifierResultCursorFactorySpec extends ObjectBehavior
         $this->createCursor($esQuery, $options)->shouldBeLike(new IdentifierResultCursor(
             [
                 new IdentifierResult('product_1', ProductInterface::class, 'product_' . $uuid->toString()),
-                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_2'),
+                new IdentifierResult('product_model_2', ProductModelInterface::class, 'product_model_product_model_2'),
             ],
             42,
             new ElasticsearchResult($result)

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
@@ -24,6 +24,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -81,6 +82,10 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         ProductAndProductModelQueryBuilder $pqb,
         CursorInterface $cursor
     ) {
+        $product1Uuid = Uuid::uuid4();
+        $product2Uuid = Uuid::uuid4();
+        $product3Uuid = Uuid::uuid4();
+
         $product1->isVariant()->willReturn(false);
         $product2->isVariant()->willReturn(false);
         $product3->isVariant()->willReturn(false);
@@ -97,9 +102,9 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->rewind()->shouldBeCalled();
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn(
-            new IdentifierResult('id1', ProductInterface::class),
-            new IdentifierResult('id2', ProductInterface::class),
-            new IdentifierResult('id3', ProductInterface::class)
+            new IdentifierResult('id1', ProductInterface::class, $product1Uuid->toString()),
+            new IdentifierResult('id2', ProductInterface::class, $product2Uuid->toString()),
+            new IdentifierResult('id3', ProductInterface::class, $product3Uuid->toString())
         );
         $cursor->next()->shouldBeCalled();
         $cursor->count()->shouldBeCalled()->willReturn(3);
@@ -145,6 +150,10 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         ConstraintViolationListInterface $violationList2,
         ConstraintViolationListInterface $violationList3
     ) {
+        $product1Uuid = Uuid::uuid4();
+        $product2Uuid = Uuid::uuid4();
+        $product3Uuid = Uuid::uuid4();
+
         $variantProduct1->isVariant()->willReturn(true);
         $variantProduct2->isVariant()->willReturn(true);
         $variantProduct3->isVariant()->willReturn(true);
@@ -161,9 +170,9 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->rewind()->shouldBeCalled();
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn(
-            new IdentifierResult('id1', ProductInterface::class),
-            new IdentifierResult('id2', ProductInterface::class),
-            new IdentifierResult('id3', ProductInterface::class)
+            new IdentifierResult('id1', ProductInterface::class, $product1Uuid->toString()),
+            new IdentifierResult('id2', ProductInterface::class, $product2Uuid->toString()),
+            new IdentifierResult('id3', ProductInterface::class, $product3Uuid->toString())
         );
         $cursor->next()->shouldBeCalled();
         $cursor->count()->shouldBeCalled()->willReturn(3);
@@ -221,6 +230,10 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         ConstraintViolationListInterface $violationList2,
         ConstraintViolationListInterface $violationList3
     ) {
+        $product1Uuid = Uuid::uuid4();
+        $product2Uuid = Uuid::uuid4();
+        $product3Uuid = Uuid::uuid4();
+
         $variantProduct1->isVariant()->willReturn(true);
         $variantProduct2->isVariant()->willReturn(true);
         $variantProduct3->isVariant()->willReturn(true);
@@ -237,9 +250,9 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->rewind()->shouldBeCalled();
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn(
-            new IdentifierResult('id1', ProductInterface::class),
-            new IdentifierResult('id2', ProductInterface::class),
-            new IdentifierResult('id3', ProductInterface::class)
+            new IdentifierResult('id1', ProductInterface::class, 'product_' . $product1Uuid->toString()),
+            new IdentifierResult('id2', ProductInterface::class, 'product_' . $product2Uuid->toString()),
+            new IdentifierResult('id3', ProductInterface::class, 'product_' . $product3Uuid->toString())
         );
         $cursor->next()->shouldBeCalled();
         $cursor->count()->shouldBeCalled()->willReturn(3);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Job/ComputeDataRelatedToFamilyProductsTaskletSpec.php
@@ -102,9 +102,9 @@ class ComputeDataRelatedToFamilyProductsTaskletSpec extends ObjectBehavior
         $cursor->rewind()->shouldBeCalled();
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn(
-            new IdentifierResult('id1', ProductInterface::class, $product1Uuid->toString()),
-            new IdentifierResult('id2', ProductInterface::class, $product2Uuid->toString()),
-            new IdentifierResult('id3', ProductInterface::class, $product3Uuid->toString())
+            new IdentifierResult('id1', ProductInterface::class, 'product_' . $product1Uuid->toString()),
+            new IdentifierResult('id2', ProductInterface::class, 'product_' . $product2Uuid->toString()),
+            new IdentifierResult('id3', ProductInterface::class, 'product_' . $product3Uuid->toString())
         );
         $cursor->next()->shouldBeCalled();
         $cursor->count()->shouldBeCalled()->willReturn(3);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -20,6 +20,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
+use Ramsey\Uuid\Uuid;
 
 class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 {
@@ -64,6 +65,10 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         ProductInterface $product2,
         ProductInterface $product3
     ) {
+        $uuid1 = Uuid::uuid4();
+        $uuid2 = Uuid::uuid4();
+        $uuid3 = Uuid::uuid4();
+
         $jobParameters->get('family_code')->willReturn('accessories');
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $familyRepository->findOneByIdentifier('accessories')->willReturn($family);
@@ -75,9 +80,9 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 
         $cursor->valid()->willReturn(true, true, true, false);
         $cursor->current()->willReturn(
-            new IdentifierResult('identifier1', ProductInterface::class),
-            new IdentifierResult('identifier2', ProductInterface::class),
-            new IdentifierResult('identifier3', ProductInterface::class),
+            new IdentifierResult('identifier1', ProductInterface::class, 'product_' . $uuid1->toString()),
+            new IdentifierResult('identifier2', ProductInterface::class, 'product_' . $uuid2->toString()),
+            new IdentifierResult('identifier3', ProductInterface::class, 'product_' . $uuid3->toString()),
         );
         $cursor->next()->shouldBeCalled();
         $cursor->rewind()->shouldBeCalled();

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTaskletSpec.php
@@ -23,6 +23,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 
 class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
 {
@@ -88,6 +89,7 @@ class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
         ProductQueryBuilderInterface $pqb,
         CursorInterface $productsCursor,
     ) {
+        $uuid = Uuid::uuid4();
         $jobParameters->get('channel_code')->willReturn('unknown');
         $jobParameters->get('locales_identifier')->willReturn(['de_DE', 'it_IT']);
         $jobParameters->get('username')->willReturn('willypapa');
@@ -105,7 +107,7 @@ class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
 
         $productsCursor->rewind()->shouldBeCalled();
         $productsCursor->current()->willReturn(
-            new IdentifierResult('jean', ProductInterface::class),
+            new IdentifierResult('jean', ProductInterface::class, 'product_' . $uuid->toString()),
         );
         $productsCursor->next()->shouldBeCalled();
         $productsCursor->valid()->willReturn(true, false);
@@ -128,6 +130,10 @@ class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
         ProductQueryBuilderInterface $pqb,
         CursorInterface $productsCursor
     ): void {
+        $jeanUuid = Uuid::uuid4();
+        $shoeUuid = Uuid::uuid4();
+        $hatUuid = Uuid::uuid4();
+
         $jeanProduct = (new Product())->setIdentifier('jean');
         $shoeProduct = (new Product())->setIdentifier('shoe');
         $hatProduct = (new Product())->setIdentifier('hat');
@@ -147,9 +153,9 @@ class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
 
         $productsCursor->rewind()->shouldBeCalled();
         $productsCursor->current()->willReturn(
-            new IdentifierResult('jean', ProductInterface::class),
-            new IdentifierResult('shoe', ProductInterface::class),
-            new IdentifierResult('hat', ProductInterface::class)
+            new IdentifierResult('jean', ProductInterface::class, 'product_' . $jeanUuid->toString()),
+            new IdentifierResult('shoe', ProductInterface::class, 'product_' . $shoeUuid->toString()),
+            new IdentifierResult('hat', ProductInterface::class, 'product_' . $hatUuid->toString())
         );
         $productsCursor->next()->shouldBeCalled();
         $productsCursor->valid()->willReturn(true, true, true, false);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When done, notify octopus team about updating components/catalogs/back/src/Infrastructure/TemporaryEnrichmentBridge/SearchAfterSizeUuidResultCursorFactory.php#L57 to also add the id in _source of the esQuery

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
