### PR TITLE
RAC-1264: Using number_format whitout toushand separator specified will add one has comma in the value

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMerger.php
@@ -7,7 +7,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Convert\MeasureConverter;
 use Akeneo\Tool\Component\Connector\Exception\BusinessArrayConversionException;
 
 /**
- * Merge columns for single value that can be provided in many columns like prices and metric
+ * Merge columns for single value that can be provided in many columns like prices and metric.
  *
  * These two values supports two different formats, we standardize here to the one column format
  *
@@ -62,11 +62,7 @@ class ColumnsMerger
                 } elseif (AttributeTypes::BACKEND_TYPE_PRICE === $attribute->getBackendType()) {
                     // For XLSX import, the value could be already converted to a DateTime object (cf PIM-10167)
                     if ($fieldValue instanceof \DateTimeInterface) {
-                        throw new BusinessArrayConversionException(
-                            "Can not convert cell {$fieldName} with date format to attribute of type date",
-                            "pim_import_export.notification.import.warnings.xlsx_cell_date_conversion_error",
-                            ['{cellName}' => $fieldName, '{attributeType}' => 'price']
-                        );
+                        throw new BusinessArrayConversionException("Can not convert cell {$fieldName} with date format to attribute of type date", 'pim_import_export.notification.import.warnings.xlsx_cell_date_conversion_error', ['{cellName}' => $fieldName, '{attributeType}' => 'price']);
                     }
 
                     $collectedPrices = $this->collectPriceData($collectedPrices, $attributeInfos, $fieldValue);
@@ -92,9 +88,7 @@ class ColumnsMerger
     }
 
     /**
-     * Returns a clean field name with code, locale and scope (without unit, currency, etc in the field)
-     *
-     * @param array $attributeInfos
+     * Returns a clean field name with code, locale and scope (without unit, currency, etc in the field).
      *
      * @return string
      */
@@ -111,10 +105,8 @@ class ColumnsMerger
     }
 
     /**
-     * Collect metric data exploded in different columns
+     * Collect metric data exploded in different columns.
      *
-     * @param array  $collectedMetrics
-     * @param array  $attributeInfos
      * @param string $fieldValue
      *
      * @return array collected metrics
@@ -136,10 +128,7 @@ class ColumnsMerger
     }
 
     /**
-     * Merge collected metric in result rows
-     *
-     * @param array $resultRow
-     * @param array $collectedMetrics
+     * Merge collected metric in result rows.
      *
      * @return array
      */
@@ -149,7 +138,7 @@ class ColumnsMerger
             $metricValue = $metricData['data'];
 
             if (is_float($metricValue)) {
-                $metricValue = number_format($metricValue, MeasureConverter::SCALE);
+                $metricValue = number_format($metricValue, decimals: MeasureConverter::SCALE, thousands_separator: '');
             }
 
             $resultRow[$fieldName] = trim(
@@ -166,10 +155,8 @@ class ColumnsMerger
     }
 
     /**
-     * Collect price data exploded in different columns
+     * Collect price data exploded in different columns.
      *
-     * @param array  $collectedPrices
-     * @param array  $attributeInfos
      * @param string $fieldValue
      *
      * @return array collected metrics
@@ -179,7 +166,7 @@ class ColumnsMerger
         $cleanField = $this->getCleanFieldName($attributeInfos);
         if (null !== $attributeInfos['price_currency']) {
             $collectedPrices[$cleanField] = $collectedPrices[$cleanField] ?? [];
-            if (trim($fieldValue) === '') {
+            if ('' === trim($fieldValue)) {
                 return $collectedPrices;
             }
             $collectedPrices[$cleanField][] = sprintf(
@@ -234,10 +221,7 @@ class ColumnsMerger
     }
 
     /**
-     * Merge collected price in result rows
-     *
-     * @param array $resultRow
-     * @param array $collectedPrices
+     * Merge collected price in result rows.
      *
      * @return array
      */

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ColumnsMergerSpec.php
@@ -3,25 +3,25 @@
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard;
 
 use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AssociationColumnsResolver;
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AttributeColumnInfoExtractor;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\Connector\Exception\BusinessArrayConversionException;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
-use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AttributeColumnInfoExtractor;
 
 class ColumnsMergerSpec extends ObjectBehavior
 {
-    function let(AttributeColumnInfoExtractor $fieldExtractor, AssociationColumnsResolver $associationColumnResolver)
+    public function let(AttributeColumnInfoExtractor $fieldExtractor, AssociationColumnsResolver $associationColumnResolver)
     {
         $this->beConstructedWith($fieldExtractor, $associationColumnResolver);
     }
 
-    function it_does_not_merge_columns_which_does_not_represents_attribute_value(
+    public function it_does_not_merge_columns_which_does_not_represents_attribute_value(
       $fieldExtractor,
       $associationColumnResolver
     ) {
         $row = [
             'enabled' => '1',
-            'categories' => 'tshirt,men'
+            'categories' => 'tshirt,men',
         ];
         $fieldExtractor->extractColumnInfo('enabled')->willReturn(null);
         $fieldExtractor->extractColumnInfo('categories')->willReturn(null);
@@ -33,18 +33,18 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_does_not_merge_columns_which_represents_text_attribute_value(
+    public function it_does_not_merge_columns_which_represents_text_attribute_value(
         $fieldExtractor,
         AttributeInterface $name
     ) {
         $row = [
-            'name-fr_FR' => 'T-shirt super beau'
+            'name-fr_FR' => 'T-shirt super beau',
         ];
         $attributeInfoData = [
             'attribute' => $name,
             'locale_code' => 'fr_FR',
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('name-fr_FR')->willReturn($attributeInfoData);
         $name->getBackendType()->willReturn('text');
@@ -53,18 +53,18 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_does_not_merge_columns_which_represents_metric_attribute_value_in_a_single_column(
+    public function it_does_not_merge_columns_which_represents_metric_attribute_value_in_a_single_column(
         $fieldExtractor,
         AttributeInterface $weight
     ) {
         $row = [
-            'weight' => '10 KILOGRAM'
+            'weight' => '10 KILOGRAM',
         ];
         $attributeInfoData = [
             'attribute' => $weight,
             'locale_code' => null,
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('weight')->willReturn($attributeInfoData);
         $weight->getCode()->willReturn('weight');
@@ -74,18 +74,18 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_does_not_merge_columns_which_represents_a_localizable_metric_attribute_value_in_a_single_column(
+    public function it_does_not_merge_columns_which_represents_a_localizable_metric_attribute_value_in_a_single_column(
         $fieldExtractor,
         AttributeInterface $weight
     ) {
         $row = [
-            'weight-fr_FR' => '10 KILOGRAM'
+            'weight-fr_FR' => '10 KILOGRAM',
         ];
         $attributeInfoData = [
             'attribute' => $weight,
             'locale_code' => 'fr_FR',
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('weight-fr_FR')->willReturn($attributeInfoData);
 
@@ -96,7 +96,7 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_merges_price_attribute_value_columns(
+    public function it_merges_price_attribute_value_columns(
         $fieldExtractor,
         AttributeInterface $price
     ) {
@@ -109,21 +109,21 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'EUR'
+            'price_currency' => 'EUR',
         ];
         $fieldExtractor->extractColumnInfo('price-EUR')->willReturn($attributeInfoEur);
         $attributeInfoUsd = [
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'USD'
+            'price_currency' => 'USD',
         ];
         $fieldExtractor->extractColumnInfo('price-USD')->willReturn($attributeInfoUsd);
         $attributeInfoChf = [
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'CHF'
+            'price_currency' => 'CHF',
         ];
         $fieldExtractor->extractColumnInfo('price-CHF')->willReturn($attributeInfoChf);
         $price->getCode()->willReturn('price');
@@ -132,19 +132,19 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_merges_columns_which_represents_metric_attribute_value_in_two_columns(
+    public function it_merges_columns_which_represents_metric_attribute_value_in_two_columns(
         $fieldExtractor,
         AttributeInterface $weight
     ) {
         $row = [
             'weight' => '10',
-            'weight-unit' => 'KILOGRAM'
+            'weight-unit' => 'KILOGRAM',
         ];
         $attributeInfoData = [
             'attribute' => $weight,
             'locale_code' => null,
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('weight')->willReturn($attributeInfoData);
 
@@ -152,7 +152,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $weight,
             'locale_code' => null,
             'scope_code' => null,
-            'metric_unit' => 'unit'
+            'metric_unit' => 'unit',
         ];
         $fieldExtractor->extractColumnInfo('weight-unit')->willReturn($attributeInfoUnit);
 
@@ -163,19 +163,19 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_merges_columns_which_represents_metric_attribute_value_with_scientific_notation_in_two_columns(
+    public function it_merges_columns_which_represents_metric_attribute_value_with_scientific_notation_in_two_columns(
         $fieldExtractor,
         AttributeInterface $weight
     ) {
         $row = [
             'weight' => 0.000075,
-            'weight-unit' => 'GRAM'
+            'weight-unit' => 'GRAM',
         ];
         $attributeInfoData = [
             'attribute' => $weight,
             'locale_code' => null,
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('weight')->willReturn($attributeInfoData);
 
@@ -183,7 +183,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $weight,
             'locale_code' => null,
             'scope_code' => null,
-            'metric_unit' => 'unit'
+            'metric_unit' => 'unit',
         ];
         $fieldExtractor->extractColumnInfo('weight-unit')->willReturn($attributeInfoUnit);
 
@@ -194,19 +194,50 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_merges_columns_which_represents_a_localizable_metric_attribute_value_in_a_two_columns(
+    public function it_merges_columns_which_represents_metric_attribute_value_with_large_decimal_number(
+        $fieldExtractor,
+        AttributeInterface $weight
+    ) {
+        $row = [
+            'weight' => 80000.75,
+            'weight-unit' => 'GRAM',
+        ];
+        $attributeInfoData = [
+            'attribute' => $weight,
+            'locale_code' => null,
+            'scope_code' => null,
+            'metric_unit' => null,
+        ];
+        $fieldExtractor->extractColumnInfo('weight')->willReturn($attributeInfoData);
+
+        $attributeInfoUnit = [
+            'attribute' => $weight,
+            'locale_code' => null,
+            'scope_code' => null,
+            'metric_unit' => 'unit',
+        ];
+        $fieldExtractor->extractColumnInfo('weight-unit')->willReturn($attributeInfoUnit);
+
+        $weight->getCode()->willReturn('weight');
+        $weight->getBackendType()->willReturn('metric');
+
+        $mergedRow = ['weight' => '80000.750000000000 GRAM'];
+        $this->merge($row)->shouldReturn($mergedRow);
+    }
+
+    public function it_merges_columns_which_represents_a_localizable_metric_attribute_value_in_a_two_columns(
         $fieldExtractor,
         AttributeInterface $weight
     ) {
         $row = [
             'weight-fr_FR' => '10',
-            'weight-fr_FR-unit' => 'KILOGRAM'
+            'weight-fr_FR-unit' => 'KILOGRAM',
         ];
         $attributeInfoData = [
             'attribute' => $weight,
             'locale_code' => 'fr_FR',
             'scope_code' => null,
-            'metric_unit' => null
+            'metric_unit' => null,
         ];
         $fieldExtractor->extractColumnInfo('weight-fr_FR')->willReturn($attributeInfoData);
 
@@ -214,7 +245,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $weight,
             'locale_code' => 'fr_FR',
             'scope_code' => null,
-            'metric_unit' => 'unit'
+            'metric_unit' => 'unit',
         ];
         $fieldExtractor->extractColumnInfo('weight-fr_FR-unit')->willReturn($attributeInfoUnit);
 
@@ -225,18 +256,18 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_does_not_merge_columns_which_represents_a_localizable_price_attribute_value_in_a_single_column(
+    public function it_does_not_merge_columns_which_represents_a_localizable_price_attribute_value_in_a_single_column(
         $fieldExtractor,
         AttributeInterface $price
     ) {
         $row = [
-            'price-fr_FR' => '10 EUR, 24 USD'
+            'price-fr_FR' => '10 EUR, 24 USD',
         ];
         $attributeInfoData = [
             'attribute' => $price,
             'locale_code' => 'fr_FR',
             'scope_code' => null,
-            'price_currency' => null
+            'price_currency' => null,
         ];
         $fieldExtractor->extractColumnInfo('price-fr_FR')->willReturn($attributeInfoData);
         $price->getCode()->willReturn('price');
@@ -246,7 +277,7 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn($mergedRow);
     }
 
-    function it_does_not_create_price_when_price_is_empty(
+    public function it_does_not_create_price_when_price_is_empty(
         $fieldExtractor,
         AttributeInterface $price
     ) {
@@ -255,7 +286,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'EUR'
+            'price_currency' => 'EUR',
         ];
         $fieldExtractor->extractColumnInfo('price-EUR')->willReturn($attributeInfoEur);
 
@@ -265,7 +296,7 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->merge($row)->shouldReturn(['price' => '']);
     }
 
-    function it_merges_columns_which_represents_price_attribute_value_in_many_columns(
+    public function it_merges_columns_which_represents_price_attribute_value_in_many_columns(
         $fieldExtractor,
         AttributeInterface $price
     ) {
@@ -278,7 +309,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'EUR'
+            'price_currency' => 'EUR',
         ];
         $fieldExtractor->extractColumnInfo('price-EUR')->willReturn($attributeInfoEur);
 
@@ -286,7 +317,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'USD'
+            'price_currency' => 'USD',
         ];
         $fieldExtractor->extractColumnInfo('price-USD')->willReturn($attributeInfoUsd);
 
@@ -294,7 +325,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'CHF'
+            'price_currency' => 'CHF',
         ];
         $fieldExtractor->extractColumnInfo('price-CHF')->willReturn($attributeInfoChf);
 
@@ -315,7 +346,7 @@ class ColumnsMergerSpec extends ObjectBehavior
             'attribute' => $price,
             'locale_code' => null,
             'scope_code' => null,
-            'price_currency' => 'USD'
+            'price_currency' => 'USD',
         ];
         $fieldExtractor->extractColumnInfo('price-USD')->willReturn($attributeInfoUsd);
 
@@ -325,13 +356,13 @@ class ColumnsMergerSpec extends ObjectBehavior
         $this->shouldThrow(BusinessArrayConversionException::class)->during('merge', [$row]);
     }
 
-    function it_merges_columns_which_represents_quantified_associations_in_two_columns(
+    public function it_merges_columns_which_represents_quantified_associations_in_two_columns(
         $fieldExtractor,
         $associationColumnResolver
     ) {
         $row = [
             'PACK-products-quantity' => '10|24',
-            'PACK-products' => 'my_sku,nice'
+            'PACK-products' => 'my_sku,nice',
         ];
         $fieldExtractor->extractColumnInfo('PACK-products-quantity')->willReturn(null);
         $fieldExtractor->extractColumnInfo('PACK-products')->willReturn(null);
@@ -343,14 +374,14 @@ class ColumnsMergerSpec extends ObjectBehavior
             'PACK-products' => [
                 [
                     'identifier' => 'my_sku',
-                    'quantity' => 10
+                    'quantity' => 10,
                 ],
                 [
                     'identifier' => 'nice',
-                    'quantity' => 24
-                ]
+                    'quantity' => 24,
+                ],
             ],
-            'PACK-product_models' => []
+            'PACK-product_models' => [],
         ];
         $this->merge($row)->shouldReturn($mergedRow);
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

add blanck thousand separator to avoid issue with large number containing decimal like 80,000.75

**Definition Of Done (for Core Developer only)**

- [x] Tests
