### PR TITLE
PIM-10553: Fix initialization of the associations grid in product edit form

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,8 +1,13 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10553: Fix initialization of the associations grid in product edit form
+
 # 5.0.105 (2022-08-03)
 
 ## Bug fixes
+
 - PIM-10551: Add filtering on locale specific attributes when fetching values
 
 # 5.0.104 (2022-07-11)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/associations.js
@@ -221,7 +221,7 @@ define([
           );
           this.renderPanes();
 
-          if (0 !== associationTypes.length) {
+          if (0 !== associationTypes.length && !isQuantifiedAssociation) {
             const currentGrid = this.datagrids[this.getCurrentAssociationTarget()];
             this.renderGrid(currentGrid.name, currentGrid.getInitialParams(this.getCurrentAssociationType()));
             this.setListenerSelectors();
@@ -458,6 +458,12 @@ define([
       this.updateListenerSelectors();
 
       const currentGrid = this.datagrids[this.getCurrentAssociationTarget()];
+
+      if (!this.isGridRendered(currentGrid) && !isQuantifiedAssociation) {
+        this.renderGrid(currentGrid.name, currentGrid.getInitialParams(this.getCurrentAssociationType()));
+        this.setListenerSelectors();
+      }
+
       mediator
         .trigger(
           'datagrid:setParam:' + currentGrid.name,
@@ -502,7 +508,7 @@ define([
       this.updateListenerSelectors();
 
       const currentGrid = this.datagrids[this.getCurrentAssociationTarget()];
-      if (!this.isGridRendered(currentGrid)) {
+      if (!this.isGridRendered(currentGrid) && !isQuantifiedAssociation) {
         this.renderGrid(currentGrid.name, currentGrid.getInitialParams(this.getCurrentAssociationType()));
         this.setListenerSelectors();
       }


### PR DESCRIPTION
The associations grid was not correctly initialized when the currently selected association type was quantified (meta was empty, thus preventing from correctly computing permissions in EE)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
