### PR TITLE
PIM-10512: Fix empty group labels format for attribute endpoints

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10512: Fix empty group labels format for attribute endpoints
+
 # 5.0.106 (2022-08-08)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/ExternalApi/AttributeNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/ExternalApi/AttributeNormalizer.php
@@ -36,12 +36,16 @@ class AttributeNormalizer implements NormalizerInterface, CacheableSupportsMetho
     {
         $normalizedAttribute = $this->stdNormalizer->normalize($attribute, 'standard', $context);
 
-        if (empty($normalizedAttribute['labels'])) {
-            $normalizedAttribute['labels'] = (object) $normalizedAttribute['labels'];
-        }
-
         // Add read-only attribute group labels inside attribute
-        $normalizedAttribute['group_labels'] = ($attribute->getGroup()) ? $this->translationNormalizer->normalize($attribute->getGroup(), $format, $context) : null;
+        $normalizedAttribute['group_labels'] = ($attribute->getGroup()) ?
+            $this->translationNormalizer->normalize($attribute->getGroup(), $format, $context) :
+            null;
+
+        foreach (['labels', 'group_labels'] as $field) {
+            if (array_key_exists($field, $normalizedAttribute) && [] === $normalizedAttribute[$field]) {
+                $normalizedAttribute[$field] = (object)[];
+            }
+        }
 
         return $normalizedAttribute;
     }

--- a/tests/back/Pim/Structure/EndToEnd/AttributeGroup/ExternalApi/CreateAttributeGroupEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/AttributeGroup/ExternalApi/CreateAttributeGroupEndToEnd.php
@@ -138,7 +138,7 @@ JSON;
     "code": "an_attr_text",
     "type": "pim_catalog_text",
     "group": "new_group",
-    "group_labels": [],
+    "group_labels": {},
     "unique": false,
     "useable_as_grid_filter": false,
     "allowed_extensions": [],

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/ExternalApi/AttributeNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/ExternalApi/AttributeNormalizerSpec.php
@@ -10,7 +10,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class AttributeNormalizerSpec extends ObjectBehavior
 {
-    function let(NormalizerInterface $stdNormalizer,NormalizerInterface $translationNormalizer)
+    function let(NormalizerInterface $stdNormalizer, NormalizerInterface $translationNormalizer)
     {
         $this->beConstructedWith($stdNormalizer);
         $this->beConstructedWith($stdNormalizer, $translationNormalizer);
@@ -29,36 +29,62 @@ class AttributeNormalizerSpec extends ObjectBehavior
         $this->supportsNormalization($attribute, 'external_api')->shouldReturn(true);
     }
 
-    function it_normalizes_an_attribute($stdNormalizer, AttributeInterface $attribute)
+    function it_normalizes_an_attribute(NormalizerInterface $stdNormalizer, AttributeInterface $attribute)
     {
-        $data = ['code' => 'my_attribute', 'labels' => []];
+        $attribute->getGroup()->willReturn(null);
 
-        $stdNormalizer->normalize($attribute, 'standard', [])->willReturn($data);
-
-        $normalizedAttribute = $this->normalize($attribute, 'external_api', []);
-        $normalizedAttribute->shouldHaveLabels($data);
-    }
-
-    function it_normalizes_an_attribute_with_his_group_labels($stdNormalizer, AttributeInterface $attribute)
-    {
-        $data = ['code' => 'my_attribute', 'labels' => [], 'group' => 'attributeGroupA'];
-
-        $stdNormalizer->normalize($attribute, 'standard', [])->willReturn($data);
-        $normalizedAttribute = $this->normalize($attribute, 'external_api', []);
-
-        $normalizedAttribute->shouldHaveLabels($data);
-        $normalizedAttribute->shouldHaveGroupLabels($data);
-    }
-
-    public function getMatchers(): array
-    {
-        return [
-            'haveLabels' => function ($subject) {
-                return is_object($subject['labels']);
-            },
-            'haveGroupLabels' => function ($subject) {
-                return array_key_exists('group_labels', $subject);
-            }
+        $data = [
+            'code' => 'my_attribute',
+            'labels' => ['en_US' => 'english_label'],
         ];
+        $stdNormalizer->normalize($attribute, 'standard', [])->shouldBeCalled()->willReturn($data);
+
+        $this->normalize($attribute, 'external_api', [])->shouldBeLike(array_merge($data, ['group_labels' => null]));
+    }
+
+    function it_normalizes_an_attribute_with_its_group_labels(
+        NormalizerInterface $stdNormalizer,
+        NormalizerInterface $translationNormalizer,
+        AttributeInterface $attribute,
+        AttributeInterface $group
+    ) {
+        $attribute->getGroup()->willReturn($group);
+
+        $data = [
+            'code' => 'my_attribute',
+            'labels' => ['en_US' => 'english_label'],
+            'group' => 'attributeGroupA',
+        ];
+        $stdNormalizer->normalize($attribute, 'standard', [])->willReturn($data);
+
+        $translationNormalizer->normalize($group, 'external_api', [])
+            ->shouldBeCalled()
+            ->willReturn(['en_US' => 'attribute group A']);
+
+        $this->normalize($attribute, 'external_api', [])
+            ->shouldBeLike(array_merge($data, ['group_labels' => ['en_US' => 'attribute group A']]));
+    }
+
+    function it_normalizes_an_attribute_with_empty_labels(
+        NormalizerInterface $stdNormalizer,
+        NormalizerInterface $translationNormalizer,
+        AttributeInterface $attribute,
+        AttributeInterface $group
+    ) {
+        $attribute->getGroup()->willReturn($group);
+
+        $data = ['code' => 'my_attribute', 'labels' => [], 'group' => 'attributeGroupA'];
+        $stdNormalizer->normalize($attribute, 'standard', [])->willReturn($data);
+
+        $translationNormalizer->normalize($group, 'external_api', [])->shouldBeCalled()->willReturn([]);
+
+        $this->normalize($attribute, 'external_api', [])->shouldBeLike(
+            [
+                'code' => 'my_attribute',
+                'labels' => (object)[],
+                'group' => 'attributeGroupA',
+                'group_labels' => (object)[],
+            ]
+        );
     }
 }


### PR DESCRIPTION
Fix attribute normalizer returning an empty array for empty group labels when it should return an empty object. 

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
