### PR TITLE
OCT-107: downgrade to lcobucci 4.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -96,7 +96,7 @@
         "imagine/imagine": "1.2.4",
         "justinrainbow/json-schema": "^5.2",
         "khaled.alshamaa/ar-php": "^6.2",
-        "lcobucci/jwt": "^4.1",
+        "lcobucci/jwt": "~4.1.5",
         "league/flysystem": "^2.0",
         "league/flysystem-memory": "^2.0",
         "liip/imagine-bundle": "2.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4149ac99d17d10f8f637e9abe951fd0",
+    "content-hash": "a5fbfab132ae6e523e62ab9b11dbcc02",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In lcobucci/jwt 4.2.0, SHA256 with 1024bits keys are not supported anymore and throws an exception.
By fixing the lib version to 4.1.5, our current implementation is still working and will give us time to upgrade correctly to newer versions.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
