### PR TITLE
PH-13: Extract services from BatchCommand

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\BatchBundle\Command;
 
-use Akeneo\Tool\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
+use Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandler;
+use Akeneo\Tool\Bundle\BatchBundle\JobExecution\ExecuteJobExecutionHandler;
 use Akeneo\Tool\Bundle\BatchBundle\Notification\Notifier;
-use Akeneo\Tool\Component\Batch\Item\ExecutionContext;
 use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use Akeneo\Tool\Component\Batch\Job\ExitStatus;
 use Akeneo\Tool\Component\Batch\Job\JobInterface;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Tool\Component\Batch\Job\JobParametersValidator;
-use Akeneo\Tool\Component\Batch\Job\JobRegistry;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
-use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Doctrine\ORM\EntityManagerInterface;
@@ -51,16 +49,14 @@ class BatchCommand extends Command
 
     public function __construct(
         private LoggerInterface $logger,
-        private BatchLogHandler $batchLogHandler,
         private JobRepositoryInterface $jobRepository,
         private ManagerRegistry $doctrine,
         private ValidatorInterface $validator,
         private Notifier $notifier,
-        private JobRegistry $jobRegistry,
         private JobParametersFactory $jobParametersFactory,
         private JobParametersValidator $jobParametersValidator,
-        private string $jobInstanceClass,
-        private string $jobExecutionClass
+        private ExecuteJobExecutionHandler $jobExecutionRunner,
+        private CreateJobExecutionHandler $jobExecutionFactory,
     ) {
         parent::__construct();
     }
@@ -125,59 +121,28 @@ class BatchCommand extends Command
         $executionId = $input->hasArgument('execution') ? $input->getArgument('execution') : null;
 
         if (null !== $executionId && null !== $input->getOption('config')) {
-            throw new \InvalidArgumentException('Configuration option cannot be specified when launching a job execution.');
+            throw new \InvalidArgumentException(
+                'Configuration option cannot be specified when launching a job execution.'
+            );
         }
 
         if (null !== $executionId && $input->hasOption('username') && null !== $input->getOption('username')) {
             throw new \InvalidArgumentException('Username option cannot be specified when launching a job execution.');
         }
 
-        if (null !== $executionId) {
-            /** @var JobExecution $jobExecution */
-            $jobExecution = $this->getJobManager()->getRepository($this->jobExecutionClass)->find($executionId);
-            if (!$jobExecution) {
-                throw new \InvalidArgumentException(sprintf('Could not find job execution "%s".', $executionId));
-            }
-            if (!$jobExecution->getStatus()->isStarting() && !$jobExecution->getStatus()->isStopping()) {
-                throw new \RuntimeException(
-                    sprintf('Job execution "%s" has invalid status: %s', $executionId, $jobExecution->getStatus())
-                );
-            }
-            if (null === $jobExecution->getExecutionContext()) {
-                $jobExecution->setExecutionContext(new ExecutionContext());
-            }
-            $jobInstance = $jobExecution->getJobInstance();
-            $job = $this->jobRegistry->get($jobInstance->getJobName());
-        } else {
-            $code = $input->getArgument('code');
-            $jobInstance = $this->getJobManager()->getRepository($this->jobInstanceClass)->findOneBy(['code' => $code]);
-            if (null === $jobInstance) {
-                throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $code));
-            }
+        $code = $input->getArgument('code');
+        $config = $input->getOption('config') ? $this->decodeConfiguration($input->getOption('config')) : [];
+        $username = $input->getOption('username');
 
-            $job = $this->jobRegistry->get($jobInstance->getJobName());
-            $jobParameters = $this->createJobParameters($job, $jobInstance, $input);
-            $this->validateJobParameters($job, $jobInstance, $jobParameters, $code);
-            $jobExecution = $job->getJobRepository()->createJobExecution($job, $jobInstance, $jobParameters);
-
-            $username = $input->getOption('username');
-            if (null !== $username) {
-                $jobExecution->setUser($username);
-                $job->getJobRepository()->updateJobExecution($jobExecution);
-            }
+        if (null === $executionId) {
+            $jobExecution = $this->jobExecutionFactory->createFromBatchCode($code, $config, $username);
+            $executionId = $jobExecution->getId();
         }
-
-        $jobExecution->setPid(getmypid());
-        $job->getJobRepository()->updateJobExecution($jobExecution);
-
-        $this->batchLogHandler->setSubDirectory($jobExecution->getId());
-
-        $job->execute($jobExecution);
-
-        $job->getJobRepository()->updateJobExecution($jobExecution);
+        $jobExecution = $this->jobExecutionRunner->executeFromJobExecutionId((int)$executionId);
 
         $verbose = $input->getOption('verbose');
-        $exitCode = null;
+        $jobInstance = $jobExecution->getJobInstance();
+
         if (
             ExitStatus::COMPLETED === $jobExecution->getExitStatus()->getExitCode() ||
             (
@@ -271,8 +236,11 @@ class BatchCommand extends Command
         return $this->doctrine->getManager();
     }
 
-    protected function createJobParameters(JobInterface $job, JobInstance $jobInstance, InputInterface $input): JobParameters
-    {
+    protected function createJobParameters(
+        JobInterface $job,
+        JobInstance $jobInstance,
+        InputInterface $input
+    ): JobParameters {
         $rawParameters = $jobInstance->getRawParameters();
 
         $config = $input->getOption('config') ? $this->decodeConfiguration($input->getOption('config')) : [];
@@ -285,8 +253,12 @@ class BatchCommand extends Command
     /**
      * @throws \RuntimeException
      */
-    protected function validateJobParameters(JobInterface $job, JobInstance $jobInstance, JobParameters $jobParameters, string $code) : void
-    {
+    protected function validateJobParameters(
+        JobInterface $job,
+        JobInstance $jobInstance,
+        JobParameters $jobParameters,
+        string $code
+    ): void {
         // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
         // in order to be able to have a working UniqueEntity validation
         $this->getDefaultEntityManager()->merge($jobInstance);

--- a/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/CreateJobExecutionHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/CreateJobExecutionHandler.php
@@ -18,11 +18,11 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
 use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
- * Batch command
+ * Create and persist a new JobExecution for the provided job code
  *
- * @author    JM Leroux
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/MIT MIT
+ * @license   https://opensource.org/licenses/MIT MIT
  */
 class CreateJobExecutionHandler
 {

--- a/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/CreateJobExecutionHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/CreateJobExecutionHandler.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\JobExecution;
+
+use Akeneo\Tool\Component\Batch\Job\JobInterface;
+use Akeneo\Tool\Component\Batch\Job\JobParameters;
+use Akeneo\Tool\Component\Batch\Job\JobParametersFactory;
+use Akeneo\Tool\Component\Batch\Job\JobParametersValidator;
+use Akeneo\Tool\Component\Batch\Job\JobRegistry;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Bridge\Doctrine\ManagerRegistry;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Batch command
+ *
+ * @author    JM Leroux
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class CreateJobExecutionHandler
+{
+    public function __construct(
+        private JobRepositoryInterface $jobRepository,
+        private ManagerRegistry $doctrine,
+        private JobRegistry $jobRegistry,
+        private JobParametersFactory $jobParametersFactory,
+        private JobParametersValidator $jobParametersValidator,
+    ) {
+    }
+
+    public function createFromBatchCode(
+        string $batchCode,
+        array $jobExecutionConfig,
+        ?string $username
+    ): JobExecution {
+        $jobInstance = $this->getJobManager()->getRepository(JobInstance::class)
+            ->findOneBy(['code' => $batchCode]);
+
+        if (null === $jobInstance) {
+            throw new \InvalidArgumentException(sprintf('Could not find job instance "%s".', $batchCode));
+        }
+
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $jobParameters = $this->createJobParameters($job, $jobInstance, $jobExecutionConfig);
+        $this->validateJobParameters($job, $jobInstance, $jobParameters, $batchCode);
+        $jobExecution = $job->getJobRepository()->createJobExecution($job, $jobInstance, $jobParameters);
+
+        if (null !== $username) {
+            $jobExecution->setUser($username);
+            $job->getJobRepository()->updateJobExecution($jobExecution);
+        }
+
+        return $jobExecution;
+    }
+
+    protected function getJobManager(): EntityManagerInterface
+    {
+        return $this->jobRepository->getJobManager();
+    }
+
+    protected function getDefaultEntityManager(): ObjectManager
+    {
+        return $this->doctrine->getManager();
+    }
+
+    protected function createJobParameters(
+        JobInterface $job,
+        JobInstance $jobInstance,
+        array $jobExecutionConfig
+    ): JobParameters {
+        $rawParameters = array_merge($jobInstance->getRawParameters(), $jobExecutionConfig);
+
+        return $this->jobParametersFactory->create($job, $rawParameters);
+    }
+
+    /**
+     * @throws \RuntimeException
+     */
+    protected function validateJobParameters(
+        JobInterface $job,
+        JobInstance $jobInstance,
+        JobParameters $jobParameters,
+        string $code
+    ): void {
+        // We merge the JobInstance from the JobManager EntityManager to the DefaultEntityManager
+        // in order to be able to have a working UniqueEntity validation
+        $this->getDefaultEntityManager()->merge($jobInstance);
+        $errors = $this->jobParametersValidator->validate($job, $jobParameters, ['Default', 'Execution']);
+
+        if (\count($errors) > 0) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Job instance "%s" running the job "%s" with parameters "%s" is invalid because of "%s"',
+                    $code,
+                    $job->getName(),
+                    print_r($jobParameters->all(), true),
+                    $this->getErrorMessages($errors)
+                )
+            );
+        }
+    }
+
+    private function getErrorMessages(ConstraintViolationList $errors): string
+    {
+        $errorsStr = '';
+
+        foreach ($errors as $error) {
+            $errorsStr .= sprintf("\n  - %s", $error);
+        }
+
+        return $errorsStr;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/ExecuteJobExecutionHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/ExecuteJobExecutionHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\JobExecution;
+
+use Akeneo\Tool\Bundle\BatchBundle\Monolog\Handler\BatchLogHandler;
+use Akeneo\Tool\Component\Batch\Item\ExecutionContext;
+use Akeneo\Tool\Component\Batch\Job\JobRegistry;
+use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class ExecuteJobExecutionHandler
+{
+    public function __construct(
+        private BatchLogHandler $batchLogHandler,
+        private JobRepositoryInterface $jobRepository,
+        private JobRegistry $jobRegistry,
+    ) {
+    }
+
+    public function executeFromJobExecutionId(int $executionId): JobExecution
+    {
+        /** @var JobExecution $jobExecution */
+        $jobExecution = $this->getJobManager()->getRepository(JobExecution::class)->find($executionId);
+
+        if (!$jobExecution) {
+            throw new \InvalidArgumentException(sprintf('Could not find job execution "%s".', $executionId));
+        }
+
+        $this->doExecute($jobExecution);
+
+        return $jobExecution;
+    }
+
+    private function doExecute(JobExecution $jobExecution): void
+    {
+        if (!$jobExecution->getStatus()->isStarting() && !$jobExecution->getStatus()->isStopping()) {
+            throw new \RuntimeException(
+                sprintf('Job execution "%s" has invalid status: %s', $jobExecution->getId(), $jobExecution->getStatus())
+            );
+        }
+        if (null === $jobExecution->getExecutionContext()) {
+            $jobExecution->setExecutionContext(new ExecutionContext());
+        }
+
+        $jobInstance = $jobExecution->getJobInstance();
+        $job = $this->jobRegistry->get($jobInstance->getJobName());
+        $jobExecution->setPid(getmypid());
+        $job->getJobRepository()->updateJobExecution($jobExecution);
+
+        $this->batchLogHandler->setSubDirectory($jobExecution->getId());
+
+        $job->execute($jobExecution);
+        $job->getJobRepository()->updateJobExecution($jobExecution);
+    }
+
+    private function getJobManager(): EntityManagerInterface
+    {
+        return $this->jobRepository->getJobManager();
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/ExecuteJobExecutionHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/JobExecution/ExecuteJobExecutionHandler.php
@@ -12,9 +12,11 @@ use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Doctrine\ORM\EntityManagerInterface;
 
 /**
+ * Execute a JobExecution with the provided ID
+ *
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/MIT MIT
+ * @license   https://opensource.org/licenses/MIT MIT
  */
 class ExecuteJobExecutionHandler
 {

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
@@ -2,16 +2,14 @@ services:
     Akeneo\Tool\Bundle\BatchBundle\Command\BatchCommand:
         arguments:
             - '@monolog.logger.batch'
-            - '@akeneo_batch.logger.batch_log_handler'
             - '@akeneo_batch.job_repository'
             - '@doctrine'
             - '@validator'
             - '@akeneo_batch.mail_notifier'
-            - '@akeneo_batch.job.job_registry'
             - '@akeneo_batch.job_parameters_factory'
             - '@akeneo_batch.job.job_parameters_validator'
-            - '%akeneo_batch.entity.job_instance.class%'
-            - '%akeneo_batch.entity.job_execution.class%'
+            - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\ExecuteJobExecutionHandler'
+            - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandler'
         tags:
             - { name: console.command }
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -122,3 +122,17 @@ services:
           - '%kernel.environment%'
         tags:
           - { name: kernel.event_listener, event: console.command }
+
+    Akeneo\Tool\Bundle\BatchBundle\JobExecution\ExecuteJobExecutionHandler:
+        arguments:
+            - '@akeneo_batch.logger.batch_log_handler'
+            - '@akeneo_batch.job_repository'
+            - '@akeneo_batch.job.job_registry'
+
+    Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandler:
+        arguments:
+            - '@akeneo_batch.job_repository'
+            - '@doctrine'
+            - '@akeneo_batch.job.job_registry'
+            - '@akeneo_batch.job_parameters_factory'
+            - '@akeneo_batch.job.job_parameters_validator'

--- a/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/JobExecution/CreateJobExecutionHandlerIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/JobExecution/CreateJobExecutionHandlerIntegration.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\BatchBundle\tests\Integration\JobExecution;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandler;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+
+class CreateJobExecutionHandlerIntegration extends TestCase
+{
+    public function test_create_job_execution_with_job_parameters()
+    {
+        $this->createJobInstance('stoppable_dumb_job');
+
+        $handler = $this->getCreateJobExecutionHandler();
+        $jobExecution = $handler->createFromBatchCode(
+            'stoppable_dumb_job_instance',
+            [],
+            null
+        );
+
+        $result = $this->selectJobExecution($jobExecution->getId());
+
+        $expectedResult = [
+            'status' => '2',
+            'exit_code' => 'UNKNOWN',
+            'raw_parameters' => '[]',
+            'is_stoppable' => '1',
+            'is_visible' => '1',
+        ];
+
+        $this->assertEquals($expectedResult['status'], $result['status']);
+        $this->assertEquals($expectedResult['exit_code'], $result['exit_code']);
+        $this->assertJsonStringEqualsJsonString($expectedResult['raw_parameters'], $result['raw_parameters']);
+        $this->assertEquals($expectedResult['is_stoppable'], $result['is_stoppable']);
+        $this->assertEquals($expectedResult['is_visible'], $result['is_visible']);
+    }
+
+    private function getCreateJobExecutionHandler(): CreateJobExecutionHandler
+    {
+        return $this->get(CreateJobExecutionHandler::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function selectJobExecution(int $id): array
+    {
+        $connection = $this->get('doctrine.orm.default_entity_manager')->getConnection();
+        $stmt = $connection->prepare('SELECT * from akeneo_batch_job_execution where id = :id');
+        $stmt->bindParam('id', $id);
+        $stmt->execute();
+
+        return $stmt->fetch();
+    }
+
+    private function createJobInstance(string $jobName): JobInstance
+    {
+        $jobInstance = new JobInstance('import', 'test', $jobName);
+        $jobInstance->setCode('stoppable_dumb_job_instance');
+        $jobInstanceSaver = $this->get('akeneo_batch.saver.job_instance');
+        $jobInstanceSaver->save($jobInstance);
+
+        return $jobInstance;
+    }
+}


### PR DESCRIPTION
Extract services from the BatchCommand:
- `CreateJobExecutionHandler` for creating the JobExecution when only batch code is provided
- `ExecuteJobExecutionHandler` for effectively executiong the JobExecution

No code changed in the services, I just decoupled them from the Console Input/Ouput interfaces.

This will allow us to reuse these services without being tied to the command, which I will need for UCS.

The BatchCommand main proces is now way simpler:

```
        if (null === $executionId) {
            $jobExecution = $this->jobExecutionFactory->createFromBatchCode($code, $config, $username);
            $executionId = $jobExecution->getId();
        }
        $jobExecution = $this->jobExecutionRunner->executeFromJobExecutionId((int)$executionId);
```

And these services can be reused more or less the same way.