### PR TITLE
PIM-10572: Fix product publishing when associated to a published product with a 2-way association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - PIM-10561: Fix associationUserIntentFactory to cast int to string
 - PIM-10557: Fix notifications not displayed for obsolete route parameters
 - PIM-10530: Fix case issue when querying products with attribute options
+- PIM-10572: Fix product publishing when associated to a published product with a 2-way association
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithAssociations/PersistTwoWayAssociationSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/EntityWithAssociations/PersistTwoWayAssociationSubscriber.php
@@ -41,6 +41,11 @@ final class PersistTwoWayAssociationSubscriber implements EventSubscriberInterfa
             return;
         }
 
+        // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
+        if ('Akeneo\Pim\WorkOrganization\Workflow\Component\Model\PublishedProduct' === \get_class($entity)) {
+            return;
+        }
+
         $em = $this->registry->getManager();
 
         /** @var AssociationInterface $association */


### PR DESCRIPTION
When publishing a product 2-way associated with a published product, we don't want the reverse association to be published (i.e we don't want the target published product to be updated)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
