### PR TITLE
PIM-10598: Fix "Cleaning removed attribute values" job failing if attribute is deleted during mass deletion of products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 - PIM-10584: Fix conversion for Volume Flow measurement units
 - PIM-10581: Fix attribute option code in linked data returned as an integer instead of a string
 - PIM-10529: Fix links on product grid
+- PIM-10598: Fix "Cleaning removed attribute values" job failing if attribute is deleted during mass deletion of products
 - PIM-10595: Fix not being able to add record with code "0" on a product
 - PIM-10588: Add potentially missing `remove_completeness_for_channel_and_locale` job instance
 - PIM-10606: Fix computeFamilyVariantStructureChange on attribute removal

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/queries.yml
@@ -302,6 +302,7 @@ services:
             - '@database_connection'
             - '@pim_catalog.normalizer.indexing_product.product.product_value_collection'
             - '@akeneo.pim.enrichment.factory.read_value_collection'
+            - '@logger'
             - !tagged akeneo.pim.enrichment.product.query.indexing_additional_properties
 
     akeneo.pim.enrichment.product.query.get_ancestor_product_model_codes:
@@ -315,6 +316,7 @@ services:
             - '@database_connection'
             - '@akeneo.pim.enrichment.factory.read_value_collection'
             - '@pim_catalog.normalizer.indexing_product.product.product_value_collection'
+            - '@logger'
             - !tagged akeneo.pim.enrichment.product_model.query.indexing_additional_properties
 
     akeneo.pim.enrichment.product.query.get_descendant_variant_product_uuids:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductModelProjection.php
@@ -47,7 +47,7 @@ class GetElasticsearchProductModelProjection implements GetElasticsearchProductM
 
         $diffCodes = \array_diff($productModelCodes, $rowCodes);
         if (\count($diffCodes) > 0) {
-            $this->logger->warning(\sprintf('Trying to get ES product model projection from product model codes "%s" which does not exist', \implode(',', $diffCodes)));
+            $this->logger->warning(\sprintf('Trying to get ES product model projection from product model codes "%s" which do not exist', \implode(',', $diffCodes)));
         }
 
         $context = ['value_collections' => \array_map(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjection.php
@@ -7,28 +7,32 @@ namespace Akeneo\Pim\Enrichment\Bundle\Storage\Sql\ElasticsearchProjection;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetAdditionalPropertiesForProductProjectionInterface;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\GetElasticsearchProductProjectionInterface;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Model\ElasticsearchProductProjection;
-use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\ReadValueCollectionFactory;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
+use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
+ * @copyright 2019 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 final class GetElasticsearchProductProjection implements GetElasticsearchProductProjectionInterface
 {
     private const INDEXING_FORMAT_PRODUCT_AND_MODEL_INDEX = 'indexing_product_and_product_model';
 
+    /**
+     * @param GetAdditionalPropertiesForProductProjectionInterface[] $additionalDataProviders
+     */
     public function __construct(
         private Connection $connection,
         private NormalizerInterface $valuesNormalizer,
         private ReadValueCollectionFactory $readValueCollectionFactory,
+        private LoggerInterface $logger,
         private iterable $additionalDataProviders = []
     ) {
         Assert::allIsInstanceOf(
@@ -60,7 +64,7 @@ final class GetElasticsearchProductProjection implements GetElasticsearchProduct
         );
 
         if (\count($notFetchedUuids) > 0) {
-            throw new ObjectNotFoundException(\sprintf('Product uuids "%s" were not found.', \implode(',', $notFetchedUuids)));
+            $this->logger->warning(\sprintf('Trying to get ES product projection from product uuids "%s" which does not exist', \implode(',', $notFetchedUuids)));
         }
 
         $rows = $this->createValueCollectionInBatchFromRows($rows);

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/ElasticsearchProjection/GetElasticsearchProductProjectionIntegration.php
@@ -481,14 +481,12 @@ class GetElasticsearchProductProjectionIntegration extends TestCase
         $this->assertEquals('2030-10-01T14:34:56+02:00', $productProjection->toArray()['updated']);
     }
 
-    public function test_that_it_throws_an_exception_when_product_identifier_does_not_exist()
+    public function test_that_it_ignores_product_identifier_which_does_not_exist()
     {
-        $this->expectException(ObjectNotFoundException::class);
-
         $uuid = Uuid::uuid4();
         $query = $this->get('akeneo.pim.enrichment.product.query.get_elasticsearch_product_projection');
         $productProjections = $query->fromProductUuids([$uuid]);
-        \iterator_to_array($productProjections);
+        $this->assertEmpty(\iterator_to_array($productProjections));
     }
 
     public function test_that_it_returns_uuid_if_column_is_filled()


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a user launch a product/product model mass delete and an attribute delete in a same time, the "Cleaning removed attribute values" will fail due to an exception thrown inside queries used to fetch ES product/product model projection.
The fix is simply to make those queries more safe and replace the throw by a logged warning. We don't need to throw an exception in those queries.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
