### PR TITLE
PIM-10574: Fix link to product page in quantified association row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PIM-10530: Fix case issue when querying products with attribute options
 - PIM-10572: Fix product publishing when associated to a published product with a 2-way association
 - PIM-10569: Fix associate bulk action screen for quantified associations
+- PIM-10574: Fix link to product page in quantified association row
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
@@ -1,6 +1,6 @@
 import React, {ChangeEvent} from 'react';
 import styled, {css} from 'styled-components';
-import {filterErrors, formatParameters, useTranslate, useSecurity, useRoute} from '@akeneo-pim-community/shared';
+import {filterErrors, formatParameters, useTranslate, useSecurity, useRouter} from '@akeneo-pim-community/shared';
 import {BrokenLinkIcon, EditIcon, CloseIcon, useTheme, Helper, Badge} from 'akeneo-design-system';
 import {ProductType, Row, QuantifiedLink, MAX_QUANTITY} from '../models';
 import {useProductThumbnail} from '../hooks';
@@ -112,10 +112,10 @@ const QuantifiedAssociationRow = ({
   const translate = useTranslate();
   const {isGranted} = useSecurity();
   const isProductModel = ProductType.ProductModel === row.productType;
-  const routeParams = isProductModel
-    ? {id: row.product?.id.toString() || ''}
-    : {uuid: row.product?.id.toString() || ''};
-  const productEditUrl = useRoute(`pim_enrich_${row.productType}_edit`, routeParams);
+  const router = useRouter();
+  const productEditUrl = isProductModel
+    ? router.generate('pim_enrich_product_model_edit', {id: row.product?.id.toString() || ''})
+    : router.generate('pim_enrich_product_edit', {uuid: row.product?.id.toString() || ''});
   const thumbnailUrl = useProductThumbnail(row.product);
   const blueColor = useTheme().color.blue100;
   const canRemoveAssociation =

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/quantified-associations/components/QuantifiedAssociationRow.tsx
@@ -112,7 +112,10 @@ const QuantifiedAssociationRow = ({
   const translate = useTranslate();
   const {isGranted} = useSecurity();
   const isProductModel = ProductType.ProductModel === row.productType;
-  const productEditUrl = useRoute(`pim_enrich_${row.productType}_edit`, {id: row.product?.id.toString() || ''});
+  const routeParams = isProductModel
+    ? {id: row.product?.id.toString() || ''}
+    : {uuid: row.product?.id.toString() || ''};
+  const productEditUrl = useRoute(`pim_enrich_${row.productType}_edit`, routeParams);
   const thumbnailUrl = useProductThumbnail(row.product);
   const blueColor = useTheme().color.blue100;
   const canRemoveAssociation =


### PR DESCRIPTION
Fixes the parameter to use uuid for products.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
