### PR TITLE
PIM-10591: Fix download log should not be possible when job is running

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-10591: Fix download log should not be possible when job is running
 - PIM-10608 [Backport PIM-10584]: Fix measurement values for volume flow conversion 
 
 # 5.0.111 (2022-08-25)

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/controllers.yml
@@ -54,7 +54,9 @@ services:
             - '@akeneo_batch_queue.manager.job_execution_manager'
             - '@pim_enrich.repository.job_execution'
             - '@pim_internal_api_serializer'
-            -
+            # @todo pull-up-to-6.0 remove this line
+            - '@oneup_flysystem.archivist_filesystem'
+
     pim_enrich.controller.job_tracker:
         public: true
         class: 'Akeneo\Platform\Bundle\ImportExportBundle\Controller\Ui\JobTrackerController'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Following this [ticket](https://akeneo.atlassian.net/browse/PIM-10591?atlOrigin=eyJpIjoiNGFhOTIzYTViMWY3NGY1NWIwY2M4MGYyY2VhNGY0YmIiLCJwIjoiaiJ9) and this [discussion](https://akeneo.slack.com/archives/GQ839T8QM/p1661332863893139), we decided to disable download log action when a job is running (same behavior on 6.0/master).

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
