### PR TITLE
GRF-228 separated legacy category UI code from the enriched category stream and refactarization

### DIFF
--- a/src/Akeneo/Category/front/src/configuration/ConfigurationProvider.tsx
+++ b/src/Akeneo/Category/front/src/configuration/ConfigurationProvider.tsx
@@ -1,4 +1,5 @@
-import React, {createContext, FC, useCallback, useState} from 'react';
+import React, {createContext, FC, useCallback} from 'react';
+import {useStorageState} from '@akeneo-pim-community/shared';
 
 type Configuration = {
   features: {
@@ -40,24 +41,28 @@ type ConfigurationState = {
   updateConfiguration: (config: WriteConfiguration) => void;
 };
 
+const CONFIGURATION_STORAGE_KEY = 'CategoryMicroFrontendConfiguration';
+
+const DEFAULT_CONFIGURATION: Configuration = {
+  features: {
+    permission: true,
+    enriched_category: true,
+  },
+  acls: {
+    pim_enrich_product_categories_view: true,
+    pim_enrich_product_category_create: true,
+    pim_enrich_product_category_edit: true,
+    pim_enrich_product_category_history: true,
+    pim_enrich_product_category_list: true,
+    pim_enrich_product_category_remove: true,
+    pimee_enrich_category_edit_permissions: true,
+  },
+};
+
 const ConfigurationContext = createContext<ConfigurationState | undefined>(undefined);
 
 const ConfigurationProvider: FC = ({children}) => {
-  const [configuration, setConfiguration] = useState({
-    features: {
-      permission: true,
-      enriched_category: true,
-    },
-    acls: {
-      pim_enrich_product_categories_view: true,
-      pim_enrich_product_category_create: true,
-      pim_enrich_product_category_edit: true,
-      pim_enrich_product_category_history: true,
-      pim_enrich_product_category_list: true,
-      pim_enrich_product_category_remove: true,
-      pimee_enrich_category_edit_permissions: true,
-    },
-  });
+  const [configuration, setConfiguration] = useStorageState(DEFAULT_CONFIGURATION, CONFIGURATION_STORAGE_KEY);
 
   const setDefaultCommunitySettings = useCallback(() => {
     setConfiguration({
@@ -75,7 +80,7 @@ const ConfigurationProvider: FC = ({children}) => {
         pimee_enrich_category_edit_permissions: false,
       },
     });
-  }, []);
+  }, [setConfiguration]);
 
   const setDefaultGrowthSettings = useCallback(() => {
     setConfiguration({
@@ -93,7 +98,7 @@ const ConfigurationProvider: FC = ({children}) => {
         pimee_enrich_category_edit_permissions: false,
       },
     });
-  }, []);
+  }, [setConfiguration]);
 
   const setDefaultEnterpriseSettings = useCallback(() => {
     setConfiguration({
@@ -111,23 +116,26 @@ const ConfigurationProvider: FC = ({children}) => {
         pimee_enrich_category_edit_permissions: true,
       },
     });
-  }, []);
+  }, [setConfiguration]);
 
   // @todo split updateConfiguration in setFeature and setAcl
-  const updateConfiguration = useCallback((config: WriteConfiguration) => {
-    setConfiguration(configuration => {
-      return {
-        features: {
-          ...configuration.features,
-          ...(config.features ?? {}),
-        },
-        acls: {
-          ...configuration.acls,
-          ...(config.acls ?? {}),
-        },
-      };
-    });
-  }, []);
+  const updateConfiguration = useCallback(
+    (config: WriteConfiguration) => {
+      setConfiguration(configuration => {
+        return {
+          features: {
+            ...configuration.features,
+            ...(config.features ?? {}),
+          },
+          acls: {
+            ...configuration.acls,
+            ...(config.acls ?? {}),
+          },
+        };
+      });
+    },
+    [setConfiguration]
+  );
 
   const state = {
     configuration,

--- a/src/Akeneo/Category/front/src/feature/CategoriesApp.tsx
+++ b/src/Akeneo/Category/front/src/feature/CategoriesApp.tsx
@@ -2,12 +2,17 @@ import React, {FC} from 'react';
 import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 import {CategoriesIndex, CategoriesTreePage, CategoryEditPage} from './pages';
 import {EditCategoryProvider} from './components';
+import {useFeatureFlags} from '@akeneo-pim-community/shared';
+import {LegacyCategoryEditPage} from './legacy/pages/LegacyCategoryEditPage';
 
 type Props = {
   setCanLeavePage: (canLeavePage: boolean) => void;
 };
 
 const CategoriesApp: FC<Props> = ({setCanLeavePage}) => {
+  const featureFlags = useFeatureFlags();
+  const categoryEnrichmentIsEnabled = featureFlags.isEnabled('enriched_category');
+
   return (
     <Router basename="/enrich/product-category-tree">
       <Switch>
@@ -16,7 +21,7 @@ const CategoriesApp: FC<Props> = ({setCanLeavePage}) => {
         </Route>
         <Route path="/:categoryId/edit">
           <EditCategoryProvider setCanLeavePage={setCanLeavePage}>
-            <CategoryEditPage />
+            {categoryEnrichmentIsEnabled ? <CategoryEditPage /> : <LegacyCategoryEditPage />}
           </EditCategoryProvider>
         </Route>
         <Route path="/">

--- a/src/Akeneo/Category/front/src/feature/legacy/README.md
+++ b/src/Akeneo/Category/front/src/feature/legacy/README.md
@@ -1,0 +1,7 @@
+# Legacy Category Edition page
+
+During the development of enriched categories a feature flag is used to switch between production code and developpements in progress.
+
+The legacy folder contains the edition page code to be removed once the enriched category is deployed on production.
+
+The content of the legacy folder should not be modified apart for maintenance.

--- a/src/Akeneo/Category/front/src/feature/legacy/components/EditPermissionsForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/EditPermissionsForm.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {useTranslate} from '@akeneo-pim-community/shared';
+import {BooleanInput, Field, Helper, MultiSelectInput} from 'akeneo-design-system';
+import {FormContainer, PermissionField} from './Style';
+import {EditCategoryForm} from '../models';
+
+type Props = {
+  formData: EditCategoryForm | null;
+  onChangePermissions: (type: string, values: string[]) => void;
+  onChangeApplyPermissionsOnChildren: (value: boolean) => void;
+};
+
+const EditPermissionsForm = ({formData, onChangePermissions, onChangeApplyPermissionsOnChildren}: Props) => {
+  const translate = useTranslate();
+
+  if (formData === null || !formData.permissions) {
+    return <></>;
+  }
+
+  return (
+    <FormContainer>
+      <PermissionField label={translate('category.permissions.view.label')}>
+        <MultiSelectInput
+          readOnly={false}
+          value={formData.permissions.view.value}
+          name={formData.permissions.view.fullName}
+          emptyResultLabel={translate('pim_common.no_result')}
+          openLabel={translate('pim_common.open')}
+          removeLabel={translate('pim_common.remove')}
+          onChange={changedValues => onChangePermissions('view', changedValues)}
+        >
+          {Object.entries(formData.permissions.view.choices).map(([key, choice]) => (
+            <MultiSelectInput.Option value={choice.value} key={`view-${key}`}>
+              {choice.label}
+            </MultiSelectInput.Option>
+          ))}
+        </MultiSelectInput>
+      </PermissionField>
+      <PermissionField label={translate('category.permissions.edit.label')}>
+        <MultiSelectInput
+          value={formData.permissions.edit.value}
+          name={formData.permissions.edit.fullName}
+          emptyResultLabel={translate('pim_common.no_result')}
+          openLabel={translate('pim_common.open')}
+          removeLabel={translate('pim_common.remove')}
+          onChange={changedValues => onChangePermissions('edit', changedValues)}
+        >
+          {Object.entries(formData.permissions.edit.choices).map(([key, choice]) => (
+            <MultiSelectInput.Option value={choice.value} key={`edit-${key}`}>
+              {choice.label}
+            </MultiSelectInput.Option>
+          ))}
+        </MultiSelectInput>
+      </PermissionField>
+      <PermissionField label={translate('category.permissions.own.label')}>
+        <MultiSelectInput
+          value={formData.permissions.own.value}
+          name={formData.permissions.own.fullName}
+          emptyResultLabel={translate('pim_common.no_result')}
+          openLabel={translate('pim_common.open')}
+          removeLabel={translate('pim_common.remove')}
+          onChange={changedValues => onChangePermissions('own', changedValues)}
+        >
+          {Object.entries(formData.permissions.own.choices).map(([key, choice]) => (
+            <MultiSelectInput.Option value={choice.value} key={`own-${key}`}>
+              {choice.label}
+            </MultiSelectInput.Option>
+          ))}
+        </MultiSelectInput>
+        <Helper level="info">{translate('category.permissions.own.help')}</Helper>
+      </PermissionField>
+      <Field label={translate('category.permissions.apply_on_children.label')}>
+        <BooleanInput
+          clearable={false}
+          readOnly={false}
+          value={formData.permissions.apply_on_children.value === '1'}
+          noLabel={translate('pim_common.no')}
+          yesLabel={translate('pim_common.yes')}
+          onChange={changedValue => onChangeApplyPermissionsOnChildren(changedValue)}
+        />
+        <Helper level="info">{translate('category.permissions.apply_on_children.help')}</Helper>
+      </Field>
+    </FormContainer>
+  );
+};
+
+export {EditPermissionsForm};

--- a/src/Akeneo/Category/front/src/feature/legacy/components/EditPropertiesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/EditPropertiesForm.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import {useSecurity, useTranslate} from '@akeneo-pim-community/shared';
+import {Category, EditCategoryForm} from '../models';
+import {Field, SectionTitle, TextInput} from 'akeneo-design-system';
+import {ErrorMessage, FormContainer} from './Style';
+
+type Props = {
+  category: Category;
+  formData: EditCategoryForm | null;
+  onChangeLabel: (locale: string, label: string) => void;
+};
+
+const EditPropertiesForm = ({category, formData, onChangeLabel}: Props) => {
+  const translate = useTranslate();
+  const {isGranted} = useSecurity();
+
+  if (formData === null) {
+    return <></>;
+  }
+
+  return (
+    <FormContainer>
+      {formData.errors.map((errorMessage, key) => {
+        return (
+          <ErrorMessage level="error" key={`error-${key}`}>
+            {errorMessage}
+          </ErrorMessage>
+        );
+      })}
+      <SectionTitle>
+        <SectionTitle.Title>{translate('pim_common.code')}</SectionTitle.Title>
+      </SectionTitle>
+      <Field label={translate('pim_common.code')} requiredLabel={translate('pim_common.required_label')}>
+        <TextInput name="code" readOnly={true} value={category.code} />
+      </Field>
+      <SectionTitle>
+        <SectionTitle.Title>{translate('pim_common.label')}</SectionTitle.Title>
+      </SectionTitle>
+      {Object.entries(formData.label).map(([locale, labelField]) => (
+        <Field label={labelField.label} key={locale}>
+          <TextInput
+            name={labelField.fullName}
+            readOnly={!isGranted('pim_enrich_product_category_edit')}
+            onChange={changedLabel => onChangeLabel(locale, changedLabel)}
+            value={labelField.value}
+          />
+        </Field>
+      ))}
+    </FormContainer>
+  );
+};
+export {EditPropertiesForm};

--- a/src/Akeneo/Category/front/src/feature/legacy/components/Style.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/Style.tsx
@@ -1,0 +1,18 @@
+import {Field, Helper} from 'akeneo-design-system';
+import styled from 'styled-components';
+
+export const FormContainer = styled.div`
+  margin-top: 20px;
+
+  & > * {
+    margin: 0 10px 20px 0;
+  }
+`;
+
+export const ErrorMessage = styled(Helper)`
+  margin: 20px 0 0 0;
+`;
+
+export const PermissionField = styled(Field)`
+  max-width: 400px;
+`;

--- a/src/Akeneo/Category/front/src/feature/legacy/components/datagrids/DeleteCategoryModal.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/datagrids/DeleteCategoryModal.tsx
@@ -1,0 +1,46 @@
+import React, {FC} from 'react';
+import {Button, DeleteIllustration, getFontSize, Modal} from 'akeneo-design-system';
+import {useTranslate} from '@akeneo-pim-community/shared';
+import styled from 'styled-components';
+
+type DeleteCategoryModalProps = {
+  categoryLabel: string;
+  closeModal: () => void;
+  deleteCategory: () => void;
+  message: string;
+};
+
+const DeleteCategoryModal: FC<DeleteCategoryModalProps> = ({categoryLabel, closeModal, deleteCategory, message}) => {
+  const translate = useTranslate();
+
+  return (
+    <Modal closeTitle="Close" onClose={closeModal} illustration={<DeleteIllustration />}>
+      <Modal.SectionTitle color="brand">{translate('pim_enrich.entity.category.plural_label')}</Modal.SectionTitle>
+      <Modal.Title>{translate('pim_common.confirm_deletion')}</Modal.Title>
+
+      <Message>{translate(message, {name: categoryLabel})}</Message>
+      <ActionButtons>
+        <Button onClick={closeModal} level="tertiary">
+          {translate('pim_common.cancel')}
+        </Button>
+        <Button onClick={() => deleteCategory()} level="danger" className="ok">
+          {translate('pim_common.delete')}
+        </Button>
+      </ActionButtons>
+    </Modal>
+  );
+};
+
+const Message = styled.p`
+  font-size: ${getFontSize('big')};
+`;
+
+const ActionButtons = styled.p`
+  margin-top: 15px;
+
+  button:first-child {
+    margin-right: 10px;
+  }
+`;
+
+export {DeleteCategoryModal};

--- a/src/Akeneo/Category/front/src/feature/legacy/components/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/index.ts
@@ -1,0 +1,3 @@
+export * from './EditPermissionsForm';
+export * from './EditPropertiesForm';
+export * from './providers';

--- a/src/Akeneo/Category/front/src/feature/legacy/components/providers/EditCategoryProvider.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/providers/EditCategoryProvider.tsx
@@ -1,0 +1,19 @@
+import React, {createContext, FC} from 'react';
+
+type EditCategoryState = {
+  setCanLeavePage: (canLeavePage: boolean) => void;
+};
+
+const EditCategoryContext = createContext<EditCategoryState>({
+  setCanLeavePage: () => {},
+});
+
+type Props = {
+  setCanLeavePage: (canLeavePage: boolean) => void;
+};
+
+const EditCategoryProvider: FC<Props> = ({children, setCanLeavePage}) => {
+  return <EditCategoryContext.Provider value={{setCanLeavePage}}>{children}</EditCategoryContext.Provider>;
+};
+
+export {EditCategoryProvider, EditCategoryContext};

--- a/src/Akeneo/Category/front/src/feature/legacy/components/providers/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/components/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './EditCategoryProvider';

--- a/src/Akeneo/Category/front/src/feature/legacy/helpers/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from './permissionsHelper';

--- a/src/Akeneo/Category/front/src/feature/legacy/helpers/permissionsHelper.test.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/helpers/permissionsHelper.test.ts
@@ -1,0 +1,87 @@
+import {EditCategoryForm} from 'feature/models';
+import {computeNewEditPermissions, computeNewOwnPermissions, computeNewViewPermissions} from './permissionsHelper';
+
+describe('permissionsHelper', () => {
+  //This test is only to have a better idea of the default state before each test
+  test('it ensures the default state is OK', () => {
+    expect(formData.permissions?.view.value).toStrictEqual(['1', '2', '5']);
+    expect(formData.permissions?.edit.value).toStrictEqual(['1', '2']);
+    expect(formData.permissions?.own.value).toStrictEqual(['1', '2']);
+  });
+
+  test('it removes a view permission that does not exist in other levels', () => {
+    const newFormData = computeNewViewPermissions(formData, ['1', '2']);
+
+    expect(newFormData.permissions?.view.value).toStrictEqual(['1', '2']);
+    expect(newFormData.permissions?.edit.value).toStrictEqual(['1', '2']);
+    expect(newFormData.permissions?.own.value).toStrictEqual(['1', '2']);
+  });
+
+  test('it removes with cascade a view permission', () => {
+    const newFormData = computeNewViewPermissions(formData, ['1', '5']);
+
+    expect(newFormData.permissions?.view.value).toStrictEqual(['1', '5']);
+    expect(newFormData.permissions?.edit.value).toStrictEqual(['1']);
+    expect(newFormData.permissions?.own.value).toStrictEqual(['1']);
+  });
+
+  test('it removes with cascade an edit permission', () => {
+    const newFormData = computeNewEditPermissions(formData, ['2']);
+
+    expect(newFormData.permissions?.view.value).toStrictEqual(['1', '2', '5']);
+    expect(newFormData.permissions?.edit.value).toStrictEqual(['2']);
+    expect(newFormData.permissions?.own.value).toStrictEqual(['2']);
+  });
+
+  test('it adds with cascade an edit permission', () => {
+    const newFormData = computeNewEditPermissions(formData, ['1', '2', '8']);
+
+    expect(newFormData.permissions?.view.value).toStrictEqual(['1', '2', '5', '8']);
+    expect(newFormData.permissions?.edit.value).toStrictEqual(['1', '2', '8']);
+    expect(newFormData.permissions?.own.value).toStrictEqual(['1', '2']);
+  });
+
+  test('it adds with cascade an own permission', () => {
+    const newFormData = computeNewOwnPermissions(formData, ['1', '2', '8']);
+
+    expect(newFormData.permissions?.view.value).toStrictEqual(['1', '2', '5', '8']);
+    expect(newFormData.permissions?.edit.value).toStrictEqual(['1', '2', '8']);
+    expect(newFormData.permissions?.own.value).toStrictEqual(['1', '2', '8']);
+  });
+});
+
+const formData: EditCategoryForm = {
+  label: {
+    en_US: {
+      value: 'Cameras',
+      fullName: 'pim_category[label][en_US]',
+      label: 'English (United States)',
+    },
+  },
+  errors: [],
+  _token: {
+    value: 'XFC_DnwJvzF5TsnB2-MbiPUjKqmUtZTJt0O1CTQLqMs',
+    fullName: 'pim_category[_token]',
+  },
+  permissions: {
+    view: {
+      value: ['1', '2', '5'],
+      fullName: 'pim_category[permissions][view][]',
+      choices: [],
+    },
+    edit: {
+      value: ['1', '2'],
+      fullName: 'pim_category[permissions][edit][]',
+      choices: [],
+    },
+    own: {
+      value: ['1', '2'],
+      fullName: 'pim_category[permissions][own][]',
+      choices: [],
+    },
+    apply_on_children: {
+      value: '1',
+      fullName: 'pim_category[permissions][apply_on_children]',
+    },
+  },
+};

--- a/src/Akeneo/Category/front/src/feature/legacy/helpers/permissionsHelper.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/helpers/permissionsHelper.ts
@@ -1,0 +1,88 @@
+import {EditCategoryForm} from '../models';
+
+const computeNewViewPermissions = (originalFormData: EditCategoryForm, values: string[]) => {
+  let newFormData = updateFormDataWithNewValues(originalFormData, values, 'view');
+  const {removedPermission} = computeDifferencesBetweenPermissions(originalFormData, newFormData, 'view');
+  if (removedPermission) {
+    newFormData = removePermissionByType('edit', removedPermission, newFormData);
+    newFormData = removePermissionByType('own', removedPermission, newFormData);
+  }
+
+  return newFormData;
+};
+
+const computeNewEditPermissions = (originalFormData: EditCategoryForm, values: string[]) => {
+  let newFormData = updateFormDataWithNewValues(originalFormData, values, 'edit');
+  const {removedPermission, addedPermission} = computeDifferencesBetweenPermissions(
+    originalFormData,
+    newFormData,
+    'edit'
+  );
+  if (removedPermission) {
+    newFormData = removePermissionByType('own', removedPermission, newFormData);
+  }
+  if (addedPermission) {
+    newFormData = addPermissionByType('view', addedPermission, newFormData);
+  }
+
+  return newFormData;
+};
+
+const computeNewOwnPermissions = (originalFormData: EditCategoryForm, values: string[]) => {
+  let newFormData = updateFormDataWithNewValues(originalFormData, values, 'own');
+  const {addedPermission} = computeDifferencesBetweenPermissions(originalFormData, newFormData, 'own');
+  if (addedPermission) {
+    newFormData = addPermissionByType('view', addedPermission, newFormData);
+    newFormData = addPermissionByType('edit', addedPermission, newFormData);
+  }
+
+  return newFormData;
+};
+
+const updateFormDataWithNewValues = (
+  originalFormData: EditCategoryForm,
+  values: string[],
+  type: 'view' | 'edit' | 'own'
+) => {
+  if (!originalFormData.permissions) {
+    return originalFormData;
+  }
+
+  return {
+    ...originalFormData,
+    permissions: {...originalFormData.permissions, [type]: {...originalFormData.permissions[type], value: values}},
+  };
+};
+
+const removePermissionByType = (type: 'view' | 'edit' | 'own', permissionId: number, newPermissions: any) => {
+  const newValues = newPermissions.permissions[type].value.filter((permission: number) => permission !== permissionId);
+
+  return {
+    ...newPermissions,
+    permissions: {...newPermissions.permissions, [type]: {...newPermissions.permissions[type], value: newValues}},
+  };
+};
+
+const addPermissionByType = (type: 'view' | 'edit' | 'own', permissionId: number, newPermissions: any) => {
+  let newValues = [...newPermissions.permissions[type].value];
+  newValues.push(permissionId);
+  newValues = Array.from(new Set(newValues)); //to remove duplicated values
+
+  return {
+    ...newPermissions,
+    permissions: {...newPermissions.permissions, [type]: {...newPermissions.permissions[type], value: newValues}},
+  };
+};
+
+const computeDifferencesBetweenPermissions = (permissionsA: any, permissionsB: any, type: string) => {
+  return {
+    removedPermission: permissionsA.permissions[type].value.filter(
+      (permissionId: number) => !permissionsB.permissions[type].value.includes(permissionId)
+    )[0],
+    addedPermission: permissionsB.permissions[type].value.filter(
+      (permissionId: number) => !permissionsA.permissions[type].value.includes(permissionId)
+    )[0],
+  };
+};
+
+export {computeNewViewPermissions, computeNewEditPermissions, computeNewOwnPermissions};

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/index.ts
@@ -1,0 +1,4 @@
+export * from './useDeleteCategory';
+export * from './useEditCategoryForm';
+export * from './useCountProductsByCategory';
+export * from './useCountProductsBeforeDeleteCategory';

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/useCategory.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/useCategory.ts
@@ -1,0 +1,23 @@
+import {FetchStatus, useFetch, useRoute} from '@akeneo-pim-community/shared';
+import {Category} from '../models';
+import type {EditCategoryForm} from '../models/Category';
+
+type EditCategoryData = {
+  category: Category;
+  form: EditCategoryForm;
+};
+
+const useCategory = (
+  categoryId: number
+): [data: EditCategoryData | null, fetch: () => Promise<void>, status: FetchStatus, error: string | null] => {
+  const url = useRoute('pim_enrich_categorytree_edit', {
+    id: categoryId.toString(),
+  });
+
+  const [categoryData, load, status, error] = useFetch<EditCategoryData>(url);
+
+  return [categoryData, load, status, error];
+};
+
+export {useCategory};
+export type {EditCategoryForm};

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/useCountProductsBeforeDeleteCategory.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/useCountProductsBeforeDeleteCategory.ts
@@ -1,0 +1,43 @@
+import {useCountProductsByCategory} from './useCountProductsByCategory';
+import {useEffect, useState} from 'react';
+
+type CategoryDeletion = {
+  callback: (nbProducts: number) => void;
+  status: 'pending' | 'ready';
+};
+
+// Wrap the category deletion to count its number of products at the last moment.
+const useCountProductsBeforeDeleteCategory = (categoryId: number) => {
+  const [categoryDeletion, setCategoryDeletion] = useState<CategoryDeletion | null>(null);
+  const {numberOfProducts, loadNumberOfProducts} = useCountProductsByCategory(categoryId);
+
+  const beforeDelete = (deleteCategory: (nbProducts: number) => void) => {
+    setCategoryDeletion({callback: deleteCategory, status: numberOfProducts !== null ? 'ready' : 'pending'});
+  };
+
+  useEffect(() => {
+    if (categoryDeletion === null) {
+      return;
+    }
+
+    if (categoryDeletion.status === 'pending') {
+      loadNumberOfProducts();
+      return;
+    }
+
+    if (categoryDeletion.status === 'ready' && numberOfProducts !== null) {
+      categoryDeletion.callback(numberOfProducts as number);
+      setCategoryDeletion(null);
+    }
+  }, [categoryDeletion]);
+
+  useEffect(() => {
+    if (categoryDeletion !== null && numberOfProducts !== null) {
+      setCategoryDeletion({...categoryDeletion, status: 'ready'});
+    }
+  }, [numberOfProducts]);
+
+  return beforeDelete;
+};
+
+export {useCountProductsBeforeDeleteCategory};

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/useCountProductsByCategory.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/useCountProductsByCategory.ts
@@ -1,0 +1,10 @@
+import {useFetch, useRoute} from '@akeneo-pim-community/shared';
+
+const useCountProductsByCategory = (categoryId: number) => {
+  const url = useRoute('pim_enrich_categorytree_count_category_products', {id: categoryId.toString()});
+  const [numberOfProducts, loadNumberOfProducts] = useFetch(url);
+
+  return {numberOfProducts, loadNumberOfProducts};
+};
+
+export {useCountProductsByCategory};

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/useDeleteCategory.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/useDeleteCategory.ts
@@ -1,0 +1,55 @@
+import {NotificationLevel, useNotify, useRouter, useTranslate} from '@akeneo-pim-community/shared';
+import {deleteCategory} from '../infrastructure';
+
+const MAX_NUMBER_OF_PRODUCTS_TO_ALLOW_DELETE = 100;
+
+type CategoryToDelete = {
+  identifier: number;
+  label: string;
+  onDelete: () => void;
+};
+
+const useDeleteCategory = () => {
+  const router = useRouter();
+  const translate = useTranslate();
+  const notify = useNotify();
+
+  const isCategoryDeletionPossible = (label: string, numberOfProducts: number): boolean => {
+    if (numberOfProducts > MAX_NUMBER_OF_PRODUCTS_TO_ALLOW_DELETE) {
+      notify(
+        NotificationLevel.INFO,
+        translate('pim_enrich.entity.category.category_deletion.products_limit_exceeded.title'),
+        translate('pim_enrich.entity.category.category_deletion.products_limit_exceeded.message', {
+          name: label,
+          limit: MAX_NUMBER_OF_PRODUCTS_TO_ALLOW_DELETE,
+        })
+      );
+
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleDeleteCategory = async (categoryToDelete: CategoryToDelete) => {
+    const response = await deleteCategory(router, categoryToDelete.identifier);
+    response.ok && categoryToDelete.onDelete();
+
+    const message = response.ok
+      ? 'pim_enrich.entity.category.category_deletion.success'
+      : response.errorMessage || 'pim_enrich.entity.category.category_deletion.error';
+
+    notify(
+      response.ok ? NotificationLevel.SUCCESS : NotificationLevel.ERROR,
+      translate(message, {name: categoryToDelete.label})
+    );
+  };
+
+  return {
+    isCategoryDeletionPossible,
+    handleDeleteCategory,
+  };
+};
+
+export {useDeleteCategory};
+export type {CategoryToDelete};

--- a/src/Akeneo/Category/front/src/feature/legacy/hooks/useEditCategoryForm.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/hooks/useEditCategoryForm.ts
@@ -1,0 +1,171 @@
+import {useCallback, useContext, useEffect, useState} from 'react';
+import {saveEditCategoryForm} from '../infrastructure';
+import {NotificationLevel, useNotify, useRouter, useTranslate} from '@akeneo-pim-community/shared';
+import {EditCategoryForm, useCategory} from './useCategory';
+import {EditCategoryContext} from '../components';
+import {computeNewEditPermissions, computeNewOwnPermissions, computeNewViewPermissions} from '../helpers';
+import {Category} from '../models';
+
+// @todo Add unit tests
+const useEditCategoryForm = (categoryId: number) => {
+  const router = useRouter();
+  const notify = useNotify();
+  const translate = useTranslate();
+  const [categoryData, loadCategory, categoryLoadingStatus] = useCategory(categoryId);
+  const [category, setCategory] = useState<Category | null>(null);
+  const [originalFormData, setOriginalFormData] = useState<EditCategoryForm | null>(null);
+  const [editedFormData, setEditedFormData] = useState<EditCategoryForm | null>(null);
+  const [thereAreUnsavedChanges, setThereAreUnsavedChanges] = useState<boolean>(false);
+  const {setCanLeavePage} = useContext(EditCategoryContext);
+
+  const haveLabelsBeenChanged = useCallback((): boolean => {
+    if (originalFormData === null || editedFormData === null) {
+      return false;
+    }
+
+    for (const [locale, changedLabel] of Object.entries(editedFormData.label)) {
+      if (!originalFormData.label.hasOwnProperty(locale) && changedLabel.value === '') {
+        return false;
+      }
+      if (
+        !originalFormData.label.hasOwnProperty(locale) ||
+        originalFormData.label[locale].value !== changedLabel.value
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }, [originalFormData, editedFormData]);
+
+  const havePermissionsBeenChanged = useCallback((): boolean => {
+    if (
+      originalFormData === null ||
+      editedFormData === null ||
+      !originalFormData.permissions ||
+      !editedFormData.permissions
+    ) {
+      return false;
+    }
+
+    return (
+      JSON.stringify(originalFormData.permissions.view.value) !==
+        JSON.stringify(editedFormData.permissions.view.value) ||
+      JSON.stringify(originalFormData.permissions.edit.value) !==
+        JSON.stringify(editedFormData.permissions.edit.value) ||
+      JSON.stringify(originalFormData.permissions.own.value) !== JSON.stringify(editedFormData.permissions.own.value)
+    );
+  }, [originalFormData, editedFormData]);
+
+  const onChangeCategoryLabel = (locale: string, label: string) => {
+    if (editedFormData === null || !editedFormData.label.hasOwnProperty(locale)) {
+      return;
+    }
+
+    const editedLabel = {...editedFormData.label[locale], value: label};
+    setEditedFormData({...editedFormData, label: {...editedFormData.label, [locale]: editedLabel}});
+  };
+
+  const onChangePermissions = (type: string, values: any) => {
+    if (editedFormData === null || !editedFormData.permissions) {
+      return;
+    }
+
+    switch (type) {
+      case 'view':
+        const newViewPermissions = computeNewViewPermissions(editedFormData, values);
+        setEditedFormData(newViewPermissions);
+        break;
+      case 'edit':
+        const newEditPermissions = computeNewEditPermissions(editedFormData, values);
+        setEditedFormData(newEditPermissions);
+        break;
+      case 'own':
+        const newOwnPermissions = computeNewOwnPermissions(editedFormData, values);
+        setEditedFormData(newOwnPermissions);
+        break;
+    }
+  };
+
+  const onChangeApplyPermissionsOnChildren = (value: any) => {
+    if (editedFormData === null || !editedFormData.permissions) {
+      return;
+    }
+
+    const editedApplyOnChildren = {...editedFormData.permissions.apply_on_children, value: value === true ? '1' : '0'};
+    setEditedFormData({
+      ...editedFormData,
+      permissions: {...editedFormData.permissions, apply_on_children: editedApplyOnChildren},
+    });
+  };
+
+  const saveCategory = useCallback(async () => {
+    if (categoryData === null || editedFormData === null) {
+      return;
+    }
+
+    const response = await saveEditCategoryForm(router, categoryData.category.id, editedFormData);
+
+    if (response.success) {
+      notify(NotificationLevel.SUCCESS, translate('pim_enrich.entity.category.content.edit.success'));
+      setOriginalFormData(response.form);
+      setCategory(response.category);
+    } else {
+      notify(NotificationLevel.ERROR, translate('pim_enrich.entity.category.content.edit.fail'));
+      const refreshedToken = {...editedFormData._token, value: response.form._token.value};
+      setEditedFormData({...editedFormData, _token: refreshedToken});
+    }
+  }, [categoryData, editedFormData]);
+
+  useEffect(() => {
+    loadCategory();
+  }, [categoryId]);
+
+  useEffect(() => {
+    if (categoryData === null) {
+      return;
+    }
+
+    setOriginalFormData(categoryData.form);
+    setCategory(categoryData.category);
+  }, [categoryData]);
+
+  useEffect(() => {
+    if (originalFormData === null) {
+      return;
+    }
+
+    // Because the value of "apply_on_children" is always returned as "1" by the backend, it should only be defined at the first load
+    if (originalFormData.permissions && editedFormData !== null && editedFormData.permissions) {
+      setEditedFormData({
+        ...originalFormData,
+        permissions: {...originalFormData.permissions, apply_on_children: editedFormData.permissions.apply_on_children},
+      });
+    } else {
+      setEditedFormData({...originalFormData});
+    }
+  }, [originalFormData]);
+
+  useEffect(() => {
+    if (editedFormData !== null) {
+      setThereAreUnsavedChanges(haveLabelsBeenChanged() || havePermissionsBeenChanged());
+    }
+  }, [editedFormData]);
+
+  useEffect(() => {
+    setCanLeavePage(!thereAreUnsavedChanges);
+  }, [thereAreUnsavedChanges]);
+
+  return {
+    categoryLoadingStatus,
+    category,
+    formData: editedFormData,
+    onChangeCategoryLabel,
+    onChangePermissions,
+    onChangeApplyPermissionsOnChildren,
+    thereAreUnsavedChanges,
+    saveCategory,
+  };
+};
+
+export {useEditCategoryForm};

--- a/src/Akeneo/Category/front/src/feature/legacy/infrastructure/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/infrastructure/index.ts
@@ -1,0 +1,2 @@
+export * from './removers';
+export * from './savers';

--- a/src/Akeneo/Category/front/src/feature/legacy/infrastructure/removers/deleteCategory.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/infrastructure/removers/deleteCategory.ts
@@ -1,0 +1,24 @@
+import {Router} from '@akeneo-pim-community/shared';
+
+const ROUTE_NAME = 'pim_enrich_categorytree_remove';
+
+type Response = {
+  ok: boolean;
+  errorMessage: string;
+};
+
+const deleteCategory = async (router: Router, id: number): Promise<Response> => {
+  const response = await fetch(router.generate(ROUTE_NAME, {id}), {
+    method: 'DELETE',
+    headers: [['X-Requested-With', 'XMLHttpRequest']],
+  });
+
+  const errorMessage = response.ok ? '' : (await response.json()).message;
+
+  return {
+    ok: response.ok,
+    errorMessage,
+  };
+};
+
+export {deleteCategory};

--- a/src/Akeneo/Category/front/src/feature/legacy/infrastructure/removers/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/infrastructure/removers/index.ts
@@ -1,0 +1,1 @@
+export * from './deleteCategory';

--- a/src/Akeneo/Category/front/src/feature/legacy/infrastructure/savers/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/infrastructure/savers/index.ts
@@ -1,0 +1,1 @@
+export * from './saveEditCategoryForm';

--- a/src/Akeneo/Category/front/src/feature/legacy/infrastructure/savers/saveEditCategoryForm.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/infrastructure/savers/saveEditCategoryForm.ts
@@ -1,0 +1,50 @@
+import {Router} from '@akeneo-pim-community/shared';
+
+import {EditCategoryForm} from '../../models';
+import {Category} from '../../models';
+
+type EditCategoryResponse = {
+  success: boolean;
+  form: EditCategoryForm;
+  category: Category;
+};
+
+const saveEditCategoryForm = async (
+  router: Router,
+  id: number,
+  formData: EditCategoryForm
+): Promise<EditCategoryResponse> => {
+  const params = new URLSearchParams();
+  params.append(formData._token.fullName, formData._token.value);
+  for (const [locale, changedLabel] of Object.entries(formData.label)) {
+    params.append(formData.label[locale].fullName, changedLabel.value);
+  }
+
+  if (formData.permissions) {
+    const permissions = formData.permissions;
+    if (permissions.apply_on_children.value === '1') {
+      params.append(permissions.apply_on_children.fullName, permissions.apply_on_children.value);
+    }
+    formData.permissions.view.value.map(value => params.append(permissions.view.fullName, value));
+    formData.permissions.edit.value.map(value => params.append(permissions.edit.fullName, value));
+    formData.permissions.own.value.map(value => params.append(permissions.own.fullName, value));
+  }
+
+  const response = await fetch(router.generate('pim_enrich_categorytree_edit', {id}), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+    },
+    body: params,
+  });
+
+  const responseContent = await response.json();
+
+  return {
+    success: response.ok,
+    form: responseContent.form,
+    category: responseContent.category,
+  };
+};
+
+export {saveEditCategoryForm};

--- a/src/Akeneo/Category/front/src/feature/legacy/models/Category.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/models/Category.ts
@@ -1,0 +1,100 @@
+import {LabelCollection} from '@akeneo-pim-community/shared';
+import {TreeNode} from './Tree';
+
+export type Category = {
+  id: number;
+  code: string;
+  labels: LabelCollection;
+  root: Category | null;
+};
+
+export type EditableCategoryProperties = {
+  labels: LabelCollection;
+};
+
+export type CategoryPermissions = {
+  view: number[];
+  edit: number[];
+  own: number[];
+  apply_on_children: '0' | '1';
+};
+
+export type BackendCategoryTree = {
+  attr: {
+    id: string; // format: node_([0-9]+)
+    'data-code': string;
+  };
+  data: string;
+  state: 'leaf' | 'closed' | 'closed jstree-root';
+  children?: BackendCategoryTree[];
+};
+
+export type CategoryTreeModel = {
+  id: number;
+  code: string;
+  label: string;
+  isRoot: boolean;
+  isLeaf: boolean;
+  children?: CategoryTreeModel[];
+  productsNumber?: number;
+};
+
+export type FormField = {
+  value: string;
+  fullName: string;
+  label: string;
+};
+
+export type HiddenFormField = {
+  value: string;
+  fullName: string;
+};
+
+export type FormChoiceField = {
+  value: string[];
+  fullName: string;
+  choices: {
+    value: string;
+    label: string;
+  }[];
+};
+
+export type EditCategoryForm = {
+  label: {[locale: string]: FormField};
+  _token: HiddenFormField;
+  permissions?: {
+    view: FormChoiceField;
+    edit: FormChoiceField;
+    own: FormChoiceField;
+    apply_on_children: HiddenFormField;
+  };
+  errors: string[];
+};
+
+const convertToCategoryTree = (tree: BackendCategoryTree): CategoryTreeModel => {
+  return {
+    id: parseInt(tree.attr.id.substring(5)), // remove the "node_" prefix and returns the number
+    code: tree.attr['data-code'],
+    label: tree.data,
+    isRoot: tree.state.match(/root/) !== null,
+    isLeaf: tree.state.match(/leaf/) !== null,
+    children: tree.children !== undefined ? tree.children.map(subtree => convertToCategoryTree(subtree)) : [],
+  };
+};
+
+const buildTreeNodeFromCategoryTree = (
+  categoryTree: CategoryTreeModel,
+  parent: number | null = null
+): TreeNode<CategoryTreeModel> => {
+  return {
+    identifier: categoryTree.id,
+    label: categoryTree.label,
+    childrenIds: Array.isArray(categoryTree.children) ? categoryTree.children.map(child => child.id) : [],
+    data: categoryTree,
+    parentId: parent,
+    type: categoryTree.isRoot ? 'root' : categoryTree.isLeaf ? 'leaf' : 'node',
+    childrenStatus: categoryTree.children && categoryTree.children.length > 0 ? 'loaded' : 'idle',
+  };
+};
+
+export {convertToCategoryTree, buildTreeNodeFromCategoryTree};

--- a/src/Akeneo/Category/front/src/feature/legacy/models/Tree.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/models/Tree.ts
@@ -1,0 +1,33 @@
+type TreeNode<T> = {
+  identifier: number;
+  label: string;
+  parentId: number | null;
+  childrenIds: number[];
+  data: T;
+  type: 'leaf' | 'root' | 'node';
+  childrenStatus: 'idle' | 'loaded' | 'loading' | 'to-reload';
+};
+
+type PlaceholderPosition = 'bottom' | 'top' | 'middle' | 'none';
+
+type DraggedNode = {
+  parentId: number;
+  position: number;
+  identifier: number;
+};
+
+type HoveredNode = {
+  parentId: number;
+  position: number;
+  identifier: number;
+};
+
+type DropTargetPosition = 'after' | 'before' | 'in';
+
+type DropTarget = {
+  position: DropTargetPosition;
+  parentId: number;
+  identifier: number;
+};
+
+export type {TreeNode, PlaceholderPosition, DraggedNode, HoveredNode, DropTargetPosition, DropTarget};

--- a/src/Akeneo/Category/front/src/feature/legacy/models/index.ts
+++ b/src/Akeneo/Category/front/src/feature/legacy/models/index.ts
@@ -1,0 +1,2 @@
+export * from './Category';
+export * from './Tree';

--- a/src/Akeneo/Category/front/src/feature/legacy/pages/HistoryPimView.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/pages/HistoryPimView.tsx
@@ -1,0 +1,53 @@
+import React, {useRef, useState, useEffect} from 'react';
+import {useIsMounted, useViewBuilder, View} from '@akeneo-pim-community/shared';
+
+type Props = {
+  viewName: string;
+  className?: string;
+  onBuild?: (view: View) => Promise<View>;
+};
+
+const HistoryPimView = ({viewName, className, onBuild}: Props) => {
+  const el = useRef<HTMLDivElement>(null);
+  const [view, setView] = useState<View | null>(null);
+
+  const viewBuilder = useViewBuilder();
+  const isMounted = useIsMounted();
+  useEffect(() => {
+    if (!viewBuilder) {
+      return;
+    }
+
+    viewBuilder
+      .build(viewName)
+      .then((view: View) => {
+        if (typeof onBuild === 'function') {
+          return onBuild(view);
+        }
+        return view;
+      })
+      .then((view: View) => {
+        if (isMounted()) {
+          view.setElement(el.current).render();
+          setView(view);
+        }
+      });
+  }, [viewBuilder, viewName, isMounted, onBuild]);
+
+  useEffect(
+    () => () => {
+      view && view.remove();
+    },
+    [view]
+  );
+
+  return (
+    <div>
+      <div ref={el} className={className} />
+    </div>
+  );
+};
+
+export type {View};
+
+export {HistoryPimView};

--- a/src/Akeneo/Category/front/src/feature/legacy/pages/LegacyCategoryEditPage.tsx
+++ b/src/Akeneo/Category/front/src/feature/legacy/pages/LegacyCategoryEditPage.tsx
@@ -30,18 +30,17 @@ import {CategoryToDelete, useDeleteCategory, useEditCategoryForm, useCountProduc
 import {Category} from '../models';
 import {HistoryPimView, View} from './HistoryPimView';
 import {DeleteCategoryModal} from '../components/datagrids/DeleteCategoryModal';
-import {EditPermissionsForm, EditPropertiesForm, EditAttributesForm} from '../components';
+import {EditPermissionsForm, EditPropertiesForm} from '../components';
 
 type Params = {
   categoryId: string;
 };
 
 const propertyTabName = '#pim_enrich-category-tab-property';
-const attributeTabName = '#pim_enrich-category-tab-attribute';
 const historyTabName = '#pim_enrich-category-tab-history';
 const permissionTabName = '#pim_enrich-category-tab-permission';
 
-const CategoryEditPage: FC = () => {
+const LegacyCategoryEditPage: FC = () => {
   const {categoryId} = useParams<Params>();
   const translate = useTranslate();
   const router = useRouter();
@@ -208,15 +207,6 @@ const CategoryEditPage: FC = () => {
           >
             {translate('pim_common.properties')}
           </TabBar.Tab>
-          <TabBar.Tab
-            isActive={isCurrent(attributeTabName)}
-            onClick={() => {
-              setActiveTab(attributeTabName);
-              switchTo(attributeTabName);
-            }}
-          >
-            {translate('Attributes')}
-          </TabBar.Tab>
           {formData &&
             formData.permissions &&
             permissionsAreEnabled &&
@@ -247,7 +237,6 @@ const CategoryEditPage: FC = () => {
         {isCurrent(propertyTabName) && category && (
           <EditPropertiesForm category={category} formData={formData} onChangeLabel={onChangeCategoryLabel} />
         )}
-        {isCurrent(attributeTabName) && <EditAttributesForm />}
         {isCurrent(historyTabName) && (
           <HistoryPimView
             viewName="pim-category-edit-form-history"
@@ -280,4 +269,4 @@ const CategoryEditPage: FC = () => {
     </>
   );
 };
-export {CategoryEditPage};
+export {LegacyCategoryEditPage};

--- a/src/Akeneo/Category/front/src/index.tsx
+++ b/src/Akeneo/Category/front/src/index.tsx
@@ -6,7 +6,7 @@ import {MicroFrontendDependenciesProvider, Routes, Translations} from '@akeneo-p
 import {routes} from './routes.json';
 import translations from './translations.json';
 import {CategoriesApp} from './feature';
-import {ConfigurationProvider, Page} from './configuration';
+import {ConfigurationProvider, Page as ConfigurationPage} from './configuration';
 import {FakePIM} from './FakePIM';
 import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 
@@ -18,7 +18,7 @@ ReactDOM.render(
           <Router basename="/">
             <Switch>
               <Route path="/configuration">
-                <Page />
+                <ConfigurationPage />
               </Route>
               <Route path="/">
                 <CategoriesApp setCanLeavePage={() => true} />


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Created a legacy folder in front in the category bounded context, so that the edition of a category before the enriched category project is stable and untouched. The main legacy component is LegacyCategoryEditPage, all its local dependencies are copied into legacy so that we can freely modify the new CategoryEditPage.

the index.tsx does the switch between the two using the _enriched_category_ feature flag in the CategoryApp component.
