### PR TITLE
GRF-207: Fix MYSQL error during the calculation of the completeness

### DIFF
--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommand.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Command/OneTimeTask/CleanCompletenessEvaluationResultsCommand.php
@@ -90,7 +90,12 @@ final class CleanCompletenessEvaluationResultsCommand extends Command
         $limit = $this->bulkSize;
 
         $query = <<<SQL
-SELECT BIN_TO_UUID(product_uuid) AS product_uuid, criterion_code, status, result
+SELECT 
+    /*+ SET_VAR(sort_buffer_size = 1000000) */
+    BIN_TO_UUID(product_uuid) AS product_uuid, 
+    criterion_code, 
+    status, 
+    result
 FROM pim_data_quality_insights_product_criteria_evaluation
 WHERE product_uuid > :lastProductUuidAsBytes
     AND criterion_code IN (:criterionCodes)


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Use `sort_buffer_size` to avoid MYSQL error during the calculation of the completeness of required and non-required attributes

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
