### PR TITLE
CXP-1253: Added notifications to user when  catalog is saved

### DIFF
--- a/components/catalogs/front/src/FakeCatalogEditContainer.tsx
+++ b/components/catalogs/front/src/FakeCatalogEditContainer.tsx
@@ -26,16 +26,16 @@ type Props = {};
 const FakeCatalogEditContainer: FC<PropsWithChildren<Props>> = () => {
     const {id} = useParams<{id: string}>();
     const [form, save, isDirty] = useCatalogForm(id);
-    const deps = useDependenciesContext();
+    const {notify} = useDependenciesContext();
 
     const saveHandler = async () => {
         const isSaveSuccessful = await save();
 
-        if (deps.notify) {
+        if (notify) {
             if (isSaveSuccessful) {
-                deps.notify(NotificationLevel.SUCCESS, 'Catalog is saved');
+                notify(NotificationLevel.SUCCESS, 'Catalog is saved');
             } else {
-                deps.notify(NotificationLevel.ERROR, 'Catalog have errors');
+                notify(NotificationLevel.ERROR, 'Catalog have errors');
             }
         }
     };

--- a/components/catalogs/front/src/FakeCatalogEditContainer.tsx
+++ b/components/catalogs/front/src/FakeCatalogEditContainer.tsx
@@ -1,4 +1,4 @@
-import React, {FC, PropsWithChildren} from 'react';
+import React, {FC, PropsWithChildren, useState} from 'react';
 import {useParams} from 'react-router';
 import {CatalogEdit, useCatalogForm} from './components/CatalogEdit';
 import {Button} from 'akeneo-design-system';
@@ -20,11 +20,31 @@ const DirtyWarning = styled.div`
     margin: 8px 0 0;
 `;
 
+const SuccessMessage = styled.div`
+    font-style: italic;
+    color: #67b373;
+    border-bottom: 1px solid #3d6b45;
+    margin: 8px 0 0;
+`;
+
+const ErrorsMessage = styled.div`
+    font-style: italic;
+    color: #d4604f;
+    border-bottom: 1px solid #7f392f;
+    margin: 8px 0 0;
+`;
+
 type Props = {};
 
 const FakeCatalogEditContainer: FC<PropsWithChildren<Props>> = () => {
     const {id} = useParams<{id: string}>();
     const [form, save, isDirty] = useCatalogForm(id);
+    const [isSuccess, setSuccess] = useState<boolean | null>(null);
+
+    const saveHandler = async () => {
+        const isSaveSuccessful = await save();
+        setSuccess(isSaveSuccessful);
+    };
 
     if (undefined === form) {
         return null;
@@ -33,10 +53,12 @@ const FakeCatalogEditContainer: FC<PropsWithChildren<Props>> = () => {
     return (
         <>
             <TopRightContainer>
-                <Button level='primary' onClick={save} disabled={!isDirty} className={'AknButton'}>
+                <Button level='primary' onClick={saveHandler} disabled={!isDirty} className={'AknButton'}>
                     Save
                 </Button>
                 {isDirty && <DirtyWarning>⚠️ There are unsaved changes.</DirtyWarning>}
+                {isSuccess && <SuccessMessage>Catalog is saved</SuccessMessage>}
+                {isSuccess === false && <ErrorsMessage>Catalog have errors</ErrorsMessage>}
             </TopRightContainer>
             <CatalogEdit form={form} />
         </>

--- a/components/catalogs/front/src/FakeCatalogEditContainer.tsx
+++ b/components/catalogs/front/src/FakeCatalogEditContainer.tsx
@@ -1,8 +1,9 @@
-import React, {FC, PropsWithChildren, useState} from 'react';
+import React, {FC, PropsWithChildren} from 'react';
 import {useParams} from 'react-router';
 import {CatalogEdit, useCatalogForm} from './components/CatalogEdit';
 import {Button} from 'akeneo-design-system';
 import styled from 'styled-components';
+import {NotificationLevel, useDependenciesContext} from '@akeneo-pim-community/shared';
 
 const TopRightContainer = styled.div`
     position: absolute;
@@ -20,30 +21,23 @@ const DirtyWarning = styled.div`
     margin: 8px 0 0;
 `;
 
-const SuccessMessage = styled.div`
-    font-style: italic;
-    color: #67b373;
-    border-bottom: 1px solid #3d6b45;
-    margin: 8px 0 0;
-`;
-
-const ErrorsMessage = styled.div`
-    font-style: italic;
-    color: #d4604f;
-    border-bottom: 1px solid #7f392f;
-    margin: 8px 0 0;
-`;
-
 type Props = {};
 
 const FakeCatalogEditContainer: FC<PropsWithChildren<Props>> = () => {
     const {id} = useParams<{id: string}>();
     const [form, save, isDirty] = useCatalogForm(id);
-    const [isSuccess, setSuccess] = useState<boolean | null>(null);
+    const deps = useDependenciesContext();
 
     const saveHandler = async () => {
         const isSaveSuccessful = await save();
-        setSuccess(isSaveSuccessful);
+
+        if (deps.notify) {
+            if (isSaveSuccessful) {
+                deps.notify(NotificationLevel.SUCCESS, 'Catalog is saved');
+            } else {
+                deps.notify(NotificationLevel.ERROR, 'Catalog have errors');
+            }
+        }
     };
 
     if (undefined === form) {
@@ -57,8 +51,6 @@ const FakeCatalogEditContainer: FC<PropsWithChildren<Props>> = () => {
                     Save
                 </Button>
                 {isDirty && <DirtyWarning>⚠️ There are unsaved changes.</DirtyWarning>}
-                {isSuccess && <SuccessMessage>Catalog is saved</SuccessMessage>}
-                {isSuccess === false && <ErrorsMessage>Catalog have errors</ErrorsMessage>}
             </TopRightContainer>
             <CatalogEdit form={form} />
         </>

--- a/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogForm.ts
+++ b/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogForm.ts
@@ -12,7 +12,7 @@ export type CatalogForm = {
     errors: CatalogFormErrors;
 };
 type Dispatch = (action: CatalogFormAction) => void;
-type Save = () => Promise<void>;
+type Save = () => Promise<boolean>;
 type IsDirty = boolean;
 type Result = [CatalogForm | undefined, Save, IsDirty];
 
@@ -46,6 +46,8 @@ export const useCatalogForm = (id: string): Result => {
         } else {
             setErrors(errors);
         }
+
+        return success;
     };
 
     const isDirtyMiddleware: (dispatch: Dispatch) => Dispatch = useCallback(

--- a/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogForm.unit.ts
+++ b/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogForm.unit.ts
@@ -102,7 +102,8 @@ test('it calls the API when save is called', async () => {
     const [form, save, isDirty] = result.current;
 
     await act(async () => {
-        await save();
+        const isSaveSuccessful = await save();
+        expect(isSaveSuccessful).toBeTruthy();
     });
 
     expect(saveCatalog).toHaveBeenCalledWith({
@@ -154,7 +155,8 @@ test('it returns validation errors if the API call failed', async () => {
     const [form, save, isDirty] = result.current;
 
     await act(async () => {
-        await save();
+        const isSaveSuccessful = await save();
+        expect(isSaveSuccessful).toBeFalsy();
     });
 
     expect(result.current).toMatchObject([

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -184,8 +184,8 @@ akeneo_connectivity.connection:
                     edit:
                         flash:
                             success: Catalog settings successfully updated.
-                            warning: The catalog could not be saved. Please resolve displayed errors, then save again.
-                            error: An error occurred while saving the catalog.
+                            error: The catalog could not be saved. Please resolve displayed errors, then save again.
+                            unknown_error: An error occurred while saving the catalog.
                         not_found: Catalog not found
                 flash:
                     load_permissions_error.title: 'Saved permissions on {{ entity }} could not be loaded.'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -182,6 +182,10 @@ akeneo_connectivity.connection:
                             3: in the settings.
                 catalogs:
                     edit:
+                        flash:
+                            success: Catalog settings successfully updated.
+                            warning: The catalog could not be saved. Please resolve displayed errors, then save again.
+                            error: An error occurred while saving the catalog.
                         not_found: Catalog not found
                 flash:
                     load_permissions_error.title: 'Saved permissions on {{ entity }} could not be loaded.'

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/Catalog/ConnectedAppCatalogContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/Catalog/ConnectedAppCatalogContainer.tsx
@@ -8,6 +8,7 @@ import {ApplyButton, PageContent, PageHeader} from '../../../../common';
 import {UserButtons} from '../../../../shared/user';
 import {DeveloperModeTag} from '../../DeveloperModeTag';
 import {CatalogEdit, useCatalogForm} from '@akeneo-pim-community/catalogs';
+import {NotificationLevel, useNotify} from '../../../../shared/notify';
 
 type Props = {
     connectedApp: ConnectedApp;
@@ -17,6 +18,7 @@ type Props = {
 export const ConnectedAppCatalogContainer: FC<Props> = ({connectedApp, catalog}) => {
     const translate = useTranslate();
     const generateUrl = useRouter();
+    const notify = useNotify();
     const dashboardHref = `#${generateUrl('akeneo_connectivity_connection_audit_index')}`;
     const connectedAppsListHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps')}`;
     const connectedAppHref = `#${generateUrl('akeneo_connectivity_connection_connect_connected_apps_edit', {
@@ -24,9 +26,25 @@ export const ConnectedAppCatalogContainer: FC<Props> = ({connectedApp, catalog})
     })}`;
     const [form, save, isDirty] = useCatalogForm(catalog.id);
 
+    const handleSave = async () => {
+        try {
+            const success = await save();
+
+            const message = success
+                ? 'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.success'
+                : 'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.warning';
+            notify(success ? NotificationLevel.SUCCESS : NotificationLevel.WARNING, translate(message));
+        } catch (error) {
+            notify(
+                NotificationLevel.ERROR,
+                translate('akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.error')
+            );
+        }
+    };
+
     const SaveButton = () => {
         return (
-            <ApplyButton onClick={save} disabled={!isDirty} classNames={['AknButtonList-item']}>
+            <ApplyButton onClick={handleSave} disabled={!isDirty} classNames={['AknButtonList-item']}>
                 <Translate id='pim_common.save' />
             </ApplyButton>
         );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/Catalog/ConnectedAppCatalogContainer.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/ConnectedApp/Catalog/ConnectedAppCatalogContainer.tsx
@@ -32,12 +32,14 @@ export const ConnectedAppCatalogContainer: FC<Props> = ({connectedApp, catalog})
 
             const message = success
                 ? 'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.success'
-                : 'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.warning';
-            notify(success ? NotificationLevel.SUCCESS : NotificationLevel.WARNING, translate(message));
+                : 'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.error';
+            notify(success ? NotificationLevel.SUCCESS : NotificationLevel.ERROR, translate(message));
         } catch (error) {
             notify(
                 NotificationLevel.ERROR,
-                translate('akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.error')
+                translate(
+                    'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.unknown_error'
+                )
             );
         }
     };

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/Catalog/ConnectAppCatalogContainer.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/Catalog/ConnectAppCatalogContainer.test.tsx
@@ -78,8 +78,8 @@ test('The save button click triggers save that results in a user error', async (
 
     await waitFor(() => {
         expect(notify).toBeCalledWith(
-            NotificationLevel.WARNING,
-            'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.warning'
+            NotificationLevel.ERROR,
+            'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.error'
         );
     });
 });
@@ -95,7 +95,7 @@ test('The save button click triggers save that results in a server error', async
     await waitFor(() => {
         expect(notify).toBeCalledWith(
             NotificationLevel.ERROR,
-            'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.error'
+            'akeneo_connectivity.connection.connect.connected_apps.edit.catalogs.edit.flash.unknown_error'
         );
     });
 });


### PR DESCRIPTION
 - Catalog save returns a boolean that indicates save success
 - Added notification inside connectivity to notify when the catalog is saved
 - Updated the fake catalog edit container to have some feedback on save
 
 Need feedback on: If catalogs cannot be saved due to user error notification is a warning