### PR TITLE
PIM-10606: Fix computeFamilyVariantStructureChange on attribute removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - PIM-10529: Fix links on product grid
 - PIM-10595: Fix not being able to add record with code "0" on a product
 - PIM-10588: Add potentially missing `remove_completeness_for_channel_and_locale` job instance
+- PIM-10606: Fix computeFamilyVariantStructureChange on attribute removal
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/ComputeFamilyVariantStructureChangesSubscriber.php
@@ -29,7 +29,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberInterface
 {
     public const DISABLE_JOB_LAUNCHING = 'DISABLE_COMPUTE_FAMILY_VARIANT_STRUCTURE_CHANGES_LAUNCHING';
-    public const FORCE_JOB_LAUNCHING = 'FORCE_COMPUTE_FAMILY_VARIANT_STRUCTURE_CHANGES_LAUNCHING';
 
     /** @var array<string, bool> */
     private array $isFamilyVariantNew = [];
@@ -73,11 +72,11 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             return;
         }
 
-        $forceJobLaunching = $event->hasArgument(self::FORCE_JOB_LAUNCHING) && $event->getArgument(self::FORCE_JOB_LAUNCHING);
-        if (!$event->hasArgument('unitary') || false === $event->getArgument('unitary')
+        if (
+            !$event->hasArgument('unitary') || false === $event->getArgument('unitary')
             || ($event->hasArgument('is_new') && $event->getArgument('is_new'))
             || ($event->hasArgument(self::DISABLE_JOB_LAUNCHING) && $event->getArgument(self::DISABLE_JOB_LAUNCHING))
-            || (!$forceJobLaunching && !$this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
+            || (!$this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
         ) {
             return;
         }
@@ -100,8 +99,6 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
             return;
         }
 
-        $forceJobLaunching = $event->hasArgument(self::FORCE_JOB_LAUNCHING) && $event->getArgument(self::FORCE_JOB_LAUNCHING);
-
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
         $familyVariantCodesToCompute = \array_values(\array_map(
             static fn (FamilyVariantInterface $familyVariant): string => $familyVariant->getCode(),
@@ -109,7 +106,7 @@ class ComputeFamilyVariantStructureChangesSubscriber implements EventSubscriberI
                 $familyVariants,
                 fn (FamilyVariantInterface $familyVariant): bool =>
                     !($this->isFamilyVariantNew[$familyVariant->getCode()] ?? false)
-                    && ($forceJobLaunching || $this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
+                    && ($this->variantAttributeSetOfFamilyVariantIsUpdated($familyVariant))
                     && $this->noOtherJobExecutionIsPending($jobInstance->getId(), $familyVariant->getCode())
             )
         ));

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriber.php
@@ -68,7 +68,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriber implements EventSubscriberInterf
         // caller know who are the listener. It means it introduced accidental coupling between the two components that
         // should not know each other.
         $this->bulkFamilyVariantSaver->saveAll($validFamilyVariants, [
-            ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true,
+            ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => false,
         ]);
 
         if (!empty($allViolations)) {

--- a/src/Akeneo/Pim/Structure/Component/Model/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/Family.php
@@ -482,6 +482,16 @@ class Family implements FamilyInterface
             $attributeCodesToRemove = array_diff($formerAttributeCodes, $newAttributeCodes);
             $attributeCodesToAdd = array_diff($newAttributeCodes, $formerAttributeCodes);
 
+            if (\count($attributeCodesToRemove) > 0) {
+                $familyVariants = $this->getFamilyVariants();
+                /** @var FamilyVariant $familyVariant */
+                foreach ($familyVariants as $familyVariant) {
+                    // for every family variants, we want to inform subscribers that the levels of product variants
+                    // and product models have been updated
+                    $familyVariant->addEvent(FamilyVariantInterface::ATTRIBUTES_WERE_UPDATED_ON_LEVEL);
+                }
+            }
+
             // removes attributes only from former attributes list
             foreach ($this->getAttributes() as $attribute) {
                 if (\in_array($attribute->getCode(), $attributeCodesToRemove)) {

--- a/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/FamilyVariant.php
@@ -367,4 +367,9 @@ class FamilyVariant implements FamilyVariantInterface
 
         return $events;
     }
+
+    public function addEvent(string $eventName): void
+    {
+        $this->events[] = $eventName;
+    }
 }

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -74,7 +74,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => false]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -109,7 +109,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
 
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants3],
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => false]
         )->shouldBeCalled();
 
         $event->getSubject()->willReturn($family);
@@ -252,7 +252,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
         $constraintViolationList->count()->willReturn(0);
         $bulkFamilyVariantSaver->saveAll(
             [$familyVariants1, $familyVariants2],
-            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
+            [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => false]
         )->shouldBeCalled();
 
         $this->onUnitarySave($event);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The job computeFamilyVariantStructureChange was not launched when an attribute was removed on the family level.
The job is created only when there has been changed on the family variant attributes or axes. We now add one event when an attribute is removed from the family

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
