### PR TITLE
CPM-695: Add uuid to old product endpoints

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/Enrichment/ProductLoader.php
@@ -10,6 +10,7 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\TraceableMessageBus;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -42,16 +43,21 @@ class ProductLoader
         $this->messageBus = $messageBus;
     }
 
-    public function create($identifier, array $data): ProductInterface
+    public function createWithUuid($uuid, $identifier, array $data): ProductInterface
     {
-        $family = isset($data['family']) ? $data['family'] : null;
+        $family = $data['family'] ?? null;
 
-        $product = $this->builder->createProduct($identifier, $family);
+        $product = $this->builder->createProduct($identifier, $family, $uuid);
         $this->update($product, $data);
 
         $this->messageBus->reset();
 
         return $product;
+    }
+
+    public function create($identifier, array $data): ProductInterface
+    {
+        return $this->createWithUuid(Uuid::uuid4()->toString(), $identifier, $data);
     }
 
     public function update(ProductInterface $product, array $data): void

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/ConsumeProductEventEndToEnd.php
@@ -22,7 +22,6 @@ use Doctrine\DBAL\Connection as DbalConnection;
 use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Request;
 use PHPUnit\Framework\Assert;
-use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -288,6 +287,7 @@ class ConsumeProductEventEndToEnd extends ApiTestCase
     {
         return [
             'resource' => [
+                'uuid' => $product->getUuid(),
                 'identifier' => $product->getIdentifier(),
                 'enabled' => true,
                 'family' => $product->getFamily()->getCode(),

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -312,6 +312,7 @@ class ProductController
         }
 
         $data = $this->getDecodedContent($request->getContent());
+
         $violations = $this->validator->validate($data, new PayloadFormat());
         if (0 < $violations->count()) {
             $firstViolation = $violations->get(0);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
@@ -48,6 +48,7 @@ final class ConnectorProductNormalizer
         $quantifiedAssociations = $this->normalizeQuantifiedAssociations($connectorProduct->quantifiedAssociations());
 
         $normalizedProduct =  [
+            'uuid' => $connectorProduct->uuid(),
             'identifier' => $connectorProduct->identifier(),
             'enabled' => $connectorProduct->enabled(),
             'family' => $connectorProduct->familyCode(),

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/AbstractProductTestCase.php
@@ -4,14 +4,20 @@ namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueValuesSet;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
+use Akeneo\Test\IntegrationTestsBundle\Helper\AuthenticatorHelper;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client as EsClient;
+use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use AkeneoTest\Pim\Enrichment\Integration\Normalizer\NormalizedProductCleaner;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
  * @author    Marie Bochu <marie.bochu@akeneo.com>
@@ -23,17 +29,19 @@ abstract class AbstractProductTestCase extends ApiTestCase
     /**
      * @param UserIntent[] $userIntents
      */
-    protected function createProduct(string $identifier, array $userIntents = []): ProductInterface
+    protected function createProductWithUuid(string $uuid, array $userIntents = []): ProductInterface
     {
-        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
-        $command = UpsertProductCommand::createFromCollection(
-            userId: $this->getUserId('admin'),
-            productIdentifier: $identifier,
-            userIntents: $userIntents
-        );
-        $this->get('pim_enrich.product.message_bus')->dispatch($command);
+        $this->getAuthenticator()->logIn('admin');
 
-        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+        $command = UpsertProductCommand::createWithUuid(
+            $this->getUserId('admin'),
+            ProductUuid::fromUuid(Uuid::fromString($uuid)),
+            $userIntents
+        );
+
+        $this->getMessageBus()->dispatch($command);
+
+        return $this->getProductRepository()->find($uuid);
     }
 
     /**
@@ -41,35 +49,44 @@ abstract class AbstractProductTestCase extends ApiTestCase
      */
     protected function createProductWithoutIdentifier(array $userIntents = []): ProductInterface
     {
-        $productUuid = Uuid::uuid4();
-        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
-        $command = UpsertProductCommand::createWithUuid(
-            $this->getUserId('admin'),
-            ProductUuid::fromUuid($productUuid),
-            $userIntents
-        );
-        $this->get('pim_enrich.product.message_bus')->dispatch($command);
-
-        return $this->get('pim_catalog.repository.product')->find($productUuid);
+        return $this->createProductWithUuid(Uuid::uuid4()->toString(), $userIntents);
     }
 
     /**
      * @param UserIntent[] $userIntents
      */
-    protected function createVariantProduct(string $identifier, array $userIntents = []) : ProductInterface
+    protected function createProduct(string $identifier, array $userIntents = []): ProductInterface
     {
-        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
+        $this->getAuthenticator()->logIn('admin');
+
         $command = UpsertProductCommand::createFromCollection(
             userId: $this->getUserId('admin'),
             productIdentifier: $identifier,
             userIntents: $userIntents
         );
-        $this->get('pim_enrich.product.message_bus')->dispatch($command);
-        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
-        $this->get('pim_connector.doctrine.cache_clearer')->clear();
 
-        return $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+        $this->getMessageBus()->dispatch($command);
+
+        return $this->getProductRepository()->findOneByIdentifier($identifier);
+    }
+
+    /**
+     * @param UserIntent[] $userIntents
+     */
+    protected function createVariantProduct(string $identifier, array $userIntents = []): ProductInterface
+    {
+        $product = $this->createProduct($identifier, $userIntents);
+
+        $this->clearAllCache();
+
+        return $product;
+    }
+
+    protected function clearAllCache()
+    {
+        $this->getUniqueValueSetValidator()->reset();
+        $this->getEsIndex()->refreshIndex();
+        $this->getOrmCacheClearer()->clear();
     }
 
     /**
@@ -81,7 +98,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
      * @return ProductModelInterface
      * @throws \Exception
      */
-    protected function createProductModel(array $data = []) : ProductModelInterface
+    protected function createProductModel(array $data = []): ProductModelInterface
     {
         $productModel = $this->get('pim_catalog.factory.product_model')->create();
         $this->get('pim_catalog.updater.product_model')->update($productModel, $data);
@@ -95,7 +112,7 @@ abstract class AbstractProductTestCase extends ApiTestCase
             ));
         }
         $this->get('pim_catalog.saver.product_model')->save($productModel);
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->getEsIndex()->refreshIndex();
 
         return $productModel;
     }
@@ -136,8 +153,8 @@ abstract class AbstractProductTestCase extends ApiTestCase
      */
     protected function assertSameProducts(array $expectedProduct, $identifier)
     {
-        $this->get('pim_connector.doctrine.cache_clearer')->clear();
-        $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier($identifier);
+        $this->getOrmCacheClearer()->clear();
+        $product = $this->getProductRepository()->findOneByIdentifier($identifier);
 
         $standardizedProduct = $this->get('pim_standard_format_serializer')->normalize($product, 'standard');
 
@@ -159,5 +176,39 @@ abstract class AbstractProductTestCase extends ApiTestCase
         }
 
         return \intval($id);
+    }
+
+    /**
+     * Type aware service accessors below
+     */
+
+    private function getAuthenticator(): AuthenticatorHelper
+    {
+        return $this->get('akeneo_integration_tests.helper.authenticator');
+    }
+
+    private function getMessageBus(): MessageBusInterface
+    {
+        return $this->get('pim_enrich.product.message_bus');
+    }
+
+    private function getProductRepository(): ProductRepositoryInterface
+    {
+        return $this->get('pim_catalog.repository.product');
+    }
+
+    private function getUniqueValueSetValidator(): UniqueValuesSet
+    {
+        return $this->get('pim_catalog.validator.unique_value_set');
+    }
+
+    protected function getEsIndex(): EsClient
+    {
+        return $this->get('akeneo_elasticsearch.client.product_and_product_model');
+    }
+
+    private function getOrmCacheClearer(): EntityManagerClearerInterface
+    {
+        return $this->get('pim_connector.doctrine.cache_clearer');
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -10,6 +10,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMultiSelectValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Test\Integration\Configuration;
@@ -21,9 +22,12 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class GetProductEndToEnd extends AbstractProductTestCase
 {
+    const PRODUCT_UUID = '412eb420-e4d1-4997-94d4-70be156a33a8';
+
     public function test_it_gets_a_product_with_attribute_options_simple_select()
     {
-        $this->createProduct('product', [
+        $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
             new SetFamily('familyA'),
             new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
@@ -32,6 +36,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
 
         $expectedProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA',
             'parent' => null,
@@ -73,7 +78,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function test_it_gets_a_product_with_attribute_options_multi_select()
     {
-        $this->createProduct('product', [
+        $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
             new SetFamily('familyA'),
             new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'optionB'])
         ]);
@@ -82,6 +88,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
 
         $expectedProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA',
             'parent' => null,
@@ -132,7 +139,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function test_it_gets_a_product_with_attribute_options_multi_select_with_wrong_case()
     {
-        $this->createProduct('product', [
+        $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
             new SetFamily('familyA'),
             new SetMultiSelectValue('a_multi_select', null, null, ['optionA', 'OptiONB'])
         ]);
@@ -141,6 +149,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product?with_attribute_options=true');
 
         $expectedProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA',
             'parent' => null,
@@ -194,7 +203,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
      */
     public function test_it_gets_a_product()
     {
-        $this->createProduct('product', [
+        $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
             new SetFamily('familyA1'),
             new SetEnabled(true),
             new SetCategories(['categoryA', 'master', 'master_china']),
@@ -206,6 +216,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product');
 
         $standardProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA1',
             'parent' => null,
@@ -249,7 +260,10 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function test_it_gets_a_product_with_quality_scores()
     {
-        $product = $this->createProduct('product', [new SetFamily('familyA')]);
+        $product = $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
+            new SetFamily('familyA')
+        ]);
 
         ($this->get('Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts'))(
             ProductUuidCollection::fromString($product->getUuid()->toString())
@@ -259,6 +273,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product?with_quality_scores=true');
 
         $expectedProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA',
             'parent' => null,
@@ -293,7 +308,8 @@ class GetProductEndToEnd extends AbstractProductTestCase
 
     public function test_it_gets_a_product_with_completenesses()
     {
-        $this->createProduct('product', [
+        $this->createProductWithUuid(self::PRODUCT_UUID, [
+            new SetIdentifierValue('sku', 'product'),
             new SetFamily('familyA'),
             new SetSimpleSelectValue('a_simple_select', null, null, 'optionA')
         ]);
@@ -302,6 +318,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
         $client->request('GET', 'api/rest/v1/products/product?with_completenesses=true');
 
         $expectedProduct = [
+            'uuid' => self::PRODUCT_UUID,
             'identifier' => 'product',
             'family' => 'familyA',
             'parent' => null,

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/ListProductWithCompletenessEndToEnd.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetDateValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFileValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetNumberValue;
@@ -20,6 +21,15 @@ use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProdu
 class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
 {
     /**
+     * product uuids used in these tests
+     */
+    private const PRODUCT_UUIDS = [
+        'product_complete' => 'aaf518b2-f91e-40f1-a53a-78ce5e81a6f9',
+        'product_complete_en_locale' => 'aec6780b-c813-4bd7-8e24-1a8574471576',
+        'product_incomplete' => '93f14b03-5ed3-4f23-87c6-ae3806041b6a',
+    ];
+
+    /**
      * {@inheritdoc}
      */
     public function setUp(): void
@@ -27,7 +37,8 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         parent::setUp();
 
         // product complete, whatever the scope
-        $this->createProduct('product_complete', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_complete'], [
+            new SetIdentifierValue('sku', 'product_complete'),
             new SetFamily('familyA2'),
             new SetCategories(['categoryA', 'categoryB', 'master']),
             new SetMeasurementValue('a_metric', null, null, 1, 'WATT'),
@@ -35,7 +46,8 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         ]);
 
         // product complete only on en_US-tablet & en-US-ecommerce
-        $this->createProduct('product_complete_en_locale', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_complete_en_locale'], [
+            new SetIdentifierValue('sku', 'product_complete_en_locale'),
             new SetFamily('familyA1'),
             new SetCategories(['categoryA', 'master', 'master_china']),
             new SetImageValue(
@@ -54,7 +66,8 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         ]);
 
         // product incomplete
-        $this->createProduct('product_incomplete', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_incomplete'], [
+            new SetIdentifierValue('sku', 'product_incomplete'),
             new SetFamily('familyA'),
             new SetCategories(['categoryA', 'master', 'master_china']),
             new SetFileValue(
@@ -75,6 +88,9 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
         $search = '{"completeness":[{"operator":"=","value":100,"scope":"ecommerce"}]}';
         $client->request('GET', 'api/rest/v1/products?scope=ecommerce&locales=en_US&limit=2&search=' . $search);
         $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+
+        $uuids = self::PRODUCT_UUIDS;
+
         $expected = <<<JSON
 {
     "_links": {
@@ -91,6 +107,7 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
 		                "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_complete"
 		            }
 		        },
+                "uuid": "{$uuids['product_complete']}",
 		        "identifier": "product_complete",
 		        "family": "familyA2",
 		        "parent": null,
@@ -135,6 +152,7 @@ class ListProductWithCompletenessEndToEnd extends AbstractProductTestCase
 		        "_links": {
 		            "self": {"href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_complete_en_locale"}
 		        },
+                "uuid": "{$uuids['product_complete_en_locale']}",
 		        "identifier": "product_complete_en_locale",
 		        "family": "familyA1",
                 "parent": null,

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\ListProducts;
 
 use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductUuidFactory;
-use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\PriceValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetBooleanValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetFamily;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetImageValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetMeasurementValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetPriceCollectionValue;
@@ -27,8 +27,18 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class SuccessListProductEndToEnd extends AbstractProductTestCase
 {
-    /** @var ProductInterface[] $products */
-    private array $products = [];
+    const PRODUCT_UUIDS = [
+        'simple' => '4cfd82f2-def8-4869-8008-eabdf658f57c',
+        'simple_with_family_and_values' => 'a1a0956a-8d89-4737-a9ae-35b756245eb1',
+        'simple_with_no_family' => '9d16f37a-6e0e-43ff-ab2b-85969c1cd4ef',
+        'simple_with_no_values' => 'f0f4ffe6-ae7c-4586-82db-e5f5360d1d0c',
+        'localizable' => 'e7dd6e7f-9801-48f9-b4d6-57620754b4bc',
+        'scopable' => '612859a6-3378-4c10-a58d-8e12931bc965',
+        'localizable_and_scopable' => '015df514-b2ec-43d3-b297-e81980c017fe',
+        'product_china' => '3947031d-6554-4586-85f0-2a3e89636dad',
+        'product_without_category' => '6d2fd8b3-734f-4141-9503-8af8d7e2e959',
+        'product_with_parent' => 'f9d366dc-631b-429b-ae81-dd5c1efedb5d',
+    ];
 
     /**
      * {@inheritdoc}
@@ -38,7 +48,8 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         parent::setUp();
 
         // no locale, no scope, 1 category
-        $this->createProduct('simple', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['simple'], [
+            new SetIdentifierValue('sku', 'simple'),
             new SetCategories(['master']),
             new SetMeasurementValue('a_metric', null, null, 10, 'KILOWATT'),
             new SetTextValue('a_text', null, null, 'Text')
@@ -46,7 +57,8 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
 
         // localizable, categorized in 1 tree (master)
         $path = $this->getFileInfoKey($this->getFixturePath('akeneo.jpg'));
-        $this->createProduct('localizable', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['localizable'], [
+            new SetIdentifierValue('sku', 'localizable'),
             new SetCategories(['categoryB']),
             new SetImageValue('a_localizable_image', null, 'en_US', $path),
             new SetImageValue('a_localizable_image', null, 'fr_FR', $path),
@@ -54,7 +66,8 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         ]);
 
         // scopable, categorized in 1 tree (master)
-        $this->createProduct('scopable', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['scopable'], [
+            new SetIdentifierValue('sku', 'scopable'),
             new SetCategories(['categoryA1', 'categoryA2']),
             new SetPriceCollectionValue('a_scopable_price', 'ecommerce', null, [
                 new PriceValue('78.77', 'CNY'),
@@ -69,7 +82,8 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
         ]);
 
         // localizable & scopable, categorized in 2 trees (master and master_china)
-        $this->createProduct('localizable_and_scopable', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['localizable_and_scopable'], [
+            new SetIdentifierValue('sku', 'localizable_and_scopable'),
             new SetCategories(['categoryA', 'master_china']),
             new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce', 'en_US', 'Big description'),
             new SetTextareaValue('a_localized_and_scopable_text_area', 'tablet', 'en_US', 'Medium description'),
@@ -78,11 +92,13 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
             new SetTextareaValue('a_localized_and_scopable_text_area', 'ecommerce_china', 'zh_CN', 'hum...'),
         ]);
 
-        $this->createProduct('product_china', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_china'], [
+            new SetIdentifierValue('sku', 'product_china'),
             new SetCategories(['master_china'])
         ]);
 
-        $this->createProduct('product_without_category', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_without_category'], [
+            new SetIdentifierValue('sku', 'product_without_category'),
             new SetBooleanValue('a_yes_no', null, null, true)
         ]);
 
@@ -113,11 +129,13 @@ class SuccessListProductEndToEnd extends AbstractProductTestCase
             ]
         );
 
-        $this->createVariantProduct('product_with_parent', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['product_with_parent'], [
+            new SetIdentifierValue('sku', 'product_with_parent'),
             new SetCategories(['master']),
             new ChangeParent('prod_mod_optA'),
             new SetBooleanValue('a_yes_no', null, null, true)
         ]);
+        $this->clearAllCache();
         $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
         $this->get('pim_connector.doctrine.cache_clearer')->clear();
     }
@@ -156,6 +174,8 @@ JSON;
         $client = $this->createAuthenticatedClient();
 
         $client->request('GET', 'api/rest/v1/products?scope=tablet&locales=fr_FR&attributes=a_scopable_price,a_metric,a_localized_and_scopable_text_area&pagination_type=page');
+
+        $uuids = self::PRODUCT_UUIDS;
         $expected = <<<JSON
 {
     "_links"       : {
@@ -169,6 +189,7 @@ JSON;
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable"}
                 },
+                "uuid"          : "{$uuids['localizable']}",
                 "identifier"    : "localizable",
                 "family"        : null,
                 "parent"        : null,
@@ -190,6 +211,7 @@ JSON;
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/localizable_and_scopable"}
                 },
+                "uuid"          : "{$uuids['localizable_and_scopable']}",
                 "identifier"    : "localizable_and_scopable",
                 "family"        : null,
                 "parent"        : null,
@@ -215,6 +237,7 @@ JSON;
                 "_links": {
                     "self": { "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_with_parent" }
                 },
+                "uuid": "{$uuids['product_with_parent']}",
                 "identifier": "product_with_parent",
                 "enabled": true,
                 "family": "familyA",
@@ -236,6 +259,7 @@ JSON;
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/scopable"}
                 },
+                "uuid"          : "{$uuids['scopable']}",
                 "identifier"    : "scopable",
                 "family"        : null,
                 "parent"        : null,
@@ -268,6 +292,7 @@ JSON;
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
                 },
+                "uuid"          : "{$uuids['simple']}",
                 "identifier"    : "simple",
                 "family"        : null,
                 "parent"        : null,
@@ -311,6 +336,8 @@ JSON;
         $search = '{"a_metric":[{"operator":">","value":{"amount":"9","unit":"KILOWATT"}}],"enabled":[{"operator":"=","value":true}]}';
         $client->request('GET', 'api/rest/v1/products?pagination_type=page&search=' . $search);
         $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+
+        $uuids = self::PRODUCT_UUIDS;
         $expected = <<<JSON
 {
     "_links"       : {
@@ -324,6 +351,7 @@ JSON;
                 "_links" : {
                     "self" : {"href" : "http://localhost/api/rest/v1/products/simple"}
                 },
+                "uuid"          : "{$uuids['simple']}",
                 "identifier"    : "simple",
                 "family"        : null,
                 "parent"        : null,
@@ -472,21 +500,24 @@ JSON;
 
     public function testListProductsWithQualityScores()
     {
-        $product1 = $this->createProduct('simple_with_family_and_values', [
+        $product1 = $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_family_and_values'], [
+            new SetIdentifierValue('sku', 'simple_with_family_and_values'),
             new SetCategories(['master']),
             new SetFamily('familyA'),
             new SetTextValue('a_text', null, null, 'Text')
         ]);
-        $product2 = $this->createProduct('simple_with_no_family', [
+        $product2 = $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_no_family'], [
+            new SetIdentifierValue('sku', 'simple_with_no_family'),
             new SetCategories(['master']),
             new SetTextValue('a_text', null, null, 'Text')
         ]);
-        $product3 = $this->createProduct('simple_with_no_values', [
+        $product3 = $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_no_values'], [
+            new SetIdentifierValue('sku', 'simple_with_no_values'),
             new SetCategories(['master']),
             new SetFamily('familyA'),
         ]);
 
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->getEsIndex()->refreshIndex();
 
         ($this->get('Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts'))(
             $this->get(ProductUuidFactory::class)->createCollection([
@@ -511,9 +542,27 @@ JSON;
             {"scope": "ecommerce_china", "locale": "en_US", "data": "E"},
             {"scope": "ecommerce_china", "locale": "zh_CN", "data": "E"}
         ]';
-        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForQualityScore('simple_with_family_and_values', '"familyA"', $values, $qualityScores);
-        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForQualityScore('simple_with_no_family', 'null', $values, '[]');
-        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForQualityScore('simple_with_no_values', '"familyA"', '{}', $qualityScores);
+        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForQualityScore(
+            self::PRODUCT_UUIDS['simple_with_family_and_values'],
+            'simple_with_family_and_values',
+            '"familyA"',
+            $values,
+            $qualityScores
+        );
+        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForQualityScore(
+            self::PRODUCT_UUIDS['simple_with_no_family'],
+            'simple_with_no_family',
+            'null',
+            $values,
+            '[]'
+        );
+        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForQualityScore(
+            self::PRODUCT_UUIDS['simple_with_no_values'],
+            'simple_with_no_values',
+            '"familyA"',
+            '{}',
+            $qualityScores
+        );
 
         $client = $this->createAuthenticatedClient();
         $search = '{"sku":[{"operator":"IN","value":["simple_with_family_and_values","simple_with_no_family","simple_with_no_values"]}]}';
@@ -542,20 +591,23 @@ JSON;
 
     public function testListProductsWithCompletenesses()
     {
-        $this->createProduct('simple_with_family_and_values', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_family_and_values'], [
+            new SetIdentifierValue('sku', 'simple_with_family_and_values'),
             new SetCategories(['master']),
             new SetFamily('familyA'),
             new SetTextValue('a_text', null, null, 'Text'),
         ]);
-        $this->createProduct('simple_with_no_family', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_no_family'], [
+            new SetIdentifierValue('sku', 'simple_with_no_family'),
             new SetCategories(['master']),
             new SetTextValue('a_text', null, null, 'Text'),
         ]);
-        $this->createProduct('simple_with_no_values', [
+        $this->createProductWithUuid(self::PRODUCT_UUIDS['simple_with_no_values'], [
+            new SetIdentifierValue('sku', 'simple_with_no_values'),
             new SetCategories(['master']),
             new SetFamily('familyA')
         ]);
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $this->getEsIndex()->refreshIndex();
 
         $values = '{
             "a_text": [{
@@ -580,9 +632,27 @@ JSON;
             {"scope":"tablet","locale":"en_US","data":5},
             {"scope":"tablet","locale":"fr_FR","data":5}
         ]';
-        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForCompletenesses('simple_with_family_and_values', '"familyA"', $values, $completenessesFamVal);
-        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForCompletenesses('simple_with_no_family', 'null', $values, '[]');
-        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForCompletenesses('simple_with_no_values', '"familyA"', '{}', $completenessesNoVal);
+        $standardizedProducts['simple_with_family_and_values'] = $this->getStandardizedProductsForCompletenesses(
+            self::PRODUCT_UUIDS['simple_with_family_and_values'],
+            'simple_with_family_and_values',
+            '"familyA"',
+            $values,
+            $completenessesFamVal
+        );
+        $standardizedProducts['simple_with_no_family'] = $this->getStandardizedProductsForCompletenesses(
+            self::PRODUCT_UUIDS['simple_with_no_family'],
+            'simple_with_no_family',
+            'null',
+            $values,
+            '[]'
+        );
+        $standardizedProducts['simple_with_no_values'] = $this->getStandardizedProductsForCompletenesses(
+            self::PRODUCT_UUIDS['simple_with_no_values'],
+            'simple_with_no_values',
+            '"familyA"',
+            '{}',
+            $completenessesNoVal
+        );
 
         $client = $this->createAuthenticatedClient();
         $search = '{"sku":[{"operator":"IN","value":["simple_with_family_and_values","simple_with_no_family","simple_with_no_values"]}]}';
@@ -790,9 +860,16 @@ JSON;
 
     public function testSearchAfterPaginationWithUppercaseIdentifier(): void
     {
-        $this->createProduct('AN_UPPERCASE_IDENTIFIER', []);
-        $this->createProduct('MY_OTHER_UPPERCASE_IDENTIFIER', []);
-        $this->get('akeneo_elasticsearch.client.product_and_product_model')->refreshIndex();
+        $anUppercaseUuid = 'bbf0d0f8-de9c-4d3d-8623-ccbe2b93ca5c';
+        $myOtherUppercaseUuid = 'fbc049ec-1594-4e79-adf3-c95215a7029a';
+
+        $this->createProductWithUuid($anUppercaseUuid, [
+            new SetIdentifierValue('sku', 'AN_UPPERCASE_IDENTIFIER'),
+        ]);
+        $this->createProductWithUuid($myOtherUppercaseUuid, [
+            new SetIdentifierValue('sku', 'MY_OTHER_UPPERCASE_IDENTIFIER'),
+        ]);
+        $this->getEsIndex()->refreshIndex();
 
         $standardizedProducts = $this->getStandardizedProducts();
         $client = $this->createAuthenticatedClient();
@@ -818,6 +895,7 @@ JSON;
                         "href": "http://localhost/api/rest/v1/products/MY_OTHER_UPPERCASE_IDENTIFIER"
                     }
                 },
+                "uuid": "$myOtherUppercaseUuid",
                 "identifier": "MY_OTHER_UPPERCASE_IDENTIFIER",
                 "family": null,
                 "parent": null,
@@ -962,7 +1040,7 @@ JSON;
 
         foreach ($result['_embedded']['items'] as $index => $product) {
             if (isset($product['values']['a_text'])) {
-	    	// TODO CPM-737: Check using Uuid instead of the text attribute value
+                // TODO CPM-737: Check using Uuid instead of the text attribute value
                 Assert::assertNotEquals('My product without identifier', $product['values']['a_text'][0]['data']);
             }
         }
@@ -973,6 +1051,8 @@ JSON;
      */
     private function getStandardizedProducts(bool $withAttributeOptions = false): array
     {
+        $uuids = self::PRODUCT_UUIDS;
+
         $standardizedProducts['simple'] = <<<JSON
 {
     "_links": {
@@ -980,6 +1060,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/simple"
         }
     },
+    "uuid": "{$uuids['simple']}",
     "identifier": "simple",
     "family": null,
     "parent": null,
@@ -1020,6 +1101,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/localizable"
         }
     },
+    "uuid": "{$uuids['localizable']}",
     "identifier": "localizable",
     "family": null,
     "parent": null,
@@ -1075,6 +1157,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/scopable"
         }
     },
+    "uuid": "{$uuids['scopable']}",
     "identifier": "scopable",
     "family": null,
     "parent": null,
@@ -1123,6 +1206,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/localizable_and_scopable"
         }
     },
+    "uuid": "{$uuids['localizable_and_scopable']}",
     "identifier": "localizable_and_scopable",
     "family": null,
     "parent": null,
@@ -1171,6 +1255,7 @@ JSON;
            "href": "http://localhost/api/rest/v1/products/product_china"
        }
    },
+   "uuid": "{$uuids['product_china']}",
    "identifier": "product_china",
    "family": null,
    "parent": null,
@@ -1197,6 +1282,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/product_without_category"
         }
     },
+    "uuid": "{$uuids['product_without_category']}",
     "identifier": "product_without_category",
     "family": null,
     "parent": null,
@@ -1230,6 +1316,7 @@ JSON;
             "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_with_parent"
         }
 	},
+    "uuid": "{$uuids['product_with_parent']}",
     "identifier": "product_with_parent",
     "enabled": true,
     "family": "familyA",
@@ -1267,7 +1354,6 @@ JSON;
     "quantified_associations": {}
 }
 JSON;
-
         } else {
             $standardizedProducts['product_with_parent'] = <<<JSON
 {
@@ -1276,6 +1362,7 @@ JSON;
             "href": "http:\/\/localhost\/api\/rest\/v1\/products\/product_with_parent"
         }
 	},
+    "uuid": "{$uuids['product_with_parent']}",
     "identifier": "product_with_parent",
     "enabled": true,
     "family": "familyA",
@@ -1313,7 +1400,7 @@ JSON;
         return $this->catalog->useTechnicalCatalog();
     }
 
-    private function getStandardizedProductsForQualityScore(string $identifier, string $family, string $values, string $qualityScores)
+    private function getStandardizedProductsForQualityScore(string $uuid, string $identifier, string $family, string $values, string $qualityScores)
     {
         return <<<JSON
 {
@@ -1322,6 +1409,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/$identifier"
         }
     },
+    "uuid": "$uuid",
     "identifier": "$identifier",
     "family": $family,
     "parent": null,
@@ -1343,7 +1431,7 @@ JSON;
 JSON;
     }
 
-    private function getStandardizedProductsForCompletenesses(string $identifier, string $family, string $values, string $completenesses)
+    private function getStandardizedProductsForCompletenesses(string $uuid, string $identifier, string $family, string $values, string $completenesses)
     {
         return <<<JSON
 {
@@ -1352,6 +1440,7 @@ JSON;
             "href": "http://localhost/api/rest/v1/products/$identifier"
         }
     },
+    "uuid": "$uuid",
     "identifier": "$identifier",
     "family": $family,
     "parent": null,

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
@@ -23,6 +23,12 @@ use Symfony\Component\Routing\RouterInterface;
 
 class ConnectorProductNormalizerSpec extends ObjectBehavior
 {
+    const PRODUCT_UUIDS = [
+        'identifier_1' => '54162e35-ff81-48f1-96d5-5febd3f00fd5',
+        'identifier_2' => 'd9f573cc-8905-4949-8151-baf9d5328f26',
+        'identifier_3' => 'fdf6f091-3f75-418f-98af-8c19db8b0000',
+    ];
+
     function let(
         ProductValueNormalizer $productValueNormalizer,
         RouterInterface $router,
@@ -47,7 +53,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
         $identifier1 = ScalarValue::value('sku', 'identifier_1');
         $value1 = ScalarValue::value('another_attribute', 'value_1');
         $connector1 = new ConnectorProduct(
-            Uuid::fromString('54162e35-ff81-48f1-96d5-5febd3f00fd5'),
+            Uuid::fromString(self::PRODUCT_UUIDS['identifier_1']),
             'identifier_1',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
@@ -108,7 +114,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
         $identifier2 = ScalarValue::value('sku', 'identifier_2');
         $value2 = ScalarValue::value('another_attribute', 'value_2');
         $connector2 = new ConnectorProduct(
-            Uuid::fromString('d9f573cc-8905-4949-8151-baf9d5328f26'),
+            Uuid::fromString(self::PRODUCT_UUIDS['identifier_2']),
             'identifier_2',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
@@ -128,7 +134,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
         $identifier3 = ScalarValue::value('sku', 'identifier_3');
         $value3 = ScalarValue::value('another_attribute', 'value_3');
         $connector3 = new ConnectorProduct(
-            Uuid::fromString('fdf6f091-3f75-418f-98af-8c19db8b0000'),
+            Uuid::fromString(self::PRODUCT_UUIDS['identifier_3']),
             'identifier_3',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
@@ -156,6 +162,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
             new ConnectorProductList(3, [$connector1, $connector2, $connector3])
         )->shouldBeLike([
             [
+                'uuid' => self::PRODUCT_UUIDS['identifier_1'],
                 'identifier' => 'identifier_1',
                 'created' => '2019-04-23T15:55:50+00:00',
                 'updated' => '2019-04-25T15:55:50+00:00',
@@ -206,6 +213,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
                 ]
             ],
             [
+                'uuid' => self::PRODUCT_UUIDS['identifier_2'],
                 'identifier' => 'identifier_2',
                 'created' => '2019-04-23T15:55:50+00:00',
                 'updated' => '2019-04-25T15:55:50+00:00',
@@ -223,6 +231,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
                 'metadata' => ['a_metadata' => 'viande'],
             ],
             [
+                'uuid' => self::PRODUCT_UUIDS['identifier_3'],
                 'identifier' => 'identifier_3',
                 'created' => '2019-04-23T15:55:50+00:00',
                 'updated' => '2019-04-25T15:55:50+00:00',
@@ -249,7 +258,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
         $identifier = ScalarValue::value('sku', 'identifier_1');
         $value = ScalarValue::value('another_attribute', 'value');
         $connector = new ConnectorProduct(
-            Uuid::fromString('54162e35-ff81-48f1-96d5-5febd3f00fd5'),
+            Uuid::fromString(self::PRODUCT_UUIDS['identifier_1']),
             'identifier_1',
             new \DateTimeImmutable('2019-04-23 15:55:50', new \DateTimeZone('UTC')),
             new \DateTimeImmutable('2019-04-25 15:55:50', new \DateTimeZone('UTC')),
@@ -292,6 +301,7 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
         $productValueNormalizer->normalize($value, 'standard')->shouldBeCalled()->willReturn(['normalizedValue']);
 
         $this->normalizeConnectorProduct($connector)->shouldBeLike([
+            'uuid' => self::PRODUCT_UUIDS['identifier_1'],
             'identifier' => 'identifier_1',
             'created' => '2019-04-23T15:55:50+00:00',
             'updated' => '2019-04-25T15:55:50+00:00',

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilderSpec.php
@@ -126,6 +126,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         $expectedCollection = new EventDataCollection();
         $expectedCollection->setEventData($blueJeanEvent, [
             'resource' => [
+                'uuid' => $blueJeanUuid,
                 'identifier' => 'blue_jean',
                 'created' => '2020-04-23T15:55:50+00:00',
                 'updated' => '2020-04-25T15:55:50+00:00',
@@ -141,6 +142,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         ]);
         $expectedCollection->setEventData($redJeanEvent, [
             'resource' => [
+                'uuid' => $redJeanUuid,
                 'identifier' => 'red_jean',
                 'created' => '2020-04-23T15:55:50+00:00',
                 'updated' => '2020-04-25T15:55:50+00:00',
@@ -188,6 +190,7 @@ class ProductCreatedAndUpdatedEventDataBuilderSpec extends ObjectBehavior
         $expectedCollection = new EventDataCollection();
         $expectedCollection->setEventData($blueJeanEvent, [
             'resource' => [
+                'uuid' => $blueJeanUuid,
                 'identifier' => 'blue_jean',
                 'created' => '2020-04-23T15:55:50+00:00',
                 'updated' => '2020-04-25T15:55:50+00:00',


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add uuid to the response of `api/rest/v1/products` endpoints

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
