### PR TITLE
PIM-10559: [Backport PIM-10478]: Disable compute_family_variant_structure_changes on familySave

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,7 @@
 
 - PIM-10512: Fix empty group labels format for attribute endpoints
 - PIM-10555 [Backport PIM-10462]: Fix ComputeFamilyVariantStructureChanges job not launched after import
+- PIM-10559 [Backport PIM-10478]: Disable compute_family_variant_structure_changes on familySave
 
 # 5.0.106 (2022-08-08)
 

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -72,6 +72,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
+        // This is an optimization to not trigger two times the jobs. Yet, it's not an ideal design because it means the
+        // caller know who are the listener. It means it introduced accidental coupling between the two components that
+        // should not know each other.
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
             ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true,
         ]);
@@ -108,6 +111,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
+        // This is an optimization to not trigger two times the jobs. Yet, it's not an ideal design because it means the
+        // caller knows who are the listeners. It means it introduced accidental coupling between the two components that
+        // should not know each other.
         $this->bulkFamilyVariantSaver->saveAll(
             $validFamilyVariants,
             [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -46,14 +46,11 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         ];
     }
 
-    // TODO change explanation text
     /**
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
      * As we are not in an import context, the `compute_family_variant_structure_changes` job is triggered
-     * by the bulkFamilyVariantSaver->saveAll(). We force the launch of this job because if an attribute
-     * at the common level is removed, the family variant stays unchanged but we need to recompute the root/sub
-     * product models.
+     * by the bulkFamilyVariantSaver->saveAll() only when the family variant structure has been updated.
      *
      * hence, updating the catalog asynchronously.
      *

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -46,6 +46,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         ];
     }
 
+    // TODO change explanation text
     /**
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
@@ -69,13 +70,15 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
             return;
         }
 
+        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
+
         $validationResponse = $this->validateFamilyVariants($subject);
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
-            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true,
+            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges,
         ]);
 
         if (!empty($allViolations)) {
@@ -110,9 +113,11 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
+        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
+
         $this->bulkFamilyVariantSaver->saveAll(
             $validFamilyVariants,
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges]
         );
 
         if (!empty($allViolations)) {

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -49,8 +49,8 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
     /**
      * Validates and saves the family variants belonging to a family whenever it is updated.
      *
-     * As we are not in an import context, the `compute_family_variant_structure_changes` job is triggered
-     * by the bulkFamilyVariantSaver->saveAll() only when the family variant structure has been updated.
+     * When the family variant are saved, we disable the launch of the 'compute_family_variant_structure_changes' job
+     * because the compute is already done by the ComputeCompletenessOfProductsFamilyTasklet job
      *
      * hence, updating the catalog asynchronously.
      *
@@ -67,15 +67,13 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
             return;
         }
 
-        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
-
         $validationResponse = $this->validateFamilyVariants($subject);
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
         Assert::isArray($validFamilyVariants);
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
-            ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges,
+            ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true,
         ]);
 
         if (!empty($allViolations)) {
@@ -110,11 +108,9 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         $validFamilyVariants = $validationResponse['valid_family_variants'];
         $allViolations = $validationResponse['violations'];
 
-        $shouldComputeFamilyVariantStructureChanges = \in_array(FamilyInterface::ATTRIBUTES_WERE_UPDATED, $subject->releaseEvents());
-
         $this->bulkFamilyVariantSaver->saveAll(
             $validFamilyVariants,
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => $shouldComputeFamilyVariantStructureChanges]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         );
 
         if (!empty($allViolations)) {

--- a/src/Akeneo/Pim/Structure/Component/Model/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/Family.php
@@ -55,9 +55,6 @@ class Family implements FamilyInterface
     /** @var Collection */
     protected $familyVariants;
 
-    /** @var string[] */
-    private array $events = [];
-
     /**
      * Constructor
      */
@@ -482,8 +479,6 @@ class Family implements FamilyInterface
         sort($newAttributeCodes);
 
         if ($formerAttributeCodes !== $newAttributeCodes) {
-            $this->events[] = FamilyInterface::ATTRIBUTES_WERE_UPDATED;
-
             $attributeCodesToRemove = array_diff($formerAttributeCodes, $newAttributeCodes);
             $attributeCodesToAdd = array_diff($newAttributeCodes, $formerAttributeCodes);
 
@@ -503,16 +498,5 @@ class Family implements FamilyInterface
                 }
             }
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function releaseEvents(): array
-    {
-        $events = $this->events;
-        $this->events = [];
-
-        return $events;
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
@@ -22,11 +22,6 @@ interface FamilyInterface extends
     TimestampableInterface
 {
     /**
-     * For now the events are a list of strings, but they can be converted to object when needed.
-     */
-    public const ATTRIBUTES_WERE_UPDATED = 'ATTRIBUTES_WERE_UPDATED';
-
-    /**
      * Get id
      *
      * @return int
@@ -204,9 +199,4 @@ interface FamilyInterface extends
      * @param AttributeInterface[] $attributes
      */
     public function updateAttributes(array $attributes): void;
-
-    /**
-     * @return string[]
-     */
-    public function releaseEvents(): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyInterface.php
@@ -22,6 +22,11 @@ interface FamilyInterface extends
     TimestampableInterface
 {
     /**
+     * For now the events are a list of strings, but they can be converted to object when needed.
+     */
+    public const ATTRIBUTES_WERE_UPDATED = 'ATTRIBUTES_WERE_UPDATED';
+
+    /**
      * Get id
      *
      * @return int
@@ -194,4 +199,14 @@ interface FamilyInterface extends
      * @param Collection $familyVariants
      */
     public function setFamilyVariants(Collection $familyVariants): void;
+
+    /**
+     * @param AttributeInterface[] $attributes
+     */
+    public function updateAttributes(array $attributes): void;
+
+    /**
+     * @return string[]
+     */
+    public function releaseEvents(): array;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariantInterface.php
@@ -15,8 +15,8 @@ interface FamilyVariantInterface extends TranslatableInterface
     /**
      * For now the events are a list of strings, but they can be converted to object when needed.
      */
-    public const AXES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
-    public const ATTRIBUTES_WERE_UPDATED_ON_LEVEL = 'AXES_WAS_UPDATED_ON_LEVEL';
+    public const AXES_WERE_UPDATED_ON_LEVEL = 'AXES_WERE_UPDATED_ON_LEVEL';
+    public const ATTRIBUTES_WERE_UPDATED_ON_LEVEL = 'ATTRIBUTES_WERE_UPDATED_ON_LEVEL';
 
     /**
      * @return null|int

--- a/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
@@ -340,27 +340,10 @@ class FamilyUpdater implements ObjectUpdaterInterface
      */
     protected function addAttributes(FamilyInterface $family, array $data)
     {
-        $currentAttributeCodes = [];
-        $wantedAttributeCodes = array_values($data);
-
-        foreach ($family->getAttributes() as $attribute) {
-            $currentAttributeCodes[] = $attribute->getCode();
-        }
-
-        $attributeCodesToRemove = array_diff($currentAttributeCodes, $wantedAttributeCodes);
-        $attributeCodesToAdd = array_diff($wantedAttributeCodes, $currentAttributeCodes);
-
-        foreach ($family->getAttributes() as $attribute) {
-            if (in_array($attribute->getCode(), $attributeCodesToRemove)) {
-                if (AttributeTypes::IDENTIFIER !== $attribute->getType()) {
-                    $family->removeAttribute($attribute);
-                }
-            }
-        }
-
-        foreach ($attributeCodesToAdd as $attributeCode) {
+        $newAttributes = [];
+        foreach ($data as $attributeCode) {
             if (null !== $attribute = $this->attributeRepository->findOneByIdentifier($attributeCode)) {
-                $family->addAttribute($attribute);
+                $newAttributes[] = $attribute;
             } else {
                 throw InvalidPropertyException::validEntityCodeExpected(
                     'attributes',
@@ -371,6 +354,8 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 );
             }
         }
+
+        $family->updateAttributes($newAttributes);
     }
 
     /**

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -4,11 +4,14 @@ namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber;
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
+use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Pim\Structure\Component\Model\FamilyVariant;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
 use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
@@ -57,20 +60,12 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
-        $familyVariantsIterator->valid()->willReturn(true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants2 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2]));
 
         $validator->validate($familyVariants1)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
@@ -79,7 +74,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -92,23 +87,14 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        FamilyVariantInterface $familyVariants3
     ) {
-        $family->getFamilyVariants()->willReturn($familyVariants);
-
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2, $familyVariants3);
-        $familyVariantsIterator->valid()->willReturn(true, true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
-
-        $familyVariants1->getCode()->willReturn('family_variant_1');
-        $familyVariants2->getCode()->willReturn('family_variant_2');
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants1->setCode('family_variant_1');
+        $familyVariants2 = new FamilyVariant();
+        $familyVariants2->setCode('family_variant_2');
+        $familyVariants3 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2, $familyVariants3]));
 
         $constraintViolation1 = new ConstraintViolation('Error 1 with family variant', '', [], '', '', '10,45');
         $constraintViolation2 = new ConstraintViolation('Error 2 with family variant', '', [], '', '', '10,45');
@@ -123,7 +109,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants3],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -249,23 +235,16 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         ValidatorInterface $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        FamilyInterface $family,
-        Collection $familyVariants,
-        \ArrayIterator $familyVariantsIterator,
-        FamilyVariantInterface $familyVariants1,
-        FamilyVariantInterface $familyVariants2,
-        ConstraintViolationList $constraintViolationList
+        ConstraintViolationList $constraintViolationList,
     ) {
+        $familyVariants1 = new FamilyVariant();
+        $familyVariants2 = new FamilyVariant();
+        $family = new Family();
+        $family->setFamilyVariants(new ArrayCollection([$familyVariants1, $familyVariants2]));
+
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(true);
-
-        $family->getFamilyVariants()->willReturn($familyVariants);
-        $familyVariants->getIterator()->willReturn($familyVariantsIterator);
-        $familyVariantsIterator->current()->willReturn($familyVariants1, $familyVariants2);
-        $familyVariantsIterator->valid()->willReturn(true, true, false);
-        $familyVariantsIterator->rewind()->shouldBeCalled();
-        $familyVariantsIterator->next()->shouldBeCalled();
 
         $validator->validate($familyVariants1)->willReturn($constraintViolationList);
         $constraintViolationList->count()->willReturn(0);
@@ -273,7 +252,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::FORCE_JOB_LAUNCHING => false]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
         $this->onUnitarySave($event);

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -86,7 +86,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
     function it_throws_an_exception_when_family_variants_are_invalid_and_saves_the_valid_ones_on_unitary_save(
         $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
-        GenericEvent $event,
+        GenericEvent $event
     ) {
         $familyVariants1 = new FamilyVariant();
         $familyVariants1->setCode('family_variant_1');
@@ -235,7 +235,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         ValidatorInterface $validator,
         BulkSaverInterface $bulkFamilyVariantSaver,
         GenericEvent $event,
-        ConstraintViolationList $constraintViolationList,
+        ConstraintViolationList $constraintViolationList
     ) {
         $familyVariants1 = new FamilyVariant();
         $familyVariants2 = new FamilyVariant();

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -3,15 +3,14 @@
 namespace Specification\Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\ComputeFamilyVariantStructureChangesSubscriber;
-use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
-use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
-use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
-use Akeneo\Tool\Component\StorageUtils\StorageEvents;
-use Doctrine\Common\Collections\Collection;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Bundle\EventSubscriber\SaveFamilyVariantOnFamilyUpdateSubscriber;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyVariantInterface;
+use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Common\Collections\Collection;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -65,7 +64,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -101,7 +99,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         FamilyVariantInterface $familyVariants3
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -163,7 +160,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         ConstraintViolationList $constraintViolationList
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -199,7 +195,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         FamilyVariantInterface $familyVariants2,
         FamilyVariantInterface $familyVariants3
     ) {
-        $family->releaseEvents()->willReturn([FamilyInterface::ATTRIBUTES_WERE_UPDATED]);
         $family->getFamilyVariants()->willReturn($familyVariants);
 
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);
@@ -264,8 +259,6 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $event->getSubject()->willReturn($family);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(true);
-
-        $family->releaseEvents()->willReturn([]);
 
         $family->getFamilyVariants()->willReturn($familyVariants);
         $familyVariants->getIterator()->willReturn($familyVariantsIterator);

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Pim\Structure\Component\Model;
 
+use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\Family;
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
@@ -56,5 +57,44 @@ class FamilySpec extends ObjectBehavior
         $name->getCode()->willReturn('pim_catalog_text');
         $this->getAttributeAsLabel()->shouldReturn(null);
         $this->setAttributeAsLabel($name)->shouldReturn($this);
+    }
+
+    function it_updates_a_family_by_adding_an_attribute(
+        AttributeInterface $skuAttribute,
+        AttributeInterface $nameAttribute,
+        AttributeInterface $descAttribute,
+    ) {
+        $skuAttribute->getCode()->willReturn('sku');
+        $nameAttribute->getCode()->willReturn('name');
+        $descAttribute->getCode()->willReturn('description');
+        $descAttribute->getType()->willReturn(AttributeTypes::TEXTAREA);
+
+        $this->addAttribute($skuAttribute);
+        $this->addAttribute($nameAttribute);
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name']);
+
+        $this->updateAttributes([$skuAttribute, $nameAttribute, $descAttribute]);
+
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name', 'description']);
+    }
+
+    function it_updates_a_family_by_removing_an_attribute(
+        AttributeInterface $skuAttribute,
+        AttributeInterface $nameAttribute,
+        AttributeInterface $descAttribute,
+    ) {
+        $skuAttribute->getCode()->willReturn('sku');
+        $nameAttribute->getCode()->willReturn('name');
+        $descAttribute->getCode()->willReturn('description');
+        $descAttribute->getType()->willReturn(AttributeTypes::TEXTAREA);
+
+        $this->addAttribute($skuAttribute);
+        $this->addAttribute($nameAttribute);
+        $this->addAttribute($descAttribute);
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name', 'description']);
+
+        $this->updateAttributes([$skuAttribute, $nameAttribute]);
+
+        $this->getAttributeCodes()->shouldReturn(['sku', 'name']);
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Model/FamilySpec.php
@@ -62,7 +62,7 @@ class FamilySpec extends ObjectBehavior
     function it_updates_a_family_by_adding_an_attribute(
         AttributeInterface $skuAttribute,
         AttributeInterface $nameAttribute,
-        AttributeInterface $descAttribute,
+        AttributeInterface $descAttribute
     ) {
         $skuAttribute->getCode()->willReturn('sku');
         $nameAttribute->getCode()->willReturn('name');
@@ -81,7 +81,7 @@ class FamilySpec extends ObjectBehavior
     function it_updates_a_family_by_removing_an_attribute(
         AttributeInterface $skuAttribute,
         AttributeInterface $nameAttribute,
-        AttributeInterface $descAttribute,
+        AttributeInterface $descAttribute
     ) {
         $skuAttribute->getCode()->willReturn('sku');
         $nameAttribute->getCode()->willReturn('name');

--- a/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
@@ -33,7 +33,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         AttributeRequirementFactory $attrRequiFactory,
         AttributeRequirementRepositoryInterface $attributeRequirementRepo,
         TranslatableUpdater $translatableUpdater,
-        IdentifiableObjectRepositoryInterface $localeRepository,
+        IdentifiableObjectRepositoryInterface $localeRepository
 
     ) {
         $this->beConstructedWith(

--- a/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
+++ b/tests/legacy/features/pim/structure/family/remove_attribute_from_a_family.feature
@@ -29,14 +29,12 @@ Feature: Remove attribute from a family
     And I save the family
     Then I should not see the text "There are unsaved changes."
     And I should see the flash message "Attribute successfully removed from the family"
-    And I wait for the "compute_family_variant_structure_changes" job to finish
+    And I wait for the "compute_completeness_of_products_family" job to finish
     And I am on the "model-braided-hat" product model page
     Then I should see the text "Supplier"
     But I should not see the text "Material"
     And I am on the "braided-hat-m" product page
-    Then I should not see the Material field
-    And 0 event of type "product.updated" should have been raised
-    And 1 event of type "product_model.updated" should have been raised
+    Then I should not see the text "Material"
 
   Scenario: Impossible to remove some attributes from a family (used as label, used as image, used as axis)
     Given I am on the "shoes" family page


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport of this PR: https://github.com/akeneo/pim-community-dev/pull/17298

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
