### PR TITLE
OCT-117: Automatically launch database tests only when a migration is added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ setup: true
 
 orbs:
     continuation: circleci/continuation@0.2.0
-    git-shallow-clone: guitarrapc/git-shallow-clone@2.4.0
+    path-filtering: circleci/path-filtering@0.1.3
 
 jobs:
     merge_config:
         executor: continuation/default
         steps:
-            - git-shallow-clone/checkout
+            - checkout
             - run:
                 name: Install yq (v4)
                 command: |
@@ -24,8 +24,17 @@ jobs:
                   command: |
                       yq eval-all '. as $item ireduce ({}; . *+ $item )' .circleci/*/*.yml .circleci/*/*/*.yml .circleci/*/*/*/*.yml > .circleci/merged_config.yml
                       cat .circleci/merged_config.yml
-            - continuation/continue:
-                  configuration_path: .circleci/merged_config.yml
+            -   path-filtering/set-parameters:
+                    base-revision: master
+                    mapping: |
+                        upgrades/.* run-database-tests true
+                    output-path: /tmp/pipeline-parameters.json
+            -   run:
+                    name: Debug parameters
+                    command: cat /tmp/pipeline-parameters.json
+            -   continuation/continue:
+                    configuration_path: .circleci/merged_config.yml
+                    parameters: /tmp/pipeline-parameters.json
 
 workflows:
     version: 2

--- a/.circleci/config/parameters.yml
+++ b/.circleci/config/parameters.yml
@@ -1,0 +1,4 @@
+parameters:
+    run-database-tests:
+        type: boolean
+        default: false

--- a/.circleci/jobs/features/catalogs/test_back_catalogs_ce.yml
+++ b/.circleci/jobs/features/catalogs/test_back_catalogs_ce.yml
@@ -24,5 +24,11 @@ jobs:
             -   run:
                     name: Acceptance back
                     command: APP_ENV=test make catalogs-acceptance-back
+            -   when:
+                    condition: << pipeline.parameters.run-database-tests >>
+                    steps:
+                        -   run:
+                                name: Migrations tests
+                                command: make migration-back
             -   store_test_results:
                     path: var/tests/phpunit

--- a/.circleci/jobs/features/catalogs/test_back_catalogs_ee.yml
+++ b/.circleci/jobs/features/catalogs/test_back_catalogs_ee.yml
@@ -20,6 +20,12 @@ jobs:
                     name: Acceptance back
                     command: PIM_CONTEXT=catalogs APP_ENV=test make catalogs-acceptance-back
             -   when:
+                    condition: << pipeline.parameters.run-database-tests >>
+                    steps:
+                        -   run:
+                                name: Database schema reference
+                                command: PIM_CONTEXT=test APP_ENV=test make test-database-structure
+            -   when:
                     condition: << parameters.notify >>
                     steps:
                         -   slack-app/notify:


### PR DESCRIPTION
<!-- It's boom boom time -->

**Introduction**

Running all integration tests on the existing migrations adds around **5min** to the CI workflow.
When we initially configured our workflow, we decided that we were going to run those tests only on demand.
It worked well for some time, but last week, I merged a broken migration without running those tests because I forgot to launch them. :boom: 

We need to prevent it from happening again.
But instead of running those tests in all workflows, we agreed it was time to implement `path-filtering`.

**Description (for Contributor and Core Developer)**

When using `path-filtering`, we can rely on the `git diff` between the latest commit and **master** to find which files are affected by the PR.

With the following mapping:
```
upgrades/.* run-database-tests true
```
Any PR affecting the `upgrades/` directory, either by adding or modifying a migration, will have the pipeline parameter `run-database-tests` at `true`.

We can then use this variable in our workflows to run the tests on the database only when needed.

---

You can check this other PR with a fake migration, to see the impact on our CI:
https://github.com/akeneo/pim-community-dev/pull/17882/files
https://app.circleci.com/pipelines/github/akeneo/pim-community-dev/40554/workflows/ed90a2ec-34e2-456d-a704-2ec4531ac3ab

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
