### PR TITLE
RAB-1039: Fix user normalizer sending visible groups ids as object

### DIFF
--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -169,7 +169,10 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
     /** @return int[] */
     private function getVisibleGroupIds(UserInterface $user): array
     {
-        $visibleGroups = array_filter($user->getGroups()->toArray(), static fn (Group $group) => $group->getName() !== 'All');
+        $visibleGroups = array_values(array_filter(
+            $user->getGroups()->toArray(),
+            static fn (Group $group) => $group->getName() !== 'All',
+        ));
 
         return array_map(static fn (Group $group) => $group->getId(), $visibleGroups);
     }


### PR DESCRIPTION
The scheduling form was crashing due to the fact that the User Normalizer was keeping indices when filtering and then sending the value as an object.

Before:
<img width="433" alt="Screenshot 2022-09-02 at 15 46 50" src="https://user-images.githubusercontent.com/3492179/188226392-45f658d7-fcce-4ea1-b679-09bf37b9839d.png">
<img width="395" alt="Screenshot 2022-09-02 at 15 46 54" src="https://user-images.githubusercontent.com/3492179/188226393-f1663546-1b7e-4b32-8483-ddbd859d49d1.png">

After:
<img width="333" alt="image" src="https://user-images.githubusercontent.com/3492179/188226513-1e327291-9cb9-419f-b609-738a57fc1095.png">
