### PR TITLE
PH-195: Step to check unique job execution

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Job/IsJobExecutionUnique.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Job/IsJobExecutionUnique.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\BatchBundle\Job;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Repository\InternalApi\JobExecutionRepository;
+use Akeneo\Tool\Bundle\BatchBundle\Manager\JobExecutionManager;
+use Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Dedicated service to check for a unique job execution, ie the only one executing for a job code
+ *
+ * @author    JMLeroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class IsJobExecutionUnique
+{
+    private const OUTDATED_JOB_EXECUTION_TIME = '-10 MINUTES';
+
+    public function __construct(
+        private SqlGetRunningJobExecution $getRunningJobExecution,
+        private JobExecutionManager $executionManager,
+        private JobExecutionRepository $jobExecutionRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function __invoke(string $jobCode): bool
+    {
+        foreach ($this->getRunningJobExecution->getByJobCode($jobCode) as $jobExecutionData) {
+            // In case of an old job execution that has not been marked as failed.
+            if (null !== $jobExecutionData['updated_time']
+                && new \DateTime($jobExecutionData['updated_time']) < new \DateTime(self::OUTDATED_JOB_EXECUTION_TIME)
+            ) {
+                $this->logger->info(
+                    'Job execution "{job_id}" is outdated: let\'s mark it has failed.',
+                    ['message' => 'job_execution_outdated', 'job_id' => $jobExecutionData['id']]
+                );
+                $this->executionManager->markAsFailed(
+                    $this->jobExecutionRepository->find((int)$jobExecutionData['id'])
+                );
+            } else {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Job/IsJobExecutionUnique.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Job/IsJobExecutionUnique.php
@@ -28,7 +28,9 @@ class IsJobExecutionUnique
 
     public function __invoke(string $jobCode): bool
     {
-        foreach ($this->getRunningJobExecution->getByJobCode($jobCode) as $jobExecutionData) {
+        $runningExecutions = $this->getRunningJobExecution->getByJobCode($jobCode);
+
+        foreach ($runningExecutions as $jobExecutionData) {
             // In case of an old job execution that has not been marked as failed.
             if (null !== $jobExecutionData['updated_time']
                 && new \DateTime($jobExecutionData['updated_time']) < new \DateTime(self::OUTDATED_JOB_EXECUTION_TIME)
@@ -40,7 +42,8 @@ class IsJobExecutionUnique
                 $this->executionManager->markAsFailed(
                     $this->jobExecutionRepository->find((int)$jobExecutionData['id'])
                 );
-            } else {
+            } elseif (new \DateTime($jobExecutionData['start_time']) > new \DateTime(self::OUTDATED_JOB_EXECUTION_TIME)
+            ) {
                 return false;
             }
         }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Manager/JobExecutionManager.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Manager/JobExecutionManager.php
@@ -8,34 +8,20 @@ use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Doctrine\ORM\EntityManager;
 
 /**
- * Job execution manager
- *
  * @author    Julien Sanchez <julien@akeneo.com>
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/MIT MIT
  */
 class JobExecutionManager
 {
-    /**
-     * @var EntityManager
-     */
-    protected $entityManager;
-
-    /**
-     * @param EntityManager $entityManager
-     */
-    public function __construct(EntityManager $entityManager)
+    public function __construct(protected EntityManager $entityManager)
     {
-        $this->entityManager = $entityManager;
     }
 
     /**
-     * Check if the given JoExecution is still running using his PID
-     * @param JobExecution $jobExecution
-     *
-     * @return bool
+     * Check if the given JobExecution is still running using his PID
      */
-    public function checkRunningStatus(JobExecution $jobExecution)
+    public function checkRunningStatus(JobExecution $jobExecution): bool
     {
         if (BatchStatus::STARTING !== $jobExecution->getStatus()->getValue() &&
             $jobExecution->getExitStatus()->isRunning()
@@ -48,11 +34,8 @@ class JobExecutionManager
 
     /**
      * Test if the process is still running
-     * @param JobExecution $jobExecution
-     *
-     * @return bool
      */
-    protected function processIsRunning(JobExecution $jobExecution)
+    protected function processIsRunning(JobExecution $jobExecution): bool
     {
         $pid = intval($jobExecution->getPid());
 
@@ -67,9 +50,8 @@ class JobExecutionManager
 
     /**
      * Mark a job execution as failed
-     * @param JobExecution $jobExecution
      */
-    public function markAsFailed(JobExecution $jobExecution)
+    public function markAsFailed(JobExecution $jobExecution): void
     {
         $jobExecution->setStatus(new BatchStatus(BatchStatus::FAILED));
         $jobExecution->setExitStatus(new ExitStatus(ExitStatus::FAILED));

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -139,3 +139,8 @@ services:
 
     Akeneo\Tool\Component\Batch\Clock\ClockInterface:
         class: Akeneo\Tool\Component\Batch\Clock\SystemClock
+
+    Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution:
+        arguments:
+            - '@database_connection'
+

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/services.yml
@@ -144,3 +144,9 @@ services:
         arguments:
             - '@database_connection'
 
+    Akeneo\Tool\Bundle\BatchBundle\Job\IsJobExecutionUnique:
+        arguments:
+            - '@Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution'
+            - '@akeneo_batch.manager.job_execution'
+            - '@pim_enrich.repository.job_execution'
+            - '@logger'

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Tasklet/CheckUniqueJobExecutionTasklet.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Tasklet/CheckUniqueJobExecutionTasklet.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\BatchBundle\Tasklet;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Repository\InternalApi\JobExecutionRepository;
+use Akeneo\Tool\Bundle\BatchBundle\Manager\JobExecutionManager;
+use Akeneo\Tool\Component\Batch\Job\JobInterruptedException;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution;
+use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Simple task to check that only one instance of a job is running.
+ *
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class CheckUniqueJobExecutionTasklet implements TaskletInterface
+{
+    private const OUTDATED_JOB_EXECUTION_TIME = '-10 MINUTES';
+
+    private StepExecution $stepExecution;
+
+    public function __construct(
+        private string $jobCode,
+        private SqlGetRunningJobExecution $getRunningJobExecution,
+        private JobExecutionManager $executionManager,
+        private JobExecutionRepository $jobExecutionRepository,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function setStepExecution(StepExecution $stepExecution): void
+    {
+        $this->stepExecution = $stepExecution;
+    }
+
+    public function execute()
+    {
+        if (!$this->isJobUniqueExecution()) {
+            throw new JobInterruptedException(
+                sprintf('Another instance of job %s is already running.', $this->jobCode),
+            );
+        }
+    }
+
+    private function isJobUniqueExecution(): bool
+    {
+        $jobExecutionData = $this->getRunningJobExecution->getByJobCode($this->jobCode);
+
+        if (null === $jobExecutionData) {
+            return true;
+        }
+
+        // In case of an old job execution that has not been marked as failed.
+        if (null !== $jobExecutionData['updated_time']
+            && new \DateTime($jobExecutionData['updated_time']) < new \DateTime(self::OUTDATED_JOB_EXECUTION_TIME)
+        ) {
+            $this->logger->info(
+                'Job execution "{job_id}" is outdated: let\'s mark it has failed.',
+                ['message' => 'job_execution_outdated', 'job_id' => $jobExecutionData['id']]
+            );
+            $this->executionManager->markAsFailed($this->jobExecutionRepository->find((int)$jobExecutionData['id']));
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/jobs.yml
@@ -43,7 +43,16 @@ services:
     Akeneo\Tool\Bundle\VersioningBundle\Job\PurgeVersioning:
         arguments:
             - '@pim_versioning.purger.version'
-            - '@pim_versioning.event_subscriber.purge_progress_bar_advancer'
+        public: false
+
+    pim_versioning.tasklet.unicity_check.versioning_purge:
+        class: Akeneo\Tool\Bundle\BatchBundle\Tasklet\CheckUniqueJobExecutionTasklet
+        arguments:
+            - 'versioning_purge'
+            - '@Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution'
+            - '@akeneo_batch.manager.job_execution'
+            - '@pim_enrich.repository.job_execution'
+            - '@logger'
         public: false
 
     pim_versioning.job.versioning_purge:
@@ -53,6 +62,7 @@ services:
             - '@event_dispatcher'
             - '@akeneo_batch.job_repository'
             -
+                - '@pim_versioning.step.unicity_check.versioning_purge'
                 - '@pim_versioning.step.versioning_purge'
             - false
             - false
@@ -62,6 +72,15 @@ services:
                 name: akeneo_batch.job
                 connector: 'internal'
                 type: 'scheduled_job'
+
+    pim_versioning.step.unicity_check.versioning_purge:
+        class: '%pim_connector.step.tasklet.class%'
+        arguments:
+            - 'versioning_purge'
+            - '@event_dispatcher'
+            - '@akeneo_batch.job_repository'
+            - '@pim_versioning.tasklet.unicity_check.versioning_purge'
+        public: false
 
     pim_versioning.step.versioning_purge:
         class: '%pim_connector.step.tasklet.class%'

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/jobs.yml
@@ -49,10 +49,7 @@ services:
         class: Akeneo\Tool\Bundle\BatchBundle\Tasklet\CheckUniqueJobExecutionTasklet
         arguments:
             - 'versioning_purge'
-            - '@Akeneo\Tool\Component\Batch\Query\SqlGetRunningJobExecution'
-            - '@akeneo_batch.manager.job_execution'
-            - '@pim_enrich.repository.job_execution'
-            - '@logger'
+            - '@Akeneo\Tool\Bundle\BatchBundle\Job\IsJobExecutionUnique'
         public: false
 
     pim_versioning.job.versioning_purge:

--- a/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Batch\Query;
+
+use Akeneo\Tool\Component\Batch\Job\ExitStatus;
+use Doctrine\DBAL\Connection;
+
+class SqlGetRunningJobExecution
+{
+    private Connection $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function getByJobCode(string $jobCode): ?array
+    {
+        $sql = <<<SQL
+            SELECT job_execution.id, job_execution.status, job_execution.updated_time
+            FROM akeneo_batch_job_execution AS job_execution
+            INNER JOIN akeneo_batch_job_instance AS job_instance ON job_instance.id = job_execution.job_instance_id
+            WHERE job_instance.code = :job_code 
+              AND exit_code IN (:exit_codes)
+        SQL;
+
+        $result = $this->connection->executeQuery(
+            $sql,
+            ['job_code' => $jobCode, 'exit_codes' => [ExitStatus::EXECUTING, ExitStatus::UNKNOWN]],
+            ['job_code' => \PDO::PARAM_STR, 'exit_codes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAssociative();
+
+        if (false === $result) {
+            return null;
+        }
+
+        return $result;
+    }
+}

--- a/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
@@ -16,7 +16,7 @@ class SqlGetRunningJobExecution
         $this->connection = $connection;
     }
 
-    public function getByJobCode(string $jobCode): ?array
+    public function getByJobCode(string $jobCode): array
     {
         $sql = <<<SQL
             SELECT job_execution.id, job_execution.status, job_execution.updated_time
@@ -33,7 +33,7 @@ class SqlGetRunningJobExecution
         )->fetchAssociative();
 
         if (false === $result) {
-            return null;
+            return [];
         }
 
         return $result;

--- a/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
+++ b/src/Akeneo/Tool/Component/Batch/Query/SqlGetRunningJobExecution.php
@@ -19,7 +19,7 @@ class SqlGetRunningJobExecution
     public function getByJobCode(string $jobCode): array
     {
         $sql = <<<SQL
-            SELECT job_execution.id, job_execution.status, job_execution.updated_time
+            SELECT job_execution.id, job_execution.status, job_execution.start_time, job_execution.updated_time
             FROM akeneo_batch_job_execution AS job_execution
             INNER JOIN akeneo_batch_job_instance AS job_instance ON job_instance.id = job_execution.job_instance_id
             WHERE job_instance.code = :job_code 
@@ -30,7 +30,7 @@ class SqlGetRunningJobExecution
             $sql,
             ['job_code' => $jobCode, 'exit_codes' => [ExitStatus::EXECUTING, ExitStatus::UNKNOWN]],
             ['job_code' => \PDO::PARAM_STR, 'exit_codes' => Connection::PARAM_STR_ARRAY]
-        )->fetchAssociative();
+        )->fetchAllAssociative();
 
         if (false === $result) {
             return [];


### PR DESCRIPTION
Introduce a new step for batches targeting "cron batch".
For a cron, we don't want to launch another cron if the first is not finished. To do so, we can add a step before executing the job to check for other running instances.