### PR TITLE
CXP-1245: rewrite validation test with mocks on queries

### DIFF
--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidLocaleValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidLocaleValidator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Akeneo\Catalogs\Infrastructure\Validation\ProductSelection;
 
 use Akeneo\Catalogs\Application\Persistence\FindOneAttributeByCodeQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\GetChannelLocalesQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\GetLocalesQueryInterface;
-use Akeneo\Catalogs\Infrastructure\Persistence\GetChannelLocalesQuery;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
@@ -26,7 +26,7 @@ final class AttributeCriterionContainsValidLocaleValidator extends ConstraintVal
     public function __construct(
         private FindOneAttributeByCodeQueryInterface $findOneAttributeByCodeQuery,
         private GetLocalesQueryInterface $getLocalesQuery,
-        private GetChannelLocalesQuery $getChannelLocalesQuery,
+        private GetChannelLocalesQueryInterface $getChannelLocalesQuery,
     ) {
     }
 

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AbstractAttributeCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AbstractAttributeCriterionTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Test\Integration\Infrastructure\Validation\ProductSelection\AttributeCriterion;
+
+use Akeneo\Catalogs\Application\Persistence\FindOneAttributeByCodeQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\GetChannelLocalesQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\GetChannelQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\GetLocalesQueryInterface;
+use Akeneo\Catalogs\Infrastructure\Persistence\FindOneAttributeByCodeQuery;
+use Akeneo\Catalogs\Infrastructure\Persistence\GetChannelLocalesQuery;
+use Akeneo\Catalogs\Infrastructure\Persistence\GetChannelQuery;
+use Akeneo\Catalogs\Infrastructure\Persistence\GetLocalesQuery;
+use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+abstract class AbstractAttributeCriterionTest extends IntegrationTestCase
+{
+    protected ?FindOneAttributeByCodeQueryInterface $findOneAttributeByCodeQuery;
+    protected ?GetChannelQueryInterface $getChannelQuery;
+    protected ?GetLocalesQueryInterface $getLocalesQuery;
+    protected ?GetChannelLocalesQueryInterface $getChannelLocalesQuery;
+
+    private array $attributes = [];
+    private array $channels = [];
+    private array $channelLocales = [];
+    private array $locales = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attributes = [];
+        $this->channels = [
+            'ecommerce' => [
+                'code' => 'ecommerce',
+                'label' => 'E-commerce',
+            ],
+        ];
+        $this->channelLocales = [
+            'ecommerce' => ['en_US'],
+        ];
+        $this->locales = [
+            'en_US' => [
+                'code' => 'en_US',
+                'label' => 'English',
+            ],
+            'fr_FR' => [
+                'code' => 'fr_FR',
+                'label' => 'French',
+            ],
+            'de_DE' => [
+                'code' => 'de_DE',
+                'label' => 'German',
+            ],
+        ];
+
+        $this->findOneAttributeByCodeQuery = $this->createMock(FindOneAttributeByCodeQueryInterface::class);
+        $this->findOneAttributeByCodeQuery
+            ->method('execute')
+            ->willReturnCallback(fn ($code) => $this->attributes[$code] ?? null);
+        self::getContainer()->set(FindOneAttributeByCodeQuery::class, $this->findOneAttributeByCodeQuery);
+
+        $this->getChannelQuery = $this->createMock(GetChannelQueryInterface::class);
+        $this->getChannelQuery
+            ->method('execute')
+            ->willReturnCallback(fn ($code) => $this->channels[$code] ?? null);
+        self::getContainer()->set(GetChannelQuery::class, $this->getChannelQuery);
+
+        $this->getLocalesQuery = $this->createMock(GetLocalesQueryInterface::class);
+        $this->getLocalesQuery
+            ->method('execute')
+            ->willReturn(\array_values($this->locales));
+        self::getContainer()->set(GetLocalesQuery::class, $this->getLocalesQuery);
+
+        $this->getChannelLocalesQuery = $this->createMock(GetChannelLocalesQueryInterface::class);
+        $this->getChannelLocalesQuery
+            ->method('execute')
+            ->willReturnCallback(function ($code): array {
+                if (!isset($this->channelLocales[$code])) {
+                    throw new \LogicException();
+                }
+
+                return \array_map(fn ($locale) => $this->locales[$locale], $this->channelLocales[$code]);
+            });
+        self::getContainer()->set(GetChannelLocalesQuery::class, $this->getChannelLocalesQuery);
+    }
+
+    protected function createAttribute(array $data): void
+    {
+        $this->attributes[$data['code']] = $data;
+    }
+
+    protected function createChannel(string $code, array $locales = []): void
+    {
+        $this->channels[$code] = [
+            'code' => $code,
+            'label' => $code,
+        ];
+        $this->channelLocales[$code] = $locales;
+    }
+}

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AttributeTextCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AttributeTextCriterionTest.php
@@ -2,17 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Catalogs\Test\Integration\Infrastructure\Validation\ProductSelection;
+namespace Akeneo\Catalogs\Test\Integration\Infrastructure\Validation\ProductSelection\AttributeCriterion;
 
 use Akeneo\Catalogs\Infrastructure\Validation\ProductSelection\AttributeCriterion\AttributeTextCriterion;
-use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AttributeTextCriterionTest extends IntegrationTestCase
+class AttributeTextCriterionTest extends AbstractAttributeCriterionTest
 {
     private ?ValidatorInterface $validator;
 
@@ -21,26 +20,21 @@ class AttributeTextCriterionTest extends IntegrationTestCase
         parent::setUp();
 
         $this->validator = self::getContainer()->get(ValidatorInterface::class);
-
-        $this->purgeDataAndLoadMinimalCatalog();
     }
 
     /**
-     * @dataProvider validCriterionDataProvider
+     * @dataProvider validDataProvider
      */
-    public function testItValidates(array $attribute, array $criterion): void
+    public function testItReturnsNoViolation(array $attribute, array $criterion): void
     {
         $this->createAttribute($attribute);
 
-        $violations = $this->validator->validate(
-            $criterion,
-            new AttributeTextCriterion(),
-        );
+        $violations = $this->validator->validate($criterion, new AttributeTextCriterion());
 
         $this->assertEmpty($violations);
     }
 
-    public function validCriterionDataProvider(): array
+    public function validDataProvider(): array
     {
         return [
             'localizable and scopable attribute' => [
@@ -111,24 +105,31 @@ class AttributeTextCriterionTest extends IntegrationTestCase
     }
 
     /**
-     * @dataProvider invalidStructureDataProvider
+     * @dataProvider invalidDataProvider
      */
-    public function testItReturnsViolationsWhenAttributeTextCriterionStructureIsInvalid(
+    public function testItReturnsViolationsWhenInvalid(
+        array $attribute,
         array $criterion,
         string $expectedMessage
     ): void {
-        $violations = $this->validator->validate(
-            $criterion,
-            new AttributeTextCriterion(),
-        );
+        $this->createAttribute($attribute);
+
+        $violations = $this->validator->validate($criterion, new AttributeTextCriterion());
 
         $this->assertViolationsListContains($violations, $expectedMessage);
     }
 
-    public function invalidStructureDataProvider(): array
+    public function invalidDataProvider(): array
     {
         return [
             'invalid field value' => [
+                'attribute' => [
+                    'code' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other',
+                    'scopable' => true,
+                    'localizable' => true,
+                ],
                 'criterion' => [
                     'field' => 42,
                     'operator' => '=',
@@ -139,6 +140,13 @@ class AttributeTextCriterionTest extends IntegrationTestCase
                 'expectedMessage' => 'This value should be of type string.',
             ],
             'invalid operator' => [
+                'attribute' => [
+                    'code' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other',
+                    'scopable' => true,
+                    'localizable' => true,
+                ],
                 'criterion' => [
                     'field' => 'name',
                     'operator' => 'IN',
@@ -149,6 +157,13 @@ class AttributeTextCriterionTest extends IntegrationTestCase
                 'expectedMessage' => 'The value you selected is not a valid choice.',
             ],
             'invalid value' => [
+                'attribute' => [
+                    'code' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other',
+                    'scopable' => true,
+                    'localizable' => true,
+                ],
                 'criterion' => [
                     'field' => 'name',
                     'operator' => '=',
@@ -159,6 +174,13 @@ class AttributeTextCriterionTest extends IntegrationTestCase
                 'expectedMessage' => 'This value should be of type string.',
             ],
             'invalid scope' => [
+                'attribute' => [
+                    'code' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other',
+                    'scopable' => true,
+                    'localizable' => true,
+                ],
                 'criterion' => [
                     'field' => 'name',
                     'operator' => '=',
@@ -169,6 +191,13 @@ class AttributeTextCriterionTest extends IntegrationTestCase
                 'expectedMessage' => 'This value should be of type string.',
             ],
             'invalid locale' => [
+                'attribute' => [
+                    'code' => 'name',
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other',
+                    'scopable' => true,
+                    'localizable' => true,
+                ],
                 'criterion' => [
                     'field' => 'name',
                     'operator' => '=',
@@ -178,30 +207,6 @@ class AttributeTextCriterionTest extends IntegrationTestCase
                 ],
                 'expectedMessage' => 'This value should be of type string.',
             ],
-        ];
-    }
-
-    /**
-     * @dataProvider invalidValuesDataProvider
-     */
-    public function testItReturnsViolationsWhenAttributeTextCriterionValuesAreInvalid(
-        array $attribute,
-        array $criterion,
-        string $expectedMessage
-    ): void {
-        $this->createAttribute($attribute);
-
-        $violations = $this->validator->validate(
-            $criterion,
-            new AttributeTextCriterion(),
-        );
-
-        $this->assertViolationsListContains($violations, $expectedMessage);
-    }
-
-    public function invalidValuesDataProvider(): array
-    {
-        return [
             'field with invalid locale for a channel' => [
                 'attribute' => [
                     'code' => 'name',


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

It's not anymore an all-layers integration test.

Nonetheless, the test content is the same.
```
    /**
     * @dataProvider validDataProvider
     */
    public function testItReturnsNoViolation(array $attribute, array $criterion): void
    {
        $this->createAttribute($attribute);

        $violations = $this->validator->validate($criterion, new AttributeTextCriterion());

        $this->assertEmpty($violations);
    }
```
The symfony validator is still called, we are still testing that our bricks are behaving as expected.
The big difference is that queries called by the validators are mocked.

If I submit a valid criterion, everything's green, if I submit an invalid one, everything's red and the test proves it.

The main benefit is, of course, performances. (measured on my machine, expect more on the CI)

**Before: 9s**
```bash
PHPUnit 9.5.21 #StandWithUkraine

..............                                                    14 / 14 (100%)

Time: 00:09.391, Memory: 96.50 MB

OK (14 tests, 4 assertions)
```

**After: 0.2s**
```
PHPUnit 9.5.21 #StandWithUkraine

..............                                                    14 / 14 (100%)

Time: 00:00.180, Memory: 42.00 MB

OK (14 tests, 4 assertions)
```

Why this change now ? We created our first attribute criterion, we have 11 more to go.
Having at least 10s of tests for each attribute criterion will explode our CI duration.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
