### PR TITLE
PIM-10569: Fix associate bulk action screen for quantified associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - PIM-10557: Fix notifications not displayed for obsolete route parameters
 - PIM-10530: Fix case issue when querying products with attribute options
 - PIM-10572: Fix product publishing when associated to a published product with a 2-way association
+- PIM-10569: Fix associate bulk action screen for quantified associations
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/mass-edit/form/product/associate.js
@@ -156,13 +156,12 @@ define([
     },
 
     renderQuantifiedAssociations: function (quantifiedAssociations) {
-      const isUserOwner = this.getFormData().meta.is_owner ?? true;
       const props = {
         quantifiedAssociations,
         parentQuantifiedAssociations: {products: [], product_models: []},
         errors: [],
         isCompact: true,
-        isUserOwner,
+        isUserOwner: true,
         onAssociationsChange: updatedAssociations => {
           const currentAssociationTypeCode = this.getCurrentAssociationTypeCode();
           this.setValue({[currentAssociationTypeCode]: updatedAssociations}, true);


### PR DESCRIPTION
Fixes a small regression introduced by #17416 : in the associate mass action screen there is no form data, and anyway we don't need to check that the user is owner (it's the job's role to check that)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
