### PR TITLE
RAC-1265: Fix error when user display the data_quality_insights_evaluations job

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
@@ -107,7 +107,7 @@ class StepExecutionNormalizer implements NormalizerInterface, CacheableSupportsM
         $result = [];
         foreach ($summary as $key => $value) {
             $key = sprintf('job_execution.summary.%s', $key);
-            $result[$this->translator->trans($key)] = $this->translator->trans($value);
+            $result[$this->translator->trans($key)] = is_string($value) ? $this->translator->trans($value) : $value;
         }
 
         return $result;

--- a/tests/back/Platform/EndToEnd/ImportExport/InternalApi/GetJobExecutionEndToEnd.php
+++ b/tests/back/Platform/EndToEnd/ImportExport/InternalApi/GetJobExecutionEndToEnd.php
@@ -98,9 +98,9 @@ SQL;
                     'job' => 'csv_product_import',
                     'status' => 'Completed',
                     'summary' => [
-                        'read lines' => '38',
-                        'skipped product (no differences)' => '37',
-                        'skipped' => '1',
+                        'read lines' => 38,
+                        'skipped product (no differences)' => 37,
+                        'skipped' => 1,
                     ],
                     'startedAt' => '10/13/2020 01:05 PM',
                     'endedAt' => '10/13/2020 01:06 PM',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**In this PR, I fixed the following error :** 
![Screenshot from 2022-08-10 12-06-50](https://user-images.githubusercontent.com/7239572/183875666-315cd37a-b3ae-43dc-93f6-ed5b9805dd43.png)
By checking the data before translate it

**When we have this error ?** 
When the user display a data_quality_insights_evaluations job this job is not visible in the process tracker but can be displayed through the URL

**Why we have this error ?** 
Because in this job the tasklet add as summary an array (https://github.com/akeneo/pim-community-dev/blob/d77dab1/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Connector/Tasklet/EvaluateProductsAndProductModelsCriteriaTasklet.php#L59)


**Definition Of Done (for Core Developer only)**
- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
