### PR TITLE
PIM-10607: Only request /announcements when the panel is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-10607: Only request /announcements when the panel is open
 - PIM-10515: Fix 'add associations' button visibility for quantified associations & category permissions
 - PIM-10487: Fix import of very tiny measurement values (e.g. 0.000075 GRAM)
 - PIM-10215: Fixed last operation widget job type translation key

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/AnnouncementList.tsx
@@ -25,10 +25,6 @@ const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
   const handleHasNewAnnouncements = useHasNewAnnouncements();
   const handleAddViewedAnnouncements = useAddViewedAnnouncements();
 
-  useEffect(() => {
-    handleHasNewAnnouncements();
-  }, []);
-
   const updateNewAnnouncements = useCallback(async () => {
     const newAnnouncements = announcementResponse.items.filter((item: Announcement) => item.tags.includes('new'));
     if (newAnnouncements.length > 0) {
@@ -50,6 +46,10 @@ const AnnouncementList = ({campaign, panelIsClosed}: ListAnnouncementProps) => {
 
   if (announcementResponse.hasError) {
     return <EmptyAnnouncementList text={__('akeneo_communication_channel.panel.list.error')} />;
+  }
+
+  if (announcementResponse.isFetching && announcementResponse.items.length === 0) {
+    return null;
   }
 
   if (announcementResponse.items.length === 0) {

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/src/components/panel/Panel.tsx
@@ -5,6 +5,7 @@ import {HeaderPanel} from './Header';
 import {AnnouncementList} from './AnnouncementList';
 import {EmptyAnnouncementList} from './announcement';
 import {formatCampaign} from '../../tools/formatCampaign';
+import {useHasNewAnnouncements} from '../../hooks/useHasNewAnnouncements';
 
 const Panel = (): JSX.Element => {
   const __ = useTranslate();
@@ -12,10 +13,15 @@ const Panel = (): JSX.Element => {
   const [isOpened, setIsOpened] = useState<boolean>(false);
   const [campaign, setCampaign] = useState<string>('');
   const pimVersion = usePimVersion();
+  const handleHasNewAnnouncements = useHasNewAnnouncements();
 
   const onClosePanel = () => {
     mediator.trigger('communication-channel:panel:close');
   };
+
+  useEffect(() => {
+    handleHasNewAnnouncements();
+  }, []);
 
   useEffect(() => {
     /* istanbul ignore next: can't test the callback function */
@@ -46,7 +52,7 @@ const Panel = (): JSX.Element => {
   return (
     <>
       <HeaderPanel title={__('akeneo_communication_channel.panel.title')} onClickCloseButton={onClosePanel} />
-      <AnnouncementList campaign={campaign} panelIsClosed={!isOpened} />
+      {isOpened && <AnnouncementList campaign={campaign} panelIsClosed={!isOpened} />}
     </>
   );
 };

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/AnnouncementList.unit.tsx
@@ -28,27 +28,6 @@ afterEach(() => {
   container = null;
 });
 
-test('it check if it has new announcements when the component is mounted', async () => {
-  const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
-  const handleHasNewAnnouncements = jest.fn();
-  useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
-
-  useInfiniteScroll.mockReturnValue([
-    {
-      items: [],
-      isFetching: false,
-      hasError: false,
-    },
-    jest.fn(),
-  ]);
-
-  await act(async () =>
-    renderDOMWithProviders(<AnnouncementList campaign={campaign} panelIsOpened={true} />, container as HTMLElement)
-  );
-
-  expect(handleHasNewAnnouncements).toBeCalledTimes(1);
-});
-
 test('it shows the announcements when we open the panel', async () => {
   const campaign = formatCampaign(expectedPimAnalyticsData.pim_edition, expectedPimAnalyticsData.pim_version);
   const handleFetchingResults = jest.fn();
@@ -193,5 +172,5 @@ test('it updates the new announcements when closing the panel', async () => {
   );
 
   expect(handleAddViewedAnnouncements).toBeCalledWith([expectedAnnouncements[0]]);
-  expect(handleHasNewAnnouncements).toBeCalledTimes(2);
+  expect(handleHasNewAnnouncements).toBeCalledTimes(1);
 });

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/front/tests/front/unit/components/panel/Panel.unit.tsx
@@ -20,6 +20,19 @@ afterEach(() => {
   document.body.removeChild(container);
 });
 
+test('it check if it has new announcements when the component is mounted', async () => {
+  usePimVersion.mockReturnValue({
+    data: {edition: 'Serenity', version: '192939349'},
+    hasError: false,
+  });
+  const handleHasNewAnnouncements = jest.fn();
+  useHasNewAnnouncements.mockReturnValue(handleHasNewAnnouncements);
+
+  await act(async () => renderDOMWithProviders(<Panel />, container));
+
+  expect(handleHasNewAnnouncements).toBeCalledTimes(1);
+});
+
 test('it displays a panel of announcements', async () => {
   useHasNewAnnouncements.mockReturnValue(jest.fn());
   usePimVersion.mockReturnValue({
@@ -38,7 +51,6 @@ test('it displays a panel of announcements', async () => {
   await act(async () => renderDOMWithProviders(<Panel />, container as HTMLElement));
 
   expect(getByText(container, 'akeneo_communication_channel.panel.title')).toBeInTheDocument();
-  expect(getByText(container, 'akeneo_communication_channel.panel.list.empty')).toBeInTheDocument();
 });
 
 test('it displays an error when it does not get the PIM Version data', async () => {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The component `AnnouncementList` was always mounted, even when the panel is never opened.
It was automatically fetching the list of announcements, which is actually quit slow (~3s).
I've deferred its mount only when opened.

I've moved the `handleHasNewAnnouncements` to the parent component to still have the visual indicator if there is new annoucements.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
