### PR TITLE
RAB-1003: Save ids instead of username & labels in automation parameters

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -159,6 +159,7 @@ class UserController
 
         //code is useful to reach the route, cannot forget it in the query
         unset($data['code']);
+        unset($data['visible_group_ids']);
 
         if (!$this->securityFacade->isGranted('pim_user_role_edit')) {
             unset($data['roles']);

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -194,6 +194,7 @@ class UserController
         unset($data['code']);
         unset($data['roles']);
         unset($data['groups']);
+        unset($data['visible_group_ids']);
 
         return $this->updateUser($user, $data);
     }

--- a/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -85,6 +85,6 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
 
     public function findOneById(int $id): ?GroupInterface
     {
-        return $this->findOneBy(['id' => $id]);
+        return $this->find($id);
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -82,4 +82,9 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
             ->where('groups = :group')
             ->setParameter('group', $group);
     }
+
+    public function findOneById(int $id): ?GroupInterface
+    {
+        return $this->findOneBy(['id' => $id]);
+    }
 }

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -169,7 +169,7 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
     /** @return int[] */
     private function getVisibleGroupIds(UserInterface $user): array
     {
-        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => $group->getType() !== Group::TYPE_DEFAULT);
+        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => $group->getName() !== 'All');
 
         return array_map(static fn (Group $group) => $group->getId(), $visibleGroups);
     }

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -77,6 +77,7 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
             'email_notifications'       => $user->isEmailNotifications(),
             'timezone'                  => $user->getTimezone(),
             'groups'                    => $user->getGroupNames(),
+            'group_ids'                 => $user->getGroupsIds(),
             'roles'                     => $this->getRoleNames($user),
             'product_grid_filters'      => $user->getProductGridFilters(),
             'profile'                   => $user->getProfile(),

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -4,6 +4,7 @@ namespace Akeneo\UserManagement\Component\Normalizer;
 
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Akeneo\UserManagement\Domain\Model\Group;
 use Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -77,7 +78,7 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
             'email_notifications'       => $user->isEmailNotifications(),
             'timezone'                  => $user->getTimezone(),
             'groups'                    => $user->getGroupNames(),
-            'group_ids'                 => $user->getGroupsIds(),
+            'visible_group_ids'         => $this->getVisibleGroupIds($user),
             'roles'                     => $this->getRoleNames($user),
             'product_grid_filters'      => $user->getProductGridFilters(),
             'profile'                   => $user->getProfile(),
@@ -163,5 +164,13 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
         }
 
         return 'pim-user-show';
+    }
+
+    /** @return int[] */
+    private function getVisibleGroupIds(UserInterface $user): array
+    {
+        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => !$group->isDefault());
+
+        return array_map(static fn (Group $group) => $group->getId(), $visibleGroups);
     }
 }

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\UserManagement\Component\Normalizer;
 
+use Akeneo\UserManagement\Component\Model\Group;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Akeneo\UserManagement\Domain\Model\Group;
 use Oro\Bundle\PimDataGridBundle\Repository\DatagridViewRepositoryInterface;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -169,7 +169,7 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
     /** @return int[] */
     private function getVisibleGroupIds(UserInterface $user): array
     {
-        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => !$group->isDefault());
+        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => $group->getType() !== Group::TYPE_DEFAULT);
 
         return array_map(static fn (Group $group) => $group->getId(), $visibleGroups);
     }

--- a/src/Akeneo/UserManagement/Component/Repository/GroupRepositoryInterface.php
+++ b/src/Akeneo/UserManagement/Component/Repository/GroupRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace Akeneo\UserManagement\Component\Repository;
 
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\UserManagement\Component\Model\GroupInterface;
 
 /**
  * @author    Arnaud Langlade <arnaud.langlade@akeneo.com>
@@ -17,4 +18,6 @@ interface GroupRepositoryInterface extends IdentifiableObjectRepositoryInterface
      * @return null|object
      */
     public function getDefaultUserGroup();
+
+    public function findOneById(int $id): ?GroupInterface;
 }

--- a/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
+++ b/src/Akeneo/UserManagement/Component/Updater/UserUpdater.php
@@ -18,6 +18,7 @@ use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Component\Model\GroupInterface;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\Persistence\ObjectRepository;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
@@ -70,7 +71,7 @@ class UserUpdater implements ObjectUpdaterInterface
      * @param IdentifiableObjectRepositoryInterface $localeRepository
      * @param IdentifiableObjectRepositoryInterface $channelRepository
      * @param IdentifiableObjectRepositoryInterface $roleRepository
-     * @param IdentifiableObjectRepositoryInterface $groupRepository
+     * @param GroupRepositoryInterface              $groupRepository
      * @param ObjectRepository                      $gridViewRepository
      * @param FileInfoRepositoryInterface           $fileInfoRepository
      * @param FileStorerInterface                   $fileStorer
@@ -82,7 +83,7 @@ class UserUpdater implements ObjectUpdaterInterface
         IdentifiableObjectRepositoryInterface $localeRepository,
         IdentifiableObjectRepositoryInterface $channelRepository,
         IdentifiableObjectRepositoryInterface $roleRepository,
-        IdentifiableObjectRepositoryInterface $groupRepository,
+        GroupRepositoryInterface $groupRepository,
         ObjectRepository $gridViewRepository,
         FileInfoRepositoryInterface $fileInfoRepository,
         FileStorerInterface $fileStorer,
@@ -199,6 +200,13 @@ class UserUpdater implements ObjectUpdaterInterface
                 $groups = [];
                 foreach ($data as $code) {
                     $groups[] = $this->findGroup($code);
+                }
+                $user->setGroups($groups);
+                break;
+            case 'group_ids':
+                $groups = [];
+                foreach ($data as $groupId) {
+                    $groups[] = $this->findGroupById($groupId);
                 }
                 $user->setGroups($groups);
                 break;
@@ -404,6 +412,26 @@ class UserUpdater implements ObjectUpdaterInterface
                 'The group does not exist',
                 static::class,
                 $code
+            );
+        }
+
+        return $group;
+    }
+
+    /**
+     * @throws InvalidPropertyException
+     */
+    private function findGroupById(int $id): GroupInterface
+    {
+        $group = $this->groupRepository->findOneById($id);
+
+        if (null === $group) {
+            throw InvalidPropertyException::validEntityCodeExpected(
+                'group_id',
+                'id',
+                'The group does not exist',
+                static::class,
+                $id
             );
         }
 

--- a/src/Akeneo/UserManagement/back/Application/Handler/UpsertUserHandler.php
+++ b/src/Akeneo/UserManagement/back/Application/Handler/UpsertUserHandler.php
@@ -60,7 +60,7 @@ final class UpsertUserHandler implements UpsertUserHandlerInterface
                 'first_name' => $upsertUserCommand->firstName,
                 'last_name' => $upsertUserCommand->lastName,
                 'email' => $upsertUserCommand->email,
-                'groups' => $upsertUserCommand->groupCodes,
+                'group_ids' => $upsertUserCommand->groupIds,
                 'roles' => $upsertUserCommand->roleCodes,
             ];
 

--- a/src/Akeneo/UserManagement/back/ServiceApi/User/UpsertUserCommand.php
+++ b/src/Akeneo/UserManagement/back/ServiceApi/User/UpsertUserCommand.php
@@ -21,13 +21,13 @@ final class UpsertUserCommand
         public string $firstName,
         public string $lastName,
         public array $roleCodes,
-        public array $groupCodes = [],
+        public array $groupIds = [],
     ) {
     }
 
     /**
      * @param string[] $roleCodes
-     * @param string[] $groupCodes
+     * @param string[] $groupIds
      */
     public static function api(
         string $username,
@@ -36,7 +36,7 @@ final class UpsertUserCommand
         string $firstName,
         string $lastName,
         array $roleCodes,
-        array $groupCodes = [],
+        array $groupIds = [],
     ): self {
         return new self(
             $username,
@@ -46,13 +46,13 @@ final class UpsertUserCommand
             $firstName,
             $lastName,
             $roleCodes,
-            $groupCodes,
+            $groupIds,
         );
     }
 
     /**
      * @param string[] $roleCodes
-     * @param string[] $groupCodes
+     * @param string[] $groupIds
      */
     public static function job(
         string $username,
@@ -61,7 +61,7 @@ final class UpsertUserCommand
         string $firstName,
         string $lastName,
         array $roleCodes,
-        array $groupCodes = [],
+        array $groupIds = [],
     ): self {
         return new self(
             $username,
@@ -71,13 +71,13 @@ final class UpsertUserCommand
             $firstName,
             $lastName,
             $roleCodes,
-            $groupCodes,
+            $groupIds,
         );
     }
 
     /**
      * @param string[] $roleCodes
-     * @param string[] $groupCodes
+     * @param string[] $groupIds
      */
     public static function user(
         string $username,
@@ -86,7 +86,7 @@ final class UpsertUserCommand
         string $firstName,
         string $lastName,
         array $roleCodes,
-        array $groupCodes = [],
+        array $groupIds = [],
     ): self {
         return new self(
             $username,
@@ -96,7 +96,7 @@ final class UpsertUserCommand
             $firstName,
             $lastName,
             $roleCodes,
-            $groupCodes,
+            $groupIds,
         );
     }
 }

--- a/src/Akeneo/UserManagement/back/tests/Integration/ServiceApi/User/UpsertUserHandlerIntegration.php
+++ b/src/Akeneo/UserManagement/back/tests/Integration/ServiceApi/User/UpsertUserHandlerIntegration.php
@@ -36,7 +36,7 @@ class UpsertUserHandlerIntegration  extends TestCase
             email: 'another_email@gmail.com',
             firstName: 'Another first name',
             lastName: 'Another last name',
-            groupCodes: ['IT support'],
+            groupIds: [1],
             roleCodes: ['ROLE_ADMINISTRATOR']
         );
 
@@ -65,7 +65,7 @@ class UpsertUserHandlerIntegration  extends TestCase
     public function testItThrowsAnExceptionWhenGroupCodeDoesNotExist()
     {
         $this->expectException(ViolationsException::class);
-        $this->upsertUser(groupCodes: ['does not exist']);
+        $this->upsertUser(groupIds: [999]);
     }
 
     private function assertUserDoesNotExist(): void
@@ -99,7 +99,7 @@ class UpsertUserHandlerIntegration  extends TestCase
         string $email = 'a_user@gmail.com',
         string $firstName = 'John',
         string $lastName = 'Doe',
-        array $groupCodes = [],
+        array $groupIds = [],
         array $roleCodes = ['ROLE_USER']
     ) {
         $this->getHandler()->handle(
@@ -110,7 +110,7 @@ class UpsertUserHandlerIntegration  extends TestCase
                 $firstName,
                 $lastName,
                 $roleCodes,
-                $groupCodes
+                $groupIds
             )
         );
     }
@@ -119,7 +119,7 @@ class UpsertUserHandlerIntegration  extends TestCase
         string $email = 'a_user@gmail.com',
         string $firstName = 'John',
         string $lastName = 'Doe',
-        array $groupCodes = [],
+        array $groupIds = [],
         array $roleCodes = ['ROLE_USER']
     ) {
         $this->getHandler()->handle(
@@ -130,7 +130,7 @@ class UpsertUserHandlerIntegration  extends TestCase
                 $firstName,
                 $lastName,
                 $roleCodes,
-                $groupCodes
+                $groupIds
             )
         );
     }

--- a/tests/back/Acceptance/User/InMemoryGroupRepository.php
+++ b/tests/back/Acceptance/User/InMemoryGroupRepository.php
@@ -97,4 +97,9 @@ class InMemoryGroupRepository implements GroupRepositoryInterface, SaverInterfac
     {
         throw new NotImplementedException();
     }
+
+    public function findOneById(int $id): ?GroupInterface
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Normalizer/UserNormalizerSpec.php
@@ -78,6 +78,7 @@ class UserNormalizerSpec extends ObjectBehavior
             'email_notifications'       => false,
             'timezone'                  => 'UTC',
             'groups'                    => [],
+            'visible_group_ids'         => [],
             'roles'                     => [],
             'product_grid_filters'      => [],
             'profile'                   => null,

--- a/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
+++ b/tests/back/UserManagement/Specification/Component/Updater/UserUpdaterSpec.php
@@ -10,6 +10,7 @@ use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Component\Model\Group;
 use Akeneo\UserManagement\Component\Model\User;
+use Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface;
 use Akeneo\UserManagement\Component\Updater\UserUpdater;
 use Doctrine\Persistence\ObjectRepository;
 use PhpSpec\ObjectBehavior;
@@ -23,7 +24,7 @@ class UserUpdaterSpec extends ObjectBehavior
         IdentifiableObjectRepositoryInterface $localeRepository,
         IdentifiableObjectRepositoryInterface $channelRepository,
         IdentifiableObjectRepositoryInterface $roleRepository,
-        IdentifiableObjectRepositoryInterface $groupRepository,
+        GroupRepositoryInterface $groupRepository,
         ObjectRepository $gridViewRepository,
         FileInfoRepositoryInterface $fileInfoRepository,
         FileStorerInterface $fileStorer


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- add a way to retrieve all visible user groups (all groups but the system "All" group)
- change the way we upsert user, it's now possible to give `group_ids` instead of group labels (as user group label can be modified later on)

**Definition Of Done (for Core Developer only)**

- [x] Tests