### PR TITLE
CPM-704: Fix Error 500 when trying to update multiselect value with an array containing empty string

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/OptionsValueFactory.php
@@ -58,6 +58,18 @@ final class OptionsValueFactory implements ValueFactory
             );
         }
 
+        try {
+            Assert::allStringNotEmpty($data);
+        } catch (\Exception $exception) {
+            throw InvalidPropertyTypeException::validArrayStructureExpected(
+                $attribute->code(),
+                'one of the options is an empty string',
+                static::class,
+                $data
+            );
+        }
+
+
         return $this->createWithoutCheckingData($attribute, $channelCode, $localeCode, $data);
     }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/ValueFactory.php
@@ -35,7 +35,7 @@ class ValueFactory
 
     public function createByCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
     {
-        if (null === $data || [] === $data || '' === $data || [''] === $data || [null] === $data) {
+        if (null === $data || [] === $data || '' === $data) {
             throw new InvalidArgumentException(get_class($this), sprintf('Data should not be empty, %s found', json_encode($data)));
         }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionsValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/OptionsValueFactorySpec.php
@@ -94,6 +94,17 @@ final class OptionsValueFactorySpec extends ObjectBehavior
             ]);
     }
 
+    public function it_throws_an_exception_if_one_of_the_options_is_empty()
+    {
+        $this->shouldThrow(InvalidPropertyTypeException::class)
+            ->during('createByCheckingData', [
+                $this->getAttribute(true, true),
+                null,
+                null,
+                [""]
+            ]);
+    }
+
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute
     {
         return new Attribute('an_attribute', AttributeTypes::OPTION_MULTI_SELECT, [], $isLocalizable, $isScopable, null, null, false, 'options', []);


### PR DESCRIPTION
The global value factory now accepts any array containing data (even an empty string); it's the role of each specific Value factory to check the data structure

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
