### PR TITLE
CPM-692: sf migration to force replaying ZDD migration

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/doctrine/Product/Product.orm.yml
@@ -16,7 +16,7 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
             type: string
             length: 255
             unique: true
-            nullable: false
+            nullable: true
         rawValues:
             type: json
             column: raw_values

--- a/upgrades/schema/Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table.php
+++ b/upgrades/schema/Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DELETE FROM pim_one_time_task where code = "zdd_SetProductIdentifierNullable"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $sql = <<<SQL
+INSERT INTO `pim_one_time_task` (`code`, `status`, `start_time`, `end_time`, `values`)
+VALUES
+	('zdd_SetProductIdentifierNullable', 'finished', '2022-08-17 17:19:48', NULL, '{}');
+SQL;
+
+        $this->addSql($sql);
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220802151250_add_automation_column_in_job_instance_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220802151250_add_automation_column_in_job_instance_Integration.php
@@ -17,7 +17,7 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;
 
-final class Version_7_0_20220802151250_add_automation_column_in_job_instance_integration extends TestCase
+final class Version_7_0_20220802151250_add_automation_column_in_job_instance_Integration extends TestCase
 {
     use ExecuteMigrationTrait;
 

--- a/upgrades/test_schema/Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table_Integration.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use Pim\Upgrade\Schema\Tests\ExecuteMigrationTrait;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_deletes_the_zdd_migration()
+    {
+        $this->givenZddMigrationHasBeenPlayed();
+        $this->reExecuteMigration('_7_0_20221808143128_remove_zdd_setidentifiernullable_from_pim_one_time_task_table');
+        $this->assertZddMigrationRemoved();
+    }
+
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function givenZddMigrationHasBeenPlayed(): void
+    {
+        $zddMigration = <<<SQL
+REPLACE INTO `pim_one_time_task` (`code`, `status`, `start_time`, `end_time`, `values`)
+VALUES
+	('zdd_SetProductIdentifierNullable', 'finished', '2022-08-17 17:19:48', NULL, '{}');
+SQL;
+        $this->connection->executeStatement($zddMigration);
+    }
+
+    private function assertZddMigrationRemoved(): void
+    {
+        $sql = 'SELECT 1 FROM pim_one_time_task WHERE code = "zdd_SetProductIdentifierNullable";';
+        $result = (bool) $this->connection->executeQuery($sql)->fetchOne();
+        $this->assertFalse($result);
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We introduce:
- doctrine migration to remove the "zdd_SetProductIdentifierNullable" from the "pim_one_time_task" table
- Change the doctrine mapping to set the identifier nullable

Why ?
See [JIRA ticket](https://akeneo.atlassian.net/browse/CPM-692)

Consequences ?
The ZDD migration will be replayed on all SaaS instances which:
- should be fast for already migrated instances (not much to do anyway)
- should be fast for new instances (and if it's not it's ok since it's a ZDD migration)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
