### PR TITLE
CPM-691: Remove triggers introduced during UUID migration + Clean versioning

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
@@ -98,7 +98,7 @@ SQL;
         $allResourceNames = $this->connection->fetchFirstColumn($sql);
         $nextResourceNameToProcess = current(array_filter(
             $allResourceNames,
-            static fn(string $resourceName) => $resourceName !== Product::class
+            static fn (string $resourceName) => $resourceName !== Product::class
         ));
 
         return false !== $nextResourceNameToProcess ? $nextResourceNameToProcess : null;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
@@ -47,9 +47,18 @@ SQL;
     private function cleanVersioningResourceUuid(): void
     {
         $resourceNameToProcess = $this->findNextResourceNameToProcess();
+        $totalVersionsCleaned = 0;
         while (null !== $resourceNameToProcess) {
             $versionIds = $this->getVersionIdsToCleanForResourceName($resourceNameToProcess);
             $this->cleanVersions($versionIds);
+            $totalVersionsCleaned += \count($versionIds);
+            $this->logger->debug(
+                sprintf(
+                    'Cleaned %d versions from their resource_uuid for resource name %s',
+                    $totalVersionsCleaned,
+                    $resourceNameToProcess
+                )
+            );
             $resourceNameToProcess = $this->findNextResourceNameToProcess();
         }
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Platform\Bundle\InstallerBundle\Command\ZddMigration;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions implements ZddMigration
+{
+    public const BLOCKING_TRIGGER_NAME = 'pim_catalog_product_unique_data_uuid_insert';
+
+    public function __construct(private Connection $connection, private LoggerInterface $logger)
+    {
+    }
+
+    public function migrate(): void
+    {
+        if ($this->migrationToRemoveTriggersHasNotRun()) {
+            throw new \LogicException(
+                'Migration Version_7_0_20220728121643_remove_uuid_triggers has to run before executing this ZDD migration.'
+            );
+        }
+        $this->cleanVersioningResourceUuid();
+    }
+
+    public function getName(): string
+    {
+        return 'CleanVersioningResourceUuidColumnForNonProductVersions';
+    }
+
+    private function migrationToRemoveTriggersHasNotRun(): bool
+    {
+        $sql = <<<SQL
+SELECT 1 from information_schema.triggers WHERE TRIGGER_NAME = 'pim_catalog_product_unique_data_uuid_insert';
+SQL;
+        return (bool) $this->connection->fetchOne($sql);
+    }
+
+    private function cleanVersioningResourceUuid(): void
+    {
+        $resourceNameToProcess = $this->findNextResourceNameToProcess();
+        while (null !== $resourceNameToProcess) {
+            $versionIds = $this->getVersionIdsToCleanForResourceName($resourceNameToProcess);
+            $this->cleanVersions($versionIds);
+            $resourceNameToProcess = $this->findNextResourceNameToProcess();
+        }
+    }
+
+    private function findNextResourceNameToProcess(): ?string
+    {
+        // This query takes ~40 secs to execute on a big catalog (4M versions)
+        $sql = <<<SQL
+SELECT DISTINCT resource_name
+FROM pim_versioning_version
+WHERE 
+	resource_uuid IS NOT NULL
+LIMIT 1000;
+SQL;
+
+        $allResourceNames = $this->connection->fetchFirstColumn($sql);
+        $nextResourceNameToProcess = current(array_filter(
+            $allResourceNames,
+            static fn(string $resourceName) => $resourceName !== Product::class
+        ));
+
+        return false !== $nextResourceNameToProcess ? $nextResourceNameToProcess : null;
+    }
+
+    private function cleanVersions(array $versionIdsToClean): void
+    {
+        $emptyResourceUuidQuery = <<<SQL
+UPDATE pim_versioning_version SET resource_uuid = NULL, resource_name = resource_name WHERE id IN (:version_ids);
+SQL;
+        $this->connection->executeStatement(
+            $emptyResourceUuidQuery,
+            ['version_ids' => $versionIdsToClean],
+            ['version_ids' => Connection::PARAM_INT_ARRAY]
+        );
+    }
+
+    private function getVersionIdsToCleanForResourceName(string $resourceName): array
+    {
+        $sql = <<<SQL
+SELECT id
+FROM pim_versioning_version
+WHERE
+	resource_uuid IS NOT NULL
+	AND resource_name = :resource_name
+LIMIT 1000;
+SQL;
+
+        return $this->connection->fetchFirstColumn(
+            $sql,
+            ['resource_name' => $resourceName]
+        );
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
@@ -52,7 +52,28 @@ SQL;
             $versionIds = $this->getVersionIdsToCleanForResourceName($resourceNameToProcess);
             $this->cleanVersions($versionIds);
             $totalVersionsCleaned += \count($versionIds);
+            $this->logger->info(
+                sprintf(
+                    'Cleaned %d versions from their resource_uuid for resource name %s',
+                    $totalVersionsCleaned,
+                    $resourceNameToProcess
+                )
+            );
             $this->logger->notice(
+                sprintf(
+                    'Cleaned %d versions from their resource_uuid for resource name %s',
+                    $totalVersionsCleaned,
+                    $resourceNameToProcess
+                )
+            );
+            $this->logger->debug(
+                sprintf(
+                    'Cleaned %d versions from their resource_uuid for resource name %s',
+                    $totalVersionsCleaned,
+                    $resourceNameToProcess
+                )
+            );
+            $this->logger->warning(
                 sprintf(
                     'Cleaned %d versions from their resource_uuid for resource name %s',
                     $totalVersionsCleaned,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/ZddMigrations/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions.php
@@ -52,7 +52,7 @@ SQL;
             $versionIds = $this->getVersionIdsToCleanForResourceName($resourceNameToProcess);
             $this->cleanVersions($versionIds);
             $totalVersionsCleaned += \count($versionIds);
-            $this->logger->debug(
+            $this->logger->notice(
                 sprintf(
                     'Cleaned %d versions from their resource_uuid for resource name %s',
                     $totalVersionsCleaned,
@@ -61,6 +61,7 @@ SQL;
             );
             $resourceNameToProcess = $this->findNextResourceNameToProcess();
         }
+        $this->logger->notice(sprintf('Successfully cleaned a total of %d versions', $totalVersionsCleaned));
     }
 
     private function findNextResourceNameToProcess(): ?string
@@ -69,9 +70,8 @@ SQL;
         $sql = <<<SQL
 SELECT DISTINCT resource_name
 FROM pim_versioning_version
-WHERE 
-	resource_uuid IS NOT NULL
-LIMIT 1000;
+WHERE resource_uuid IS NOT NULL
+;
 SQL;
 
         $allResourceNames = $this->connection->fetchFirstColumn($sql);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -85,3 +85,10 @@ services:
             - '@database_connection'
         tags:
             - { name: 'akeneo.pim.zdd_migration' }
+
+    Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations\V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions:
+        arguments:
+            - '@database_connection'
+            - '@monolog.logger'
+        tags:
+            - { name: 'akeneo.pim.zdd_migration' }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/MigrateZddCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/MigrateZddCommand.php
@@ -46,14 +46,15 @@ final class MigrateZddCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$this->tableExists('pim_one_time_task')) {
-            $this->logger->warning('%s - skip - Table pim_one_time_task does not exist', [
-                'action' => 'skip',
-            ]);
+            $this->logger->warning(
+                sprintf('%s - skip - Table pim_one_time_task does not exist', self::$defaultName),
+                ['action' => 'skip']
+            );
 
             return Command::SUCCESS;
         }
 
-        $this->logger->info(sprintf('%s - start_command', self::$defaultName), [
+        $this->logger->notice(sprintf('%s - start_command', self::$defaultName), [
             'action' => 'start_command'
         ]);
 
@@ -62,7 +63,7 @@ final class MigrateZddCommand extends Command
         foreach ($this->zddMigrations as $zddMigration) {
             if (!$this->isMigrated($zddMigration)) {
                 try {
-                    $this->logger->info(
+                    $this->logger->notice(
                         sprintf('%s - start_migration - %s', self::$defaultName, $zddMigration->getName()),
                         [
                             'action' => 'start_migration',
@@ -72,7 +73,7 @@ final class MigrateZddCommand extends Command
                     $startMigrationTime = \time();
                     $zddMigration->migrate();
                     $duration = time() - $startMigrationTime;
-                    $this->logger->info(
+                    $this->logger->notice(
                         sprintf('%s - end_migration - %s in %ss', self::$defaultName, $zddMigration->getName(), $duration),
                         [
                             'action' => 'end_migration',
@@ -99,7 +100,7 @@ final class MigrateZddCommand extends Command
             }
         }
 
-        $this->logger->info(sprintf('%s - end_command - %d migration(s) done', self::$defaultName, $migrationCount), [
+        $this->logger->notice(sprintf('%s - end_command - %d migration(s) done', self::$defaultName, $migrationCount), [
             'action' => 'end_command',
             'migrations_done' => $migrationCount,
         ]);

--- a/tests/back/Pim/Enrichment/Integration/Product/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsIntegration.php
@@ -52,7 +52,7 @@ class V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsInteg
 
     public function test_it_throws_if_the_migration_that_removes_triggers_has_not_run()
     {
-        $this->createBlockingTrigger();
+        $this->givenTheMigrationThatRemovesTriggerHasNotRun();
 
         $this->expectException(\LogicException::class);
         $this->migrationToTest->migrate();
@@ -105,7 +105,7 @@ SQL;
         return $stmt->fetchOne();
     }
 
-    private function createBlockingTrigger(): void
+    private function givenTheMigrationThatRemovesTriggerHasNotRun(): void
     {
         $createDummyTriggerQuery = <<<SQL
 CREATE TRIGGER {trigger_name}

--- a/tests/back/Pim/Enrichment/Integration/Product/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsIntegration.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+class V20220729171405CleanVersioningResourceUuidColumnForNonProductVersionsIntegration extends TestCase
+{
+    private const PRODUCT_VERSION_ID = 1;
+    private const NON_PRODUCT_VERSION_ID = 2;
+
+    private Connection $connection;
+    private V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions $migrationToTest;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+        $this->migrationToTest = $this->get(V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->connection->executeStatement(
+            sprintf(
+                'DROP TRIGGER IF EXISTS %s;',
+                V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions::BLOCKING_TRIGGER_NAME
+            )
+        );
+    }
+
+    public function test_it_empties_the_resource_uuid_when_the_version_is_not_product_related()
+    {
+        $this->createProductRelatedVersionWithResourceUuid();
+        $this->createNonProductRelatedVersionWithResourceUuid();
+
+        $this->migrationToTest->migrate();
+
+        $this->assertProductRelatedVersionHasResourceUuid();
+        $this->assertNonProductRelatedVersionHasNoResourceUuid();
+    }
+
+    public function test_it_throws_if_the_migration_that_removes_triggers_has_not_run()
+    {
+        $this->createBlockingTrigger();
+
+        $this->expectException(\LogicException::class);
+        $this->migrationToTest->migrate();
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createProductRelatedVersionWithResourceUuid(): void
+    {
+        $sql = <<<SQL
+INSERT INTO `pim_versioning_version` (`id`, `author`, `resource_name`, `resource_id`, `resource_uuid`, `snapshot`, `changeset`, `context`, `version`, `logged_at`, `pending`)
+VALUES
+	(:version_id, 'system', :resource_name, NULL, 'A_UUID', 'a:11:{s:6:\"family\";s:16:\"multifunctionals\";s:6:\"groups\";s:0:\"\";s:10:\"categories\";s:41:\"lexmark,multifunctionals,print_scan_sales\";s:6:\"parent\";s:0:\"\";s:14:\"color_scanning\";s:1:\"0\";s:23:\"description-en_US-print\";s:1477:\"<b>Streamlined Reliability</b>\\nA smart, reliable option for bringing duplex printing, copying, scanning and high-speed faxing into one machine, with up to 40 ppm and the ability to scan documents straight to e-mail or a flash drive.\\n\\n<b>As Easy as It Gets</b>\\nRight out of the box, you’ll power through tasks at exceptionally fast speeds—up to 40 ppm. It’s a breeze to set up, install, and start enjoying the benefit of doing all those multiple tasks on one user-friendly machine.\\n\\n<b>Smarter Printer, Smarter Business</b>\\nThe large LCD color touch screen offers amazingly simple access to a rich range of features, including duplex scanning, advanced copying and easy user authorization for enhanced security. You can even customize the touch screen to meet your workgroup’s specific needs.\\n\\n<b>Small in Size, Huge on Features</b>\\nEnjoy an intelligent, efficient combination of built-in features like duplex printing, copying and scanning plus a front Direct USB port. Gives you the ability to scan to multiple destinations, letting your workgroup breeze through intense workloads.\\n\\n<b>Save the Earth and Money</b>\\nLower your cost per page while helping conserve resources with up to 9,000*-page or 15,000*-page replacement cartridges. Add that to the automatic duplex printing and the energy savings of consolidating to one smart device, and you’re taking big steps toward an eco-conscious workplace. (*Declared yield in accordance with ISO/IEC 19752.)\";s:18:\"maximum_print_size\";s:19:\"legal_216_x_356_mm_\";s:4:\"name\";s:14:\"Lexmark X464de\";s:22:\"release_date-ecommerce\";s:25:\"2012-04-20T00:00:00+00:00\";s:3:\"sku\";s:8:\"13871461\";s:7:\"enabled\";i:1;}', 'a:9:{s:6:\"family\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:16:\"multifunctionals\";}s:10:\"categories\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:41:\"lexmark,multifunctionals,print_scan_sales\";}s:14:\"color_scanning\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:1:\"0\";}s:23:\"description-en_US-print\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:1477:\"<b>Streamlined Reliability</b>\\nA smart, reliable option for bringing duplex printing, copying, scanning and high-speed faxing into one machine, with up to 40 ppm and the ability to scan documents straight to e-mail or a flash drive.\\n\\n<b>As Easy as It Gets</b>\\nRight out of the box, you’ll power through tasks at exceptionally fast speeds—up to 40 ppm. It’s a breeze to set up, install, and start enjoying the benefit of doing all those multiple tasks on one user-friendly machine.\\n\\n<b>Smarter Printer, Smarter Business</b>\\nThe large LCD color touch screen offers amazingly simple access to a rich range of features, including duplex scanning, advanced copying and easy user authorization for enhanced security. You can even customize the touch screen to meet your workgroup’s specific needs.\\n\\n<b>Small in Size, Huge on Features</b>\\nEnjoy an intelligent, efficient combination of built-in features like duplex printing, copying and scanning plus a front Direct USB port. Gives you the ability to scan to multiple destinations, letting your workgroup breeze through intense workloads.\\n\\n<b>Save the Earth and Money</b>\\nLower your cost per page while helping conserve resources with up to 9,000*-page or 15,000*-page replacement cartridges. Add that to the automatic duplex printing and the energy savings of consolidating to one smart device, and you’re taking big steps toward an eco-conscious workplace. (*Declared yield in accordance with ISO/IEC 19752.)\";}s:18:\"maximum_print_size\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:19:\"legal_216_x_356_mm_\";}s:4:\"name\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:14:\"Lexmark X464de\";}s:22:\"release_date-ecommerce\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:25:\"2012-04-20T00:00:00+00:00\";}s:3:\"sku\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:8:\"13871461\";}s:7:\"enabled\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";i:1;}}', NULL, 1, '2022-07-27 16:20:49', 0);
+SQL;
+        $this->connection->executeStatement($sql, ['version_id' => self::PRODUCT_VERSION_ID, 'resource_name' => Product::class]);
+    }
+
+    private function createNonProductRelatedVersionWithResourceUuid(): void
+    {
+        $sql = <<<SQL
+INSERT INTO `pim_versioning_version` (`id`, `author`, `resource_name`, `resource_id`, `resource_uuid`, `snapshot`, `changeset`, `context`, `version`, `logged_at`, `pending`)
+VALUES
+	(:version_id, 'system', 'Akeneo\\Channel\\Infrastructure\\Component\\Model\\Locale', '6', 'A_UUID', 'a:3:{s:4:\"code\";s:5:\"ar_EG\";s:15:\"view_permission\";s:0:\"\";s:15:\"edit_permission\";s:0:\"\";}', 'a:1:{s:4:\"code\";a:2:{s:3:\"old\";s:0:\"\";s:3:\"new\";s:5:\"ar_EG\";}}', NULL, 1, '2022-07-27 16:20:26', 0);
+SQL;
+        $this->connection->executeStatement($sql, ['version_id' => self::NON_PRODUCT_VERSION_ID]);
+    }
+
+    private function assertProductRelatedVersionHasResourceUuid(): void
+    {
+        $result = $this->fetchResourceIdForVersion(self::PRODUCT_VERSION_ID);
+        $this->assertNotNull($result);
+    }
+
+    private function assertNonProductRelatedVersionHasNoResourceUuid(): void
+    {
+        $result = $this->fetchResourceIdForVersion(self::NON_PRODUCT_VERSION_ID);
+        $this->assertNull($result);
+    }
+
+    private function fetchResourceIdForVersion(int $versionId): ?string
+    {
+        $stmt = $this->connection->executeQuery(
+            'SELECT resource_uuid FROM pim_versioning_version WHERE id = :version_id',
+            ['version_id' => $versionId]
+        );
+
+        return $stmt->fetchOne();
+    }
+
+    private function createBlockingTrigger(): void
+    {
+        $createDummyTriggerQuery = <<<SQL
+CREATE TRIGGER {trigger_name}
+BEFORE INSERT ON pim_catalog_category_product FOR EACH ROW
+BEGIN
+IF NEW.product_uuid IS NULL THEN SET NEW.category_id = 1;
+END IF;
+END
+SQL;
+        $query = \strtr(
+            $createDummyTriggerQuery,
+            ['{trigger_name}' => V20220729171405CleanVersioningResourceUuidColumnForNonProductVersions::BLOCKING_TRIGGER_NAME]
+        );
+        $this->connection->executeStatement($query);
+    }
+}

--- a/upgrades/schema/Version_7_0_20220728121643_remove_uuid_triggers.php
+++ b/upgrades/schema/Version_7_0_20220728121643_remove_uuid_triggers.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\IrreversibleMigration;
+
+/**
+ * Remove triggers added in the UUID migration which add triggers on foreign uuid column.
+ * @see https://github.com/akeneo/pim-community-dev/blob/77be7d26721554834bbbabae39bf6f11a90f77ac/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidAddTriggers.php#L15
+ */
+final class Version_7_0_20220728121643_remove_uuid_triggers extends AbstractMigration
+{
+    public const TRIGGERS_TO_REMOVE = [
+        'pim_catalog_association_uuid_insert',
+        'pim_catalog_association_uuid_update',
+        'pim_catalog_association_product_uuid_insert',
+        'pim_catalog_association_product_uuid_update',
+        'pim_catalog_association_product_model_to_product_uuid_insert',
+        'pim_catalog_association_product_model_to_product_uuid_update',
+        'pim_catalog_category_product_uuid_insert',
+        'pim_catalog_category_product_uuid_update',
+        'pim_catalog_group_product_uuid_insert',
+        'pim_catalog_group_product_uuid_update',
+        'pim_catalog_product_unique_data_uuid_insert',
+        'pim_catalog_product_unique_data_uuid_update',
+        'pim_catalog_completeness_uuid_insert',
+        'pim_catalog_completeness_uuid_update',
+        'pim_dqi_product_criteria_evaluation_uuid_insert',
+        'pim_dqi_product_criteria_evaluation_uuid_update',
+        'pim_dqi_product_score_uuid_insert',
+        'pim_dqi_product_score_uuid_update',
+        'pim_versioning_version_uuid_insert',
+        'pim_versioning_version_uuid_update',
+        'pim_comment_comment_uuid_insert',
+        'pim_comment_comment_uuid_update',
+        'pimee_workflow_product_draft_uuid_insert',
+        'pimee_workflow_product_draft_uuid_update',
+        'pimee_workflow_published_product_uuid_insert',
+        'pimee_workflow_published_product_uuid_update',
+        'pimee_twa_completeness_per_attribute_group_uuid_insert',
+        'pimee_twa_completeness_per_attribute_group_uuid_update',
+        'pimee_twa_project_product_uuid_insert',
+        'pimee_twa_project_product_uuid_update',
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Remove UUID triggers';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach(self::TRIGGERS_TO_REMOVE as $triggerToRemove) {
+            $this->addSql(sprintf('DROP TRIGGER IF EXISTS %s', $triggerToRemove));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        throw new IrreversibleMigration();
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220722090828_remove_old_file_path_on_product_and_product_model_quick_export_job_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220722090828_remove_old_file_path_on_product_and_product_model_quick_export_job_Integration.php
@@ -2,8 +2,6 @@
 
 namespace Pim\Upgrade\Schema\Tests;
 
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;

--- a/upgrades/test_schema/Version_7_0_20220728121643_remove_uuid_triggers_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220728121643_remove_uuid_triggers_Integration.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use Pim\Upgrade\Schema\Tests\ExecuteMigrationTrait;
+
+
+/**
+ * Remove triggers added in the UUID migration which add triggers on foreign uuid column.
+ * @see https://github.com/akeneo/pim-community-dev/blob/77be7d26721554834bbbabae39bf6f11a90f77ac/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidAddTriggers.php#L15
+ */
+final class Version_7_0_20220728121643_remove_uuid_triggers_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+    private const MIGRATION_LABEL = '_7_0_20220728121643_remove_uuid_triggers';
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_removes_the_triggers(): void
+    {
+        $this->createDummyTriggersToBeRemoved();
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->assertTriggersRemoved();
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createDummyTriggersToBeRemoved(): void
+    {
+        $createDummyTriggerQuery = <<<SQL
+Create Trigger {trigger_name}
+BEFORE INSERT ON pim_catalog_category_product FOR EACH ROW  
+BEGIN  
+IF NEW.product_uuid IS NULL THEN SET NEW.category_id = 1;  
+END IF;  
+END
+SQL;
+        foreach(Version_7_0_20220728121643_remove_uuid_triggers::TRIGGERS_TO_REMOVE as $triggerName) {
+            $query = \strtr($createDummyTriggerQuery, ['{trigger_name}' => $triggerName]);
+            $this->connection->executeStatement($query);
+        }
+    }
+
+    private function assertTriggersRemoved(): void
+    {
+        $stmt = $this->connection->executeQuery('SHOW TRIGGERS;');
+        $result = $stmt->fetchFirstColumn();
+        $this->assertEmpty($result);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR introduces 2 migrations:
- A Doctrine migration to drop all triggers during the UUID migration project
- A ZDD migration which empties the `pim_versioning_version.resource_uuid` for versions that are not product related.
    - When running the command `pim:zdd-migration:migrate` we can see the migration updates successfully
<img width="1017" alt="Screenshot 2022-07-29 at 16 30 47" src="https://user-images.githubusercontent.com/1826473/181782361-35d08ffc-473c-4762-a8d4-677ebc0c036a.png">


**Definition Of Done (for Core Developer only)**

- [x] Tests
