### PR TITLE
RAB-927: Upsert running user on job save

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
@@ -14,7 +14,7 @@ use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Akeneo\UserManagement\ServiceApi\User\UpsertUserCommand;
 use Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface;
 
-final class UpsertRunningUser
+class UpsertRunningUser
 {
     private const AUTOMATED_USER_PREFIX = 'job_automated_';
 
@@ -32,7 +32,7 @@ final class UpsertRunningUser
         $upsertUserCommand = UpsertUserCommand::job(
             $username,
             'fakepassword',
-            sprintf('%s@fake.com', $username),
+            sprintf('%s@example.com', $username),
             $jobCode,
             'Automated Job',
             $allRoleCodes,

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
@@ -16,7 +16,7 @@ use Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface;
 
 final class UpsertRunningUser
 {
-    private const AUTOMATED_USER_PREFIX = 'automated_';
+    private const AUTOMATED_USER_PREFIX = 'job_automated_';
 
     public function __construct(
         private UpsertUserHandlerInterface $upsertUserHandler,

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement;
+
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
+use Akeneo\UserManagement\ServiceApi\User\UpsertUserCommand;
+use Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface;
+
+final class UpsertRunningUser
+{
+    private const AUTOMATED_USER_PREFIX = 'automated_';
+
+    public function __construct(
+        private UpsertUserHandlerInterface $upsertUserHandler,
+        private RoleRepositoryInterface $roleRepository,
+    ) {
+    }
+
+    public function execute(string $jobCode, array $userGroupCodes): void
+    {
+        $username = sprintf('%s%s', self::AUTOMATED_USER_PREFIX, $jobCode);
+        $allRoleCodes = array_map(static fn (RoleInterface $role) => $role->getRole(), $this->roleRepository->findAll());
+
+        $upsertUserCommand = UpsertUserCommand::job(
+            $username,
+            'fakepassword',
+            sprintf('%s@fake.com', $username),
+            $jobCode,
+            'Automated Job',
+            $allRoleCodes,
+            $userGroupCodes,
+        );
+
+        $this->upsertUserHandler->handle($upsertUserCommand);
+    }
+}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
@@ -21,3 +21,8 @@ services:
             - { name: console.command }
 
     Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\RemoteStorageFeatureFlag: ~
+
+    Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement\UpsertRunningUser:
+        arguments:
+            - '@Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface'
+            - '@pim_user.repository.role'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php
@@ -13,13 +13,7 @@ $builder = new RuleBuilder();
 $rules = [
     $builder->only(
         [
-            'Akeneo\Platform\Bundle\ImportExportBundle\Domain',
-            'Webmozart\Assert\Assert',
-        ],
-    )->in('Akeneo\Platform\Bundle\ImportExportBundle\Application'),
-    $builder->only(
-        [
-            /** We should not need to be coupled with Application layer */
+            // We should not need to be coupled with Application layer
             'Akeneo\Platform\Bundle\ImportExportBundle\Application\TransferFilesToStorage\FileToTransfer',
 
             'Webmozart\Assert\Assert',
@@ -27,12 +21,24 @@ $rules = [
     )->in('Akeneo\Platform\Bundle\ImportExportBundle\Domain'),
     $builder->only(
         [
-            'Akeneo\Tool',
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags',
-            'Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface',
+            'Akeneo\Platform\Bundle\ImportExportBundle\Domain',
 
+            'Webmozart\Assert\Assert',
+        ],
+    )->in('Akeneo\Platform\Bundle\ImportExportBundle\Application'),
+    $builder->only(
+        [
             'Akeneo\Platform\Bundle\ImportExportBundle\Application',
             'Akeneo\Platform\Bundle\ImportExportBundle\Domain',
+
+            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags',
+            'Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface',
+            'Akeneo\UserManagement\ServiceApi',
+            'Akeneo\Tool',
+
+            // TODO RAB-981: remove this coupling
+            'Akeneo\UserManagement\Component\Model\RoleInterface',
+            'Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface',
 
             'League\Flysystem',
             'Symfony\Component',

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/fixture_loader.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/fixture_loader.yml
@@ -54,3 +54,4 @@ services:
         arguments:
             - '@akeneo_batch.job_parameters_factory'
             - '@akeneo_batch.job.job_registry'
+            - '@Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement\UpsertRunningUser'

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
@@ -1,8 +1,7 @@
 Akeneo\Tool\Component\Batch\Model\JobInstance:
     type: entity
     table: akeneo_batch_job_instance
-    # TODO: should be like other entities
-    #changeTrackingPolicy: DEFERRED_EXPLICIT
+    changeTrackingPolicy: DEFERRED_EXPLICIT
     uniqueConstraints:
         searchunique_idx:
             columns:

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/updaters.yml
@@ -7,3 +7,4 @@ services:
         arguments:
             - '@akeneo_batch.job_parameters_factory'
             - '@akeneo_batch.job.job_registry'
+            - '@Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement\UpsertRunningUser'

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/security.yml
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/Resources/config/security.yml
@@ -5,7 +5,7 @@ services:
     pim_connector.event_listener.job_execution_authenticator:
         class: '%pim_connector.event_listener.job_execution_authenticator.class%'
         arguments:
-            - '@pim_user.provider.user'
+            - '@pim_user.provider.job_user'
             - '@security.token_storage'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
@@ -63,7 +63,7 @@ class JobInstance
 
     protected bool $scheduled = false;
 
-    protected array $automation;
+    protected ?array $automation = null;
 
     /** @var Collection|JobExecution[] */
     protected $jobExecutions;
@@ -272,7 +272,7 @@ class JobInstance
         return $this;
     }
 
-    public function getAutomation(): array
+    public function getAutomation(): ?array
     {
         return $this->automation;
     }

--- a/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
@@ -61,11 +61,9 @@ class JobInstance
     /** @var array */
     protected $rawParameters = [];
 
-    /** @var bool */
-    protected $scheduled = false;
+    protected bool $scheduled = false;
 
-    /** @var string */
-    protected $automation;
+    protected array $automation;
 
     /** @var Collection|JobExecution[] */
     protected $jobExecutions;
@@ -267,22 +265,14 @@ class JobInstance
         return $this->scheduled;
     }
 
-    /**
-     * @param string $automation
-     *
-     * @return JobInstance
-     */
-    public function setAutomation($automation)
+    public function setAutomation(array $automation): self
     {
         $this->automation = $automation;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getAutomation()
+    public function getAutomation(): array
     {
         return $this->automation;
     }

--- a/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
+++ b/src/Akeneo/Tool/Component/Batch/Model/JobInstance.php
@@ -265,7 +265,7 @@ class JobInstance
         return $this->scheduled;
     }
 
-    public function setAutomation(array $automation): self
+    public function setAutomation(?array $automation): self
     {
         $this->automation = $automation;
 

--- a/src/Akeneo/Tool/Component/Batch/Updater/JobInstanceUpdater.php
+++ b/src/Akeneo/Tool/Component/Batch/Updater/JobInstanceUpdater.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Component\Batch\Updater;
 
+use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement\UpsertRunningUser;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
 use Akeneo\Tool\Component\Batch\Job\JobParametersFactory;
 use Akeneo\Tool\Component\Batch\Job\JobRegistry;
@@ -19,18 +20,11 @@ use Doctrine\Common\Util\ClassUtils;
  */
 class JobInstanceUpdater implements ObjectUpdaterInterface
 {
-    protected JobParametersFactory $jobParametersFactory;
-
-    protected JobRegistry $jobRegistry;
-
-    /**
-     * @param JobParametersFactory $jobParametersFactory
-     * @param JobRegistry          $jobRegistry
-     */
-    public function __construct(JobParametersFactory $jobParametersFactory, JobRegistry $jobRegistry)
-    {
-        $this->jobParametersFactory = $jobParametersFactory;
-        $this->jobRegistry = $jobRegistry;
+    public function __construct(
+        private JobParametersFactory $jobParametersFactory,
+        private JobRegistry $jobRegistry,
+        private UpsertRunningUser $upsertRunningUser,
+    ) {
     }
 
     /**
@@ -50,6 +44,18 @@ class JobInstanceUpdater implements ObjectUpdaterInterface
         foreach ($data as $field => $value) {
             $this->setData($jobInstance, $field, $value);
         }
+
+        $this->upsertRunningUser($jobInstance);
+    }
+
+    private function upsertRunningUser(JobInstance $jobInstance): void
+    {
+        if (!$jobInstance->isScheduled()) {
+            return;
+        }
+
+        $automation = $jobInstance->getAutomation();
+        $this->upsertRunningUser->execute($jobInstance->getCode(), $automation['running_user_groups']);
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Batch/Updater/JobInstanceUpdater.php
+++ b/src/Akeneo/Tool/Component/Batch/Updater/JobInstanceUpdater.php
@@ -55,7 +55,7 @@ class JobInstanceUpdater implements ObjectUpdaterInterface
         }
 
         $automation = $jobInstance->getAutomation();
-        $this->upsertRunningUser->execute($jobInstance->getCode(), $automation['running_user_groups']);
+        $this->upsertRunningUser->execute($jobInstance->getCode(), $automation['running_user_groups'] ?? []);
     }
 
     /**

--- a/src/Akeneo/Tool/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
+++ b/src/Akeneo/Tool/Component/Batch/spec/Updater/JobInstanceUpdaterSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace spec\Akeneo\Tool\Component\Batch\Updater;
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement\UpsertRunningUser;
@@ -48,6 +50,7 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
         $jobParametersFactory->create($job, ['filePath' => 'currencies.csv'])->willReturn($jobParameters);
         $jobParameters->all()->willReturn(['filePath' => 'currencies.csv']);
 
+        $jobInstance->isScheduled()->willReturn(false);
         $jobInstance->setJobName('fixtures_currency_csv')->shouldBeCalled();
         $jobInstance->setCode('fixtures_currency_csv')->shouldBeCalled();
         $jobInstance->setConnector('Data fixtures')->shouldBeCalled();
@@ -69,7 +72,7 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
         ]);
     }
 
-    function it_throw_an_exception_id_it_is_not_a_job_instance()
+    function it_throws_an_exception_if_it_is_not_a_job_instance()
     {
         $this->shouldThrow(
             InvalidObjectException::objectExpected(
@@ -79,31 +82,45 @@ class JobInstanceUpdaterSpec extends ObjectBehavior
         )->during('update', [new \stdClass(), []]);
     }
 
-    function it_create_a_upsert_a_user_when_there_is_an_automation(
+    function it_upserts_an_user_when_job_is_scheduled(
         JobInstance $jobInstance,
-        UpsertRunningUser $upsertRunningUser
+        UpsertRunningUser $upsertRunningUser,
     ) {
+        $automation = [
+            'cron_expression' => '0 */8 * * *',
+            'running_user_groups' => ['IT Support'],
+        ];
+
+        $jobInstance->getCode()->willReturn('xlsx_product_import');
+        $jobInstance->setScheduled(true)->shouldBeCalled();
+        $jobInstance->setAutomation($automation)->shouldBeCalled();
+        $jobInstance->isScheduled()->willReturn(true);
+        $jobInstance->getAutomation()->willReturn($automation);
         $upsertRunningUser->execute('xlsx_product_import', ['IT Support'])->shouldBeCalledOnce();
+
         $this->update($jobInstance, [
             'scheduled' => true,
-            'automation' => [
-                'cron_expression' => '0 */8 * * *',
-                'running_user_groups' => ['IT Support'],
-            ]
+            'automation' => $automation,
         ]);
     }
 
-    function it_does_not_create_a_user_when_there_is_an_automation(
+    function it_does_not_upsert_an_user_when_job_is_not_scheduled(
         JobInstance $jobInstance,
-        UpsertRunningUser $upsertRunningUser
+        UpsertRunningUser $upsertRunningUser,
     ) {
+        $automation = [
+            'cron_expression' => '0 */8 * * *',
+            'running_user_groups' => ['IT Support'],
+        ];
+
+        $jobInstance->setScheduled(false)->shouldBeCalled();
+        $jobInstance->setAutomation($automation)->shouldBeCalled();
+        $jobInstance->isScheduled()->willReturn(false);
         $upsertRunningUser->execute('xlsx_product_import', ['IT Support'])->shouldNotBeCalled();
+
         $this->update($jobInstance, [
             'scheduled' => false,
-            'automation' => [
-                'cron_expression' => '0 */8 * * *',
-                'running_user_groups' => ['IT Support'],
-            ]
+            'automation' => $automation,
         ]);
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/providers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/providers.yml
@@ -12,3 +12,8 @@ services:
     class: '%pim_user.provider.user_api.class%'
     arguments:
       - '@pim_user.repository.user'
+
+  pim_user.provider.job_user:
+    class: 'Akeneo\UserManagement\Bundle\Security\JobUserProvider'
+    arguments:
+      - '@pim_user.repository.user'

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/validators.en_US.yml
@@ -3,3 +3,4 @@ pim_user:
   password_match: "The password fields must match."
   role:
     invalid_role_format: 'The role should begin with "ROLE_" and should contain only underscores, dashes and alphanumeric characters in uppercase.'
+  reserved_prefix_username: "The username prefix '{{ prefix }}' is reserved"

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\UserManagement\Bundle\Security;
+
+use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class JobUserProvider implements UserProviderInterface
+{
+    public function __construct(
+        private UserRepositoryInterface $userRepository,
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        $user = $this->userRepository->findOneByIdentifier($username);
+        if (!$user || $user->isApiUser()) {
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist.', $username));
+        }
+
+        if (!$user->isEnabled()) {
+            throw new UserNotFoundException('User account is disabled.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$this->supportsClass($user::class)) {
+            throw new UnsupportedUserException(sprintf('User object of class "%s" is not supported.', $user::class));
+        }
+
+        $reloadedUser = $this->userRepository->find($user->getId());
+        if (null === $reloadedUser || $reloadedUser->isApiUser()) {
+            throw new UserNotFoundException(sprintf('User with id %d not found', $user->getId()));
+        }
+
+        return $reloadedUser;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return is_subclass_of($class, 'Akeneo\UserManagement\Component\Model\UserInterface');
+    }
+}

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\UserManagement\Bundle\Security;
 
 use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -28,7 +29,7 @@ class JobUserProvider implements UserProviderInterface
         }
 
         if (!$user->isEnabled()) {
-            throw new UserNotFoundException('User account is disabled.');
+            throw new DisabledException('User account is disabled.');
         }
 
         return $user;

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -25,7 +25,7 @@ class JobUserProvider implements UserProviderInterface
     {
         $user = $this->userRepository->findOneByIdentifier($username);
         if (!$user || $user->isApiUser()) {
-            throw new UserNotFoundException(sprintf('User with username "%s" does not exist.', $username));
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Job user.', $username));
         }
 
         if (!$user->isEnabled()) {
@@ -46,7 +46,7 @@ class JobUserProvider implements UserProviderInterface
 
         $reloadedUser = $this->userRepository->find($user->getId());
         if (null === $reloadedUser || $reloadedUser->isApiUser()) {
-            throw new UserNotFoundException(sprintf('User with id %d not found', $user->getId()));
+            throw new UserNotFoundException(sprintf('User with id %d does not exist or is not a Job user.', $user->getId()));
         }
 
         return $reloadedUser;

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -36,7 +36,7 @@ class UserApiProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);
-        if (!$user) {
+        if (!$user || $user->isJobUser()) {
             throw new UsernameNotFoundException(sprintf('User with username "%s" does not exist.', $username));
         }
 

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -58,7 +58,7 @@ class UserApiProvider implements UserProviderInterface
         }
 
         $reloadedUser = $this->userRepository->find($user->getId());
-        if (null === $reloadedUser) {
+        if (null === $reloadedUser || $reloadedUser->isJobUser()) {
             throw new UsernameNotFoundException(sprintf('User with id %d not found', $user->getId()));
         }
 

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\UserManagement\Bundle\Security;
 
 use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -37,7 +39,7 @@ class UserApiProvider implements UserProviderInterface
     {
         $user = $this->userRepository->findOneByIdentifier($username);
         if (!$user || $user->isJobUser()) {
-            throw new UsernameNotFoundException(sprintf('User with username "%s" does not exist.', $username));
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Api user.', $username));
         }
 
         if (!$user->isEnabled()) {
@@ -59,7 +61,7 @@ class UserApiProvider implements UserProviderInterface
 
         $reloadedUser = $this->userRepository->find($user->getId());
         if (null === $reloadedUser || $reloadedUser->isJobUser()) {
-            throw new UsernameNotFoundException(sprintf('User with id %d not found', $user->getId()));
+            throw new UserNotFoundException(sprintf('User with id %d does not exist or is not a Api user.', $user->getId()));
         }
 
         return $reloadedUser;

--- a/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
@@ -57,7 +57,7 @@ class UserProvider implements UserProviderInterface
         }
 
         $reloadedUser = $this->userRepository->find($user->getId());
-        if (null === $reloadedUser || $reloadedUser->isApiUser()) {
+        if (null === $reloadedUser || $reloadedUser->isApiUser() || $reloadedUser->isJobUser()) {
             throw new UsernameNotFoundException(sprintf('User with id %d not found', $user->getId()));
         }
 

--- a/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
@@ -35,7 +35,7 @@ class UserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);
-        if (!$user || $user->isApiUser()) {
+        if (!$user || $user->isApiUser() || $user->isJobUser()) {
             throw new UsernameNotFoundException(sprintf('User with username "%s" does not exist.', $username));
         }
 

--- a/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUser.php
+++ b/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUser.php
@@ -13,7 +13,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class CreateUser extends Constraint
 {
-    public $errorSpaceInUsername = 'The username should not contain space character.';
+    public string $errorSpaceInUsername = 'The username should not contain space character.';
+    public const RESERVED_PREFIX_USERNAME = 'pim_user.reserved_prefix_username';
 
     /**
      * {@inheritdoc}

--- a/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUserValidator.php
+++ b/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUserValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class CreateUserValidator extends ConstraintValidator
 {
+    private const JOB_USERNAME_PREFIX = 'job_automated_';
+
     /**
      * @param UserInterface         $user
      * @param Constraint|CreateUser $constraint
@@ -35,8 +37,15 @@ class CreateUserValidator extends ConstraintValidator
 
     private function validateUsername(UserInterface $user, CreateUser $constraint)
     {
-        if (preg_match('/\s/', $user->getUserIdentifier()) !== 0) {
+        $username = $user->getUserIdentifier();
+        if (preg_match('/\s/', $username) !== 0) {
             $this->context->buildViolation($constraint->errorSpaceInUsername)
+                ->atPath('username')
+                ->addViolation();
+        }
+
+        if (!$user->isJobUser() && str_starts_with($username, self::JOB_USERNAME_PREFIX)) {
+            $this->context->buildViolation(CreateUser::RESERVED_PREFIX_USERNAME, ['{{ prefix }}' => self::JOB_USERNAME_PREFIX])
                 ->atPath('username')
                 ->addViolation();
         }

--- a/src/Akeneo/UserManagement/Component/Repository/RoleRepositoryInterface.php
+++ b/src/Akeneo/UserManagement/Component/Repository/RoleRepositoryInterface.php
@@ -11,4 +11,5 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
  */
 interface RoleRepositoryInterface extends IdentifiableObjectRepositoryInterface
 {
+    public function findAll();
 }

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
@@ -9,16 +9,10 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement;
 
-use Akeneo\Platform\Bundle\ImportExportBundle\Application\TransferFilesToStorage\FileToTransfer;
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\StorageInterface;
-use Akeneo\Platform\Bundle\ImportExportBundle\Domain\StorageClientInterface;
-use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\StorageClient\StorageClientProviderInterface;
-use Akeneo\Tool\Component\FileStorage\FilesystemProvider;
 use Akeneo\UserManagement\Component\Model\RoleInterface;
 use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Akeneo\UserManagement\ServiceApi\User\UpsertUserCommand;
 use Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface;
-use League\Flysystem\FilesystemOperator;
 use PhpSpec\ObjectBehavior;
 
 class UpsertRunningUserSpec extends ObjectBehavior
@@ -30,11 +24,11 @@ class UpsertRunningUserSpec extends ObjectBehavior
         $this->beConstructedWith($upsertUserHandler, $roleRepository);
     }
 
-    public function it_call_upsert_the_user_through_user_management_public_api(
+    public function it_calls_upsert_user_through_user_management_public_api(
         UpsertUserHandlerInterface $upsertUserHandler,
         RoleRepositoryInterface $roleRepository,
         RoleInterface $administratorRole,
-        RoleInterface $userRole
+        RoleInterface $userRole,
     ) {
         $administratorRole->getRole()->willReturn('ROLE_ADMINISTRATOR');
         $userRole->getRole()->willReturn('ROLE_USER');

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
@@ -36,7 +36,7 @@ class UpsertRunningUserSpec extends ObjectBehavior
         $command = UpsertUserCommand::job(
             'job_automated_my_job_name',
             'fakepassword',
-            'job_automated_my_job_name@fake.com',
+            'job_automated_my_job_name@example.com',
             'my_job_name',
             'Automated Job',
             ['ROLE_ADMINISTRATOR', 'ROLE_USER'],

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
@@ -40,9 +40,9 @@ class UpsertRunningUserSpec extends ObjectBehavior
         $userRole->getRole()->willReturn('ROLE_USER');
         $roleRepository->findAll()->willReturn([$administratorRole, $userRole]);
         $command = UpsertUserCommand::job(
-            'automated_my_job_name',
+            'job_automated_my_job_name',
             'fakepassword',
-            'automated_my_job_name@fake.com',
+            'job_automated_my_job_name@fake.com',
             'my_job_name',
             'Automated Job',
             ['ROLE_ADMINISTRATOR', 'ROLE_USER'],

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/UserManagement/UpsertRunningUserSpec.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\UserManagement;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Application\TransferFilesToStorage\FileToTransfer;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\StorageInterface;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\StorageClientInterface;
+use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\StorageClient\StorageClientProviderInterface;
+use Akeneo\Tool\Component\FileStorage\FilesystemProvider;
+use Akeneo\UserManagement\Component\Model\RoleInterface;
+use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
+use Akeneo\UserManagement\ServiceApi\User\UpsertUserCommand;
+use Akeneo\UserManagement\ServiceApi\User\UpsertUserHandlerInterface;
+use League\Flysystem\FilesystemOperator;
+use PhpSpec\ObjectBehavior;
+
+class UpsertRunningUserSpec extends ObjectBehavior
+{
+    public function let(
+        UpsertUserHandlerInterface $upsertUserHandler,
+        RoleRepositoryInterface $roleRepository,
+    ) {
+        $this->beConstructedWith($upsertUserHandler, $roleRepository);
+    }
+
+    public function it_call_upsert_the_user_through_user_management_public_api(
+        UpsertUserHandlerInterface $upsertUserHandler,
+        RoleRepositoryInterface $roleRepository,
+        RoleInterface $administratorRole,
+        RoleInterface $userRole
+    ) {
+        $administratorRole->getRole()->willReturn('ROLE_ADMINISTRATOR');
+        $userRole->getRole()->willReturn('ROLE_USER');
+        $roleRepository->findAll()->willReturn([$administratorRole, $userRole]);
+        $command = UpsertUserCommand::job(
+            'automated_my_job_name',
+            'fakepassword',
+            'automated_my_job_name@fake.com',
+            'my_job_name',
+            'Automated Job',
+            ['ROLE_ADMINISTRATOR', 'ROLE_USER'],
+            ['IT Support'],
+        );
+
+        $upsertUserHandler->handle($command)->shouldBeCalledOnce();
+
+        $this->execute('my_job_name', ['IT Support']);
+    }
+}

--- a/tests/back/UserManagement/Specification/Bundle/Security/JobUserProviderSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Security/JobUserProviderSpec.php
@@ -9,62 +9,61 @@ use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
-use Symfony\Component\Security\Core\User\User;
 
-class UserApiProviderSpec extends ObjectBehavior
+class JobUserProviderSpec extends ObjectBehavior
 {
-    function let(UserRepositoryInterface $userRepository)
+    public function let(UserRepositoryInterface $userRepository)
     {
         $this->beConstructedWith($userRepository);
     }
 
-    function it_loads_a_user_by_its_username(UserRepositoryInterface $userRepository, UserInterface $julia)
+    public function it_loads_a_user_by_its_username(UserRepositoryInterface $userRepository, UserInterface $julia)
     {
-        $julia->isJobUser()->willReturn(false);
+        $julia->isApiUser()->willReturn(false);
         $julia->isEnabled()->willReturn(true);
         $userRepository->findOneByIdentifier('julia')->willReturn($julia);
         $this->loadUserByUsername('julia')->shouldReturn($julia);
     }
 
-    function it_throws_an_exception_if_username_does_not_exist(UserRepositoryInterface $userRepository)
+    public function it_throws_an_exception_if_username_does_not_exist(UserRepositoryInterface $userRepository)
     {
         $userRepository->findOneByIdentifier('jean-pacôme')->willReturn(null);
         $this->shouldThrow(UsernameNotFoundException::class)
             ->during('loadUserByUsername', ['jean-pacôme']);
     }
 
-    function it_throws_an_exception_if_user_is_disabled(UserRepositoryInterface $userRepository, UserInterface $disabledGuy)
+    public function it_throws_an_exception_if_user_is_disabled(UserRepositoryInterface $userRepository, UserInterface $disabledGuy)
     {
-        $disabledGuy->isJobUser()->willReturn(false);
+        $disabledGuy->isApiUser()->willReturn(false);
         $disabledGuy->isEnabled()->willReturn(false);
         $userRepository->findOneByIdentifier('disabled-guy')->willReturn($disabledGuy);
         $this->shouldThrow(DisabledException::class)
             ->during('loadUserByUsername', ['disabled-guy']);
     }
 
-    function it_throws_an_exception_if_user_is_job_user(UserRepositoryInterface $userRepository, UserInterface $jobUser)
+    public function it_throws_an_exception_if_user_is_api_user(UserRepositoryInterface $userRepository, UserInterface $apiUser)
     {
-        $jobUser->isJobUser()->willReturn(true);
-        $userRepository->findOneByIdentifier('job-user')->willReturn($jobUser);
+        $apiUser->isApiUser()->willReturn(true);
+        $userRepository->findOneByIdentifier('job-user')->willReturn($apiUser);
         $this->shouldThrow(UsernameNotFoundException::class)
             ->during('loadUserByUsername', ['job-user']);
     }
 
-    function it_refreshes_a_user($userRepository, UserInterface $julia)
+    public function it_refreshes_a_user($userRepository, UserInterface $julia)
     {
         $userRepository->find(42)->willReturn($julia);
         $julia->getId()->willReturn(42);
-        $julia->isJobUser()->willReturn(false);
+        $julia->isApiUser()->willReturn(false);
         $this->refreshUser($julia)->shouldReturn($julia);
     }
 
-    function it_throw_an_exception_if_user_class_is_not_supported()
+    public function it_throw_an_exception_if_user_class_is_not_supported()
     {
         $julia = new InMemoryUser('julia', 'jambon');
         $this->shouldThrow(UnsupportedUserException::class)->during('refreshUser', [$julia]);
     }
 
-    function it_throws_an_exception_if_user_cannot_be_refreshed(
+    public function it_throws_an_exception_if_user_cannot_be_refreshed(
         UserRepositoryInterface $userRepository,
         UserInterface $julia
     ) {

--- a/tests/back/UserManagement/Specification/Bundle/Validator/Constraints/CreateUserValidatorSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Validator/Constraints/CreateUserValidatorSpec.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Specification\Akeneo\UserManagement\Bundle\Validator\Constraints;
@@ -31,6 +32,7 @@ class CreateUserValidatorSpec extends ObjectBehavior
     function it_does_not_add_violation_if_created_user_is_valid(CreateUser $constraint, UserInterface $user)
     {
         $user->getId()->willReturn(null);
+        $user->isJobUser()->willReturn(false);
         $user->getUserIdentifier()->willReturn('foobar');
         $this->validate($user, $constraint)->shouldReturn(null);
     }
@@ -42,6 +44,7 @@ class CreateUserValidatorSpec extends ObjectBehavior
         CreateUser $constraint
     ) {
         $user->getId()->willReturn(null);
+        $user->isJobUser()->willReturn(false);
         $user->getUserIdentifier()->willReturn('foo bar');
 
         $context->buildViolation('The username should not contain space character.')


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Why we added `changeTrackingPolicy: DEFERRED_EXPLICIT ` ? 
Because when we persist the user then flush, the job instance is saved. Problem is that the job instance is not validated yet. As by default the changeTrackingPolicy is DEFERRED_IMPLICIT doctrine save the entity as he detect that there is a change in the entity. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
