### PR TITLE
CPM-522: Fix coupling detector

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -59,6 +59,9 @@ catalogs-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect \
 		--config-file=$(CATALOGS_PATH)/back/.php_cd.php \
 		$(CATALOGS_PATH)/back/src
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements \
+		--config-file=$(CATALOGS_PATH)/back/.php_cd.php \
+		$(CATALOGS_PATH)/back/src
 
 .PHONY: catalogs-unit-back
 catalogs-unit-back:

--- a/components/catalogs/back/.php_cd.php
+++ b/components/catalogs/back/.php_cd.php
@@ -15,7 +15,6 @@ $rules = [
     $builder->only(
         [
             'Akeneo\Catalogs\Domain',
-            'Akeneo\Catalogs\ServiceAPI\Model',
         ]
     )->in('Akeneo\Catalogs\Domain'),
 

--- a/composer.json
+++ b/composer.json
@@ -149,7 +149,7 @@
         "webmozart/assert": "1.9.1"
     },
     "require-dev": {
-        "akeneo/php-coupling-detector": "^0.7.0",
+        "akeneo/php-coupling-detector": "^0.8.1",
         "behat/mink-selenium2-driver": "^v1.5.0",
         "dvdoug/behat-code-coverage": "^5.2.1",
         "friends-of-behat/mink": "^v1.9.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5fbfab132ae6e523e62ab9b11dbcc02",
+    "content-hash": "7ae3f390405c1e447230da0a534f4983",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -11546,29 +11546,29 @@
     "packages-dev": [
         {
             "name": "akeneo/php-coupling-detector",
-            "version": "v0.7.1",
+            "version": "v0.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/akeneo/php-coupling-detector.git",
-                "reference": "7dce8d4541b2675d4632384090c53dbace2f6de2"
+                "reference": "8141a08421c114f23ad8ec4ee307dea18f643377"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/akeneo/php-coupling-detector/zipball/7dce8d4541b2675d4632384090c53dbace2f6de2",
-                "reference": "7dce8d4541b2675d4632384090c53dbace2f6de2",
+                "url": "https://api.github.com/repos/akeneo/php-coupling-detector/zipball/8141a08421c114f23ad8ec4ee307dea18f643377",
+                "reference": "8141a08421c114f23ad8ec4ee307dea18f643377",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^2.1||^3.0",
-                "php": "^7.2||8.0.*",
-                "symfony/console": "^4.4||^5.0",
-                "symfony/event-dispatcher": "^4.4||^5.0",
-                "symfony/filesystem": "^4.4||^5.0",
-                "symfony/finder": "^4.4||^5.0"
+                "php": "^7.2||^8.0",
+                "symfony/console": "^4.4||^5.0||^6.0",
+                "symfony/event-dispatcher": "^4.4||^5.0||^6.0",
+                "symfony/filesystem": "^4.4||^5.0||^6.0",
+                "symfony/finder": "^4.4||^5.0||^6.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
-                "phpstan/phpstan": "^0.12.0"
+                "phpspec/phpspec": "^7.0",
+                "phpstan/phpstan": "^1.0"
             },
             "bin": [
                 "bin/php-coupling-detector"
@@ -11601,9 +11601,9 @@
             "description": "Detect all the coupling issues of your project with respect to the coupling rules you have defined.",
             "support": {
                 "issues": "https://github.com/akeneo/php-coupling-detector/issues",
-                "source": "https://github.com/akeneo/php-coupling-detector/tree/v0.7.1"
+                "source": "https://github.com/akeneo/php-coupling-detector/tree/v0.8.1"
             },
-            "time": "2022-01-07T10:22:35+00:00"
+            "time": "2022-09-09T15:49:15+00:00"
         },
         {
             "name": "amphp/amp",

--- a/make-file/category.mk
+++ b/make-file/category.mk
@@ -10,6 +10,7 @@ category-lint-fix-back: #Doc: launch PHPStan for category bounded context
 .PHONY: category-coupling-back
 category-coupling-back: #Doc: launch coupling detector for category bounded context
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Category/back/tests/.php_cd.php src/Akeneo/Category/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Category/back/tests/.php_cd.php src/Akeneo/Category/back
 
 .PHONY: category-unit-back
 category-unit-back: #Doc: launch PHPSpec for category bounded context

--- a/make-file/channel.mk
+++ b/make-file/channel.mk
@@ -10,6 +10,7 @@ channel-lint-fix-back: #Doc: launch PHPStan for channel bounded context
 .PHONY: channel-coupling-back
 channel-coupling-back: #Doc: launch coupling detector for channel bounded context
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Channel/back/tests/.php_cd.php src/Akeneo/Channel/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Channel/back/tests/.php_cd.php src/Akeneo/Channel/back
 
 .PHONY: channel-unit-back
 channel-unit-back: #Doc: launch PHPSpec for channel bounded context

--- a/make-file/communication-channel.mk
+++ b/make-file/communication-channel.mk
@@ -62,6 +62,7 @@ communication-channel-lint-back:
 
 communication-channel-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/.php_cd.php src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back
 
 communication-channel-unit-back:
 	$(PHP_RUN) vendor/bin/phpspec run src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Unit/spec/

--- a/make-file/connectivity-connection.mk
+++ b/make-file/connectivity-connection.mk
@@ -59,6 +59,7 @@ _PERMISSION_FORM_YARN_RUN = $(YARN_RUN) run --cwd=src/Akeneo/Connectivity/Connec
 
 connectivity-connection-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php src/Akeneo/Connectivity/Connection/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php src/Akeneo/Connectivity/Connection/back
 
 connectivity-connection-lint-back:
 ifneq ($(CI),true)

--- a/make-file/data-quality-insights.mk
+++ b/make-file/data-quality-insights.mk
@@ -59,6 +59,7 @@
 .PHONY: data-quality-insights-coupling-back
 data-quality-insights-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php src/Akeneo/Pim/Automation/DataQualityInsights
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Pim/Automation/DataQualityInsights/tests/back/.php_cd.php src/Akeneo/Pim/Automation/DataQualityInsights
 
 .PHONY: data-quality-insights-phpstan
 data-quality-insights-phpstan: var/cache/dev

--- a/make-file/enrichment-product.mk
+++ b/make-file/enrichment-product.mk
@@ -1,9 +1,7 @@
 .PHONY: enrichment-product-coupling-back
 enrichment-product-coupling-back:
-	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back/API
-	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back/Application
-	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back/Domain
-	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back/Infrastructure
+	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php src/Akeneo/Pim/Enrichment/Product/back
 
 .PHONY: enrichment-product-static-back
 enrichment-product-static-back:

--- a/make-file/enrichment.mk
+++ b/make-file/enrichment.mk
@@ -55,6 +55,7 @@
 .PHONY: enrichment-coupling-back
 enrichment-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Enrichment/.php_cd.php src/Akeneo/Pim/Enrichment
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Pim/Enrichment/.php_cd.php src/Akeneo/Pim/Enrichment
 
 .PHONY: enrichment-lint-back
 enrichment-lint-back:

--- a/make-file/import-export.mk
+++ b/make-file/import-export.mk
@@ -10,6 +10,7 @@ import-export-lint-fix-back: #Doc: launch PHPStan for ImportExport bounded conte
 .PHONY: import-export-coupling-back
 import-export-coupling-back: #Doc: launch coupling detector for ImportExport bounded context
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php src/Akeneo/Platform/Bundle/ImportExportBundle
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php src/Akeneo/Platform/Bundle/ImportExportBundle
 
 .PHONY: import-export-unit-back
 import-export-unit-back: #Doc: launch PHPSpec for ImportExport bounded context

--- a/make-file/job.mk
+++ b/make-file/job.mk
@@ -12,6 +12,7 @@ job-lint-fix-back: #Doc: launch PHPStan for job bounded context
 .PHONY: job-coupling-back
 job-coupling-back: #Doc: launch coupling detector for job bounded context
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Platform/Job/back/tests/.php_cd.php src/Akeneo/Platform/Job/back
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Platform/Job/back/tests/.php_cd.php src/Akeneo/Platform/Job/back
 
 .PHONY: job-unit-back
 job-unit-back: #Doc: launch PHPSpec for job bounded context

--- a/make-file/structure.mk
+++ b/make-file/structure.mk
@@ -55,3 +55,4 @@
 .PHONY: structure-coupling-back
 structure-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/Pim/Structure/.php_cd.php src/Akeneo/Pim/Structure
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/Pim/Structure/.php_cd.php src/Akeneo/Pim/Structure

--- a/make-file/test.mk
+++ b/make-file/test.mk
@@ -8,6 +8,7 @@ find-legacy-translations:
 .PHONY: coupling-back
 coupling-back: structure-coupling-back user-management-coupling-back channel-coupling-back enrichment-coupling-back connectivity-connection-coupling-back communication-channel-coupling-back import-export-coupling-back job-coupling-back data-quality-insights-coupling-back enrichment-product-coupling-back
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=upgrades/.php_cd.php upgrades/schema
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=upgrades/.php_cd.php upgrades/schema
 
 ### Static tests
 static-back: check-pullup check-sf-services enrichment-product-static-back

--- a/make-file/user-management.mk
+++ b/make-file/user-management.mk
@@ -59,6 +59,7 @@ user-management-unit-back: #Doc: launch PHPSpec for user-management bounded cont
 .PHONY: user-management-coupling-back
 user-management-coupling-back:
 	$(PHP_RUN) vendor/bin/php-coupling-detector detect --config-file=src/Akeneo/UserManagement/.php_cd.php src/Akeneo/UserManagement
+	$(PHP_RUN) vendor/bin/php-coupling-detector list-unused-requirements --config-file=src/Akeneo/UserManagement/.php_cd.php src/Akeneo/UserManagement
 
 .PHONY: user-management-integration-back
 user-management-integration-back: #Doc: launch PHPUnit integration tests for user-management bounded context

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -142,7 +142,6 @@ $rules = [
             'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
             'Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface',
 
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
             'Akeneo\Platform\Bundle\FrameworkBundle\Service\PimUrl',
             'Akeneo\Platform\Component\EventQueue\BulkEventInterface',
             'Akeneo\Platform\Component\EventQueue\EventInterface',
@@ -174,7 +173,6 @@ $rules = [
 
             'Akeneo\Connectivity\Connection\Domain\ClockInterface',
 
-            'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\User',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\Read\ConnectionWithCredentials',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\Write\Connection',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\FlowType',
@@ -190,8 +188,6 @@ $rules = [
 
             'Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\ClientProviderInterface',
             'Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperRegistry',
-
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag',
 
             'Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface',
             'Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface',
@@ -261,7 +257,7 @@ $rules = [
             'Symfony\Component\Validator\ConstraintValidator',
             'Symfony\Component\Validator\Exception\UnexpectedTypeException',
         ]
-    )->in('Akeneo\Connectiettings/Command/CreateConnectionHandler.php vity\Connection\Application\Settings'),
+    )->in('Akeneo\Connectivity\Connection\Application\Settings'),
 
     $builder->only(
         [

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -36,8 +36,6 @@ $rules = [
         // TODO: dependencies related to the front end, remove twig screens
         'Twig',
         'Akeneo\Pim\Enrichment\Product\API',
-        // TODO: CPM-714
-        'Akeneo\Pim\Enrichment\Product\Domain\Query\GetProductUuids',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',
@@ -53,8 +51,6 @@ $rules = [
 
         // TIP-1005: Clean UI form types
         'Akeneo\Platform\Bundle\UIBundle\Form\Type\ObjectIdentifierType',
-        'Akeneo\Platform\Bundle\UIBundle\Form\Type\TranslatableFieldType',
-        'Akeneo\Platform\Bundle\UIBundle\Form\Subscriber\DisableFieldSubscriber',
 
         // TODO: EASY PICK! it should be registered in the structure bundle
         'Akeneo\Pim\Structure\Bundle\DependencyInjection\Compiler\RegisterAttributeTypePass',
@@ -130,13 +126,10 @@ $rules = [
         'Akeneo\Category\Api', // legit
         'Akeneo\Category\Infrastructure\Component\Model\CategoryInterface',
         'Akeneo\Category\Infrastructure\Component\Model\Category',
-        'Akeneo\Category\Infrastructure\Component\CategoryTree\ReadModel\RootCategory',//todo
         'Akeneo\Category\Infrastructure\Component\Classification\Model\CategoryInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\Repository\CategoryRepositoryInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\Repository\ItemCategoryRepositoryInterface',
-        'Akeneo\Category\Infrastructure\Component\Classification\CategoryAwareInterface',
         'Akeneo\Category\Infrastructure\Symfony\Form\CategoryFormViewNormalizerInterface',
-        'Akeneo\Category\Infrastructure\Component\CategoryTree\Normalizer\RootCategory',//todo
     ])->in('Akeneo\Pim\Enrichment\Bundle'),
     $builder->only([
         'Symfony\Component',
@@ -265,12 +258,9 @@ $rules = [
         'Akeneo\Platform\Bundle\NotificationBundle\NotifierInterface',
 
         'Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperInterface',
-        'Akeneo\Pim\Enrichment\Bundle\Storage\Sql\Product\SqlFindProductUuids',
 
         // Category Bounded Context
-        'Akeneo\Category\Api', // legit
         'Akeneo\Category\Infrastructure\Component\Model\CategoryInterface',
-        'Akeneo\Category\Infrastructure\Component\CategoryTree\ReadModel\RootCategory',//todo
         'Akeneo\Category\Infrastructure\Component\Classification\Model\CategoryInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\Repository\ItemCategoryRepositoryInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\CategoryAwareInterface',

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
@@ -4,7 +4,8 @@ use Akeneo\CouplingDetector\Configuration\Configuration;
 use Akeneo\CouplingDetector\Configuration\DefaultFinder;
 use Akeneo\CouplingDetector\RuleBuilder;
 
-$finder = new DefaultFinder();
+$finder = (new DefaultFinder())
+    ->exclude('Test');
 $builder = new RuleBuilder();
 
 $rules = [
@@ -29,8 +30,6 @@ $rules = [
         'Akeneo\Pim\Structure\Component\AttributeTypes',
         'Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException',
         'Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException',
-        'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface',
-        'Akeneo\Pim\Structure\Component\AttributeTypes',
         'Ramsey\Uuid\UuidInterface',
 
         // API
@@ -54,7 +53,6 @@ $rules = [
 
         // Public APIs
         'Akeneo\Pim\Structure\Component\AttributeTypes',
-        'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface',
 
         // TODO: remove when Upsert product does not use token interface
         'Akeneo\UserManagement\Component\Model\UserInterface',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Test/.php_cd.php
@@ -15,15 +15,11 @@ $rules = [
         [
             // We should not need to be coupled with Application layer
             'Akeneo\Platform\Bundle\ImportExportBundle\Application\TransferFilesToStorage\FileToTransfer',
-
-            'Webmozart\Assert\Assert',
         ],
     )->in('Akeneo\Platform\Bundle\ImportExportBundle\Domain'),
     $builder->only(
         [
             'Akeneo\Platform\Bundle\ImportExportBundle\Domain',
-
-            'Webmozart\Assert\Assert',
         ],
     )->in('Akeneo\Platform\Bundle\ImportExportBundle\Application'),
     $builder->only(
@@ -31,15 +27,12 @@ $rules = [
             'Akeneo\Platform\Bundle\ImportExportBundle\Application',
             'Akeneo\Platform\Bundle\ImportExportBundle\Domain',
 
-            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags',
-            'Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface',
             'Akeneo\UserManagement\ServiceApi',
             'Akeneo\Tool',
 
             'League\Flysystem',
             'Symfony\Component',
             'Symfony\Contracts',
-            'Webmozart\Assert\Assert',
         ],
     )->in('Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure'),
 ];

--- a/src/Akeneo/Platform/Job/back/tests/.php_cd.php
+++ b/src/Akeneo/Platform/Job/back/tests/.php_cd.php
@@ -18,9 +18,7 @@ $rules = [
         ],
     )->in('Akeneo\Platform\Job\Application'),
     $builder->only(
-        [
-            'Webmozart\Assert\Assert',
-        ],
+        [],
     )->in('Akeneo\Platform\Job\Domain'),
     $builder->only(
         [

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -18,8 +18,6 @@ $rules = [
         'Webmozart\Assert\Assert',
         // TODO: The feature uses the datagrid
         'Oro\Bundle\PimDataGridBundle',
-        //PIM-9806
-        'Doctrine\ORM\Mapping',
 
         // TIP-945: User Management should not depend on Channel and Enrichment
         'Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface',
@@ -85,7 +83,7 @@ $rules = [
         'Twig\Environment',
         'Throwable',
         'Psr\Log\LoggerInterface',
-        
+
         // These files moved from Tool to Category bounded context
         // Usermanagement BC should query BC via exposed Commands
         // Ticket created : GRF-180

--- a/upgrades/.php_cd.php
+++ b/upgrades/.php_cd.php
@@ -53,7 +53,6 @@ $rules = [
             'Symfony\Component\Console\Command\Command',
             'Symfony\Component\Console\Input\ArrayInput',
             'Symfony\Component\Console\Output\BufferedOutput',
-            'Symfony\Component\Console\Output\NullOutput',
             'Symfony\Component\DependencyInjection\ParameterBag\ParameterBag',
             'Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity',
             'Webmozart\Assert\Assert',


### PR DESCRIPTION
**Unused coupling ?**

When a developer adds a dependency in a namespace, he have to add it in a dependency list.
A big job was done to plan how to remove (or decrease) these dependencies.
The issue is that the already-fixed dependencies are not always removed from the dependency list.
Having this dependency add some dirt and does not help us on focusing on a removal of a dependency.
This PR adds a step in the coupling detector step, to ensure there are no unused dependency on any context.


This PR
- Avoid to list all directories except "Test" one on Enrichment one
- Adds a step to check unused coupling
- Removes unused coupling
