### PR TITLE
CPM-633: Enable identifier configuration for family attribute requirements

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Family/DefaultSqlGetRequiredAttributesMasks.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/InternalApi/Family/DefaultSqlGetRequiredAttributesMasks.php
@@ -66,6 +66,13 @@ WHERE
     AND family.code IN (:familyCodes)
     AND attribute.attribute_type IN (:attributeTypes)
 GROUP BY family.code, channel_code, locale_code
+UNION
+SELECT family.code as family_code, channel_code, locale_code, JSON_ARRAY() AS mask
+FROM pim_catalog_family family
+    LEFT JOIN pim_catalog_attribute_requirement pcar ON family.id = pcar.family_id
+    CROSS JOIN channel_locale
+WHERE pcar.id IS NULL
+    AND family.code IN (:familyCodes)
 SQL;
 
         $rows = $this->connection->executeQuery(

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/validators.yml
@@ -3,7 +3,6 @@ services:
         class: 'Akeneo\Pim\Structure\Component\Validator\Constraints\FamilyRequirementsValidator'
         arguments:
             - '@pim_catalog.repository.attribute'
-            - '@pim_catalog.repository.channel'
         tags:
             - { name: validator.constraint_validator, alias: pim_family_requirements_validator }
 

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/FamilyNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/InternalApi/FamilyNormalizer.php
@@ -95,10 +95,11 @@ class FamilyNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
 
         $normalizedFamily['attributes'] = $this->normalizeAttributes($family, $fullAttributes, $context);
 
-        $normalizedFamily['attribute_requirements'] = $this->normalizeRequirements(
+        $normalizedRequirements = $this->normalizeRequirements(
             $normalizedFamily['attribute_requirements'],
             $fullAttributes
         );
+        $normalizedFamily['attribute_requirements'] = [] === $normalizedRequirements ? (object) []: $normalizedRequirements;
 
         $firstVersion = $this->versionManager->getOldestLogEntry($family);
         $lastVersion = $this->versionManager->getNewestLogEntry($family);

--- a/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
@@ -240,9 +240,9 @@ class FamilyUpdater implements ObjectUpdaterInterface
             if (array_key_exists($channelCode, $newRequirements)) {
                 $attribute = $requirement->getAttribute();
                 $key = array_search($attribute->getCode(), $newRequirements[$channelCode], true);
-                if (false === $key && AttributeTypes::IDENTIFIER !== $attribute->getType()) {
+                if (false === $key) {
                     $family->removeAttributeRequirement($requirement);
-                } elseif (false !== $key && true === $requirement->isRequired()) {
+                } elseif (true === $requirement->isRequired()) {
                     unset($newRequirements[$channelCode][$key]);
                 }
             }
@@ -295,9 +295,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                     $attributeCode
                 );
             }
-            if (AttributeTypes::IDENTIFIER !== $attribute->getType()) {
-                $requirements[] = $this->createAttributeRequirement($family, $attribute, $channel);
-            }
+            $requirements[] = $this->createAttributeRequirement($family, $attribute, $channel);
         }
 
         return $requirements;

--- a/src/Akeneo/Pim/Structure/Component/Validator/Constraints/FamilyRequirementsValidator.php
+++ b/src/Akeneo/Pim/Structure/Component/Validator/Constraints/FamilyRequirementsValidator.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\Pim\Structure\Component\Validator\Constraints;
 
-use Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Symfony\Component\Validator\Constraint;
@@ -22,22 +21,9 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class FamilyRequirementsValidator extends ConstraintValidator
 {
-    /** @var AttributeRepositoryInterface */
-    protected $attributeRepository;
-
-    /** @var ChannelRepositoryInterface */
-    protected $channelRepository;
-
-    /**
-     * @param AttributeRepositoryInterface $attributeRepository
-     * @param ChannelRepositoryInterface   $channelRepository
-     */
     public function __construct(
-        AttributeRepositoryInterface $attributeRepository,
-        ChannelRepositoryInterface $channelRepository
+        protected AttributeRepositoryInterface $attributeRepository,
     ) {
-        $this->attributeRepository = $attributeRepository;
-        $this->channelRepository = $channelRepository;
     }
 
     /**

--- a/src/Akeneo/Pim/Structure/Component/Validator/Constraints/FamilyRequirementsValidator.php
+++ b/src/Akeneo/Pim/Structure/Component/Validator/Constraints/FamilyRequirementsValidator.php
@@ -50,31 +50,7 @@ class FamilyRequirementsValidator extends ConstraintValidator
         }
 
         if ($family instanceof FamilyInterface) {
-            $this->validateMissingChannels($family, $constraint);
             $this->validateRequiredAttributes($family, $constraint);
-        }
-    }
-
-    /**
-     * Validates that there is no missing channel for the family.
-     *
-     * @param FamilyInterface    $family
-     * @param FamilyRequirements $constraint
-     */
-    protected function validateMissingChannels(FamilyInterface $family, FamilyRequirements $constraint)
-    {
-        $missingChannelCodes = $this->getMissingChannelCodes($family);
-        if (0 < count($missingChannelCodes)) {
-            $identifierCode = $this->attributeRepository->getIdentifierCode();
-            $this->context->buildViolation(
-                $constraint->messageChannel,
-                [
-                    '%family%'    => $family->getCode(),
-                    '%id%'        => $identifierCode,
-                    '%channels%'  => implode(', ', $missingChannelCodes)
-
-                ]
-            )->atPath($constraint->propertyPath)->addViolation();
         }
     }
 
@@ -99,27 +75,5 @@ class FamilyRequirementsValidator extends ConstraintValidator
                     ->addViolation();
             }
         }
-    }
-
-    /**
-     * @param FamilyInterface $family
-     *
-     * @return string[]
-     */
-    protected function getMissingChannelCodes(FamilyInterface $family)
-    {
-        $requirements = $family->getAttributeRequirements();
-        $identifierCode = $this->attributeRepository->getIdentifierCode();
-        $currentChannelCodes = [];
-        foreach ($requirements as $requirement) {
-            if ($requirement->getAttributeCode() === $identifierCode) {
-                $currentChannelCodes[] = $requirement->getChannelCode();
-            }
-        }
-
-        $expectedChannelCodes = $this->channelRepository->getChannelCodes();
-        $missingChannelCodes = array_diff($expectedChannelCodes, $currentChannelCodes);
-
-        return $missingChannelCodes;
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -200,14 +200,13 @@ define([
      */
     toggleAttribute(event) {
       const attributeCode = event.currentTarget.dataset.attribute;
-      const attributeType = event.currentTarget.dataset.type;
       const channelCode = event.currentTarget.dataset.channel;
 
       if (!SecurityContext.isGranted('pim_enrich_family_edit_attributes')) {
         return;
       }
 
-      if (!this.isAttributeEditable(channelCode, attributeCode, attributeType)) {
+      if (!this.isAttributeEditable()) {
         return;
       }
 
@@ -222,15 +221,10 @@ define([
 
     /**
      * Checks if attribute is editable
-     *
-     * @param {string} channelCode
-     * @param {string} attributeCode
-     * @param {string} attributeType
-     *
      * @returns {boolean}
      */
-    isAttributeEditable(channelCode, attributeCode, attributeType) {
-      return !this.readOnly && this.identifierAttributeType !== attributeType;
+    isAttributeEditable() {
+      return !this.readOnly;
     },
 
     /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/family/tab/attributes/attributes.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/family/tab/attributes/attributes.html
@@ -40,7 +40,7 @@
                         <i
                             class="AknAcl-icon
                                 <%- isRequired ? 'AknSelectButton AknSelectButton--selected required' : 'AknSelectButton non-required' %>
-                                <%- isAttributeEditable(channel.code, attribute.code, attribute.type) ? '' : 'AknAcl-disabled' %>"
+                                <%- isAttributeEditable() ? '' : 'AknAcl-disabled' %>"
                             data-attribute="<%- attribute.code %>"
                             data-type="<%- attribute.type %>"
                             data-channel="<%- channel.code %>"

--- a/tests/back/Pim/Structure/EndToEnd/Family/ExternalApi/PartialUpdateFamilyEndToEnd.php
+++ b/tests/back/Pim/Structure/EndToEnd/Family/ExternalApi/PartialUpdateFamilyEndToEnd.php
@@ -398,9 +398,7 @@ JSON;
             'attribute_as_label'     => 'sku',
             'attribute_as_image'     => null,
             'attribute_requirements' => [
-                'ecommerce'          => [ 'sku' ],
-                'ecommerce_china'    => [ 'sku' ],
-                'tablet'             => [ 'sku' ],
+                'ecommerce_china'    => ['sku'],
             ],
             'labels'                 => [
                 'en_US' => 'A family A1'

--- a/tests/back/Pim/Structure/Integration/Family/ImportFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/ImportFamilyIntegration.php
@@ -66,8 +66,8 @@ final class ImportFamilyIntegration extends TestCase
 
         $content = <<<CSV
         code;attributes;attribute_as_label;requirements-mobile;requirements-tablet;label-en_US
-        heels;sku,name,manufacturer,heel_color;sku;manufacturer;manufacturer,heel_color;Heels
-        tractors;sku,name,manufacturer;name;manufacturer;;Tractor
+        heels;sku,name,manufacturer,heel_color;sku;manufacturer,sku;manufacturer,heel_color;Heels
+        tractors;sku,name,manufacturer;name;sku,manufacturer;;Tractor
         CSV;
         $this->jobLauncher->launchImport(static::CSV_IMPORT_JOB_CODE, $content);
 
@@ -76,7 +76,7 @@ final class ImportFamilyIntegration extends TestCase
         self::assertSame('[heels]', $heelsFamily->getLabel());
         self::assertSame('[sku]', $heelsFamily->getAttributeAsLabel()->getLabel());
         self::assertSame('manufacturer,sku', $this->getRequirementAttributeCodes($heelsFamily, 'mobile'));
-        self::assertSame('heel_color,manufacturer,sku', $this->getRequirementAttributeCodes($heelsFamily, 'tablet'));
+        self::assertSame('heel_color,manufacturer', $this->getRequirementAttributeCodes($heelsFamily, 'tablet'));
 
         $tractorsFamily = $this->getFamily('tractors');
         self::assertNotNull($tractorsFamily);
@@ -130,14 +130,14 @@ final class ImportFamilyIntegration extends TestCase
         self::assertNotNull($heelsFamily);
         self::assertSame('[heels]', $heelsFamily->getLabel());
         self::assertSame('[sku]', $heelsFamily->getAttributeAsLabel()->getLabel());
-        self::assertSame('manufacturer,sku', $this->getRequirementAttributeCodes($heelsFamily, 'mobile'));
-        self::assertSame('heel_color,manufacturer,sku', $this->getRequirementAttributeCodes($heelsFamily, 'tablet'));
+        self::assertSame('manufacturer', $this->getRequirementAttributeCodes($heelsFamily, 'mobile'));
+        self::assertSame('heel_color,manufacturer', $this->getRequirementAttributeCodes($heelsFamily, 'tablet'));
 
         $tractorsFamily = $this->getFamily('tractors');
         self::assertNotNull($tractorsFamily);
         self::assertSame('[tractors]', $tractorsFamily->getLabel());
         self::assertSame('[name]', $tractorsFamily->getAttributeAsLabel()->getLabel());
-        self::assertSame('manufacturer,sku', $this->getRequirementAttributeCodes($tractorsFamily, 'mobile'));
+        self::assertSame('manufacturer', $this->getRequirementAttributeCodes($tractorsFamily, 'mobile'));
         self::assertSame('sku', $this->getRequirementAttributeCodes($tractorsFamily, 'tablet'));
     }
 
@@ -188,7 +188,7 @@ final class ImportFamilyIntegration extends TestCase
 
         $heelsFamily = $this->getFamily('heels');
         self::assertNotNull($heelsFamily);
-        self::assertSame('manufacturer,name,sku', $this->getRequirementAttributeCodes($heelsFamily, 'mobile'));
+        self::assertSame('manufacturer,name', $this->getRequirementAttributeCodes($heelsFamily, 'mobile'));
 
         $this->get('akeneo.pim.structure.query.get_required_attributes_masks')->clearCache();
         $productCompletenessCollection = $this->getProductCompletenesses->fromProductUuid(
@@ -196,9 +196,9 @@ final class ImportFamilyIntegration extends TestCase
         );
         $productCompleteness = $productCompletenessCollection->getCompletenessForChannelAndLocale('mobile', 'en_US');
         self::assertNotNull($productCompleteness);
-        self::assertSame(3, $productCompleteness->requiredCount());
+        self::assertSame(2, $productCompleteness->requiredCount());
         self::assertSame(1, $productCompleteness->missingCount());
-        self::assertSame(66, $productCompleteness->ratio());
+        self::assertSame(50, $productCompleteness->ratio());
     }
 
     private function getFamily(string $familycode): ?FamilyInterface

--- a/tests/back/Pim/Structure/Integration/Query/InternalApi/Family/DefaultSqlGetRequiredAttributesMasksIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Query/InternalApi/Family/DefaultSqlGetRequiredAttributesMasksIntegration.php
@@ -55,11 +55,23 @@ final class DefaultSqlGetRequiredAttributesMasksIntegration extends AbstractGetR
             [
                 'code' => 'familyB',
                 'attribute_codes' => ['sku', 'a_non_required_text'],
+                'attribute_requirements' => [
+                    'ecommerce' => ['sku'],
+                    'tablet' => ['sku'],
+                ],
             ],
             [
                 'code' => 'familyC',
                 'attribute_codes' => [],
-            ]
+            ],
+            [
+                'code' => 'familyD',
+                'attribute_codes' => ['sku'],
+                'attribute_requirements' => [
+                    'ecommerce' => [],
+                    'tablet' => [],
+                ],
+            ],
         ]);
     }
 
@@ -88,7 +100,7 @@ final class DefaultSqlGetRequiredAttributesMasksIntegration extends AbstractGetR
             'a_non_localizable_scopable_locale_specific-tablet-<all_locales>',
         ], $tabletEnUS->mask());
 
-        $this->assertEqualsCanonicalizing( [
+        $this->assertEqualsCanonicalizing([
             'sku-<all_channels>-<all_locales>',
             'a_non_localizable_non_scopable_text-<all_channels>-<all_locales>',
             'a_non_localizable_scopable_text-tablet-<all_locales>',
@@ -101,7 +113,7 @@ final class DefaultSqlGetRequiredAttributesMasksIntegration extends AbstractGetR
 
     public function test_the_generated_mask_is_ok_for_a_family_without_requirement()
     {
-        $result = $this->defaultSqlGetRequiredAttributesMasks->fromFamilyCodes(['familyB', 'familyC']);
+        $result = $this->defaultSqlGetRequiredAttributesMasks->fromFamilyCodes(['familyB', 'familyC', 'familyD']);
         Assert::count($result['familyB']->masks(), 3);
         foreach ($result['familyB']->masks() as $maskPerChannelAndLocale) {
             $this->assertEqualsCanonicalizing(['sku-<all_channels>-<all_locales>'], $maskPerChannelAndLocale->mask());
@@ -109,6 +121,11 @@ final class DefaultSqlGetRequiredAttributesMasksIntegration extends AbstractGetR
         Assert::count($result['familyC']->masks(), 3);
         foreach ($result['familyC']->masks() as $maskPerChannelAndLocale) {
             $this->assertEqualsCanonicalizing(['sku-<all_channels>-<all_locales>'], $maskPerChannelAndLocale->mask());
+        }
+
+        Assert::count($result['familyD']->masks(), 3);
+        foreach ($result['familyD']->masks() as $maskPerChannelAndLocale) {
+            $this->assertEqualsCanonicalizing([], $maskPerChannelAndLocale->mask());
         }
     }
 }

--- a/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
@@ -22,7 +22,6 @@ use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
 class FamilyUpdaterSpec extends ObjectBehavior
@@ -164,7 +163,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $family->addAttributeRequirement($nameMobileRqrmt)->shouldBeCalled();
         $family->addAttributeRequirement($descPrintRqrmt)->shouldBeCalled();
         $family->addAttributeRequirement($namePrintRqrmt)->shouldBeCalled();
-        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
+        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldBeCalled();
 
         $attributeRepository->findOneByIdentifier('sku')->willReturn($skuAttribute);
         $attributeRepository->findOneByIdentifier('picture')->willReturn($pictureAttribute);
@@ -232,19 +231,6 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $this->update($family, $values, []);
     }
 
-    function it_does_not_remove_identifier_requirements_when_no_requirements_are_provided(
-        FamilyInterface $family
-    ) {
-        $values = [
-            'code' => 'mycode',
-        ];
-
-        $family->setCode('mycode')->shouldBeCalled();
-        $family->setAttributeRequirements(Argument::any())->shouldNotBeCalled();
-
-        $this->update($family, $values, []);
-    }
-
     function it_does_not_remove_requirements_when_channel_column_is_missing(
         $channelRepository,
         ChannelInterface $mobileChannel,
@@ -287,99 +273,6 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $family->addAttributeRequirement($nameEcommerceRqrmt)->shouldNotBeCalled();
         $family->addAttributeRequirement($skuEcommerceRqrmt)->shouldNotBeCalled();
         $family->addAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
-
-        $this->update($family, $values, []);
-    }
-
-    function it_does_not_remove_identifier_requirements_when_empty_requirements_are_provided(
-        FamilyInterface $family,
-        AttributeRequirementInterface $skuMobileRqrmt,
-        AttributeRequirementInterface $skuPrintRqrmt
-    ) {
-        $values = [
-            'attribute_requirements' => []
-        ];
-        $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
-
-        $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
-        $skuPrintRqrmt->getChannelCode()->willReturn('print');
-
-        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
-        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
-        $family->addAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
-        $family->addAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
-
-        $this->update($family, $values, []);
-    }
-
-    function it_does_not_remove_identifier_requirements_when_other_requirements_are_provided(
-        $attrRequiFactory,
-        $channelRepository,
-        $attributeRepository,
-        $attributeRequirementRepo,
-        FamilyInterface $family,
-        AttributeInterface $skuAttribute,
-        AttributeInterface $nameAttribute,
-        AttributeInterface $descriptionAttribute,
-        AttributeRequirementInterface $skuMobileRqrmt,
-        AttributeRequirementInterface $skuPrintRqrmt,
-        AttributeRequirementInterface $namePrintRqrmt,
-        AttributeRequirementInterface $descPrintRqrmt,
-        ChannelInterface $printChannel
-    ) {
-        $values = [
-            'code'                   => 'mycode',
-            'attribute_requirements' => [
-                'print' => ['name', 'description']
-            ]
-        ];
-
-        $family->setCode('mycode')->shouldBeCalled();
-        $family->getAttributeRequirements()->willReturn([$skuMobileRqrmt, $skuPrintRqrmt]);
-
-        $skuMobileRqrmt->getChannelCode()->willReturn('mobile');
-
-        $skuPrintRqrmt->getChannelCode()->willReturn('print');
-        $skuPrintRqrmt->getAttribute()->willReturn($skuAttribute);
-
-        $skuAttribute->getCode()->willReturn('sku');
-        $skuAttribute->getType()->willReturn(AttributeTypes::IDENTIFIER);
-
-        $family->removeAttributeRequirement($skuMobileRqrmt)->shouldNotBeCalled();
-        $family->removeAttributeRequirement($skuPrintRqrmt)->shouldNotBeCalled();
-
-        $attributeRepository->findOneByIdentifier('name')->willReturn($nameAttribute);
-        $attributeRepository->findOneByIdentifier('description')->willReturn($descriptionAttribute);
-
-        $channelRepository->findOneByIdentifier('print')->willReturn($printChannel);
-
-        $printChannel->getId()->willReturn('1');
-        $nameAttribute->getId()->willReturn('1');
-        $descriptionAttribute->getId()->willReturn('2');
-        $nameAttribute->getType()->willReturn('text');
-        $descriptionAttribute->getType()->willReturn('text');
-        $family->getId()->willReturn('1');
-
-        $attributeRequirementRepo->findOneBy([
-            'attribute' => '1',
-            'channel' => '1',
-            'family' => '1'
-        ])->willReturn(null);
-        $attributeRequirementRepo->findOneBy([
-            'attribute' => '2',
-            'channel' => '1',
-            'family' => '1'
-        ])->willReturn(null);
-
-        $attrRequiFactory->createAttributeRequirement($nameAttribute, $printChannel, true)->willReturn($namePrintRqrmt);
-        $attrRequiFactory->createAttributeRequirement(
-            $descriptionAttribute,
-            $printChannel,
-            true
-        )->willReturn($descPrintRqrmt);
-
-        $family->addAttributeRequirement($namePrintRqrmt)->shouldBeCalled();
-        $family->addAttributeRequirement($descPrintRqrmt)->shouldBeCalled();
 
         $this->update($family, $values, []);
     }
@@ -758,6 +651,7 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $family->setCode('mycode')->shouldBeCalled();
         $nameNewChannelRqrmt->setRequired(true)->shouldBeCalled();
         $family->addAttributeRequirement($nameNewChannelRqrmt)->shouldBeCalled();
+        $family->removeAttributeRequirement($skuNewChannelRqrmt)->shouldBeCalled();
 
         $this->update($family, $data);
     }

--- a/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Updater/FamilyUpdaterSpec.php
@@ -22,6 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
 
 class FamilyUpdaterSpec extends ObjectBehavior
@@ -227,6 +228,19 @@ class FamilyUpdaterSpec extends ObjectBehavior
         $attributeRepository->findOneByIdentifier('description')->willReturn($descAttribute);
 
         $family->updateAttributes([$skuAttribute, $nameAttribute])->shouldBeCalled();
+
+        $this->update($family, $values, []);
+    }
+
+    function it_does_not_remove_identifier_requirements_when_no_requirements_are_provided(
+        FamilyInterface $family
+    ) {
+        $values = [
+            'code' => 'mycode',
+        ];
+
+        $family->setCode('mycode')->shouldBeCalled();
+        $family->setAttributeRequirements(Argument::any())->shouldNotBeCalled();
 
         $this->update($family, $values, []);
     }

--- a/tests/back/Pim/Structure/Specification/Component/Validator/Constraints/FamilyRequirementsValidatorSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Validator/Constraints/FamilyRequirementsValidatorSpec.php
@@ -53,7 +53,7 @@ class FamilyRequirementsValidatorSpec extends ObjectBehavior
         $this->validate($family, $minimumRequirements);
     }
 
-    function it_does_not_validate_families_with_missing_identifier_requirements(
+    function it_validates_families_without_identifier_requirements(
         $attributeRepository,
         $channelRepository,
         $context,
@@ -75,10 +75,7 @@ class FamilyRequirementsValidatorSpec extends ObjectBehavior
 
         $family->getCode()->willReturn('familyCode');
         $context->buildViolation(Argument::any(), Argument::any())
-            ->willReturn($violation)
-            ->shouldBeCalled();
-        $violation->atPath(Argument::any())->willReturn($violation);
-        $violation->addViolation(Argument::any())->shouldBeCalled();
+            ->shouldNotBeCalled();
 
         $this->validate($family, $minimumRequirements);
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

This PR aims to enable the configuration of sku for family attribute requirements.
It can now be enabled or disabled for completeness

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
