### PR TITLE
PIM-10620: Fix export product options values with label to be case insensitive with codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PIM-10598: Fix "Cleaning removed attribute values" job failing if attribute is deleted during mass deletion of products
 - PIM-10595: Fix not being able to add record with code "0" on a product
 - PIM-10588: Add potentially missing `remove_completeness_for_channel_and_locale` job instance
+- PIM-10620: Fix export product options values with label to be case insensitive with codes
 - PIM-10606: Fix computeFamilyVariantStructureChange on attribute removal
 
 ## Improvements

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
@@ -45,7 +45,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionCodes = explode(',', $value);
             $labelizedOptions = array_map(
                 function ($optionCode) use ($attributeCode, $locale, $attributeOptionTranslations) {
-                    $optionKey = sprintf('%s.%s', $attributeCode, $optionCode);
+                    $optionKey = self::generateOptionKey($attributeCode, $optionCode);
 
                     return $attributeOptionTranslations[$optionKey][$locale] ?? sprintf(FlatTranslatorInterface::FALLBACK_PATTERN, $optionCode);
                 },
@@ -67,9 +67,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             }
             $optionCodes = explode(',', $value);
             $currentOptionKeys = array_map(
-                function ($optionCode) use ($attributeCode) {
-                    return sprintf('%s.%s', $attributeCode, $optionCode);
-                },
+                static fn ($optionCode) => self::generateOptionKey($attributeCode, $optionCode),
                 $optionCodes
             );
 
@@ -77,5 +75,10 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
         }
 
         return $optionKeys;
+    }
+
+    private static function generateOptionKey(string $attributeCode, string $optionCode): string
+    {
+        return sprintf('%s.%s', strtolower($attributeCode), strtolower($optionCode));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
@@ -29,13 +29,7 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
 
     public function translate(string $attributeCode, array $properties, array $values, string $locale): array
     {
-        $optionKeys = array_map(
-            function ($value) use ($attributeCode) {
-                return sprintf('%s.%s', $attributeCode, $value);
-            },
-            $values
-        );
-
+        $optionKeys = $this->generateOptionKeys($attributeCode, $values);
         $attributeOptionTranslations = $this->getExistingAttributeOptionsWithValues->fromAttributeCodeAndOptionCodes(
             $optionKeys
         );
@@ -47,11 +41,30 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
                 continue;
             }
 
-            $optionKey = sprintf('%s.%s', $attributeCode, $value);
+            $optionKey = self::generateOptionKey($attributeCode, $value);
             $attributeOptionTranslation = $attributeOptionTranslations[$optionKey][$locale] ?? sprintf(FlatTranslatorInterface::FALLBACK_PATTERN, $value);
             $result[$valueIndex] = $attributeOptionTranslation;
         }
 
         return $result;
+    }
+
+    private function generateOptionKeys(string $attributeCode, array $values): array
+    {
+        $optionKeys = [];
+        foreach ($values as $optionCode) {
+            if (null === $optionCode || '' === $optionCode) {
+                continue;
+            }
+
+            $optionKeys[] = self::generateOptionKey($attributeCode, $optionCode);
+        }
+
+        return array_values(array_unique($optionKeys));
+    }
+
+    private static function generateOptionKey(string $attributeCode, string $optionCode): string
+    {
+        return sprintf('%s.%s', strtolower($attributeCode), strtolower($optionCode));
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
@@ -89,6 +89,26 @@ class MultiSelectTranslatorSpec extends ObjectBehavior
             ->shouldReturn(['[purple],[green]', '[red]']);
     }
 
+    public function it_is_case_insensitive_to_find_options_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $locale = 'fr_FR';
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                $this->optionKey('color', 'red'),
+                $this->optionKey('color', 'yellow'),
+                $this->optionKey('color', 'purple')
+            ])
+            ->willReturn([
+                $this->optionKey('color', 'red')    => [$locale => 'rouge'],
+                $this->optionKey('color', 'yellow') => [$locale => 'jaune'],
+                $this->optionKey('color', 'purple') => [$locale => 'purple']
+            ]);
+
+        $this->translate('color', [], ['ReD,YeLLoW', 'PURPle', ''], $locale)
+            ->shouldReturn(['rouge,jaune', 'purple', '']);
+    }
+
     private function optionKey(string $attributeCode, string $optionCode): string
     {
         return sprintf('%s.%s', $attributeCode, $optionCode);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
@@ -61,6 +61,26 @@ class SimpleSelectTranslatorSpec extends ObjectBehavior
         )->shouldReturn([$redTranslation, $yellowTranslation, $optionWithoutTranslation]);
     }
 
+    function it_is_case_insensitive_to_find_option_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $locale = 'fr_FR';
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                $this->optionKey('color', 'red'),
+                $this->optionKey('color', 'yellow'),
+                $this->optionKey('color', 'purple')
+            ])
+            ->willReturn([
+                $this->optionKey('color', 'red')    => [$locale => 'rouge'],
+                $this->optionKey('color', 'yellow') => [$locale => 'jaune'],
+                $this->optionKey('color', 'purple') => [$locale => 'purple']
+            ]);
+
+        $this->translate('color', [], ['ReD', 'YeLLoW', 'PURPle', ''], $locale)
+            ->shouldReturn(['rouge', 'jaune', 'purple', '']);
+    }
+
     function it_translates_simple_select_value_with_numeric_label(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

- be case insensitive when retrieving option labels to mimic MySQL behavior

**Definition Of Done (for Core Developer only)**
- [x] Tests
- [x] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
