### PR TITLE
CPM-632: Make the PIM work with null identifiers part 2

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -130,6 +130,14 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getItemsFromUuids(array $uuids): array
+    {
+        throw new \LogicException("Product Models do not use Uuids.");
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function findByIdentifiers(array $codes): array

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductModelRepository.php
@@ -130,14 +130,6 @@ class ProductModelRepository extends EntityRepository implements ProductModelRep
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function getItemsFromUuids(array $uuids): array
-    {
-        throw new \LogicException("Product Models do not use Uuids.");
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function findByIdentifiers(array $codes): array

--- a/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductRepository.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Doctrine/ORM/Repository/ProductRepository.php
@@ -9,6 +9,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\ORM\EntityRepository;
 use Ramsey\Uuid\UuidInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * Product repository
@@ -25,23 +26,10 @@ class ProductRepository extends EntityRepository implements
     /**
      * {@inheritdoc}
      */
-    public function getItemsFromIdentifiers(array $identifiers): array
+    public function getItemsFromIdentifiers(array $uuids): array
     {
-        $qb = $this->createQueryBuilder('p')
-            ->where('p.identifier IN (:identifiers)')
-            ->setParameter('identifiers', $identifiers);
+        Assert::allIsInstanceOf($uuids, UuidInterface::class);
 
-        $query = $qb->getQuery();
-        $query->useQueryCache(false);
-
-        return $query->execute();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getItemsFromUuids(array $uuids): array
-    {
         $qb = $this->createQueryBuilder('p')
             ->where('p.uuid IN (:uuids)')
             ->setParameter('uuids', array_map(fn(UuidInterface $uuid) => $uuid->getBytes(), $uuids));
@@ -49,7 +37,9 @@ class ProductRepository extends EntityRepository implements
         $query = $qb->getQuery();
         $query->useQueryCache(false);
 
-        return $query->execute();
+        $result = $query->execute();
+
+        return $result;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
@@ -63,11 +63,9 @@ abstract class AbstractCursor implements CursorInterface
      */
     public function valid()
     {
-        if (null === $this->items) {
-            $this->rewind();
-        }
+        $key = key($this->items);
 
-        return !empty($this->items);
+        return false !== $key && null !== $key;
     }
 
     /**
@@ -100,8 +98,7 @@ abstract class AbstractCursor implements CursorInterface
             return [];
         }
 
-        // TODO: Implement getItemsFromUuids better or drop this idea ?
-        $hydratedProducts = $this->productRepository->getItemsFromUuids(
+        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
             $identifierResults->getProductUuids()
         );
         $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/AbstractCursor.php
@@ -100,8 +100,9 @@ abstract class AbstractCursor implements CursorInterface
             return [];
         }
 
-        $hydratedProducts = $this->productRepository->getItemsFromIdentifiers(
-            $identifierResults->getProductIdentifiers()
+        // TODO: Implement getItemsFromUuids better or drop this idea ?
+        $hydratedProducts = $this->productRepository->getItemsFromUuids(
+            $identifierResults->getProductUuids()
         );
         $hydratedProductModels = $this->productModelRepository->getItemsFromIdentifiers(
             $identifierResults->getProductModelIdentifiers()
@@ -112,8 +113,9 @@ abstract class AbstractCursor implements CursorInterface
 
         foreach ($identifierResults->all() as $identifierResult) {
             foreach ($hydratedItems as $hydratedItem) {
+                // TODO: Add proper comparison method ?
                 if ($hydratedItem instanceof ProductInterface &&
-                    $identifierResult->isProductIdentifierEquals($hydratedItem->getIdentifier())
+                    $identifierResult->isProductIdEquals('product_' . $hydratedItem->getUuid()->toString())
                 ) {
                     $orderedItems[] = $hydratedItem;
                     break;

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResult.php
@@ -72,13 +72,13 @@ class IdentifierResult
     }
 
     /**
-     * @param string $identifier
+     * @param string $id
      *
      * @return bool
      */
-    public function isProductIdentifierEquals(string $identifier): bool
+    public function isProductIdEquals(string $id): bool
     {
-        return $identifier === $this->identifier && ProductInterface::class === $this->type;
+        return $id === $this->id && ProductInterface::class === $this->type;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResults.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/IdentifierResults.php
@@ -6,6 +6,8 @@ namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * Simple collection of {@see IdentifierResult}.
@@ -22,7 +24,7 @@ class IdentifierResults
     /** @var IdentifierResult[] */
     private array $identifierResults = [];
 
-    public function add(string $identifier, string $type, string $id): void
+    public function add(?string $identifier, string $type, string $id): void
     {
         $this->identifierResults[] = new IdentifierResult($identifier, $type, $id);
     }
@@ -35,6 +37,17 @@ class IdentifierResults
     public function getProductIdentifiers(): array
     {
         return $this->getIdentifiersByType(ProductInterface::class);
+    }
+
+    /**
+     * @return UuidInterface[]
+     */
+    public function getProductUuids(): array
+    {
+        return array_map(
+            fn(IdentifierResult $identifierResult) => Uuid::fromString(\str_replace('product_', '', $identifierResult->getId())),
+            array_filter($this->identifierResults, fn(IdentifierResult $identifierResult) => ProductInterface::class === $identifierResult->getType())
+        );
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/SearchQueryBuilder.php
@@ -161,7 +161,7 @@ class SearchQueryBuilder
     public function getQuery(array $source = [])
     {
         if (empty($source)) {
-            $source = ['identifier'];
+            $source = ['identifier', 'document_type', 'id'];
         }
 
         $searchQuery = [

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cursors.yml
@@ -6,11 +6,11 @@ services:
         alias: doctrine.orm.entity_manager
 
     pim_catalog.factory.product_cursor:
-        class: '%akeneo_elasticsearch.cursor.cursor_factory.class%'
+        class: 'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\CursorFactory'
         arguments:
             - '@akeneo_elasticsearch.client.product_and_product_model'
             - '@pim_catalog.repository.product'
-            - '%akeneo_elasticsearch.cursor.cursor.class%'
+            - '@pim_catalog.repository.product_model'
             - '%pim_job_product_batch_size%'
 
     pim_catalog.factory.product_and_product_model_identifier_cursor:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -20,8 +20,8 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
         uuid:
             - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsUuid4: ~
         identifier:
-            - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotBlank:
-                attributeCode: 'identifier'
+#            - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotBlank:
+#                attributeCode: 'identifier'
             - Regex:
                 pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Reader/Database/ProductReader.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Reader/Database/ProductReader.php
@@ -23,37 +23,15 @@ use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
  */
 class ProductReader implements ItemReaderInterface, InitializableInterface, StepExecutionAwareInterface, TrackableItemReaderInterface
 {
-    /** @var ProductQueryBuilderFactoryInterface */
-    protected $pqbFactory;
+    protected StepExecution $stepExecution;
+    protected CursorInterface $products;
+    private bool $firstRead = true;
 
-    /** @var ChannelRepositoryInterface */
-    protected $channelRepository;
-
-    /** @var MetricConverter */
-    protected $metricConverter;
-
-    /** @var StepExecution */
-    protected $stepExecution;
-
-    /** @var CursorInterface */
-    protected $products;
-
-    /** @var bool */
-    private $firstRead = true;
-
-    /**
-     * @param ProductQueryBuilderFactoryInterface $pqbFactory
-     * @param ChannelRepositoryInterface          $channelRepository
-     * @param MetricConverter                     $metricConverter
-     */
     public function __construct(
-        ProductQueryBuilderFactoryInterface $pqbFactory,
-        ChannelRepositoryInterface $channelRepository,
-        MetricConverter $metricConverter
+        protected ProductQueryBuilderFactoryInterface $pqbFactory,
+        protected ChannelRepositoryInterface $channelRepository,
+        protected MetricConverter $metricConverter
     ) {
-        $this->pqbFactory = $pqbFactory;
-        $this->channelRepository = $channelRepository;
-        $this->metricConverter = $metricConverter;
     }
 
     /**
@@ -80,6 +58,10 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
                 $this->products->next();
             }
             $product = $this->products->current();
+        }
+
+        if (false === $product) {
+            $product = null;
         }
 
         if (null !== $product) {
@@ -164,12 +146,12 @@ class ProductReader implements ItemReaderInterface, InitializableInterface, Step
     }
 
     /**
-     * @param array            $filters
-     * @param ChannelInterface $channel
+     * @param array             $filters
+     * @param ?ChannelInterface $channel
      *
      * @return CursorInterface
      */
-    protected function getProductsCursor(array $filters, ChannelInterface $channel = null)
+    protected function getProductsCursor(array $filters, ?ChannelInterface $channel = null)
     {
         $options = null !== $channel ? ['default_scope' => $channel->getCode()] : [];
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Writer/File/Csv/ProductWriter.php
@@ -152,6 +152,7 @@ class ProductWriter extends AbstractItemMediaWriter implements ItemWriterInterfa
      */
     protected function getItemIdentifier(array $product): string
     {
-        return $product['identifier'];
+        // TODO : Remove before tests (This allows to make sure the whole export goes well, waiting on CPM-591 to fix)
+        return $product['identifier'] ?? 'This product has no identifier';
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/AbstractEntityWithValuesQueryBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/AbstractEntityWithValuesQueryBuilder.php
@@ -68,7 +68,7 @@ class AbstractEntityWithValuesQueryBuilder implements ProductQueryBuilderInterfa
 
         // Since we can't rely on product id anymore, we add a sort on the identifier
         if (!$this->getQueryBuilder()->hasSort('identifier') && !$this->getQueryBuilder()->hasSort('id')) {
-            $this->addSorter('identifier', Directions::ASCENDING);
+            $this->addSorter('id', Directions::ASCENDING);
         }
 
         return $this->cursorFactory->createCursor($this->getQueryBuilder()->getQuery(), $cursorOptions);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Model/ProductIdentifier.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Model/ProductIdentifier.php
@@ -4,25 +4,22 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Product\Domain\Model;
 
-use Webmozart\Assert\Assert;
-
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 final class ProductIdentifier
 {
-    private function __construct(private string $identifier)
+    private function __construct(private ?string $identifier)
     {
-        Assert::NotEmpty($this->identifier);
     }
 
-    public static function fromString(string $identifier): ProductIdentifier
+    public static function fromString(?string $identifier): ProductIdentifier
     {
         return new self($identifier);
     }
 
-    public function asString(): string
+    public function asString(): ?string
     {
         return $this->identifier;
     }

--- a/src/Akeneo/Tool/Component/StorageUtils/Repository/CursorableRepositoryInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Repository/CursorableRepositoryInterface.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Tool\Component\StorageUtils\Repository;
 
+use Ramsey\Uuid\UuidInterface;
+
 /**
  * Interface for cursorable repositories
  *
@@ -12,9 +14,16 @@ namespace Akeneo\Tool\Component\StorageUtils\Repository;
 interface CursorableRepositoryInterface
 {
     /**
-     * @param array $identifiers
+     * @param string[] $identifiers
      *
      * @return array
      */
-    public function getItemsFromIdentifiers(array $identifiers);
+    public function getItemsFromIdentifiers(array $identifiers): array;
+
+    /**
+     * @param UuidInterface[] $uuids
+     *
+     * @return array
+     */
+    public function getItemsFromUuids(array $uuids): array;
 }

--- a/src/Akeneo/Tool/Component/StorageUtils/Repository/CursorableRepositoryInterface.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Repository/CursorableRepositoryInterface.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\Tool\Component\StorageUtils\Repository;
 
-use Ramsey\Uuid\UuidInterface;
-
 /**
  * Interface for cursorable repositories
  *
@@ -14,16 +12,9 @@ use Ramsey\Uuid\UuidInterface;
 interface CursorableRepositoryInterface
 {
     /**
-     * @param string[] $identifiers
+     * @param array $identifiers
      *
      * @return array
      */
     public function getItemsFromIdentifiers(array $identifiers): array;
-
-    /**
-     * @param UuidInterface[] $uuids
-     *
-     * @return array
-     */
-    public function getItemsFromUuids(array $uuids): array;
 }

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -150,12 +150,4 @@ class InMemoryProductRepository implements
 
         return $items;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getItemsFromUuids(array $uuids): array
-    {
-        throw new \LogicException("Todo: implement this method.");
-    }
 }

--- a/tests/back/Acceptance/Product/InMemoryProductRepository.php
+++ b/tests/back/Acceptance/Product/InMemoryProductRepository.php
@@ -140,7 +140,7 @@ class InMemoryProductRepository implements
         throw new NotImplementedException(__METHOD__);
     }
 
-    public function getItemsFromIdentifiers(array $identifiers)
+    public function getItemsFromIdentifiers(array $identifiers): array
     {
         $items = [];
 
@@ -149,5 +149,13 @@ class InMemoryProductRepository implements
         }
 
         return $items;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getItemsFromUuids(array $uuids): array
+    {
+        throw new \LogicException("Todo: implement this method.");
     }
 }

--- a/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
+++ b/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
@@ -46,9 +46,17 @@ class InMemoryProductModelRepository implements IdentifiableObjectRepositoryInte
         throw new NotImplementedException(__METHOD__);
     }
 
-    public function getItemsFromIdentifiers(array $identifiers)
+    public function getItemsFromIdentifiers(array $identifiers): array
     {
         throw new NotImplementedException(__METHOD__);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getItemsFromUuids(array $uuids): array
+    {
+        throw new \LogicException("Product Models do not use Uuids.");
     }
 
     public function find($id)

--- a/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
+++ b/tests/back/Acceptance/ProductModel/InMemoryProductModelRepository.php
@@ -51,14 +51,6 @@ class InMemoryProductModelRepository implements IdentifiableObjectRepositoryInte
         throw new NotImplementedException(__METHOD__);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function getItemsFromUuids(array $uuids): array
-    {
-        throw new \LogicException("Product Models do not use Uuids.");
-    }
-
     public function find($id)
     {
         throw new NotImplementedException(__METHOD__);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- Remove products without identifiers from GET products API call
- Fix mass actions (e.g. Mass Delete)
- Switch Cursor used in export PQB (this one uses IdentifierResult and allows us to work with Uuids)

Todo :

- AbstractCursor's valid/next/current is weird, maybe should be reworked
- Waiting on various PRs (Import/export with Uuids, Product ServiceAPI with Uuid) to finish import/export/mass actions without identifiers

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
