### PR TITLE
OCT-114: adds purge() to FixturesLoaderInterface

### DIFF
--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -241,15 +241,19 @@ abstract class IntegrationTestCase extends WebTestCase
      * @param array{
      *     code: string,
      *     type: string,
-     *     available_locales: array<string>,
-     *     group: string,
+     *     available_locales?: array<string>,
+     *     group?: string,
      *     scopable: bool,
      *     localizable: bool,
-     *     options: array<string>
+     *     options?: array<string>,
      * } $data
      */
     protected function createAttribute(array $data): void
     {
+        $data = \array_merge([
+            'group' => 'other',
+        ], $data);
+
         $options = $data['options'] ?? [];
         unset($data['options']);
 

--- a/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoaderInterface.php
+++ b/tests/back/Integration/IntegrationTestsBundle/Loader/FixturesLoaderInterface.php
@@ -21,4 +21,9 @@ interface FixturesLoaderInterface
      * @param Configuration $configuration
      */
     public function load(Configuration $configuration): void;
+
+    /**
+     * Remove all data from all storages
+     */
+    public function purge(): void;
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

FixturesLoader has the method `purge()` that we started using in a test only since this morning.
It was not in the interface, so it broke the EE implementation of FixturesLoaderInterface.

This PR is there to remedy this problem.

Also, when attributes are created without the group "other" in EE, we have errors with permissions.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
