### PR TITLE
CPM-592: use external api normalizer in e2e tests

### DIFF
--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -8,11 +8,35 @@ use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 
 class CreateProductEndToEnd extends AbstractProductTestCase
 {
     use AssertEventCountTrait;
+
+    private array $emptyAssociations = [
+        'PACK' => [
+            'groups' => [],
+            'product_models' => [],
+            'products' => [],
+        ],
+        'SUBSTITUTION' => [
+            'groups' => [],
+            'product_models' => [],
+            'products' => [],
+        ],
+        'UPSELL' => [
+            'groups' => [],
+            'product_models' => [],
+            'products' => [],
+        ],
+        'X_SELL' => [
+            'groups' => [],
+            'product_models' => [],
+            'products' => [],
+        ]
+    ];
 
     /**
      * {@inheritdoc}
@@ -69,15 +93,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_family'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -110,15 +130,11 @@ JSON;
             'groups'        => ["groupA", "groupB"],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_groups'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -149,15 +165,11 @@ JSON;
             'groups'        => [],
             'categories'    => ["categoryA", "master"],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -201,11 +213,7 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_associations'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
@@ -230,7 +238,7 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -243,13 +251,11 @@ JSON;
     public function testProductCreationWithProductValues()
     {
         $client = $this->createAuthenticatedClient();
-
         $files = [
             'akeneo_pdf' => $this->getFileInfoKey($this->getFixturePath('akeneo.pdf')),
             'akeneo_jpg' => $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')),
             'ziggy_png'  => $this->getFileInfoKey($this->getFixturePath('ziggy.png')),
         ];
-
         $data =
             <<<JSON
     {
@@ -435,7 +441,6 @@ JSON;
         }
     }
 JSON;
-
         $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
 
         $expectedProduct = [
@@ -446,14 +451,16 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_product_values'],
-                ],
                 'a_file'                             => [
                     [
                         'locale' => null,
                         'scope'  => null,
                         'data'   => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
                     ],
                 ],
                 'an_image'                           => [
@@ -461,6 +468,11 @@ JSON;
                         'locale' => null,
                         'scope'  => null,
                         'data'   => '1/5/7/5/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
                     ],
                 ],
                 'a_date'                             => [
@@ -563,11 +575,21 @@ JSON;
                         'locale' => 'en_US',
                         'scope'  => 'ecommerce',
                         'data'   => '6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_ziggy_en_US.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/62e376e75300d27bfec78878db4d30ff1490bc53_ziggy_en_US.png/download'
+                            ]
+                        ]
                     ],
                     [
                         'locale' => 'fr_FR',
                         'scope'  => 'tablet',
                         'data'   => '0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_akeneo_fr_FR.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/0f5058de76f68446bb6b2371f19cd2234b245c00_akeneo_fr_FR.jpg/download'
+                            ]
+                        ]
                     ],
                 ],
                 'a_scopable_price'                   => [
@@ -608,8 +630,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -631,6 +653,7 @@ JSON;
         "updated": "2014-06-14T13:12:50+02:00"
     }
 JSON;
+        $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
 
         $expectedProduct = [
             'identifier'    => 'foo',
@@ -639,18 +662,12 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'foo'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
-
-        $client->request('POST', 'api/rest/v1/products', [], [], [], $data);
 
         $response = $client->getResponse();
 
@@ -659,8 +676,14 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'foo');
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
 
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('foo');
-        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
+        $query = <<<SQL
+            SELECT BIN_TO_UUID(uuid) as uuid FROM pim_catalog_product WHERE identifier = 'foo'
+        SQL;
+        $uuid = $this->get('database_connection')->executeQuery($query)->fetchOne();
+
+        $userId = $this->getUserId('admin');
+        $product = $this->get('akeneo.pim.enrichment.product.connector.get_product_from_uuids')->fromProductUuid(Uuid::fromString($uuid), $userId);
+        $standardizedProduct = $this->get('pim_api.normalizer.connector_products')->normalizeConnectorProduct($product);
 
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['created']);
         $this->assertNotSame('2014-06-14T13:12:50+02:00', $standardizedProduct['updated']);
@@ -1010,21 +1033,6 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
-    }
-
-    /**
-     * @param array  $expectedProduct normalized data of the product that should be created
-     * @param string $identifier identifier of the product that should be created
-     */
-    protected function assertSameProducts(array $expectedProduct, $identifier)
-    {
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
-
-        NormalizedProductCleaner::clean($standardizedProduct);
-        NormalizedProductCleaner::clean($expectedProduct);
-
-        $this->assertSame($expectedProduct, $standardizedProduct);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductWithUuidEndToEnd.php
@@ -88,15 +88,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_family'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -135,15 +131,11 @@ JSON;
             'groups'        => ["groupA", "groupB"],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_groups'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -180,15 +172,11 @@ JSON;
             'groups'        => [],
             'categories'    => ["categoryA", "master"],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -245,12 +233,11 @@ JSON;
             'values' => [
                 'a_simple_select' => [['data' => 'optionB', 'locale' => null, 'scope' => null]],
                 'a_yes_no' => [['data' => true, 'locale' => null, 'scope' => null]],
-                'sku' => [['data' => 'foo', 'locale' => null, 'scope' => null]],
             ],
             'created' => 'this is a date formatted to ISO-8601',
             'updated' => 'this is a date formatted to ISO-8601',
-            'associations' => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ], 'foo');
     }
 
@@ -302,11 +289,7 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_associations'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
@@ -334,7 +317,7 @@ JSON;
             'quantified_associations' => [
                 'QUANTIFIEDASSOCIATION' => [
                     'products' => [[
-                        'uuid' => $this->getProductUuidFromIdentifier('simple')->toString(),
+                        'identifier' => 'simple',
                         'quantity' => 12,
                     ]],
                     'product_models' => [],
@@ -559,14 +542,16 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_creation_product_values'],
-                ],
                 'a_file'                             => [
                     [
                         'locale' => null,
                         'scope'  => null,
                         'data'   => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
                     ],
                 ],
                 'an_image'                           => [
@@ -574,6 +559,11 @@ JSON;
                         'locale' => null,
                         'scope'  => null,
                         'data'   => '1/5/7/5/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
                     ],
                 ],
                 'a_date'                             => [
@@ -676,11 +666,21 @@ JSON;
                         'locale' => 'en_US',
                         'scope'  => 'ecommerce',
                         'data'   => '6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_ziggy_en_US.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
                     ],
                     [
                         'locale' => 'fr_FR',
                         'scope'  => 'tablet',
                         'data'   => '0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_akeneo_fr_FR.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
                     ],
                 ],
                 'a_scopable_price'                   => [
@@ -721,8 +721,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -758,15 +758,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'foo'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('POST', 'api/rest/v1/products-uuid', [], [], [], $data);
@@ -1135,21 +1131,6 @@ JSON;
         $response = $client->getResponse();
 
         $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
-    }
-
-    /**
-     * @param array  $expectedProduct normalized data of the product that should be created
-     * @param string $identifier identifier of the product that should be created
-     */
-    protected function assertSameProducts(array $expectedProduct, $identifier): void
-    {
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
-        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
-
-        NormalizedProductCleaner::clean($standardizedProduct);
-        NormalizedProductCleaner::clean($expectedProduct);
-
-        $this->assertSame($expectedProduct, $standardizedProduct);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -58,15 +58,11 @@ JSON;
                 'groups'        => [],
                 'categories'    => [],
                 'enabled'       => true,
-                'values'        => [
-                    'sku' => [
-                        ['locale' => null, 'scope' => null, 'data' => 'product_family'],
-                    ],
-                ],
+                'values'        => new \stdClass(),
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
-                'associations'  => [],
-                'quantified_associations' => [],
+                'associations'  => $this->EMPTY_ASSOCIATIONS,
+                'quantified_associations' => new \stdClass(),
             ],
             'my_identifier'  => [
                 'identifier'    => 'my_identifier',
@@ -75,15 +71,11 @@ JSON;
                 'groups'        => [],
                 'categories'    => [],
                 'enabled'       => true,
-                'values'        => [
-                    'sku' => [
-                        ['locale' => null, 'scope' => null, 'data' => 'my_identifier'],
-                    ],
-                ],
+                'values'        => new \stdClass(),
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
-                'associations'  => [],
-                'quantified_associations' => [],
+                'associations'  => $this->EMPTY_ASSOCIATIONS,
+                'quantified_associations' => new \stdClass(),
             ],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -80,15 +80,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_create_with_identifier'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_create_with_identifier', [], [], [], $data);
@@ -118,15 +114,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_create_without_identifier'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_create_without_identifier', [], [], [], $data);
@@ -282,15 +274,11 @@ JSON;
             'groups'        => [],
             'categories'    => ['master'],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_categories', [], [], [], $data);
@@ -320,15 +308,11 @@ JSON;
             'groups'        => [],
             'categories'    => ['master'],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_categories', [], [], [], $data);
@@ -363,15 +347,11 @@ JSON;
             'groups'        => [],
             'categories'    => ['master'],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'new_product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_categories', [], [], [], $data);
@@ -442,15 +422,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_family'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -482,15 +458,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_family'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -521,15 +493,11 @@ JSON;
             'groups'        => ['groupA', 'groupB'],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_groups'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -562,15 +530,11 @@ JSON;
 
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_groups'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -603,15 +567,11 @@ JSON;
 
             'categories'    => ["categoryA", "categoryA1"],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -644,15 +604,11 @@ JSON;
 
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -701,11 +657,7 @@ JSON;
 
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_associations'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations' => [
@@ -730,7 +682,7 @@ JSON;
                     'product_models' => [],
                 ],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -769,11 +721,7 @@ JSON;
 
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_associations'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
@@ -782,7 +730,7 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => [], 'products' => ['product_categories'], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -823,11 +771,7 @@ JSON;
 
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_associations'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
             'associations'  => [
@@ -836,7 +780,7 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -869,15 +813,11 @@ JSON;
 
             'categories'    => ['master'],
             'enabled'       => false,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -919,19 +859,43 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'localizable'],
-                ],
                 'a_localizable_image' => [
-                    ['locale' => 'en_US', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
-                    ['locale' => 'fr_FR', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
-                    ['locale' => 'zh_CN', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
+                    [
+                        'locale' => 'en_US',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
+                    ],
+                    [
+                        'locale' => 'fr_FR',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
+                    ],
+                    [
+                        'locale' => 'zh_CN',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt/download'
+                            ]
+                        ]
+                    ],
                 ]
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -973,18 +937,33 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'localizable'],
-                ],
                 'a_localizable_image' => [
-                    ['locale' => 'en_US', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_ziggy.png'],
-                    ['locale' => 'fr_FR', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
+                    [
+                        'locale' => 'en_US',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_ziggy.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
+                    ],
+                    [
+                        'locale' => 'fr_FR',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
+                    ],
                 ]
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1023,17 +1002,23 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'localizable'],
-                ],
                 'a_localizable_image' => [
-                    ['locale' => 'fr_FR', 'scope' => null, 'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt'],
+                    [
+                        'locale' => 'fr_FR',
+                        'scope' => null,
+                        'data' => '4/d/e/b/4deb535f0979dea59cf34661e22336459a56bed3_akeneo.txt',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
+                    ],
                 ]
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1141,9 +1126,6 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku'                                => [
-                    ['locale' => null, 'scope' => null, 'data' => 'complete'],
-                ],
                 'a_date'   => [
                     ['locale' => null, 'scope' => null, 'data' => '2016-06-13T00:00:00+02:00'],
                 ],
@@ -1181,11 +1163,21 @@ JSON;
                         'locale' => 'en_US',
                         'scope'  => 'ecommerce',
                         'data'   => '6/2/e/3/62e376e75300d27bfec78878db4d30ff1490bc53_ziggy_en_US.png',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
                     ],
                     [
                         'locale' => 'fr_FR',
                         'scope'  => 'tablet',
                         'data'   => '0/f/5/0/0f5058de76f68446bb6b2371f19cd2234b245c00_akeneo_fr_FR.jpg',
+                        '_links' => [
+                            'download' => [
+                                'href' => 'http://localhost/api/rest/v1/media_files/4/d/e/b/15757827125efa686c1c0f1e7930ca0c528f1c2c_ziggy.png/download'
+                            ]
+                        ]
                     ],
                 ],
                 'a_localized_and_scopable_text_area' => [
@@ -1214,7 +1206,7 @@ JSON;
                 'UPSELL'       => ['groups'   => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups'   => ['groupA'], 'products' => ['product_categories'], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1236,35 +1228,29 @@ JSON;
         "updated": "2014-06-14T13:12:50+02:00"
     }
 JSON;
+        $client->request('PATCH', 'api/rest/v1/products/product_categories', [], [], [], $data);
+
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
 
         $expectedProduct = [
             'identifier'    => 'product_categories',
             'family'        => null,
             'parent'        => null,
             'groups'        => [],
-
             'categories'    => ['master'],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_categories'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
-        $client->request('PATCH', 'api/rest/v1/products/product_categories', [], [], [], $data);
 
-        $response = $client->getResponse();
-
-
-        $this->assertSame('', $response->getContent());
         $this->assertSameProducts($expectedProduct, 'product_categories');
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
-
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('product_categories');
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductEndToEnd.php
@@ -69,14 +69,10 @@ JSON;
             'groups' => [],
             'categories' => [],
             'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => new \stdClass(),
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 'PRODUCTSET' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToProductWithUuidEndToEnd.php
@@ -73,14 +73,10 @@ JSON;
             'groups' => [],
             'categories' => [],
             'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => new \stdClass(),
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 'PRODUCTSET' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromProductEndToEnd.php
@@ -81,20 +81,11 @@ JSON;
             'groups' => [],
             'categories' => [],
             'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => new \stdClass(),
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
-            'quantified_associations' => [
-                'PRODUCTSET' => [
-                    'products' => [],
-                    'product_models' => [],
-                ],
-            ],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInProductEndToEnd.php
@@ -86,14 +86,10 @@ JSON;
             'groups' => [],
             'categories' => [],
             'enabled' => true,
-            'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => $identifier],
-                ],
-            ],
+            'values' => new \stdClass(),
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 '1234' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductEndToEnd.php
@@ -89,9 +89,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_family'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -131,8 +128,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -175,9 +172,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_family'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -217,8 +211,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -450,9 +444,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_groups'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -492,8 +483,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -535,9 +526,6 @@ JSON;
             'categories'    => ["categoryA", "master"],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_categories'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -577,8 +565,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -627,9 +615,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_associations'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -691,7 +676,7 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -903,9 +888,6 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_creation_product_values'],
-                ],
                 'a_number_float' => [
                     ['locale' => null, 'scope' => null, 'data' => '12.5000'],
                 ],
@@ -937,8 +919,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -986,9 +968,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'foo'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1028,8 +1007,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('POST', 'api/rest/v1/products', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
@@ -95,9 +95,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_family']
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -137,8 +134,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -223,9 +220,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_family'],
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -265,8 +259,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -511,9 +505,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_groups'],
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -553,8 +544,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -598,9 +589,6 @@ JSON;
             'categories'    => ["categoryA", "master"],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_categories'],
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -640,8 +628,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -692,9 +680,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_associations'],
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -756,7 +741,7 @@ JSON;
                     "product_models" => [],
                 ],
             ],
-            'quantified_associations' => [],
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -970,9 +955,6 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'product_variant_creation_product_values'],
-                ],
                 'a_number_float' => [
                     ["locale" => null, "scope" => null, "data" => '12.5000'],
                 ],
@@ -1004,8 +986,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1055,9 +1037,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                "sku" => [
-                    ["locale" => null, "scope" => null, "data" => 'foo'],
-                ],
                 'a_simple_select' => [
                     ["locale" => null, "scope" => null, "data" => 'optionB'],
                 ],
@@ -1097,8 +1076,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $client->request('POST', 'api/rest/v1/products-uuid', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateListVariantProductEndToEnd.php
@@ -90,9 +90,6 @@ JSON;
                 'categories'    => ["master"],
                 'enabled'       => true,
                 'values'        => [
-                    'sku'                                => [
-                        ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_true'],
-                    ],
                     'a_simple_select'                    => [
                         ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                     ],
@@ -132,8 +129,8 @@ JSON;
                 ],
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
-                'associations'  => [],
-                'quantified_associations' => [],
+                'associations'  => $this->EMPTY_ASSOCIATIONS,
+                'quantified_associations' => new \stdClass(),
             ],
             'apollon_optionb_false' => [
                 'identifier'    => 'apollon_optionb_false',
@@ -143,9 +140,6 @@ JSON;
                 'categories'    => [],
                 'enabled'       => true,
                 'values'        => [
-                    'sku'                                => [
-                        ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                    ],
                     'a_simple_select'                    => [
                         ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                     ],
@@ -185,8 +179,8 @@ JSON;
                 ],
                 'created'       => '2016-06-14T13:12:50+02:00',
                 'updated'       => '2016-06-14T13:12:50+02:00',
-                'associations'  => [],
-                'quantified_associations' => [],
+                'associations'  => $this->EMPTY_ASSOCIATIONS,
+                'quantified_associations' => new \stdClass(),
             ],
         ];
 

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateProductToVariantEndToEnd.php
@@ -35,6 +35,7 @@ JSON;
             'family' => 'familyA',
             'parent' => 'amor',
             'groups' => [],
+            'categories' => ['categoryA2', 'master'],
             'enabled' => true,
             'values' => [
                 'a_localized_and_scopable_text_area' => [['locale' => 'en_US', 'scope' => 'ecommerce', 'data' => 'my pink tshirt']],
@@ -44,24 +45,18 @@ JSON;
                 ],
                 'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionB']],
                 'a_yes_no' => [['locale' => null, 'scope' => null, 'data' => true]],
-                'sku' => [['locale' => null, 'scope' => null, 'data' => 'product_family_variant']],
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $this->assertSame('', $response->getContent());
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $this->assertEventCount(1, ProductUpdated::class);
 
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('product_family_variant');
-        $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
-        unset($standardizedProduct['categories']);
-        NormalizedProductCleaner::clean($expectedProduct);
-        NormalizedProductCleaner::clean($standardizedProduct);
-        $this->assertEquals($standardizedProduct, $expectedProduct);
+        $this->assertSameProducts($expectedProduct, 'product_family_variant');
 
         $this->assertArrayHasKey('location', $response->headers->all());
         $this->assertSame(

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -109,9 +109,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_variant_create_with_identifier'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -151,8 +148,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_variant_create_with_identifier', [], [], [], $data);
@@ -182,15 +179,11 @@ JSON;
             'groups'        => [],
             'categories'    => [],
             'enabled'       => true,
-            'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_create_without_identifier'],
-                ],
-            ],
+            'values'        => new \stdClass(),
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/product_create_without_identifier', [], [], [], $data);
@@ -425,9 +418,6 @@ JSON;
             'categories'    => ['master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -467,8 +457,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -511,9 +501,6 @@ JSON;
             'categories'    => ["master"],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -553,8 +540,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -598,9 +585,6 @@ JSON;
             'categories'    => ["categoryA"],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -640,8 +624,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -685,9 +669,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -727,8 +708,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -781,9 +762,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -845,7 +823,7 @@ JSON;
                     'product_models' => [],
                 ],
             ],
-            'quantified_associations' => [],
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -894,9 +872,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -942,7 +917,7 @@ JSON;
                 'UPSELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -991,9 +966,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1039,7 +1011,7 @@ JSON;
                 'UPSELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
                 'X_SELL'       => ['groups' => [], 'products' => [], 'product_models' => []],
             ],
-            'quantified_associations' => [],
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1084,9 +1056,6 @@ JSON;
             'categories'    => [],
             'enabled'       => false,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1126,8 +1095,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1178,9 +1147,6 @@ JSON;
             'categories'    => [],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1220,8 +1186,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1380,9 +1346,6 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1422,8 +1385,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1538,9 +1501,6 @@ JSON;
             'categories'    => ['categoryA', 'master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1580,8 +1540,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $response = $client->getResponse();
@@ -1622,9 +1582,6 @@ JSON;
             'categories'    => ['master'],
             'enabled'       => true,
             'values'        => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
                 'a_simple_select' => [
                     ['locale' => null, 'scope' => null, 'data' => 'optionB'],
                 ],
@@ -1664,8 +1621,8 @@ JSON;
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);
@@ -1788,14 +1745,11 @@ JSON;
                         "data"   => false,
                     ],
                 ],
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'apollon_optionb_false'],
-                ],
             ],
             'created'       => '2016-06-14T13:12:50+02:00',
             'updated'       => '2016-06-14T13:12:50+02:00',
-            'associations'  => [],
-            'quantified_associations' => [],
+            'associations'  => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client->request('PATCH', 'api/rest/v1/products/apollon_optionb_false', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantToSimpleEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantToSimpleEndToEnd.php
@@ -39,11 +39,8 @@ class PartialUpdateVariantToSimpleEndToEnd extends AbstractProductTestCase
             'categories' => ['master', 'categoryA2'],
             'enabled' => true,
             'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_family_variant_yes'],
-                ],
                 'a_price' => [
-                    'data' => [
+                    [
                         'data' => [
                             ['amount' => '400.00', 'currency' => 'CNY'],
                             ['amount' => '50.00', 'currency' => 'EUR'],
@@ -66,29 +63,8 @@ class PartialUpdateVariantToSimpleEndToEnd extends AbstractProductTestCase
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [
-                'PACK' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'SUBSTITUTION' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'UPSELL' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'X_SELL' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-            ],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client = $this->createAuthenticatedClient();
@@ -141,9 +117,6 @@ class PartialUpdateVariantToSimpleEndToEnd extends AbstractProductTestCase
             'categories' => ['categoryA1', 'categoryA2'],
             'enabled' => true,
             'values' => [
-                'sku' => [
-                    ['locale' => null, 'scope' => null, 'data' => 'product_family_variant_no'],
-                ],
                 'a_number_float' => [['data' => '12.5000', 'locale' => null, 'scope' => null]],
                 'a_localized_and_scopable_text_area' => [
                     [
@@ -158,29 +131,8 @@ class PartialUpdateVariantToSimpleEndToEnd extends AbstractProductTestCase
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [
-                'PACK' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'SUBSTITUTION' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'UPSELL' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-                'X_SELL' => [
-                    'products' => [],
-                    'product_models' => [],
-                    'groups' => [],
-                ],
-            ],
-            'quantified_associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations'  => new \stdClass(),
         ];
 
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductEndToEnd.php
@@ -75,13 +75,10 @@ JSON;
                 "a_yes_no"=>[
                     ["data" => true, "locale" => null, "scope" => null]
                 ],
-                "sku" => [
-                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
-                ]
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 'PRODUCTSET' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/AddQuantifiedAssociationsToVariantProductWithUuidEndToEnd.php
@@ -76,14 +76,11 @@ JSON;
                 ],
                 "a_yes_no"=>[
                     ["data" => true, "locale" => null, "scope" => null]
-                ],
-                "sku" => [
-                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
                 ]
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 'PRODUCTSET' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/DeleteQuantifiedAssociationsFromVariantProductEndToEnd.php
@@ -85,19 +85,11 @@ JSON;
                 "a_yes_no"=>[
                     ["data" => true, "locale" => null, "scope" => null]
                 ],
-                "sku" => [
-                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
-                ]
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
-            'quantified_associations' => [
-                'PRODUCTSET' => [
-                    'products' => [],
-                    'product_models' => [],
-                ],
-            ],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
+            'quantified_associations' => new \stdClass(),
         ];
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/QuantifiedAssociations/UpdateQuantifiedAssociationsInVariantProductEndToEnd.php
@@ -83,13 +83,10 @@ JSON;
                 "a_yes_no"=>[
                     ["data" => true, "locale" => null, "scope" => null]
                 ],
-                "sku" => [
-                    ["data" => "garden_table_set-black-gold", "locale" => null, "scope" => null]
-                ]
             ],
             'created' => '2016-06-14T13:12:50+02:00',
             'updated' => '2016-06-14T13:12:50+02:00',
-            'associations' => [],
+            'associations' => $this->EMPTY_ASSOCIATIONS,
             'quantified_associations' => [
                 'PRODUCTSET' => [
                     'products' => [

--- a/tests/back/Pim/Enrichment/Integration/Normalizer/NormalizedProductCleaner.php
+++ b/tests/back/Pim/Enrichment/Integration/Normalizer/NormalizedProductCleaner.php
@@ -25,10 +25,16 @@ class NormalizedProductCleaner
     {
         self::sanitizeDateFields($productNormalized);
         self::sanitizeMediaAttributeData($productNormalized);
-        self::sortValues($productNormalized['values']);
+        // this condition prevents values from ConnectorProductNormalizer to be sorted (because they're an stdClass)
+        if (is_array($productNormalized['values'])) {
+            self::sortValues($productNormalized['values']);
+        }
         self::sortAssociations($productNormalized['associations']);
         if (isset($productNormalized['categories'])) {
             self::sortCategories($productNormalized['categories']);
+        }
+        if (isset($productNormalized['metadata'])) {
+            unset($productNormalized['metadata']);
         }
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We used the wrong normalizer in e2e tests related to external apis, so the expected products were not correct.
This PR will help differentiate future expected products with uuids

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
