### PR TITLE
Use Google mirror cache registry to pull Docker images

### DIFF
--- a/.circleci/configure_docker_mirrors.sh
+++ b/.circleci/configure_docker_mirrors.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 # see https://cloud.google.com/container-registry/docs/pulling-cached-images#configure
-echo 'DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=https://mirror.gcr.io"' >> /etc/default/docker
+echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' >> /etc/docker/daemon.json
 
 service docker restart

--- a/.circleci/configure_docker_mirrors.sh
+++ b/.circleci/configure_docker_mirrors.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# see https://cloud.google.com/container-registry/docs/pulling-cached-images#configure
+echo 'DOCKER_OPTS="${DOCKER_OPTS} --registry-mirror=https://mirror.gcr.io"' >> /etc/default/docker
+
+service docker restart

--- a/.circleci/configure_docker_mirrors.sh
+++ b/.circleci/configure_docker_mirrors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # see https://cloud.google.com/container-registry/docs/pulling-cached-images#configure
 echo '{"registry-mirrors": ["https://mirror.gcr.io"]}' >> /etc/docker/daemon.json

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -49,6 +49,9 @@ jobs:
                   name: Change owner on project dir in order to archive the project into the workspace
                   command: sudo chown -R 1000:1000 ../project
             - run:
+                  name: Add GCR mirror for Docker pull
+                  command: sudo .circleci/configure_docker_mirrors.sh
+            - run:
                   name: Start containers
                   command: |
                       docker load -i php-pim-image.tar
@@ -81,6 +84,9 @@ jobs:
                   name: Change owner on project dir in order to archive the project into the workspace
                   command: sudo chown -R 1000:1000 ../project
             - run:
+                  name: Add GCR mirror for Docker pull
+                  command: sudo .circleci/configure_docker_mirrors.sh
+            - run:
                   name: Create yarn cache folder
                   command: mkdir -p  ~/.cache/yarn
             - run:
@@ -110,6 +116,9 @@ jobs:
         steps:
             - attach_workspace:
                   at: ~/
+            - run:
+                  name: Add GCR mirror for Docker pull
+                  command: sudo .circleci/configure_docker_mirrors.sh
             - run:
                   name: Get Behat Suite name to run
                   command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - 'pim'
 
   elasticsearch:
-    image: 'docker.elastic.co/elasticsearch/elasticsearch:7.16.2'
+    image: 'elastic/elasticsearch:7.16.2'
     environment:
       ES_JAVA_OPTS: '${ES_JAVA_OPTS:--Xms512m -Xmx512m}'
       discovery.type: 'single-node'


### PR DESCRIPTION
Add a Docker image registry cache mirror to increase CI stability

see https://cloud.google.com/container-registry/docs/pulling-cached-images#configure

I chose to apply it mainly on parallel runs because they are the most error prone, but we may add this Docker configuration on other jobs if needed.

Note for debug on the CI: you can activate the debug log for docker daemon by using this configuration:

```json
{
  "registry-mirrors": ["https://mirror.gcr.io"],
  "debug": true
}
```

The log will then be available in `var/log/syslog` or in the journal with `sudo journalctl -fu docker.service`

You can then check which mirror is used, like in this extract:
```
Aug  3 15:47:40 ip-172-28-21-188 dockerd[4341]: time="2022-08-03T15:47:40.684988496Z" level=debug msg="hostDir: /etc/docker/certs.d/mirror.gcr.io"
Aug  3 15:47:40 ip-172-28-21-188 dockerd[4341]: time="2022-08-03T15:47:40.685025246Z" level=debug msg="Trying to pull mysql from https://mirror.gcr.io/ v2"
Aug  3 15:47:40 ip-172-28-21-188 dockerd[4341]: time="2022-08-03T15:47:40.866125415Z" level=debug msg="Fetching manifest from remote" digest="sha256:5d52dc010398db422949f079c76e98f6b62230e5b59c0bf7582409d2c85abacb" error="<nil>" remote="docker.io/library/mysql:8.0.26"
Aug  3 15:47:40 ip-172-28-21-188 dockerd[4341]: time="2022-08-03T15:47:40.975054421Z" level=debug msg="Pulling ref from V2 registry: mysql:8.0.26"
Aug  3 15:47:40 ip-172-28-21-188 dockerd[4341]: time="2022-08-03T15:47:40.975295801Z" level=debug msg="docker.io/library/mysql:8.0.26 resolved to a manifestList object with 1 entries; looking for a unknown/amd64 match"
```
