### PR TITLE
PIM-10556: Fix cannot create a measurement attribute if measurement family or unit code is too long

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10556: [Backport PIM-10214] Fix can't create a measurement attribute if measurement family or unit code is too long
+
 # 5.0.104 (2022-07-11)
 
 # 5.0.103 (2022-07-11)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Attribute.orm.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/model/doctrine/Attribute.orm.yml
@@ -74,12 +74,12 @@ Akeneo\Pim\Structure\Component\Model\Attribute:
             column: date_max
         metricFamily:
             type: string
-            length: 30
+            length: 100
             nullable: true
             column: metric_family
         defaultMetricUnit:
             type: string
-            length: 30
+            length: 100
             nullable: true
             column: default_metric_unit
         maxFileSize:

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
@@ -10,16 +11,19 @@ use Symfony\Component\Validator\Validation;
 
 class CodeValidator extends ConstraintValidator
 {
-    private const MAX_CODE_LENGTH = 255;
+    private const MAX_CODE_LENGTH = 100;
 
     public function validate($code, Constraint $constraint)
     {
         $validator = Validation::createValidator();
-        $violations = $validator->validate($code, [
+        $violations = $validator->validate(
+            $code,
+            [
                 new Constraints\NotBlank(),
                 new Constraints\Type(['type' => 'string']),
                 new Constraints\Length(['max' => self::MAX_CODE_LENGTH]),
-                new Constraints\Regex([
+                new Constraints\Regex(
+                    [
                         'pattern' => '/^[a-zA-Z0-9_]+$/',
                         'message' => 'pim_measurements.validation.common.code.pattern',
                     ]

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/CreateMeasurementFamilyTest.php
@@ -573,8 +573,8 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
     {
         return [
             'Should not be too long' => [
-                str_repeat('a', 256),
-                'This value is too long. It should have 255 characters or less.'
+                str_repeat('a', 101),
+                'This value is too long. It should have 100 characters or less.'
             ],
             'Should not blank' => [null, 'This value should not be blank.'],
             'Should not a string' => [123, 'This value should be of type string.'],
@@ -649,7 +649,7 @@ class CreateMeasurementFamilyTest extends AcceptanceTestCase
                             Operation::create("mul", "1"),
                         ],
                         "km",
-                        );
+                    );
                 }, $unitCodes)
             )
         );

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/SaveMeasurementFamilyTest.php
@@ -641,8 +641,8 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
     {
         return [
             'Should not be too long' => [
-                str_repeat('a', 256),
-                'This value is too long. It should have 255 characters or less.'
+                str_repeat('a', 101),
+                'This value is too long. It should have 100 characters or less.'
             ],
             'Should not blank' => [null, 'This value should not be blank.'],
             'Should not a string' => [123, 'This value should be of type string.'],
@@ -717,7 +717,7 @@ class SaveMeasurementFamilyTest extends AcceptanceTestCase
                             Operation::create("mul", "1"),
                         ],
                         "km",
-                        );
+                    );
                 }, $unitCodes)
             )
         );

--- a/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
+++ b/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
@@ -34,7 +34,7 @@ final class Version_5_0_20220801160000_modify_metric_family_and_default_metric_u
 
         $result = $this->connection->executeQuery($sql, [
             'table_schema' => $schema->getName()
-        ])->fetchAllAssociative();
+        ])->fetchAll(\PDO::FETCH_ASSOC);
 
         return 100 === (int) $result[0]['CHARACTER_MAXIMUM_LENGTH'] && 100 === (int) $result[1]['CHARACTER_MAXIMUM_LENGTH'];
     }

--- a/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
+++ b/upgrades/schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(
+            $this->columnsAreModified($schema),
+            'metric_family and default_metric_unit columns are already modified'
+        );
+
+        $this->addSql('ALTER TABLE pim_catalog_attribute MODIFY COLUMN metric_family VARCHAR(100), MODIFY COLUMN default_metric_unit VARCHAR(100)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function columnsAreModified(Schema $schema): bool
+    {
+        $sql = <<<SQL
+            SELECT DISTINCT COLUMN_NAME, CHARACTER_MAXIMUM_LENGTH
+            FROM information_schema.columns
+            WHERE TABLE_SCHEMA = :table_schema AND TABLE_NAME = 'pim_catalog_attribute' AND COLUMN_NAME IN ('metric_family', 'default_metric_unit')
+        SQL;
+
+        $result = $this->connection->executeQuery($sql, [
+            'table_schema' => $schema->getName()
+        ])->fetchAllAssociative();
+
+        return 100 === (int) $result[0]['CHARACTER_MAXIMUM_LENGTH'] && 100 === (int) $result[1]['CHARACTER_MAXIMUM_LENGTH'];
+    }
+}

--- a/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
@@ -81,7 +81,7 @@ class Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_In
             WHERE id = :attribute_id
         SQL;
 
-        $result = $this->getConnection()->executeQuery($sql, ['attribute_id' => $attributeId])->fetchAssociative();
+        $result = $this->getConnection()->executeQuery($sql, ['attribute_id' => $attributeId])->fetch(\PDO::FETCH_ASSOC);
 
         return $result['metric_family'] === $metricFamily && $result['default_metric_unit'] === $defaultMetricUnit;
     }

--- a/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+class Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration';
+
+    public function test_it_modify_columns_and_keep_the_data(): void
+    {
+        $this->resetModify();
+
+        $metricFamily = 'family';
+        $defaultMetricUnit = 'unit';
+        $attributeId = $this->addAttribute($metricFamily, $defaultMetricUnit);
+        $this->assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeId, $metricFamily, $defaultMetricUnit));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeId, $metricFamily, $defaultMetricUnit));
+
+        $longMetricFamily = str_repeat('a', 100);
+        $longDefaultMetricUnit = str_repeat('a', 100);
+        $attributeIdWithLongValues = $this->addAttribute($longMetricFamily, $longDefaultMetricUnit);
+        $this->assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeIdWithLongValues, $longMetricFamily, $longDefaultMetricUnit));
+    }
+
+    public function test_migration_is_idempotent(): void
+    {
+        $this->resetModify();
+
+        $metricFamily = 'family';
+        $defaultMetricUnit = 'unit';
+        $attributeId = $this->addAttribute($metricFamily, $defaultMetricUnit);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        Assert::assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeId, $metricFamily, $defaultMetricUnit));
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+
+    private function addAttribute(string $metricFamily, string $defaultMetricUnit): int
+    {
+        $sql = <<<SQL
+            INSERT INTO pim_catalog_attribute (sort_order, is_required, is_unique, is_localizable, is_scopable, code, entity_type, attribute_type, backend_type, created, updated, metric_family, default_metric_unit)
+            VALUES (0, 1, 1, 1, 1, :code, 'entity', 'type', 'type', NOW(), NOW(), :metric_family, :default_metric_unit)
+        SQL;
+
+        $this->getConnection()->executeQuery($sql, [
+            'code' => sprintf('code_%s', uniqid()),
+            'metric_family' => $metricFamily,
+            'default_metric_unit' => $defaultMetricUnit,
+        ]);
+
+        return (int) $this->getConnection()->lastInsertId();
+    }
+
+    private function attributeHasMetricFamilyAndDefaultMetricUnitSet(int $attributeId, string $metricFamily, string $defaultMetricUnit): bool
+    {
+        $sql = <<<SQL
+            SELECT *
+            FROM pim_catalog_attribute
+            WHERE id = :attribute_id
+        SQL;
+
+        $result = $this->getConnection()->executeQuery($sql, ['attribute_id' => $attributeId])->fetchAssociative();
+
+        return $result['metric_family'] === $metricFamily && $result['default_metric_unit'] === $defaultMetricUnit;
+    }
+
+    private function resetModify(): void
+    {
+        $this->getConnection()->executeQuery('ALTER TABLE pim_catalog_attribute MODIFY COLUMN metric_family VARCHAR(30), MODIFY COLUMN default_metric_unit VARCHAR(30)');
+    }
+}

--- a/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
@@ -33,20 +33,6 @@ class Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_In
         $this->assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeIdWithLongValues, $longMetricFamily, $longDefaultMetricUnit));
     }
 
-    public function test_migration_is_idempotent(): void
-    {
-        $this->resetModify();
-
-        $metricFamily = 'family';
-        $defaultMetricUnit = 'unit';
-        $attributeId = $this->addAttribute($metricFamily, $defaultMetricUnit);
-
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
-        $this->reExecuteMigration(self::MIGRATION_LABEL);
-
-        Assert::assertTrue($this->attributeHasMetricFamilyAndDefaultMetricUnitSet($attributeId, $metricFamily, $defaultMetricUnit));
-    }
-
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useMinimalCatalog();

--- a/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
+++ b/upgrades/test_schema/Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration.php
@@ -13,7 +13,7 @@ class Version_5_0_20220801160000_modify_metric_family_and_default_metric_unit_In
 {
     use ExecuteMigrationTrait;
 
-    private const MIGRATION_LABEL = '_5_0_20220801160000_modify_metric_family_and_default_metric_unit_Integration';
+    private const MIGRATION_LABEL = '_5_0_20220801160000_modify_metric_family_and_default_metric_unit';
 
     public function test_it_modify_columns_and_keep_the_data(): void
     {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport of [https://github.com/akeneo/pim-community-dev/pull/16052](https://github.com/akeneo/pim-community-dev/pull/16052).

[Issue](https://akeneo.atlassian.net/jira/software/c/projects/PIM/boards/9?modal=detail&selectedIssue=PIM-10556&quickFilter=651).

We cannot create measurement attribute if measurement family or unit code is too long, a limit is set to 30 chars max in database datatype of metric_family and default_metric_unit columns. This PR set this limit to 100 chars max (same as code and standard_unit columns in akeneo_measurement).

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
