### PR TITLE
CPM-717: Replace null bytes by empty strings in VersionBuilder

### DIFF
--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Builder/VersionBuilder.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Builder/VersionBuilder.php
@@ -206,11 +206,14 @@ class VersionBuilder
      *
      * @return bool|null True if the date has changed, False otherwise. Null if the comparison can't be done.
      */
-    private function hasLegacyDateChanged($old, $new)
+    private function hasLegacyDateChanged($old, $new): bool | null
     {
         if (!is_string($old) || !is_string($new)) {
             return null;
         }
+
+        $old = str_replace(chr(0), '', $old);
+        $new = str_replace(chr(0), '', $new);
 
         $oldDateTime = \DateTimeImmutable::createFromFormat('Y-m-d', $old, new \DateTimeZone('UTC'));
         if (false === $oldDateTime) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In the error logs, there are null bytes in $old property, so we replace null bytes by empty string to prevent errors on `DateTimeImmutable::createFromFormat`

[Related logs](https://app.datadoghq.eu/logs?query=project%3Aakecld-saas-prod%20%40context.akeneo_context%3A%28Enrichment%20OR%20Structure%20OR%20Permissions%20OR%20%22Rule%20Engine%22%29%20status%3A%28error%20OR%20critical%29%20-%40context.exception.message%3A%2AHY000%2A%20-%40context.exception.message%3A%2Ano_shard_available_action_exception%2A&agg_q=%40context.exception.message&agg_t=count&cols=host%2Cservice&index=%2A&messageDisplay=inline&panel=%7B%22timeRange%22%3A%7B%22from%22%3A1661267574801%2C%22to%22%3A1661872374801%2C%22live%22%3Atrue%7D%2C%22queryString%22%3A%22%28project%3Aakecld-saas-prod%20%40context.akeneo_context%3A%28Enrichment%20OR%20Structure%20OR%20Permissions%20OR%20%5C%22Rule%20Engine%5C%22%29%20status%3A%28error%20OR%20critical%29%20-%40context.exception.message%3A%2AHY000%2A%20-%40context.exception.message%3A%2Ano_shard_available_action_exception%2A%29%20AND%20%40context.exception.message%3A%5C%22DateTimeImmutable%3A%3AcreateFromFormat%28%29%3A%20Argument%20%232%20%28%24datetime%29%20must%20not%20contain%20any%20null%20bytes%5C%22%22%7D&stream_sort=desc&top_n=25&top_o=top&viz=toplist&from_ts=1661267574801&to_ts=1661872374801&live=true)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
