### PR TITLE
GRF-122: Add JSON value collection field for the category in the database

### DIFF
--- a/src/Akeneo/Category/back/Infrastructure/EventSubscriber/InitCategoryDbSchemaSubscriber.php
+++ b/src/Akeneo/Category/back/Infrastructure/EventSubscriber/InitCategoryDbSchemaSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Category\Infrastructure\EventSubscriber;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvent;
+use Akeneo\Platform\Bundle\InstallerBundle\Event\InstallerEvents;
+use Doctrine\DBAL\Connection;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class InitCategoryDbSchemaSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private Connection $dbalConnection)
+    {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            InstallerEvents::POST_DB_CREATE => 'initDbSchema'
+        ];
+    }
+
+    public function initDbSchema(InstallerEvent $event): void
+    {
+        $columns = $this->dbalConnection->getSchemaManager()->listTableColumns('pim_catalog_category');
+        if (array_key_exists('value_collection', $columns)) {
+            return;
+        }
+
+        $addCategoryValueCollectionQuery = <<<SQL
+ALTER TABLE pim_catalog_category ADD value_collection JSON;
+SQL;
+
+        $this->dbalConnection->executeQuery($addCategoryValueCollectionQuery);
+    }
+}

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/DependencyInjection/AkeneoCategoryExtension.php
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/DependencyInjection/AkeneoCategoryExtension.php
@@ -42,5 +42,6 @@ class AkeneoCategoryExtension extends Extension
         $loader->load('handlers.yml');
         $loader->load('appliers.yml');
         $loader->load('factories.yml');
+        $loader->load('subscribers.yml');
     }
 }

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/subscribers.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/config/subscribers.yml
@@ -1,0 +1,6 @@
+services:
+    Akeneo\Category\Infrastructure\EventSubscriber\InitCategoryDbSchemaSubscriber:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'kernel.event_subscriber' }

--- a/upgrades/schema/Version_7_0_20220808143128_add_value_collection_to_category.php
+++ b/upgrades/schema/Version_7_0_20220808143128_add_value_collection_to_category.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_7_0_20220808143128_add_value_collection_to_category extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->skipIf(
+            $schema->getTable('pim_catalog_category')->hasColumn('value_collection'),
+            'value_collection column already exists in pim_catalog_category'
+        );
+
+        $this->addSql('ALTER TABLE pim_catalog_category ADD value_collection JSON, ALGORITHM=INPLACE, LOCK=NONE;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Migration which add a column `value_collection` (json) in the table `pim_catalog_category`.
Tested in a Corabelux env (20,777 categories) : took 2783ms.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
