### PR TITLE
CPM-697: Add userIntents for associations and quantified associations using uuids

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/AssociateProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/AssociateProductUuids.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Ramsey\Uuid\UuidInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * The former associated products that are not defined in this object will stay associated.
+ *
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AssociateProductUuids implements AssociationUserIntent
+{
+    /**
+     * @param array<UuidInterface> $productUuids
+     */
+    public function __construct(
+        private string $associationType,
+        private array  $productUuids,
+    ) {
+        Assert::notEmpty($productUuids);
+        Assert::allIsInstanceOf($productUuids, UuidInterface::class);
+        Assert::stringNotEmpty($associationType);
+    }
+
+    public function associationType(): string
+    {
+        return $this->associationType;
+    }
+
+    /**
+     * @return array<UuidInterface>
+     */
+    public function productUuids(): array
+    {
+        return $this->productUuids;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/AssociationUserIntentCollection.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/AssociationUserIntentCollection.php
@@ -4,22 +4,48 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
 
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\AssociateQuantifiedProductUuids;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\DissociateQuantifiedProductUuids;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\ReplaceAssociatedQuantifiedProductUuids;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Webmozart\Assert\Assert;
 
 /**
+ * Association user intent collection can either contain identifier related user intents or uuid related user intents
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 final class AssociationUserIntentCollection implements UserIntent
 {
+    private array $associationUserIntentsByUuids = [
+        AssociateProductUuids::class,
+        DissociateProductUuids::class,
+        ReplaceAssociatedProductUuids::class,
+        AssociateQuantifiedProductUuids::class,
+        DissociateQuantifiedProductUuids::class,
+        ReplaceAssociatedQuantifiedProductUuids::class
+    ];
+
     /**
      * @param array<AssociationUserIntent> $associationUserIntents
      */
-    public function __construct(
-        private array $associationUserIntents = []
-    ) {
+    public function __construct(private array $associationUserIntents = []) {
         Assert::allIsInstanceOf($this->associationUserIntents, AssociationUserIntent::class);
+
+        $associationUserIntentsIndexedByAssociationType = [];
+        foreach ($this->associationUserIntents as $userIntent) {
+            $associationUserIntentsIndexedByAssociationType[$userIntent->associationType()][] = $userIntent::class;
+        }
+
+        foreach ($associationUserIntentsIndexedByAssociationType as $type => $userIntents) {
+            $diffCount = count(\array_diff($userIntents, $this->associationUserIntentsByUuids));
+            $firstIsWithUuid = \in_array($userIntents[0], $this->associationUserIntentsByUuids);
+            $isAllUuids = $firstIsWithUuid && $diffCount === 0;
+            $isAllIdentifiers = !$firstIsWithUuid && $diffCount === count($this->associationUserIntentsByUuids);
+            if (!$isAllUuids || !$isAllIdentifiers) {
+                throw new \InvalidArgumentException('AssociationUserIntentCollection should contain either only uuids user intents or identifier user intents');
+            }
+        }
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/DissociateProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/DissociateProductUuids.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Ramsey\Uuid\UuidInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class DissociateProductUuids implements AssociationUserIntent
+{
+    /**
+     * @param array<UuidInterface> $productUuids
+     */
+    public function __construct(
+        private string $associationType,
+        private array  $productUuids,
+    ) {
+        Assert::notEmpty($productUuids);
+        Assert::allIsInstanceOf($productUuids, UuidInterface::class);
+        Assert::stringNotEmpty($associationType);
+    }
+
+    public function associationType(): string
+    {
+        return $this->associationType;
+    }
+
+    /**
+     * @return array<UuidInterface>
+     */
+    public function productUuids(): array
+    {
+        return $this->productUuids;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/ReplaceAssociatedProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UserIntent/Association/ReplaceAssociatedProductUuids.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Ramsey\Uuid\UuidInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * For the given association type, the former associated products that are not defined in this object
+ * will be dissociated.
+ *
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ReplaceAssociatedProductUuids implements AssociationUserIntent
+{
+    /**
+     * @param array<UuidInterface> $productUuids
+     */
+    public function __construct(
+        private string $associationType,
+        private array  $productUuids,
+    ) {
+        Assert::allIsInstanceOf($this->productUuids, UuidInterface::class);
+        Assert::stringNotEmpty($associationType);
+    }
+
+    public function associationType(): string
+    {
+        return $this->associationType;
+    }
+
+    /**
+     * @return array<UuidInterface>
+     */
+    public function productUuids(): array
+    {
+        return $this->productUuids;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetViewableProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetViewableProducts.php
@@ -16,4 +16,11 @@ interface GetViewableProducts
      * @return array<string>
      */
     public function fromProductIdentifiers(array $productIdentifiers, int $userId): array;
+
+    /**
+     * @param array<string> $productUuids
+     * @param int $userId
+     * @return array<string>
+     */
+    public function fromProductUuids(array $productUuids, int $userId): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/GetViewableProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/GetViewableProducts.php
@@ -19,4 +19,9 @@ final class GetViewableProducts implements GetViewableProductsInterface
     {
         return $productIdentifiers;
     }
+
+    public function fromProductUuids(array $productUuids, int $userId): array
+    {
+        return $productUuids;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/AssociateProductUuidsSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/AssociateProductUuidsSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProductUuids;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociationUserIntent;
+use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class AssociateProductUuidsSpec extends ObjectBehavior
+{
+    private UuidInterface $uuid1;
+    private UuidInterface $uuid2;
+
+    function let()
+    {
+        $this->uuid1 = Uuid::uuid4();
+        $this->uuid2 = Uuid::uuid4();
+        $this->beConstructedWith('X_SELL', [$this->uuid1, $this->uuid2]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(AssociateProductUuids::class);
+        $this->shouldImplement(AssociationUserIntent::class);
+    }
+
+    function it_returns_the_association_type()
+    {
+        $this->associationType()->shouldReturn('X_SELL');
+    }
+
+    function it_returns_product_uuids()
+    {
+        $this->productUuids()->shouldReturn([$this->uuid1, $this->uuid2]);
+    }
+
+    function it_can_only_be_instantiated_with_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', ['uuid', 1012, false]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_cannot_be_instantiated_with_empty_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', []);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_cannot_be_instantiated_with_empty_association_type()
+    {
+        $this->beConstructedWith('', [$this->uuid1, $this->uuid2]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/AssociationUserIntentCollectionSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/AssociationUserIntentCollectionSpec.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
 
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProducts;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociateProductUuids;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociationUserIntentCollection;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateProducts;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -37,6 +40,16 @@ class AssociationUserIntentCollectionSpec extends ObjectBehavior
     function it_cannot_be_instantiated_with_other_intent_than_association_intent()
     {
         $this->beConstructedWith([new SetTextValue('code', null, null, 'value')]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_should_throw_an_exception_when_constructed_with_user_intents_both_with_identifier_and_uuids_on_same_type()
+    {
+        $this->beConstructedWith([
+            new AssociateProducts('code', ['identifier']),
+            new AssociateProductUuids('code', [Uuid::uuid4()]),
+            new DissociateProducts('code2', ['identifier2'])
+        ]);
         $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/DissociateProductUuidsSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/DissociateProductUuidsSpec.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociationUserIntent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\DissociateProductUuids;
+use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class DissociateProductUuidsSpec extends ObjectBehavior
+{
+    private UuidInterface $uuid1;
+    private UuidInterface $uuid2;
+    function let()
+    {
+        $this->uuid1 = Uuid::uuid4();
+        $this->uuid2 = Uuid::uuid4();
+
+        $this->beConstructedWith('X_SELL', [$this->uuid1, $this->uuid2]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(DissociateProductUuids::class);
+        $this->shouldImplement(AssociationUserIntent::class);
+    }
+
+    function it_returns_the_association_type()
+    {
+        $this->associationType()->shouldReturn('X_SELL');
+    }
+
+    function it_returns_the_product_uuids()
+    {
+        $this->productUuids()->shouldReturn([$this->uuid1, $this->uuid2]);
+    }
+
+    function it_can_only_be_instantiated_with_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', ['test', 12, false]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_cannot_be_instantiated_with_empty_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', []);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_cannot_be_instantiated_with_empty_association_type()
+    {
+        $this->beConstructedWith('', [$this->uuid1, $this->uuid2]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/ReplaceAssociatedProductUuidsSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/API/Command/UserIntent/Association/ReplaceAssociatedProductUuidsSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\AssociationUserIntent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Association\ReplaceAssociatedProductUuids;
+use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class ReplaceAssociatedProductUuidsSpec extends ObjectBehavior
+{
+    private UuidInterface $uuid1;
+    private UuidInterface $uuid2;
+
+    function let()
+    {
+        $this->uuid1 = Uuid::uuid4();
+        $this->uuid2 = Uuid::uuid4();
+
+        $this->beConstructedWith('X_SELL', [$this->uuid1, $this->uuid2]);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ReplaceAssociatedProductUuids::class);
+        $this->shouldImplement(AssociationUserIntent::class);
+    }
+
+    function it_returns_the_association_type()
+    {
+        $this->associationType()->shouldReturn('X_SELL');
+    }
+
+    function it_returns_the_product_uuids()
+    {
+        $this->productUuids()->shouldReturn([$this->uuid1, $this->uuid2]);
+    }
+
+    function it_can_only_be_instantiated_with_uuid_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', ['test', 12, false]);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+
+    function it_can_be_instantiated_with_empty_product_uuids()
+    {
+        $this->beConstructedWith('X_SELL', []);
+        $this->productUuids()->shouldReturn([]);
+    }
+
+    function it_cannot_be_instantiated_with_empty_association_type()
+    {
+        $this->beConstructedWith('', ['identifier1', 'identifier2']);
+        $this->shouldThrow(\InvalidArgumentException::class)->duringInstantiation();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add: 
- Associate, Dissociate and Replace products using uuids
- Association, Dissociate, and Replace quantified products using uuids

Update:
- Associations related user intents applier to handle the new ones
- Quantified associations related user intents applier to handle the new ones

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
