### PR TITLE
PIM-10529: Fix links on product grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - PIM-10548: Fix yaml reader does not display an error message when imported file does not contain the root level
 - PIM-10571: Fix infinite scroll of attribute group selector in family edit form
 - PIM-10581: Fix attribute option code in linked data returned as an integer instead of a string
+- PIM-10529: Fix links on product grid
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -83,16 +83,6 @@ datagrid:
                 frontend_type: complete-variant-product
             document_type: ~
             technical_id: ~
-            delete_link:
-                type: url
-                route: pim_enrich_product_rest_remove
-                params:
-                    uuid: id
-            toggle_status_link:
-                type: url
-                route: pim_enrich_product_toggle_status
-                params:
-                    uuid: id
         actions:
             edit:
                 type:      navigate-product-and-product-model

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/datagrid/action/toggle-product-action.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/datagrid/action/toggle-product-action.js
@@ -1,4 +1,4 @@
-define(['oro/datagrid/ajax-action'], function (AjaxAction) {
+define(['oro/datagrid/ajax-action', 'pim/router'], function (AjaxAction, Router) {
   return AjaxAction.extend({
     /** @property {Boolean} */
     noHref: true,
@@ -24,6 +24,15 @@ define(['oro/datagrid/ajax-action'], function (AjaxAction) {
      */
     getMethod: function () {
       return 'POST';
+    },
+
+    getLink() {
+      const productType = this.model.get('document_type');
+      const id = this.model.get('technical_id');
+
+      if (productType === 'product') {
+        return Router.generate('pim_enrich_product_toggle_status', {uuid: id});
+      }
     },
   });
 });

--- a/src/Oro/Bundle/DataGridBundle/Extension/Action/Actions/AjaxAction.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Action/Actions/AjaxAction.php
@@ -7,7 +7,7 @@ class AjaxAction extends AbstractAction
     /**
      * @var array
      */
-    protected $requiredOptions = ['link'];
+    protected $requiredOptions = [];
 
     /**
      * @return array

--- a/src/Oro/Bundle/DataGridBundle/Extension/Action/Actions/DeleteAction.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Action/Actions/DeleteAction.php
@@ -9,7 +9,7 @@ class DeleteAction extends AbstractAction
     /**
      * @var array
      */
-    protected $requiredOptions = ['link'];
+    protected $requiredOptions = [];
 
     /**
      * @param ActionConfiguration $options


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The delete and toggle status actions are only related to products but were both calculated in the datagrid for products and product models.
The two endpoints were excepting a correct uuids passed with the technical id so we had an error for product models.

The actions are now just overrided with the getLink function in order to handle uuids and ids

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
