### PR TITLE
PIM-10571: Fix infinite scroll of attribute group selector in family edit form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - PIM-10569: Fix associate bulk action screen for quantified associations
 - PIM-10574: Fix link to product page in quantified association row
 - PIM-10548: Fix yaml reader does not display an error message when imported file does not contain the root level
+- PIM-10571: Fix infinite scroll of attribute group selector in family edit form
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/toolbar/add-select/attribute-group/select.js
@@ -7,13 +7,7 @@
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-define(['jquery', 'underscore', 'oro/translator', 'pim/common/add-select', 'pim/fetcher-registry'], function (
-  $,
-  _,
-  __,
-  BaseAddSelect,
-  FetcherRegistry
-) {
+define(['jquery', 'underscore', 'oro/translator', 'pim/common/add-select'], function ($, _, __, BaseAddSelect) {
   return BaseAddSelect.extend({
     className: 'AknButtonList-item add-attribute-group',
 
@@ -22,7 +16,7 @@ define(['jquery', 'underscore', 'oro/translator', 'pim/common/add-select', 'pim/
      *
      * @param {Object} loadedGroups
      */
-    filterAllowedAttributeGroups(loadedGroups) {
+    filterItems(loadedGroups) {
       const allowedGroups = {};
 
       Object.entries(loadedGroups).forEach(([group, data]) => {
@@ -41,17 +35,6 @@ define(['jquery', 'underscore', 'oro/translator', 'pim/common/add-select', 'pim/
       });
 
       return allowedGroups;
-    },
-
-    /**
-     * Fetches filtered attribute groups for the select
-     *
-     * @param {Promise} searchParameters
-     */
-    fetchItems(searchParameters) {
-      return FetcherRegistry.getFetcher(this.mainFetcher)
-        .search(searchParameters)
-        .then(loadedGroups => this.filterAllowedAttributeGroups(loadedGroups));
     },
   });
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/add-select/select.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/form/common/add-select/select.js
@@ -214,15 +214,17 @@ define([
      * @return {Object}
      */
     prepareChoices: function (items) {
-      return _.chain(
-        _.sortBy(items, function (item) {
-          return item.sort_order;
-        })
-      )
-        .map(function (item) {
-          return ChoicesFormatter.formatOne(item);
-        })
-        .value();
+      return 0 === Object.keys(items).length
+        ? items
+        : _.chain(
+            _.sortBy(items, function (item) {
+              return item.sort_order;
+            })
+          )
+            .map(function (item) {
+              return ChoicesFormatter.formatOne(item);
+            })
+            .value();
     },
 
     /**
@@ -251,6 +253,13 @@ define([
     },
 
     /**
+     * Optionally filters items fetched from the server
+     *
+     * @param {Object} items
+     */
+    filterItems: items => items,
+
+    /**
      * Creates request according to recieved options
      *
      * @param {Object} options
@@ -267,11 +276,11 @@ define([
 
           this.fetchItems(searchParameters).then(
             function (items) {
-              var choices = this.prepareChoices(items);
+              var choices = this.prepareChoices(this.filterItems(items));
 
               options.callback({
                 results: choices,
-                more: choices.length === this.resultsPerPage,
+                more: Object.keys(items).length === this.resultsPerPage,
                 context: {
                   page: page + 1,
                 },


### PR DESCRIPTION
Before fix, not all attribute groups were shown in the infinite scroll of attribute group selector in family edit form because empty family groups were not returned by the item fetcher, thus not returning as many options as results per page, which made the function think there were no more options. At the end, this caused the "more" condition to not be triggered.

The fix allows to filter the loaded items while preserving all the items found before filtering, making it possible for the function to know that there still are options to look for.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
