### PR TITLE
CPM-716: Fix UpsertProductCommand validation on permissions

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetProductUuids.php
@@ -19,4 +19,17 @@ interface GetProductUuids
      * @return array<string, UuidInterface>
      */
     public function fromIdentifiers(array $identifiers): array;
+
+    /**
+     * checks that a given uuid is assigned to an existing product
+     */
+    public function fromUuid(UuidInterface $uuid): ?UuidInterface;
+
+    /**
+     * checks which uuids are assigned to existing products
+     * @param UuidInterface[] $uuids
+     *
+     * @return array<string, UuidInterface>
+     */
+    public function fromUuids(array $uuids): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetProductUuids.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetProductUuids.php
@@ -38,4 +38,21 @@ class InMemoryGetProductUuids implements GetProductUuids
 
         return $result;
     }
+
+    public function fromUuid(UuidInterface $uuid): ?UuidInterface
+    {
+        return null === $this->productRepository->find($uuid) ? null : $uuid;
+    }
+
+    public function fromUuids(array $uuids): array
+    {
+        $existingUuids = [];
+        foreach ($uuids as $uuid) {
+            if (null !== $this->productRepository->find($uuid)) {
+                $existingUuids[$uuid->toString()] = $uuid;
+            }
+        }
+
+        return $existingUuids;
+    }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\QuantifiedEntity;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -96,9 +97,9 @@ abstract class EnrichmentProductTestCase extends TestCase
     protected function createProduct(string $identifier, array $userIntents): void
     {
         $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
-        $command = UpsertProductCommand::createFromCollection(
+        $command = UpsertProductCommand::createWithIdentifier(
             userId: $this->getUserId('peter'),
-            productIdentifier: $identifier,
+            productIdentifier: ProductIdentifier::fromIdentifier($identifier),
             userIntents: $userIntents
         );
         $this->commandMessageBus->dispatch($command);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductWithPermissionIntegration.php
@@ -19,11 +19,14 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\R
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\ReplaceAssociatedQuantifiedProducts;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\RemoveCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
 use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
 use Akeneo\Test\Pim\Enrichment\Product\Integration\EnrichmentProductTestCase;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 final class UpsertProductWithPermissionIntegration extends EnrichmentProductTestCase
 {
@@ -140,30 +143,27 @@ final class UpsertProductWithPermissionIntegration extends EnrichmentProductTest
         $this->commandMessageBus->dispatch($command);
     }
 
-    /**
-     * @test
-     * @FIXME CPM-716: uncomment this test
-     */
-//    public function it_creates_a_product_without_owned_category(): void
-//    {
-//        $uuid = Uuid::uuid4();
-//        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
-//        $command = UpsertProductCommand::createWithUuid(
-//            userId: $this->getUserId('betty'),
-//            productUuid: ProductUuid::fromUuid($uuid),
-//            userIntents: [
-//                new SetIdentifierValue('sku', 'my_new_product'),
-//                new SetCategories(['sales'])
-//            ]
-//        );
-//        $this->commandMessageBus->dispatch($command);
-//
-//        $this->clearDoctrineUoW();
-//
-//        $product = $this->productRepository->find($uuid);
-//        Assert::assertNotNull($product);
-//        Assert::assertEqualsCanonicalizing(['sales'], $product->getCategoryCodes());
-//    }
+    /** @test */
+    public function it_creates_a_product_without_owned_category(): void
+    {
+        $uuid = Uuid::uuid4();
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('betty');
+        $command = UpsertProductCommand::createWithUuid(
+            userId: $this->getUserId('betty'),
+            productUuid: ProductUuid::fromUuid($uuid),
+            userIntents: [
+                new SetIdentifierValue('sku', 'my_new_product'),
+                new SetCategories(['sales'])
+            ]
+        );
+        $this->commandMessageBus->dispatch($command);
+
+        $this->clearDoctrineUoW();
+
+        $product = $this->productRepository->find($uuid);
+        Assert::assertNotNull($product);
+        Assert::assertEqualsCanonicalizing(['sales'], $product->getCategoryCodes());
+    }
 
     /** @test */
     public function it_throws_an_exception_when_there_is_no_more_owned_category_after_update(): void

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/GetProductUuidsIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/GetProductUuidsIntegration.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\Pim\Enrichment\Product\Integration\Query;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
+use Akeneo\Pim\Enrichment\Product\Infrastructure\Query\Cache\LRUCacheGetProductUuids;
+use Akeneo\Pim\Enrichment\Product\Infrastructure\Query\SqlGetProductUuids;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductUuidsIntegration extends TestCase
+{
+    private UuidInterface $uuidFoo;
+    private UuidInterface $uuidBar;
+    private int $adminUserId;
+    private SqlGetProductUuids $sqlQuery;
+    private LRUCacheGetProductUuids $cachedQuery;
+
+    /** @test */
+    public function it_returns_uuid_for_product_identifier(): void
+    {
+        Assert::assertEquals($this->uuidFoo, $this->sqlQuery->fromIdentifier('foo'));
+        Assert::assertEquals($this->uuidFoo, $this->cachedQuery->fromIdentifier('foo'));
+    }
+
+    /** @test */
+    public function it_returns_null_for_non_existing_product(): void
+    {
+        Assert::assertNull($this->sqlQuery->fromIdentifier('non_existing_product'));
+        Assert::assertNull($this->cachedQuery->fromIdentifier('non_existing_product'));
+    }
+
+    /** @test */
+    public function it_returns_uuids_by_identifiers_for_product_uuids()
+    {
+        $expected = [
+            'foo' => $this->uuidFoo,
+            'bar' => $this->uuidBar,
+        ];
+
+        Assert::assertEqualsCanonicalizing(
+            $expected,
+            $this->sqlQuery->fromIdentifiers(['foo', 'non_existing_product', 'bar'])
+        );
+        Assert::assertEqualsCanonicalizing(
+            $expected,
+            $this->cachedQuery->fromIdentifiers(['foo', 'non_existing_product', 'bar'])
+        );
+    }
+
+    /** @test */
+    public function it_returns_an_existing_product_uuid(): void
+    {
+        Assert::assertEquals($this->uuidFoo, $this->sqlQuery->fromUuid($this->uuidFoo));
+        Assert::assertEquals($this->uuidFoo, $this->cachedQuery->fromUuid($this->uuidFoo));
+    }
+
+    /** @test */
+    public function it_returns_null_when_a_uuid_does_not_exist_yet(): void
+    {
+        Assert::assertNull($this->sqlQuery->fromUuid(Uuid::uuid4()));
+        Assert::assertNull($this->cachedQuery->fromUuid(Uuid::uuid4()));
+    }
+
+    /** @test */
+    public function it_returns_existing_product_uuids(): void
+    {
+        $expected = [
+            $this->uuidFoo->toString() => $this->uuidFoo,
+            $this->uuidBar->toString() => $this->uuidBar,
+        ];
+        Assert::assertEqualsCanonicalizing(
+            $expected,
+            $this->sqlQuery->fromUuids([$this->uuidFoo, Uuid::uuid4(), $this->uuidBar])
+        );
+        Assert::assertEqualsCanonicalizing(
+            $expected,
+            $this->cachedQuery->fromUuids([$this->uuidFoo, Uuid::uuid4(), $this->uuidBar])
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->uuidFoo = Uuid::uuid4();
+        $this->uuidBar = Uuid::uuid4();
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('admin');
+        $this->adminUserId = (int) $this->get('database_connection')->fetchOne(
+            'SELECT id from oro_user WHERE username = \'admin\''
+        );
+        $this->sqlQuery = $this->get('Akeneo\Pim\Enrichment\Product\Infrastructure\Query\SqlGetProductUuids');
+        $this->cachedQuery = $this->get('Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids');
+        $this->createProduct($this->uuidFoo, 'foo');
+        $this->createProduct($this->uuidBar, 'bar');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createProduct(UuidInterface $uuid, string $identifier): void
+    {
+        $identifierAttribute = $this->get('pim_catalog.repository.attribute')->getIdentifierCode();
+        $this->get('pim_enrich.product.message_bus')->dispatch(
+            UpsertProductCommand::createWithUuid(
+                $this->adminUserId,
+                ProductUuid::fromUuid($uuid),
+                [new SetIdentifierValue($identifierAttribute, $identifier)],
+            )
+        );
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/ShouldStayOwnerOfTheProductValidatorSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Infrastructure/Validation/ShouldStayOwnerOfTheProductValidatorSpec.php
@@ -7,6 +7,7 @@ namespace Specification\Akeneo\Pim\Enrichment\Product\Infrastructure\Validation;
 use Akeneo\Pim\Enrichment\Category\API\Query\GetOwnedCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\AddCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\Groups\SetGroups;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\RemoveCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
@@ -20,6 +21,7 @@ use Akeneo\Pim\Enrichment\Product\Infrastructure\Validation\ShouldStayOwnerOfThe
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
@@ -43,23 +45,103 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         $this->shouldImplement(ConstraintValidatorInterface::class);
     }
 
-    function it_gets_product_uuid_from_identifier(
-        ExecutionContext $context,
+    function it_only_validates_the_right_constraint()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)
+             ->during('validate', [new SetCategories(['foo']), new NotBlank()]);
+    }
+
+    function it_only_validates_category_user_intents()
+    {
+        $this->shouldThrow(\InvalidArgumentException::class)->during(
+            'validate',
+            [new SetGroups(['foo']), new ShouldStayOwnerOfTheProduct()]
+        );
+    }
+
+    function it_does_not_check_add_categories_user_intents(
         GetProductUuids $getProductUuids,
+        ExecutionContext $context
     ) {
+        $getProductUuids->fromIdentifier(Argument::any())->shouldNotBeCalled();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+        $this->validate(new AddCategories(['bar', 'baz']), new ShouldStayOwnerOfTheProduct());
+    }
+
+    function it_does_nothing_when_the_product_is_being_created(
+        GetProductUuids $getProductUuids,
+        GetCategoryCodes $getCategoryCodes,
+        ExecutionContext $context
+    ) {
+        $productUuid = Uuid::uuid4();
+        $context->getRoot()->shouldBeCalled()->willReturn(
+            UpsertProductCommand::createWithUuid(42, ProductUuid::fromUuid($productUuid), [])
+        );
+        $getProductUuids->fromUuid($productUuid)->shouldBeCalled()->willReturn(null);
+
+        $getCategoryCodes->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate(new SetCategories([]), new ShouldStayOwnerOfTheProduct());
+    }
+
+    function it_does_nothing_when_the_user_is_not_already_owner_of_the_product(
+        GetOwnedCategories $getOwnedCategories,
+        GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
+        GetCategoryCodes $getCategoryCodes,
+        GetProductUuids $getProductUuids,
+        ExecutionContext $context,
+    ) {
+        $productUuid = Uuid::uuid4();
+        $context->getRoot()->shouldBeCalled()->willReturn(
+            UpsertProductCommand::createWithUuid(
+                42,
+                ProductUuid::fromUuid($productUuid),
+                []
+            )
+        );
+        $getProductUuids->fromUuid($productUuid)->shouldBeCalled()->willReturn($productUuid);
+        $getCategoryCodes->fromProductUuids([$productUuid])->shouldBeCalled()
+            ->willReturn([$productUuid->toString() => ['foo']]);
+        $getOwnedCategories->forUserId(['foo'], 42)->shouldBeCalled()->willReturn([]);
+
+        $getNonViewableCategoryCodes->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $context->buildViolation(Argument::cetera())->shouldNotBeCalled();
+
+        $this->validate(new SetCategories([]), new ShouldStayOwnerOfTheProduct());
+    }
+
+    function it_does_not_raise_any_violation_when_the_user_leaves_an_owned_category(
+        GetOwnedCategories $getOwnedCategories,
+        GetCategoryCodes $getCategoryCodes,
+        GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
+        GetProductUuids $getProductUuids,
+        ExecutionContext $context
+    ) {
+        $uuid = Uuid::uuid4();
         $context->getRoot()->willReturn(UpsertProductCommand::createWithIdentifier(
             userId: 10,
-            productIdentifier: ProductIdentifier::fromIdentifier('foo'),
+            productIdentifier: ProductIdentifier::fromIdentifier('my_sku'),
             userIntents: []
         ));
-        $getProductUuids->fromIdentifier('foo')->shouldBeCalled()->willReturn(null);
+        $getProductUuids->fromIdentifier('my_sku')->shouldBeCalled()->willReturn($uuid);
 
-        $this->validate(new SetCategories([]), new ShouldStayOwnerOfTheProduct());
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()
+             ->willReturn([$uuid->toString() => ['categoryA', 'categoryB']]);
+        $getOwnedCategories->forUserId(['categoryA', 'categoryB'], 10)->shouldBeCalled()->willReturn(['categoryA', 'categoryB']);
+
+        $getOwnedCategories->forUserId(['categoryA', 'categoryC'], Argument::cetera())->shouldNotBeCalled();
+        $getNonViewableCategoryCodes->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+
+        $this->validate(new SetCategories(['categoryA', 'categoryC']), new ShouldStayOwnerOfTheProduct());
     }
 
-    function it_validates_when_the_user_stays_owner_on_categories(
+    function it_does_not_raise_a_violation_when_the_user_adds_an_owned_category(
         GetOwnedCategories $getOwnedCategories,
+        GetCategoryCodes $getCategoryCodes,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
+        GetProductUuids $getProductUuids,
         ExecutionContext $context
     ) {
         $uuid = Uuid::uuid4();
@@ -68,38 +150,44 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
             productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
-            ->shouldBeCalled()
-            ->willReturn([$uuid->toString() => ['categoryA']])
-        ;
-        $getOwnedCategories->forUserId(['categoryB', 'categoryA'], 10)->willReturn(['categoryB']);
+        $getProductUuids->fromUuid($uuid)->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn([$uuid->toString() => ['categoryA']]);
+        $getOwnedCategories->forUserId(['categoryA'], 10)->shouldBeCalled()->willReturn(['categoryA']);
+        $getOwnedCategories->forUserId(['categoryC'], 10)->shouldBeCalled()->willReturn(['categoryC']);
+
+        $getNonViewableCategoryCodes->fromProductUuids(Argument::any())->shouldNotBeCalled();
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
-        $this->validate(new SetCategories(['categoryB']), new ShouldStayOwnerOfTheProduct());
+        $this->validate(new SetCategories(['categoryC']), new ShouldStayOwnerOfTheProduct());
     }
 
-    function it_validates_when_the_product_becomes_uncategorized(
+    function it_does_not_raise_any_violation_when_the_product_gets_unclassified(
+        GetOwnedCategories $getOwnedCategories,
+        GetCategoryCodes $getCategoryCodes,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
+        GetProductUuids $getProductUuids,
         ExecutionContext $context
     ) {
-
         $uuid = Uuid::uuid4();
         $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
             userId: 10,
             productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
-            ->willReturn([$uuid->toString() => []])
-        ;
+        $getProductUuids->fromUuid($uuid)->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn([$uuid->toString() => ['categoryA', 'categoryB']]);
+        $getOwnedCategories->forUserId(['categoryA', 'categoryB'], 10)->shouldBeCalled()->willReturn(['categoryA', 'categoryB']);
+        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)->shouldBeCalled()->willReturn([$uuid->toString() => []]);
+
         $context->buildViolation(Argument::any())->shouldNotBeCalled();
 
-        $this->validate(new SetCategories([]), new ShouldStayOwnerOfTheProduct());
+        $this->validate(new RemoveCategories(['categoryA', 'categoryB']), new ShouldStayOwnerOfTheProduct());
     }
 
-    function it_adds_a_violation_when_the_user_does_not_stay_owner_on_categories_with_set_categories(
+    function it_adds_a_violation_when_the_user_replaces_all_owned_categories(
         GetOwnedCategories $getOwnedCategories,
-        GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
+        GetCategoryCodes $getCategoryCodes,
+        GetProductUuids $getProductUuids,
         ExecutionContext $context,
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
@@ -110,20 +198,22 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
             productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)
-            ->willReturn([$uuid->toString() => ['categoryA']])
-        ;
-        $getOwnedCategories->forUserId(['categoryB', 'categoryA'], 10)->willReturn([]);
+        $getProductUuids->fromUuid($uuid)->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->shouldBeCalled()->willReturn(['categoryA', 'categoryB']);
+        $getOwnedCategories->forUserId(['categoryA', 'categoryB'], 10)->willReturn(['categoryA']);
+        $getOwnedCategories->forUserId(['categoryB', 'categoryC'], 10)->shouldBeCalled()->willReturn([]);
+
         $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($violationBuilder);
         $violationBuilder->setCode((string) ViolationCode::PERMISSION)->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalledOnce();
 
-        $this->validate(new SetCategories(['categoryB']), $constraint);
+        $this->validate(new SetCategories(['categoryB', 'categoryC']), $constraint);
     }
 
-    function it_adds_a_violation_when_the_user_does_not_stay_owner_on_categories_by_removing_categories(
+    function it_adds_a_violation_when_the_user_removes_all_owned_categories(
         GetOwnedCategories $getOwnedCategories,
         GetCategoryCodes $getCategoryCodes,
+        GetProductUuids $getProductUuids,
         ExecutionContext $context,
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
@@ -134,10 +224,11 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
             productUuid: ProductUuid::fromUuid($uuid),
             userIntents: []
         ));
-        $getCategoryCodes->fromProductUuids([$uuid])
-            ->willReturn([$uuid->toString() => ['categoryA', 'categoryB', 'categoryC']])
-        ;
+        $getProductUuids->fromUuid($uuid)->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->willReturn([$uuid->toString() => ['categoryA', 'categoryB', 'categoryC']]);
+        $getOwnedCategories->forUserId(['categoryA', 'categoryB', 'categoryC'], 10)->willReturn(['categoryB']);
         $getOwnedCategories->forUserId(['categoryA', 'categoryC'], 10)->willReturn([]);
+
         $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($violationBuilder);
         $violationBuilder->setCode((string) ViolationCode::PERMISSION)->willReturn($violationBuilder);
         $violationBuilder->addViolation()->shouldBeCalledOnce();
@@ -145,14 +236,30 @@ class ShouldStayOwnerOfTheProductValidatorSpec extends ObjectBehavior
         $this->validate(new RemoveCategories(['categoryB']), $constraint);
     }
 
-    function it_does_nothing_when_the_user_intent_is_to_add_categories(
+    function it_adds_a_violation_when_all_viewable_categories_are_removed(
         GetOwnedCategories $getOwnedCategories,
+        GetCategoryCodes $getCategoryCodes,
+        GetProductUuids $getProductUuids,
         GetNonViewableCategoryCodes $getNonViewableCategoryCodes,
         ExecutionContext $context,
         ConstraintViolationBuilderInterface $violationBuilder
     ) {
-        $context->buildViolation(Argument::any())->shouldNotBeCalled();
+        $constraint = new ShouldStayOwnerOfTheProduct();
+        $uuid = Uuid::uuid4();
+        $context->getRoot()->willReturn(UpsertProductCommand::createWithUuid(
+            userId: 10,
+            productUuid: ProductUuid::fromUuid($uuid),
+            userIntents: []
+        ));
+        $getProductUuids->fromUuid($uuid)->shouldBeCalled()->willReturn($uuid);
+        $getCategoryCodes->fromProductUuids([$uuid])->willReturn([$uuid->toString() => ['categoryA', 'categoryB']]);
+        $getOwnedCategories->forUserId(['categoryA', 'categoryB'], 10)->willReturn(['categoryB']);
+        $getNonViewableCategoryCodes->fromProductUuids([$uuid], 10)->shouldBeCalled()->willReturn([$uuid->toString() => ['non_viewable_category']]);
 
-        $this->validate(new AddCategories(['categoryB']), new ShouldStayOwnerOfTheProduct());
+        $context->buildViolation($constraint->message)->shouldBeCalledOnce()->willReturn($violationBuilder);
+        $violationBuilder->setCode((string) ViolationCode::PERMISSION)->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalledOnce();
+
+        $this->validate(new RemoveCategories(['categoryA', 'categoryB']), $constraint);
     }
 }


### PR DESCRIPTION
Allow creating a product without owning it via the service API. It essentially fixes this test: https://github.com/akeneo/pim-community-dev/pull/17847/files#diff-40fbe65847c0b0ff6966625232a49b54d2d8e03a6f343ce1f18d571bd421dbf8

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
