### PR TITLE
SP-223: Implement findAll method in InMemoryUserRepository

### DIFF
--- a/tests/back/Acceptance/User/InMemoryUserRepository.php
+++ b/tests/back/Acceptance/User/InMemoryUserRepository.php
@@ -80,7 +80,7 @@ class InMemoryUserRepository implements IdentifiableObjectRepositoryInterface, S
      */
     public function findAll()
     {
-        throw new NotImplementedException(__METHOD__);
+        return $this->users->toArray();
     }
 
     /**

--- a/tests/back/Acceptance/spec/User/InMemoryUserRepositorySpec.php
+++ b/tests/back/Acceptance/spec/User/InMemoryUserRepositorySpec.php
@@ -110,4 +110,22 @@ class InMemoryUserRepositorySpec extends ObjectBehavior
 
         $this->findBy(['username' => 'julia'])->shouldReturn([]);
     }
+
+    function it_returns_an_empty_array_if_there_is_no_user()
+    {
+        $this->findAll()->shouldReturn([]);
+    }
+
+    function it_finds_all_the_users()
+    {
+        $julia = (new User())->setUsername('julia');
+        $mary = (new User())->setUsername('mary');
+        $this->save($julia);
+        $this->save($mary);
+
+        $this->findAll()->shouldReturn([
+            'julia' => $julia,
+            'mary' => $mary
+        ]);
+    }
 }


### PR DESCRIPTION
The [InMemory implem of this repository](https://github.com/akeneo/pim-community-dev/blob/master/tests/back/Acceptance/User/InMemoryUserRepository.php#L81-L84) does not implement the `findAll()` method but we need it in order to be able to test a subscriber.