### PR TITLE
Do not throw an exception when filepath is null

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Validation/FilePathValidator.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Validation/FilePathValidator.php
@@ -16,6 +16,10 @@ class FilePathValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, FilePath::class);
         }
 
+        if (null === $value) {
+            return;
+        }
+
         $this->validateFileExtension($value, $constraint->getSupportedFileExtensions());
     }
 

--- a/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/Storage/ValidateLocalStorageTest.php
+++ b/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/Storage/ValidateLocalStorageTest.php
@@ -39,6 +39,12 @@ class ValidateLocalStorageTest extends AbstractValidationTest
                     'file_path' => '/tmp/products.xlsx',
                 ],
             ],
+            'a storage with null file_path' => [
+                [
+                    'type' => 'local',
+                    'file_path' => null,
+                ],
+            ]
         ];
     }
 

--- a/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/Storage/ValidateNoneStorageTest.php
+++ b/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/Storage/ValidateNoneStorageTest.php
@@ -38,6 +38,12 @@ class ValidateNoneStorageTest extends AbstractValidationTest
                     'type' => 'none',
                 ],
             ],
+            'a storage with null file_path' => [
+                [
+                    'type' => 'none',
+                    'file_path' => null,
+                ],
+            ]
         ];
     }
 

--- a/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/ValidateFilePathTest.php
+++ b/tests/back/Platform/Acceptance/ImportExport/Infrastructure/Validation/ValidateFilePathTest.php
@@ -11,7 +11,7 @@ class ValidateFilePathTest extends AbstractValidationTest
     /**
      * @dataProvider validFilePath
      */
-    public function test_it_does_not_build_violations_when_file_path_are_valid(string $value): void
+    public function test_it_does_not_build_violations_when_file_path_are_valid(mixed $value): void
     {
         $violations = $this->getValidator()->validate($value, new FilePath(['xlsx', 'xls']));
 
@@ -37,6 +37,7 @@ class ValidateFilePathTest extends AbstractValidationTest
             'valid file path' => [
                 '/tmp/file.xlsx',
             ],
+            'a null file path' => [null],
         ];
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
Actually, import jobs have an null filePath problem is that it throw an error 500 on save. In this PR, we fixed that.

Now we early return when value is null. 

```
Uncaught PHP Exception TypeError: "Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Validation\FilePathValidator::validateFileExtension(): Argument #1 ($filePath) must be of type string, null given, called in /srv/pim/vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Validation/FilePathValidator.php on line 19" at /srv/pim/vendor/akeneo/pim-community-dev/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Validation/FilePathValidator.php line 22
```

We tried to use validation groups in order to check that the file_path is not empty when we launched the job execution (job launch vs job save).

Problem is that we cannot do it because we use validator inside the validator so we didn't have anymore the initial group. In Symfony, the validator validate the first group given then remove the contraints already validated and then validate the constraint with the next group and retry on all other groups. We pass on ```src/Akeneo/Tool/Component/Connector/Job/JobParameters/ConstraintCollectionProvider/SimpleXlsxImport.php``` then on ```src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Validation/StorageValidator.php``` but when we are in StorageValidator we didn't know which groups will be validated only the current group so we cannot launch the validator with the right groups
 
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
