### PR TITLE
OCT-89: Authenticate automatically in a microfrontend

### DIFF
--- a/components/catalogs/front/src/index.tsx
+++ b/components/catalogs/front/src/index.tsx
@@ -5,7 +5,10 @@ import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 import {ThemeProvider} from 'styled-components';
 import {pimTheme} from 'akeneo-design-system';
 import {QueryClient, QueryClientProvider} from 'react-query';
-import {MicroFrontendDependenciesProvider} from '@akeneo-pim-community/shared';
+import {
+    MicroFrontendDependenciesProvider,
+    DangerousMicrofrontendAutomaticAuthenticator,
+} from '@akeneo-pim-community/shared';
 import {FakePIM} from './FakePIM';
 import {FakeCatalogEditContainer} from './FakeCatalogEditContainer';
 import {FakeCatalogListContainer} from './FakeCatalogListContainer';
@@ -30,6 +33,8 @@ const routes = {
         schemes: [],
     },
 };
+
+DangerousMicrofrontendAutomaticAuthenticator.enable('admin', 'admin');
 
 const client = new QueryClient();
 

--- a/front-packages/shared/src/microfrontend/DangerousMicrofrontendAutomaticAuthenticator.ts
+++ b/front-packages/shared/src/microfrontend/DangerousMicrofrontendAutomaticAuthenticator.ts
@@ -1,0 +1,57 @@
+let authentication_in_progress = false;
+
+export const DangerousMicrofrontendAutomaticAuthenticator = {
+  enable: (username = 'admin', password = 'admin') => {
+    window.addEventListener('unhandledrejection', (e: PromiseRejectionEvent): void => {
+      if (e.reason.toString() !== 'Error: You are not logged in the PIM') {
+        return;
+      }
+
+      if (authentication_in_progress) {
+        return;
+      }
+
+      authentication_in_progress = true;
+
+      fetch('/user/login')
+        .then(response => response.text())
+        .then(html => {
+          const parser = new DOMParser();
+          const dom = parser.parseFromString(html, 'text/html');
+          const input = dom.querySelector('input[name="_csrf_token"]');
+          const csrf = input?.getAttribute('value');
+
+          if (!csrf) {
+            console.error('Cannot find a CSRF token in the login page');
+
+            return;
+          }
+
+          const form = new FormData();
+          form.append('_username', username);
+          form.append('_password', password);
+          form.append('_submit', '');
+          form.append('_target_path', '');
+          form.append('_csrf_token', csrf);
+
+          fetch('/user/login-check', {
+            method: 'POST',
+            body: form,
+          })
+            // It's not the keyword "then" because the browsers are unhappy with the redirection
+            // response to a different domain (CORS). Response or error are both opaques.
+            // Using another request in "finally" is the only available way to check either the authentication
+            // was successful or not.
+            .finally(() => {
+              fetch('/rest/user/').then(response => {
+                if (response.ok) {
+                  location.reload();
+                } else {
+                  console.error(`Cannot login automatically with the credentials: ${username}/${password}`);
+                }
+              });
+            });
+        });
+    });
+  },
+};

--- a/front-packages/shared/src/microfrontend/index.ts
+++ b/front-packages/shared/src/microfrontend/index.ts
@@ -1,1 +1,2 @@
 export * from './MicroFrontendDependenciesProvider';
+export * from './DangerousMicrofrontendAutomaticAuthenticator';


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In our microfrontends, the PIM API is proxied.
If you don't have an active session with the correct cookies on the PIM (localhost:8080), the microfronted calls to the PIM API are rejected.

This PR introduce a dirty solution to automatically authenticate and reload the page when this error is detected, that can be enabled with 2 lines in the `index.ts` of a create-react-app microfrontend.

```
import {DangerousMicrofrontendAutomaticAuthenticator} from '@akeneo-pim-community/shared';

DangerousMicrofrontendAutomaticAuthenticator.enable('admin', 'admin');
```

https://user-images.githubusercontent.com/1421130/185653409-e92ed2f3-b290-45d6-91a0-44c29412b897.mp4

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
