### PR TITLE
RAB-974: Fix typescript error

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base-interface.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base-interface.ts
@@ -11,7 +11,7 @@ export default interface View extends Backbone.View<any> {
   getParent: () => View | null;
   configure: () => JQueryPromise<any>;
   shutdown: () => void;
-  triggerExtensions: () => void;
+  triggerExtensions: (eventName: string, ...args: any[]) => void;
   getFormData: () => any;
   getExtension: (code: string) => View | undefined;
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/view/base.ts
@@ -39,6 +39,7 @@ class BaseView extends Backbone.View<any> implements View {
 
     this.extensions = {};
     this.zones = {};
+    this.position = 0;
     this.targetZone = '';
     this.configured = false;
   }
@@ -321,12 +322,10 @@ class BaseView extends Backbone.View<any> implements View {
   /**
    * Trigger event on each child extensions and their childs
    */
-  triggerExtensions() {
-    const options = Object.values(arguments);
-
+  triggerExtensions(eventName: string, ...args: any[]) {
     Object.values(this.extensions).forEach(extension => {
-      extension.trigger.apply(extension, options);
-      extension.triggerExtensions.apply(extension, options);
+      extension.trigger.apply(extension, [eventName, ...args]);
+      extension.triggerExtensions.apply(extension, [eventName, ...args]);
     });
   }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/tools/validator.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/legacy-bridge/src/tools/validator.ts
@@ -6,7 +6,7 @@ const ajv = new Ajv();
 export const isValidAgainstSchema = <T>(data: any, schema: object): data is T => {
   try {
     return ajv.validate(schema, data);
-  } catch (e) {
+  } catch (e: any) {
     throw Error(e.message);
   }
 };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I fixed some error that typescript detect when we check the backbone bridge.

- triggerExtensions has now two parameters instead of none and using the magic argument `argument`
- position is now initialized as typescript detect it as not used

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
