### PR TITLE
CPM-698: Add uuid in UpsertProductCommand

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/CreateProductByUuidController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/CreateProductByUuidController.php
@@ -15,7 +15,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\ProductModel\Filter\AttributeFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\QuantifiedAssociations;
-use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\VariantProductParent;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\ExternalApi\PayloadFormat;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/ValueObject/ProductIdentifier.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/ValueObject/ProductIdentifier.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\ValueObject;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductIdentifier
+{
+    private function __construct(private string $identifier)
+    {
+        Assert::stringNotEmpty($identifier, 'The product identifier requires a non empty string');
+    }
+
+    public static function fromIdentifier(string $identifier): self
+    {
+        return new self($identifier);
+    }
+
+    public function identifier(): string
+    {
+        return $this->identifier;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/ValueObject/ProductUuid.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/ValueObject/ProductUuid.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\ValueObject;
+
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductUuid
+{
+    private function __construct(private UuidInterface $uuid)
+    {
+    }
+
+    public static function fromUuid(UuidInterface $uuid): self
+    {
+        return new self($uuid);
+    }
+
+    public function uuid(): UuidInterface
+    {
+        return $this->uuid;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetCategoryCodes.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Product\Domain\Query;
 
 use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -13,6 +14,8 @@ use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 interface GetCategoryCodes
 {
     /**
+     * @deprecated
+     *
      * @param ProductIdentifier[] $productIdentifiers
      * @return array<string, string[]> example:
      *  {
@@ -22,4 +25,15 @@ interface GetCategoryCodes
      *  }
      */
     public function fromProductIdentifiers(array $productIdentifiers): array;
+
+    /**
+     * @param UuidInterface[] $uuids
+     * @return array<string, string[]> example:
+     *  {
+     *      "973ba04e-a035-41f4-86f4-2664730fc0ff": ["categoryA", "categoryB"],
+     *      "0399ae56-8f80-4190-ad0f-28dd42772b83": ["categoryA"],
+     *      ...
+     *  }
+     */
+    public function fromProductUuids(array $uuids): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetNonViewableCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetNonViewableCategoryCodes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Product\Domain\Query;
 
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -13,13 +13,13 @@ use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 interface GetNonViewableCategoryCodes
 {
     /**
-     * @param ProductIdentifier[] $productIdentifiers
+     * @param UuidInterface[] $productUuids
      * @return array<string, string[]> example:
      *  {
-     *      "product1": ["categoryA", "categoryB"],
-     *      "product2": ["categoryA"],
+     *      "uuid1": ["categoryA", "categoryB"],
+     *      "uuid2": ["categoryA"],
      *      ...
      *  }
      */
-    public function fromProductIdentifiers(array $productIdentifiers, int $userId): array;
+    public function fromProductUuids(array $productUuids, int $userId): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/GetNonViewableCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/GetNonViewableCategoryCodes.php
@@ -20,23 +20,20 @@ class GetNonViewableCategoryCodes implements GetNonViewableCategoryCodesInterfac
     ) {
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public function fromProductIdentifiers(array $productIdentifiers, int $userId): array
+    public function fromProductUuids(array $productUuids, int $userId): array
     {
-        $categoryCodesPerProductIdentifier = $this->getCategoryCodes->fromProductIdentifiers($productIdentifiers);
+        $categoryCodesPerProductUuids = $this->getCategoryCodes->fromProductUuids($productUuids);
         $categoryCodes = [];
-        foreach ($categoryCodesPerProductIdentifier as $categoryCodesForProduct) {
+
+        foreach ($categoryCodesPerProductUuids as $categoryCodesForProduct) {
             $categoryCodes = \array_merge($categoryCodes, $categoryCodesForProduct);
         }
         $categoryCodes = \array_values(\array_unique($categoryCodes));
-
         $viewableCategoryCodes = $this->getViewableCategories->forUserId($categoryCodes, $userId);
 
         return \array_map(
             static fn (array $categoryCodes): array => \array_values(\array_diff($categoryCodes, $viewableCategoryCodes)),
-            $categoryCodesPerProductIdentifier
+            $categoryCodesPerProductUuids
         );
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/SqlGetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/SqlGetCategoryCodes.php
@@ -7,6 +7,7 @@ namespace Akeneo\Pim\Enrichment\Product\Infrastructure\Query;
 use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\UuidInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -78,6 +79,68 @@ final class SqlGetCategoryCodes implements GetCategoryCodes
             /** @var string[] $decoded */
             $decoded = \json_decode($result['category_codes'], true);
             $indexedResults[(string) $result['identifier']] = $decoded;
+        }
+
+        return $indexedResults;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fromProductUuids(array $uuids): array
+    {
+        if ([] === $uuids) {
+            return [];
+        }
+
+        Assert::allIsInstanceOf($uuids, UuidInterface::class);
+        $productUuidsAsBytes = \array_map(
+            static fn (UuidInterface $uuid): string => $uuid->getBytes(),
+            $uuids
+        );
+
+        $sql = <<<SQL
+        WITH
+        existing_product AS (
+            SELECT uuid, product_model_id FROM pim_catalog_product WHERE uuid IN (:product_uuids)
+        )
+        SELECT BIN_TO_UUID(p.uuid) AS uuid, IF(COUNT(mc.category_code) = 0, JSON_ARRAY(), JSON_ARRAYAGG(mc.category_code)) as category_codes
+        FROM 
+            existing_product p
+            LEFT JOIN (
+                SELECT
+                    p.uuid, c.code AS category_code
+                FROM existing_product p
+                    INNER JOIN pim_catalog_category_product cp ON cp.product_uuid = p.uuid
+                    INNER JOIN pim_catalog_category c ON c.id = cp.category_id
+                UNION ALL
+                SELECT
+                    p.uuid, c.code AS category_code
+                FROM existing_product p
+                    INNER JOIN pim_catalog_product_model sub ON sub.id = p.product_model_id
+                    INNER JOIN pim_catalog_category_product_model cpm ON cpm.product_model_id = sub.id
+                    INNER JOIN pim_catalog_category c ON c.id = cpm.category_id
+                UNION ALL
+                SELECT
+                    p.uuid, c.code AS category_code
+                FROM existing_product p
+                    INNER JOIN pim_catalog_product_model sub ON sub.id = p.product_model_id
+                    INNER JOIN pim_catalog_product_model root ON root.id = sub.parent_id
+                    INNER JOIN pim_catalog_category_product_model cpm ON cpm.product_model_id = root.id
+                    INNER JOIN pim_catalog_category c ON c.id = cpm.category_id
+            ) AS mc ON mc.uuid = p.uuid
+        GROUP BY p.uuid
+        SQL;
+
+        $results = $this->connection->executeQuery(
+            $sql,
+            ['product_uuids' => $productUuidsAsBytes],
+            ['product_uuids' => Connection::PARAM_STR_ARRAY]
+        )->fetchAllAssociative();
+
+        $indexedResults = [];
+        foreach ($results as $result) {
+            $indexedResults[(string) $result['uuid']] = \json_decode($result['category_codes'], true);
         }
 
         return $indexedResults;

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/validation/product_commands.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/validation/product_commands.yml
@@ -7,9 +7,6 @@ Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand:
         userId:
             - Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\UserShouldExist:
                   groups: [User]
-        productIdentifier:
-            - NotBlank:
-                  message: pim_enrich.product.validation.upsert.product_identifier_empty
         familyUserIntent:
             - Valid: ~
         categoryUserIntent:

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/validators.yml
@@ -10,6 +10,7 @@ services:
         arguments:
             - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes'
             - '@Akeneo\Pim\Enrichment\Category\API\Query\GetOwnedCategories'
+            - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids'
         tags:
             - { name: validator.constraint_validator }
 
@@ -18,6 +19,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Category\API\Query\GetOwnedCategories'
             - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes'
             - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes'
+            - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids'
         tags:
             - { name: validator.constraint_validator }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetCategoryCodes.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
 use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -34,6 +35,22 @@ final class InMemoryGetCategoryCodes implements GetCategoryCodes
         foreach ($this->productRepository->findAll() as $product) {
             if (\in_array(\strtolower($product->getIdentifier()), $productIdentifiers)) {
                 $results[$product->getIdentifier()] = $product->getCategoryCodes();
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fromProductUuids(array $productUuids): array
+    {
+        $results = [];
+        $productUuidsAsString = \array_map(fn (UuidInterface $uuid): string => $uuid->toString(), $productUuids);
+        foreach ($this->productRepository->findAll() as $product) {
+            if (\in_array(\strtolower($product->getUuid()->toString()), $productUuidsAsString)) {
+                $results[$product->getUuid()->toString()] = $product->getCategoryCodes();
             }
         }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetProductUuids.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory;
+
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class InMemoryGetProductUuids implements GetProductUuids
+{
+    public function __construct(private ProductRepositoryInterface $productRepository)
+    {
+    }
+
+    public function fromIdentifier(string $identifier): ?UuidInterface
+    {
+        return $this->productRepository->findOneByIdentifier($identifier)?->getUuid();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fromIdentifiers(array $identifiers): array
+    {
+        $result = [];
+        foreach ($identifiers as $identifier) {
+            $product = $this->productRepository->findOneByIdentifier($identifier);
+            if (null !== $product) {
+                $result[$identifier] = $product->getUuid();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Resources/config/services.yml
@@ -68,3 +68,8 @@ services:
 
     Akeneo\Pim\Enrichment\Product\Domain\Query\GetAttributeTypes:
         class: Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory\InMemoryGetAttributeTypes
+
+    Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids:
+        class: Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory\InMemoryGetProductUuids
+        arguments:
+            - '@pim_catalog.repository.product'

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetCategoryCodesSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetCategoryCodesSpec.php
@@ -11,6 +11,7 @@ use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory\InMemoryGetCategoryCodes;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 class InMemoryGetCategoryCodesSpec extends ObjectBehavior
 {
@@ -57,5 +58,38 @@ class InMemoryGetCategoryCodesSpec extends ObjectBehavior
             'id2' => ['master'],
             'id3' => [],
         ]);
+    }
+
+    function it_returns_the_category_codes_by_uuid(ProductRepositoryInterface $productRepository)
+    {
+        $master = new Category();
+        $master->setCode('master');
+        $print = new Category();
+        $print->setCode('print');
+
+        $uuid1 = Uuid::uuid4();
+        $product1 = new Product($uuid1->toString());
+        $product1->setIdentifier('id1');
+        $product1->addCategory($master);
+        $product1->addCategory($print);
+
+        $uuid2 = Uuid::uuid4();
+        $product2 = new Product($uuid2->toString());
+        $product2->setIdentifier('id2');
+        $product2->addCategory($master);
+
+        $uuid3 = Uuid::uuid4();
+        $product3 = new Product($uuid3->toString());
+        $product3->setIdentifier('id3');
+
+        $productRepository->findAll()->willReturn([$product1, $product2, $product3]);
+
+        $this->fromProductUuids([])->shouldReturn([]);
+        $this->fromProductUuids([$uuid1, $uuid2, $uuid3, Uuid::uuid4()])
+             ->shouldReturn([
+                $uuid1->toString() => ['master', 'print'],
+                $uuid2->toString() => ['master'],
+                $uuid3->toString() => [],
+            ]);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetProductUuidsSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetProductUuidsSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory\InMemoryGetProductUuids;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
+
+class InMemoryGetProductUuidsSpec extends ObjectBehavior
+{
+    private const FOO_UUID = 'de18ff6f-29a6-4b2a-9c38-0135aad32dbb';
+    private const BAZ_UUID = 'a5ba5f6b-3307-4f44-8a98-0ac4d1370245';
+
+    function let(ProductRepositoryInterface $productRepository)
+    {
+        $fooProduct = new Product(self::FOO_UUID);
+        $productRepository->findOneByIdentifier('foo')->willReturn($fooProduct);
+        $bazProduct = new Product(self::BAZ_UUID);
+        $productRepository->findOneByIdentifier('baz')->willReturn($bazProduct);
+        $productRepository->findOneByIdentifier(Argument::type('string'))->willReturn(null);
+
+        $this->beConstructedWith($productRepository);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(InMemoryGetProductUuids::class);
+    }
+
+    function it_retrieves_a_product_uuid_from_an_identifier()
+    {
+        $this->fromIdentifier('foo')->shouldBeLike(Uuid::fromString(self::FOO_UUID));
+    }
+
+    function it_returns_null_if_identifier_does_not_exist()
+    {
+        $this->fromIdentifier('unknown')->shouldBe(null);
+    }
+
+    function it_retrieves_a_map_of_product_uuids_indexed_by_identifier()
+    {
+        $this->fromIdentifiers(['foo', 'bar', 'baz'])->shouldBeLike([
+            'foo' => Uuid::fromString(self::FOO_UUID),
+            'baz' => Uuid::fromString(self::BAZ_UUID),
+        ]);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Feature/upsert.feature
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Feature/upsert.feature
@@ -25,10 +25,6 @@ Feature: Upsert a product
     When an unknown user tries to upsert the "foo" product
     Then there is a violation saying the user is unknown
 
-  Scenario: Create an empty product with empty string identifier
-    When the "julia" user upserts the "" product
-    Then there is a violation with message: The product identifier requires a non empty string
-
   Scenario: Create a product with text attribute value
     Given a set text value intent on the "a_text" attribute with the "test" text value
     When the "julia" user upserts the "foo" product with the previous intent

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -18,7 +18,6 @@ use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 abstract class EnrichmentProductTestCase extends TestCase
 {
@@ -104,6 +103,7 @@ abstract class EnrichmentProductTestCase extends TestCase
         );
         $this->commandMessageBus->dispatch($command);
         $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo.pim.storage_utils.cache.cached_queries_clearer')->clear();
         $this->clearDoctrineUoW();
     }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
@@ -140,20 +140,30 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->commandMessageBus->dispatch($command);
     }
 
-    /** @test */
-    public function it_throws_an_exception_when_creating_a_product_without_owned_category(): void
-    {
-        $this->expectException(ViolationsException::class);
-        $this->expectExceptionMessage("You should at least keep your product in one category on which you have an own permission");
-
-        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
-        $command = UpsertProductCommand::createFromCollection(
-            userId: $this->getUserId('betty'),
-            productIdentifier: 'identifier',
-            userIntents: [new SetCategories(['sales'])]
-        );
-        $this->commandMessageBus->dispatch($command);
-    }
+    /**
+     * @test
+     * @FIXME CPM-716: uncomment this test
+     */
+//    public function it_creates_a_product_without_owned_category(): void
+//    {
+//        $uuid = Uuid::uuid4();
+//        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
+//        $command = UpsertProductCommand::createWithUuid(
+//            userId: $this->getUserId('betty'),
+//            productUuid: ProductUuid::fromUuid($uuid),
+//            userIntents: [
+//                new SetIdentifierValue('sku', 'my_new_product'),
+//                new SetCategories(['sales'])
+//            ]
+//        );
+//        $this->commandMessageBus->dispatch($command);
+//
+//        $this->clearDoctrineUoW();
+//
+//        $product = $this->productRepository->find($uuid);
+//        Assert::assertNotNull($product);
+//        Assert::assertEqualsCanonicalizing(['sales'], $product->getCategoryCodes());
+//    }
 
     /** @test */
     public function it_throws_an_exception_when_there_is_no_more_owned_category_after_update(): void

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/SqlGetCategoryCodesIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/SqlGetCategoryCodesIntegration.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Pim\Enrichment\Product\Integration\Query;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
+use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class SqlGetCategoryCodesIntegration extends TestCase
+{
+    private const UUID_FOO = 'eac5393e-8de8-4d3a-90db-93bbba8b4ffb';
+    private const UUID_BAR = '49aa038f-b7d9-465c-b12d-88f048d60dd4';
+    private const UUID_BAZ = 'a76cbde9-929b-4d2c-8ff1-a69e48cf063d';
+
+    private GetCategoryCodes $getCategoryCodes;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->getCategoryCodes = $this->get('Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes');
+
+        $this->createProductModel([
+            'code' => 'root_a1',
+            'family_variant' => 'familyVariantA1',
+            'categories' => ['categoryA'],
+        ]);
+        $this->createProductModel([
+            'code' => 'subpm_a1',
+            'family_variant' => 'familyVariantA1',
+            'parent' => 'root_a1',
+            'values' => [
+                'a_simple_select' => [['locale' => null, 'scope' => null, 'data' => 'optionA']]
+            ],
+            'categories' => ['categoryA1'],
+        ]);
+        $this->createProductModel([
+            'code' => 'root_a2',
+            'family_variant' => 'familyVariantA2',
+            'categories' => ['categoryC'],
+        ]);
+
+        $this->upsertProduct(
+            Uuid::fromString(self::UUID_FOO),
+            [
+                new SetIdentifierValue('sku', 'foo'),
+                new SetCategories(['categoryA', 'categoryB']),
+            ]
+        );
+        $this->upsertProduct(
+            Uuid::fromString(self::UUID_BAR),
+            [
+                new ChangeParent('subpm_a1'),
+                new SetIdentifierValue('sku', 'bar'),
+                new SetBooleanValue('a_yes_no', null, null, true),
+            ]
+        );
+        $this->upsertProduct(
+            Uuid::fromString(self::UUID_BAZ),
+            [
+                new ChangeParent('root_a2'),
+                new SetIdentifierValue('sku', 'baz'),
+                new SetBooleanValue('a_yes_no', null, null, false),
+                new SetSimpleSelectValue('a_simple_select', null, null, 'optionB'),
+                new SetCategories(['categoryA', 'categoryA1']),
+            ]
+        );
+    }
+
+    /** @test */
+    public function it_gets_product_categories_by_identifier(): void
+    {
+        Assert::assertSame([], $this->getCategoryCodes->fromProductIdentifiers([]));
+        $this->assertEqualArrays(
+            [
+                'foo' => ['categoryA', 'categoryB'],
+                'bar' => ['categoryA', 'categoryA1'],
+                'baz' => ['categoryA', 'categoryA1', 'categoryC'],
+            ],
+            $this->getCategoryCodes->fromProductIdentifiers(
+                [
+                    ProductIdentifier::fromString('foo'),
+                    ProductIdentifier::fromString('unknown_sku'),
+                    ProductIdentifier::fromString('baz'),
+                    ProductIdentifier::fromString('bar'),
+                    ProductIdentifier::fromString('foo'),
+                ]
+            )
+        );
+    }
+
+    /** @test */
+    public function it_gets_product_category_codes_by_uuids(): void
+    {
+        Assert::assertSame([], $this->getCategoryCodes->fromProductUuids([]));
+        $this->assertEqualArrays(
+            [
+                self::UUID_FOO => ['categoryA', 'categoryB'],
+                self::UUID_BAR => ['categoryA', 'categoryA1'],
+                self::UUID_BAZ => ['categoryA', 'categoryA1', 'categoryC'],
+            ],
+            $this->getCategoryCodes->fromProductUuids([
+                Uuid::fromString(self::UUID_FOO),
+                Uuid::fromString(self::UUID_BAZ),
+                Uuid::uuid4(),
+                Uuid::fromString(self::UUID_BAR),
+                Uuid::fromString(self::UUID_BAZ),
+            ])
+        );
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    private function upsertProduct(UuidInterface $uuid, array $userIntents): void
+    {
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
+
+        $this->get('pim_enrich.product.message_bus')->dispatch(
+            UpsertProductCommand::createWithUuid(
+                $this->getUserId('admin'),
+                ProductUuid::fromUuid($uuid),
+                $userIntents
+            )
+        );
+    }
+
+    private function createProductModel(array $data): void
+    {
+        $productModel = $this->get('pim_catalog.factory.product_model')->create();
+        $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
+        Assert::assertCount(0, $this->get('validator')->validate($productModel));
+        $this->get('pim_catalog.saver.product_model')->save($productModel);
+    }
+
+    private function getUserId(string $username): int
+    {
+        return (int)$this->get('database_connection')->fetchOne(
+            'SELECT id FROM oro_user WHERE username = :username',
+            ['username' => $username]
+        );
+    }
+
+    private function assertEqualArrays(array $expected, array $actual): void
+    {
+        Assert::assertSameSize($expected, $actual);
+        foreach ($expected as $key => $value) {
+            Assert::assertArrayHasKey($key, $actual);
+            Assert::assertEqualsCanonicalizing($value, $actual[$key]);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/SetCategoriesApplierSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\SetCategoriesApplier;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\UserIntentApplier;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -36,7 +35,7 @@ class SetCategoriesApplierSpec extends ObjectBehavior
         $product = new Product();
         $product->setIdentifier('foo');
 
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)->willReturn([]);
+        $getNonViewableCategoryCodes->fromProductUuids([$product->getUuid()], 10)->willReturn([]);
 
         $productUpdater->update($product, ['categories' => ['categoryA', 'categoryB']])->shouldBeCalledOnce();
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/UpsertProductHandlerSpec.php
@@ -104,6 +104,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $command = UpsertProductCommand::createFromCollection(1, 'identifier1', userIntents: []);
         $product = new Product();
         $product->setIdentifier('identifier1');
+        $product->setCreated(\DateTime::createFromFormat('Y-m-d H:i:s', '2022-02-12 10:05:24'));
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
         $tokenStorage->getToken()->willReturn($token);
@@ -133,6 +134,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
     ) {
         $command = UpsertProductCommand::createFromCollection(1, 'identifier1', userIntents: []);
         $product->getIdentifier()->willReturn('identifier1');
+        $product->getCreated()->willReturn(\DateTime::createFromFormat('Y-m-d H:i:s', '2022-02-12 10:05:24'));
         $product->isDirty()->willReturn(false);
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());
@@ -248,6 +250,7 @@ class UpsertProductHandlerSpec extends ObjectBehavior
         $setTextUserIntent = new SetTextValue('name', null, null, 'Lorem Ipsum');
         $command = UpsertProductCommand::createFromCollection(1, 'identifier1', userIntents: [$userIntent, $setTextUserIntent]);
         $product = new Product();
+        $product->setCreated(\DateTime::createFromFormat('Y-m-d H:i:s', '2022-02-12 10:05:24'));
         $product->setIdentifier('identifier1');
 
         $validator->validate($command)->shouldBeCalledOnce()->willReturn(new ConstraintViolationList());

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Query/GetNonViewableCategoryCodesSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Query/GetNonViewableCategoryCodesSpec.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Product\Infrastructure\Query;
 
 use Akeneo\Pim\Enrichment\Category\API\Query\GetViewableCategories;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes as GetNonViewableCategoryCodesInterface;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Query\GetNonViewableCategoryCodes;
 use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
 
 class GetNonViewableCategoryCodesSpec extends ObjectBehavior
 {
@@ -28,22 +28,22 @@ class GetNonViewableCategoryCodesSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes,
         GetViewableCategories $getViewableCategories
     ) {
-        $productIdentifier1 = ProductIdentifier::fromString('id1');
-        $productIdentifier2 = ProductIdentifier::fromString('id2');
-        $productIdentifier3 = ProductIdentifier::fromString('id3');
+        $productUuid1 = Uuid::uuid4();
+        $productUuid2 = Uuid::uuid4();
+        $productUuid3 = Uuid::uuid4();
 
-        $getCategoryCodes->fromProductIdentifiers([$productIdentifier1, $productIdentifier2, $productIdentifier3])
+        $getCategoryCodes->fromProductUuids([$productUuid1, $productUuid2, $productUuid3])
             ->willReturn([
-                'id1' => ['categoryA', 'categoryB', 'categoryC'],
-                'id2' => ['categoryA', 'categoryD', 'categoryE'],
+                $productUuid1->toString() => ['categoryA', 'categoryB', 'categoryC'],
+                $productUuid2->toString() => ['categoryA', 'categoryD', 'categoryE'],
             ]);
         $getViewableCategories->forUserId(['categoryA', 'categoryB', 'categoryC', 'categoryD', 'categoryE'], 10)
             ->willReturn(['categoryA', 'categoryB', 'categoryC', 'categoryD']);
 
-        $this->fromProductIdentifiers([$productIdentifier1, $productIdentifier2, $productIdentifier3], 10)
+        $this->fromProductUuids([$productUuid1, $productUuid2, $productUuid3], 10)
             ->shouldreturn([
-                'id1' => [],
-                'id2' => ['categoryE'],
+                $productUuid1->toString() => [],
+                $productUuid2->toString() => ['categoryE'],
             ]);
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/IsUserOwnerOfTheProductValidatorSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/IsUserOwnerOfTheProductValidatorSpec.php
@@ -6,12 +6,15 @@ namespace Specification\Akeneo\Pim\Enrichment\Product\Infrastructure\Validation;
 
 use Akeneo\Pim\Enrichment\Category\API\Query\GetOwnedCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
+use Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\IsUserOwnerOfTheProduct;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\IsUserOwnerOfTheProductValidator;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
@@ -22,16 +25,10 @@ class IsUserOwnerOfTheProductValidatorSpec extends ObjectBehavior
     function let(
         GetCategoryCodes $getCategoryCodes,
         GetOwnedCategories $getOwnedCategories,
+        GetProductUuids $getProductUuids,
         ExecutionContext $context
     ) {
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('unknown')])
-            ->willReturn([]);
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('product_without_category')])
-            ->willReturn(['product_without_category' => []]);
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('product_with_category')])
-            ->willReturn(['product_with_category' => ['master', 'print']]);
-
-        $this->beConstructedWith($getCategoryCodes, $getOwnedCategories);
+        $this->beConstructedWith($getCategoryCodes, $getOwnedCategories, $getProductUuids);
         $this->initialize($context);
     }
 
@@ -43,8 +40,11 @@ class IsUserOwnerOfTheProductValidatorSpec extends ObjectBehavior
 
     function it_throws_an_exception_with_a_wrong_constraint()
     {
-        $command = UpsertProductCommand::createFromCollection(userId: 1, productIdentifier: 'foo', userIntents: []);
-
+        $command = UpsertProductCommand::createWithIdentifier(
+            userId: 1,
+            productIdentifier: ProductIdentifier::fromIdentifier('foo'),
+            userIntents: []
+        );
         $this->shouldThrow(\InvalidArgumentException::class)->during('validate', [$command, new Type([])]);
     }
 
@@ -54,17 +54,36 @@ class IsUserOwnerOfTheProductValidatorSpec extends ObjectBehavior
             ->during('validate', [new \stdClass(), new IsUserOwnerOfTheProduct([])]);
     }
 
-    function it_does_nothing_when_product_does_not_exist(ExecutionContext $context)
-    {
-        $command = UpsertProductCommand::createFromCollection(userId: 1, productIdentifier: 'unknown', userIntents: []);
+    function it_does_nothing_when_product_does_not_exist(
+        ExecutionContext $context,
+        GetProductUuids $getProductUuids,
+    ) {
+        $command = UpsertProductCommand::createWithIdentifier(
+            userId: 1,
+            productIdentifier: ProductIdentifier::fromIdentifier('unknown'),
+            userIntents: []
+        );
+        $getProductUuids->fromIdentifier('unknown')->shouldBeCalled()->willReturn(null);
+
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
         $this->validate($command, new IsUserOwnerOfTheProduct());
     }
 
-    function it_validates_when_the_product_does_not_have_any_category(ExecutionContext $context)
-    {
-        $command = UpsertProductCommand::createFromCollection(userId: 1, productIdentifier: 'product_without_category', userIntents: []);
+    function it_validates_when_the_product_does_not_have_any_category(
+        ExecutionContext $context,
+        GetProductUuids $getProductUuids,
+        GetCategoryCodes $getCategoryCodes,
+    ) {
+        $command = UpsertProductCommand::createWithIdentifier(
+            userId: 1,
+            productIdentifier: ProductIdentifier::fromIdentifier('product_without_category'),
+            userIntents: []
+        );
+        $uuid = Uuid::uuid4();
+        $getProductUuids->fromIdentifier('product_without_category')->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn([$uuid->toString() => []]);
+
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
         $this->validate($command, new IsUserOwnerOfTheProduct());
@@ -72,9 +91,19 @@ class IsUserOwnerOfTheProductValidatorSpec extends ObjectBehavior
 
     function it_validates_when_the_product_has_owned_category(
         GetOwnedCategories $getOwnedCategories,
+        GetProductUuids $getProductUuids,
+        GetCategoryCodes $getCategoryCodes,
         ExecutionContext $context
     ) {
-        $command = UpsertProductCommand::createFromCollection(userId: 1, productIdentifier: 'product_with_category', userIntents: []);
+        $command = UpsertProductCommand::createWithIdentifier(
+            userId: 1,
+            productIdentifier: ProductIdentifier::fromIdentifier('product_with_category'),
+            userIntents: []
+        );
+        $uuid = Uuid::uuid4();
+        $getProductUuids->fromIdentifier('product_with_category')->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn([$uuid->toString() => ['master', 'print']]);
+
         $getOwnedCategories->forUserId(['master', 'print'], 1)->willReturn(['master']);
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
@@ -83,12 +112,20 @@ class IsUserOwnerOfTheProductValidatorSpec extends ObjectBehavior
 
     function it_adds_a_violation_when_the_product_does_not_have_owned_category(
         GetOwnedCategories $getOwnedCategories,
+        GetCategoryCodes $getCategoryCodes,
         ExecutionContext $context,
-        ConstraintViolationBuilderInterface $constraintViolationBuilder
+        ConstraintViolationBuilderInterface $constraintViolationBuilder,
     ) {
         $constraint = new IsUserOwnerOfTheProduct();
 
-        $command = UpsertProductCommand::createFromCollection(userId: 1, productIdentifier: 'product_with_category', userIntents: []);
+        $uuid = Uuid::uuid4();
+        $command = UpsertProductCommand::createWithUuid(
+            userId: 1,
+            productUuid: ProductUuid::fromUuid($uuid),
+            userIntents: []
+        );
+
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn([$uuid->toString() => ['master', 'print']]);
         $getOwnedCategories->forUserId(['master', 'print'], 1)->willReturn([]);
         $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($constraintViolationBuilder);
         $constraintViolationBuilder->atPath('userId')->shouldBeCalledOnce()->willReturn($constraintViolationBuilder);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/ShouldStayOwnerOfTheProductValidatorSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/ShouldStayOwnerOfTheProductValidatorSpec.php
@@ -9,14 +9,17 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\AddCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\RemoveCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
 use Akeneo\Pim\Enrichment\Product\Domain\Model\ViolationCode;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetNonViewableCategoryCodes;
+use Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\ShouldStayOwnerOfTheProduct;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\ShouldStayOwnerOfTheProductValidator;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -27,9 +30,10 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         GetOwnedCategories $getOwnedCategories,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
         GetCategoryCodes $getCategoryCodes,
-        ExecutionContext $context
+        GetProductUuids $getProductUuids,
+        ExecutionContext $context,
     ) {
-        $this->beConstructedWith($getOwnedCategories, $getNonViewableCategoryCodes, $getCategoryCodes);
+        $this->beConstructedWith($getOwnedCategories, $getNonViewableCategoryCodes, $getCategoryCodes, $getProductUuids);
         $this->initialize($context);
     }
 
@@ -39,18 +43,34 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         $this->shouldImplement(ConstraintValidatorInterface::class);
     }
 
+    function it_gets_product_uuid_from_identifier(
+        ExecutionContext $context,
+        GetProductUuids $getProductUuids,
+    ) {
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithIdentifier(
+            userId: 10,
+            productIdentifier: ProductIdentifier::fromIdentifier('foo'),
+            userIntents: []
+        ));
+        $getProductUuids->fromIdentifier('foo')->shouldBeCalled()->willReturn(null);
+
+        $this->validate(new SetCategories([]), new ShouldStayOwnerOfTheProduct());
+    }
+
     function it_validates_when_the_user_stays_owner_on_categories(
         GetOwnedCategories $getOwnedCategories,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
         ExecutionContext $context
     ) {
-        $context->getRoot()->willReturn(UpsertProductCommand::createFromCollection(
+        $uuid = Uuid::uuid4();
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
             userId: 10,
-            productIdentifier: 'foo',
+            productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)
-            ->willReturn(['foo' => ['categoryA']])
+        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
+            ->shouldBeCalled()
+            ->willReturn([$uuid->toString() => ['categoryA']])
         ;
         $getOwnedCategories->forUserId(['categoryB', 'categoryA'], 10)->willReturn(['categoryB']);
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
@@ -62,13 +82,15 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
         ExecutionContext $context
     ) {
-        $context->getRoot()->willReturn(UpsertProductCommand::createFromCollection(
+
+        $uuid = Uuid::uuid4();
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
             userId: 10,
-            productIdentifier: 'foo',
+            productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)
-            ->willReturn(['foo' => []])
+        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
+            ->willReturn([$uuid->toString() => []])
         ;
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
@@ -82,13 +104,14 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $constraint = new ShouldStayOwnerOfTheProduct();
-        $context->getRoot()->willReturn(UpsertProductCommand::createFromCollection(
+        $uuid = Uuid::uuid4();
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
             userId: 10,
-            productIdentifier: 'foo',
+            productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')], 10)
-            ->willReturn(['foo' => ['categoryA']])
+        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
+            ->willReturn([$uuid->toString() => ['categoryA']])
         ;
         $getOwnedCategories->forUserId(['categoryB', 'categoryA'], 10)->willReturn([]);
         $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($violationBuilder);
@@ -105,13 +128,14 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
         $constraint = new ShouldStayOwnerOfTheProduct();
-        $context->getRoot()->willReturn(UpsertProductCommand::createFromCollection(
+        $uuid = Uuid::uuid4();
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
             userId: 10,
-            productIdentifier: 'foo',
+            productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('foo')])
-            ->willReturn(['foo' => ['categoryA', 'categoryB', 'categoryC']])
+        $getCategoryCodes->fromProductUuids([$uuid])
+            ->willReturn([$uuid->toString() => ['categoryA', 'categoryB', 'categoryC']])
         ;
         $getOwnedCategories->forUserId(['categoryA', 'categoryC'], 10)->willReturn([]);
         $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($violationBuilder);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- UpsertProductCommand constructor is now private
- Methods to create a command:
-> createFromCollection (legacy, now deprecated, kept to minimize BC break)
-> createWithUuid
-> createWithIdentifier
-> createWithoutUuidNorIdentifier

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
