### PR TITLE
RAB: Fix deprecated self::$container of symfony

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/Command/UpdateAuditDataCommandEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Audit/Command/UpdateAuditDataCommandEndToEnd.php
@@ -31,8 +31,8 @@ class UpdateAuditDataCommandEndToEnd extends CommandTestCase
         parent::setUp();
 
         $this->command = $this->application->find('akeneo:connectivity-audit:update-data');
-        $this->dbalConnection = self::$container->get('database_connection');
-        $this->productClass = self::$container->getParameter('pim_catalog.entity.product.class');
+        $this->dbalConnection = self::getContainer()->get('database_connection');
+        $this->productClass = self::getContainer()->getParameter('pim_catalog.entity.product.class');
     }
 
     public function test_it_updates_audit_data(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Audit/Persistence/DbalExtractConnectionsProductEventCountQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Audit/Persistence/DbalExtractConnectionsProductEventCountQueryIntegration.php
@@ -43,8 +43,8 @@ class DbalExtractConnectionsProductEventCountQueryIntegration extends TestCase
 
         $this->connectionLoader = $this->get('akeneo_connectivity.connection.fixtures.connection_loader');
         $this->extractConnectionsProductEventCountQuery = $this->get(DbalExtractConnectionsProductEventCountQuery::class);
-        $this->dbalConnection = self::$container->get('database_connection');
-        $this->productClass = self::$container->getParameter('pim_catalog.entity.product.class');
+        $this->dbalConnection = self::getContainer()->get('database_connection');
+        $this->productClass = self::getContainer()->getParameter('pim_catalog.entity.product.class');
     }
 
     public function test_it_extracts_created_products_by_connection(): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/Persistence/GetUserProfileQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Marketplace/Persistence/GetUserProfileQueryIntegration.php
@@ -35,7 +35,7 @@ class GetUserProfileQueryIntegration extends TestCase
         parent::setUp();
 
         $this->getUserProfileQuery = $this->get(GetUserProfileQuery::class);
-        $this->dbalConnection = self::$container->get('database_connection');
+        $this->dbalConnection = self::getContainer()->get('database_connection');
     }
 
     protected function getConfiguration(): Configuration

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindAnnouncementItemsIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindAnnouncementItemsIntegration.php
@@ -38,7 +38,7 @@ class ApiFindAnnouncementItemsIntegration extends KernelTestCase
 
     public function test_it_finds_first_page_of_announcements()
     {
-        $query = self::$container->get('akeneo_communication_channel.query.api.find_announcement_items');
+        $query = self::getContainer()->get('akeneo_communication_channel.query.api.find_announcement_items');
         $result = $query->byPimVersion('Serenity', '2020105', 'en_US', null, 10);
         Assert::assertCount(10, $result);
         Assert::assertEquals(
@@ -59,7 +59,7 @@ class ApiFindAnnouncementItemsIntegration extends KernelTestCase
 
     public function test_it_finds_second_page_of_announcements()
     {
-        $query = self::$container->get('akeneo_communication_channel.query.api.find_announcement_items');
+        $query = self::getContainer()->get('akeneo_communication_channel.query.api.find_announcement_items');
         $result = $query->byPimVersion('Serenity', '2020105', 'en_US', 'update_1-new-screen-for-measurements-families_2020-05', 10);
         Assert::assertCount(1, $result);
         Assert::assertEquals(
@@ -83,7 +83,7 @@ class ApiFindAnnouncementItemsIntegration extends KernelTestCase
         $attempt = 0;
         do {
             try {
-                $httpClient = new Client(['base_uri' => self::$container->getParameter('comm_panel_api_url')]);
+                $httpClient = new Client(['base_uri' => self::getContainer()->getParameter('comm_panel_api_url')]);
                 $httpClient->get('/');
             } catch (ConnectException $e) {
                 usleep(100000);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindNewAnnouncementIdsIntegration.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/CommunicationChannel/Api/ApiFindNewAnnouncementIdsIntegration.php
@@ -38,7 +38,7 @@ class ApiFindNewAnnouncementIdsIntegration extends KernelTestCase
 
     public function test_it_finds_new_announcement_ids()
     {
-        $query = self::$container->get('akeneo_communication_channel.query.api.find_new_announcement_ids');
+        $query = self::getContainer()->get('akeneo_communication_channel.query.api.find_new_announcement_ids');
         $result = $query->find('Serenity', '2020105', 'en_US');
         Assert::assertCount(4, $result);
         Assert::assertEquals(
@@ -57,7 +57,7 @@ class ApiFindNewAnnouncementIdsIntegration extends KernelTestCase
         $attempt = 0;
         do {
             try {
-                $httpClient = new Client(['base_uri' => self::$container->getParameter('comm_panel_api_url')]);
+                $httpClient = new Client(['base_uri' => self::getContainer()->getParameter('comm_panel_api_url')]);
                 $httpClient->get('/');
             } catch (ConnectException $e) {
                 usleep(100000);

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/WebTestCase.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/WebTestCase.php
@@ -24,7 +24,7 @@ abstract class WebTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = self::$container->get('test.client');
+        $this->client = self::getContainer()->get('test.client');
     }
 
     protected function authenticateAsAdmin(): UserInterface

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/Acceptance/AckMessageEventListenerTest.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/Acceptance/AckMessageEventListenerTest.php
@@ -26,7 +26,7 @@ final class AckMessageEventListenerTest extends KernelTestCase
 
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return self::getContainer()->get($service);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/AcceptanceTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/AcceptanceTestCase.php
@@ -31,7 +31,7 @@ abstract class AcceptanceTestCase extends KernelTestCase
 
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return self::getContainer()->get($service);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/WebTestCase.php
@@ -23,7 +23,7 @@ abstract class WebTestCase extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->client = self::$container->get('test.client');
+        $this->client = self::getContainer()->get('test.client');
     }
 
     protected function tearDown(): void
@@ -40,7 +40,7 @@ abstract class WebTestCase extends TestCase
     protected function getAdminUser(): UserInterface
     {
         if ($this->user === null) {
-            $this->user = self::$container->get('pim_user.manager')->findUserByUsername('admin') ?? $this->createAdminUser();
+            $this->user = self::getContainer()->get('pim_user.manager')->findUserByUsername('admin') ?? $this->createAdminUser();
         }
 
         return $this->user;

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/SqlIntegrationTestCase.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Integration/SqlIntegrationTestCase.php
@@ -35,7 +35,7 @@ abstract class SqlIntegrationTestCase extends KernelTestCase
 
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return self::getContainer()->get($service);
     }
 
     protected function resetDB(): void

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/tests/integration/OrderingKeySolverIntegration.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/tests/integration/OrderingKeySolverIntegration.php
@@ -26,7 +26,7 @@ final class OrderingKeySolverIntegration extends KernelTestCase
     protected function setUp(): void
     {
         $this->testKernel = static::bootKernel(['debug' => false]);
-        $this->orderingKeySolver = self::$container->get(OrderingKeySolver::class);
+        $this->orderingKeySolver = self::getContainer()->get(OrderingKeySolver::class);
     }
 
     public function test_it_returns_null_for_an_unknown_message(): void

--- a/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Controller/ControllerIntegrationTestCase.php
+++ b/src/Oro/Bundle/PimDataGridBundle/tests/Integration/Controller/ControllerIntegrationTestCase.php
@@ -39,7 +39,7 @@ abstract class ControllerIntegrationTestCase extends WebTestCase
 
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return self::getContainer()->get($service);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
@@ -85,12 +85,12 @@ abstract class InternalApiTestCase extends TestCase
 
     private function getClient(): HttpKernelBrowser
     {
-        return self::$container->get('test.client');
+        return self::getContainer()->get('test.client');
     }
 
     private function getSession(): SessionInterface
     {
-        return self::$container->get('session');
+        return self::getContainer()->get('session');
     }
 
     protected function clearDoctrineUoW(): void

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/AbstractQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/EntityWithQuantifiedAssociations/AbstractQuantifiedAssociationsTestCase.php
@@ -30,6 +30,6 @@ abstract class AbstractQuantifiedAssociationsTestCase extends InternalApiTestCas
 
     protected function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/MassEdit/AbstractMassEditEndToEnd.php
@@ -220,6 +220,6 @@ SQL;
 
     protected function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -73,11 +73,11 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
 
     private function getRouter(): RouterInterface
     {
-        return self::$container->get('router');
+        return self::getContainer()->get('router');
     }
 
     private function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
@@ -62,6 +62,6 @@ class ProductCreationEndToEnd extends InternalApiTestCase
 
     protected function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/QuantifiedAssociations/AbstractProductWithQuantifiedAssociationsTestCase.php
@@ -52,6 +52,6 @@ abstract class AbstractProductWithQuantifiedAssociationsTestCase extends Abstrac
 
     protected function getProductUpdater(): ObjectUpdaterInterface
     {
-        return self::$container->get('pim_catalog.updater.product');
+        return self::getContainer()->get('pim_catalog.updater.product');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/AbstractProductModelWithQuantifiedAssociationsTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/InternalApi/QuantifiedAssociations/AbstractProductModelWithQuantifiedAssociationsTestCase.php
@@ -63,11 +63,11 @@ abstract class AbstractProductModelWithQuantifiedAssociationsTestCase extends Ab
 
     protected function getProductModelSaver(): SaverInterface
     {
-        return self::$container->get('pim_catalog.saver.product_model');
+        return self::getContainer()->get('pim_catalog.saver.product_model');
     }
 
     protected function getProductModelUpdater(): ObjectUpdaterInterface
     {
-        return self::$container->get('pim_catalog.updater.product_model');
+        return self::getContainer()->get('pim_catalog.updater.product_model');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/InternalApi/UpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/InternalApi/UpdateVariantProductEndToEnd.php
@@ -105,7 +105,7 @@ class UpdateVariantProductEndToEnd extends InternalApiTestCase
 
     protected function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 
     protected function getConfiguration(): Configuration

--- a/tests/back/Pim/Enrichment/EndToEnd/RemoveLocaleFromChannelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/RemoveLocaleFromChannelEndToEnd.php
@@ -121,7 +121,7 @@ class RemoveLocaleFromChannelEndToEnd extends InternalApiTestCase
 
     private function getRouter(): RouterInterface
     {
-        return self::$container->get('router');
+        return self::getContainer()->get('router');
     }
 
     private function waitForJobExecutionToEnd()

--- a/tests/back/Platform/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Platform/EndToEnd/InternalApiTestCase.php
@@ -39,16 +39,16 @@ abstract class InternalApiTestCase extends TestCase
 
     private function getClient(): HttpKernelBrowser
     {
-        return self::$container->get('test.client');
+        return self::getContainer()->get('test.client');
     }
 
     private function getSession(): SessionInterface
     {
-        return self::$container->get('session');
+        return self::getContainer()->get('session');
     }
 
     protected function getAdminUser(): UserInterface
     {
-        return self::$container->get('pim_user.repository.user')->findOneByIdentifier('admin');
+        return self::getContainer()->get('pim_user.repository.user')->findOneByIdentifier('admin');
     }
 }

--- a/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
+++ b/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
@@ -28,7 +28,7 @@ class GetJobExecutionTrackingIntegration extends TestCase
     {
         parent::setUp();
 
-        self::$container->set('pim_import_export.clock', new FrozenClock());
+        self::getContainer()->set('pim_import_export.clock', new FrozenClock());
 
         $this->sqlConnection = $this->get('database_connection');
         $this->getJobExecutionTracking = $this->get('pim_import_export.query.get_job_execution_tracking');

--- a/tests/back/UserManagement/Integration/Bundle/ControllerIntegrationTestCase.php
+++ b/tests/back/UserManagement/Integration/Bundle/ControllerIntegrationTestCase.php
@@ -44,7 +44,7 @@ abstract class ControllerIntegrationTestCase extends WebTestCase
 
     protected function get(string $service)
     {
-        return self::$container->get($service);
+        return self::getContainer()->get($service);
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since Symfony 5.3 usage of self::$container is deprecated we should use now self::getContainer(). 

In this PR, I manage this deprecation

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
