### PR TITLE
PIM-10548: Fix yaml reader does not display an error message when imported file does not contain the root level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - PIM-10572: Fix product publishing when associated to a published product with a 2-way association
 - PIM-10569: Fix associate bulk action screen for quantified associations
 - PIM-10574: Fix link to product page in quantified association row
+- PIM-10548: Fix yaml reader does not display an error message when imported file does not contain the root level
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/readers.yml
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/readers.yml
@@ -77,12 +77,8 @@ services:
             - '@pim_connector.array_converter.flat_to_standard.group_type'
 
     # Yaml file readers
-    pim_connector.reader.file.yaml:
-        class: '%pim_connector.reader.file.yaml.class%'
-        arguments:
-            - '@pim_connector.array_converter.dummy'
-
     pim_connector.reader.file.yaml_job_instance:
         class: '%pim_connector.reader.file.yaml.class%'
         arguments:
             - '@pim_connector.array_converter.standard.job_instance'
+            - 'jobs'

--- a/src/Akeneo/Tool/Component/Connector/Exception/InvalidYamlFileException.php
+++ b/src/Akeneo/Tool/Component/Connector/Exception/InvalidYamlFileException.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Component\Connector\Exception;
+
+class InvalidYamlFileException extends \Exception
+{
+    public static function doesNotContainRootLevel(string $expectedRootLevel): self
+    {
+        return new self(
+            sprintf(
+                'File do not respect the expected structure: missing root level "%s"',
+                $expectedRootLevel
+            )
+        );
+    }
+
+    public static function rowShouldBeAnArray(mixed $key, mixed $value): self
+    {
+        return new self(
+            sprintf(
+                'File do not respect the expected structure: Value at "%s" should be an array, actual value is "%s"',
+                $key,
+                $value,
+            ),
+        );
+    }
+}

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Yaml/Reader.php
@@ -10,7 +10,9 @@ use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\ArrayConverter\ArrayConverterInterface;
 use Akeneo\Tool\Component\Connector\Exception\DataArrayConversionException;
 use Akeneo\Tool\Component\Connector\Exception\InvalidItemFromViolationsException;
+use Akeneo\Tool\Component\Connector\Exception\InvalidYamlFileException;
 use Akeneo\Tool\Component\Connector\Reader\File\FileReaderInterface;
+use Symfony\Component\Filesystem\Exception\FileNotFoundException;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -22,34 +24,21 @@ use Symfony\Component\Yaml\Yaml;
  */
 class Reader implements FileReaderInterface, TrackableItemReaderInterface
 {
-    /** @var ArrayConverterInterface */
-    protected $converter;
-
-    /** @var bool */
-    protected $multiple = false;
-
-    /** @var string */
-    protected $codeField = 'code';
-
-    /** @var bool */
-    protected $uploadAllowed = false;
-
-    /** @var StepExecution */
-    protected $stepExecution;
-
-    /** @var \ArrayIterator */
-    protected $yaml;
+    protected bool $uploadAllowed = false;
+    protected ?StepExecution $stepExecution = null;
+    protected ?\ArrayIterator $yaml = null;
 
     /**
      * @param ArrayConverterInterface $converter
      * @param bool                    $multiple
      * @param string                  $codeField
      */
-    public function __construct(ArrayConverterInterface $converter, $multiple = false, $codeField = 'code')
-    {
-        $this->converter = $converter;
-        $this->codeField = $codeField;
-        $this->multiple = $multiple;
+    public function __construct(
+        private ArrayConverterInterface $converter,
+        private string $rootLevel,
+        private bool $multiple = false,
+        private string $codeField = 'code'
+    ) {
     }
 
     /**
@@ -127,6 +116,7 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface
      * Returns the file data
      *
      * @return array
+     * @throws InvalidYamlFileException
      */
     protected function getFileData()
     {
@@ -137,18 +127,32 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface
             ? $jobParameters->get('storage')['file_path']
             : $jobParameters->get('filePath');
 
-        $fileContent = file_get_contents($filePath);
-        if (false !== $fileContent) {
-            if (null !== $this->stepExecution) {
-                $this->stepExecution->setSummary(['item_position' => 0]);
-            }
+        if (!file_exists($filePath)) {
+            throw new FileNotFoundException(sprintf('File "%s" could not be found', $filePath));
         }
-        $fileData = current(Yaml::parse($fileContent));
+
+        $fileContent = file_get_contents($filePath);
+        if (false === $fileContent) {
+            return null;
+        }
+
+        $this->stepExecution?->setSummary(['item_position' => 0]);
+
+        $yamlContent = Yaml::parse($fileContent);
+        if (!array_key_exists($this->rootLevel, $yamlContent)) {
+            throw InvalidYamlFileException::doesNotContainRootLevel($this->rootLevel);
+        }
+
+        $fileData = $yamlContent[$this->rootLevel];
         if (null === $fileData) {
             return null;
         }
 
         foreach ($fileData as $key => $row) {
+            if (!is_array($row)) {
+                throw InvalidYamlFileException::rowShouldBeAnArray($key, $row);
+            }
+
             if ($this->codeField && !isset($row[$this->codeField])) {
                 $fileData[$key][$this->codeField] = $key;
             }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 

- I added a validation about the root level in YAML file. Before wet retrieve the first root level, now we search the expected root level. By doing it we can display an understandable error message to the user if root level is not found.
 
I also added the following check in order to do not having an SLA on this error :
- An error when the file is not found (like the other readers)
- An error if the row is not a row (an array)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
