### PR TITLE
PIM-10561: Fix associationUserIntentFactory to cast in to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - PIM-10528: Fix escaped special characters in page titles
 - PIM-10541: Fix SetTableValue userIntent to allow null data in enrichment Service Api
 - PIM-10543: Fix selected categories sent to listCategories
+- PIM-10561: Fix associationUserIntentFactory to cast int to string
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/AssociationsUserIntentFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/AssociationsUserIntentFactory.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Product\Domain\UserIntent\Factory;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\ReplaceAssociatedGroups;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\ReplaceAssociatedProductModels;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\ReplaceAssociatedProducts;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
@@ -44,13 +43,13 @@ class AssociationsUserIntentFactory implements UserIntentFactory
                 $this->validateScalarArray('association', $associationsByEntity);
             }
             if (\array_key_exists('products', $associations)) {
-                $userIntents[] = new ReplaceAssociatedProducts($associationType, $associations['products']);
+                $userIntents[] = new ReplaceAssociatedProducts((string) $associationType, $associations['products']);
             }
             if (\array_key_exists('product_models', $associations)) {
-                $userIntents[] = new ReplaceAssociatedProductModels($associationType, $associations['product_models']);
+                $userIntents[] = new ReplaceAssociatedProductModels((string) $associationType, $associations['product_models']);
             }
             if (\array_key_exists('groups', $associations)) {
-                $userIntents[] = new ReplaceAssociatedGroups($associationType, $associations['groups']);
+                $userIntents[] = new ReplaceAssociatedGroups((string) $associationType, $associations['groups']);
             }
         }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/QuantifiedAssociationUserIntentFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/UserIntent/Factory/QuantifiedAssociationUserIntentFactory.php
@@ -40,14 +40,14 @@ class QuantifiedAssociationUserIntentFactory implements UserIntentFactory
                     fn ($association) => new QuantifiedEntity($association['identifier'], $association['quantity']),
                     $associations['products']
                 );
-                $userIntents[] = new ReplaceAssociatedQuantifiedProducts($associationType, $productQuantityValues);
+                $userIntents[] = new ReplaceAssociatedQuantifiedProducts((string)$associationType, $productQuantityValues);
             }
             if (\array_key_exists('product_models', $associations)) {
                 $productModelQuantityValues = \array_map(
                     fn ($association) => new QuantifiedEntity($association['identifier'], $association['quantity']),
                     $associations['product_models']
                 );
-                $userIntents[] = new ReplaceAssociatedQuantifiedProductModels($associationType, $productModelQuantityValues);
+                $userIntents[] = new ReplaceAssociatedQuantifiedProductModels((string)$associationType, $productModelQuantityValues);
             }
         }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/AssociationsUserIntentFactorySpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/AssociationsUserIntentFactorySpec.php
@@ -28,6 +28,11 @@ class AssociationsUserIntentFactorySpec extends ObjectBehavior
                 'products' => [],
                 'product_models' => ['code1', 'code2'],
                 'groups' => [],
+            ],
+            11 => [
+                'products' => ['identifier1'],
+                'product_models' => [],
+                'groups' => [],
             ]
         ])->shouldBeLike([
             new ReplaceAssociatedProducts('PACK', ['identifier1', 'identifier2']),
@@ -36,6 +41,9 @@ class AssociationsUserIntentFactorySpec extends ObjectBehavior
             new ReplaceAssociatedProducts('X_SELL', []),
             new ReplaceAssociatedProductModels('X_SELL', ['code1', 'code2']),
             new ReplaceAssociatedGroups('X_SELL', []),
+            new ReplaceAssociatedProducts('11', ['identifier1']),
+            new ReplaceAssociatedProductModels('11', []),
+            new ReplaceAssociatedGroups('11', []),
         ]);
     }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/QuantifiedAssociationUserIntentFactorySpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Domain/UserIntent/Factory/QuantifiedAssociationUserIntentFactorySpec.php
@@ -23,7 +23,7 @@ class QuantifiedAssociationUserIntentFactorySpec extends ObjectBehavior
 
     function it_returns_quantified_association_user_intents()
     {
-        $this->create('associations', [
+        $this->create('quantified_associations', [
             'QUANTIFIED_ASS' => [
                 'products' => [
                     ['identifier' => 'identifier1', 'quantity' => 10],
@@ -33,7 +33,15 @@ class QuantifiedAssociationUserIntentFactorySpec extends ObjectBehavior
                     ['identifier' => 'code1', 'quantity' => 20],
                     ['identifier' => 'code2', 'quantity' => 10]
                 ],
-            ]
+            ],
+            '123' => [
+                'products' => [
+                    ['identifier' => 'foo', 'quantity' => 2],
+                ],
+                'product_models' => [
+                    ['identifier' => 'bar', 'quantity' => 5],
+                ],
+            ],
         ])->shouldBeLike([
             new ReplaceAssociatedQuantifiedProducts('QUANTIFIED_ASS', [
                 new QuantifiedEntity('identifier1', 10),
@@ -42,6 +50,12 @@ class QuantifiedAssociationUserIntentFactorySpec extends ObjectBehavior
             new ReplaceAssociatedQuantifiedProductModels('QUANTIFIED_ASS', [
                 new QuantifiedEntity('code1', 20),
                 new QuantifiedEntity('code2', 10),
+            ]),
+            new ReplaceAssociatedQuantifiedProducts('123', [
+                new QuantifiedEntity('foo', 2),
+            ]),
+            new ReplaceAssociatedQuantifiedProductModels('123', [
+                new QuantifiedEntity('bar', 5),
             ]),
         ]);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Associations codes can come as an int value whearas the userIntent expects a string, so we cast it in the factory

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
