### PR TITLE
OCT-119: Events with UUID

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -24,30 +24,15 @@ use Psr\Log\LoggerInterface;
  */
 class SendBusinessEventToWebhooksHandler
 {
-    private SelectActiveWebhooksQueryInterface $selectActiveWebhooksQuery;
-    private WebhookUserAuthenticator $webhookUserAuthenticator;
-    private WebhookClientInterface $client;
-    private WebhookEventBuilder $builder;
-    private LoggerInterface $logger;
-    private EventSubscriptionSkippedOwnEventLoggerInterface $eventSubscriptionSkippedOwnEventLogger;
-    private string $pimSource;
-
     public function __construct(
-        SelectActiveWebhooksQueryInterface $selectActiveWebhooksQuery,
-        WebhookUserAuthenticator $webhookUserAuthenticator,
-        WebhookClientInterface $client,
-        WebhookEventBuilder $builder,
-        LoggerInterface $logger,
-        EventSubscriptionSkippedOwnEventLoggerInterface $eventSubscriptionSkippedOwnEventLogger,
-        string $pimSource
+        private SelectActiveWebhooksQueryInterface $selectActiveWebhooksQuery,
+        private WebhookUserAuthenticator $webhookUserAuthenticator,
+        private WebhookClientInterface $client,
+        private WebhookEventBuilder $builder,
+        private LoggerInterface $logger,
+        private EventSubscriptionSkippedOwnEventLoggerInterface $eventSubscriptionSkippedOwnEventLogger,
+        private string $pimSource
     ) {
-        $this->selectActiveWebhooksQuery = $selectActiveWebhooksQuery;
-        $this->webhookUserAuthenticator = $webhookUserAuthenticator;
-        $this->client = $client;
-        $this->builder = $builder;
-        $this->logger = $logger;
-        $this->eventSubscriptionSkippedOwnEventLogger = $eventSubscriptionSkippedOwnEventLogger;
-        $this->pimSource = $pimSource;
     }
 
     public function handle(SendBusinessEventToWebhooksCommand $command): void
@@ -80,7 +65,7 @@ class SendBusinessEventToWebhooksHandler
                             'user' => $user,
                             'pim_source' => $this->pimSource,
                             'connection_code' => $webhook->connectionCode(),
-                            'use_uuid' => $webhook->usesUuid(),
+                            'is_using_uuid' => $webhook->isUsingUuid(),
                         ]
                     );
 

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/SendBusinessEventToWebhooksHandler.php
@@ -80,6 +80,7 @@ class SendBusinessEventToWebhooksHandler
                             'user' => $user,
                             'pim_source' => $this->pimSource,
                             'connection_code' => $webhook->connectionCode(),
+                            'use_uuid' => $webhook->usesUuid(),
                         ]
                     );
 

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookCommand.php
@@ -10,17 +10,12 @@ namespace Akeneo\Connectivity\Connection\Application\Webhook\Command;
  */
 class UpdateWebhookCommand
 {
-    private string $code;
-
-    private bool $enabled;
-
-    private ?string $url;
-
-    public function __construct(string $code, bool $enabled, ?string $url = null)
-    {
-        $this->code = $code;
-        $this->enabled = $enabled;
-        $this->url = $url;
+    public function __construct(
+        private string $code,
+        private bool $enabled,
+        private ?string $url = null,
+        private bool $usesUuid = false,
+    ) {
     }
 
     public function code(): string
@@ -36,5 +31,10 @@ class UpdateWebhookCommand
     public function url(): ?string
     {
         return $this->url;
+    }
+
+    public function usesUuid(): bool
+    {
+        return $this->usesUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookCommand.php
@@ -14,7 +14,7 @@ class UpdateWebhookCommand
         private string $code,
         private bool $enabled,
         private ?string $url = null,
-        private bool $usesUuid = false,
+        private bool $isUsingUuid = false,
     ) {
     }
 
@@ -33,8 +33,8 @@ class UpdateWebhookCommand
         return $this->url;
     }
 
-    public function usesUuid(): bool
+    public function isUsingUuid(): bool
     {
-        return $this->usesUuid;
+        return $this->isUsingUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookHandler.php
@@ -33,7 +33,7 @@ class UpdateWebhookHandler
             $connectionCode,
             $command->enabled(),
             $command->url(),
-            $command->usesUuid()
+            $command->isUsingUuid()
         );
 
         $violations = $this->validator->validate($webhook);

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookHandler.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Command/UpdateWebhookHandler.php
@@ -29,7 +29,12 @@ class UpdateWebhookHandler
     {
         $connectionCode = $command->code();
 
-        $webhook = new ConnectionWebhook($connectionCode, $command->enabled(), $command->url());
+        $webhook = new ConnectionWebhook(
+            $connectionCode,
+            $command->enabled(),
+            $command->url(),
+            $command->usesUuid()
+        );
 
         $violations = $this->validator->validate($webhook);
         if (0 !== $violations->count()) {

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
@@ -22,19 +22,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class WebhookEventBuilder
 {
-    /** @var iterable<EventDataBuilderInterface> */
-    private iterable $eventDataBuilders;
-    private ApiEventBuildErrorLoggerInterface $apiEventBuildErrorLogger;
-
     /**
      * @param iterable<EventDataBuilderInterface> $eventDataBuilders
      */
     public function __construct(
-        iterable $eventDataBuilders,
-        ApiEventBuildErrorLoggerInterface $apiEventBuildErrorLogger
+        private iterable $eventDataBuilders,
+        private ApiEventBuildErrorLoggerInterface $apiEventBuildErrorLogger
     ) {
-        $this->eventDataBuilders = $eventDataBuilders;
-        $this->apiEventBuildErrorLogger = $apiEventBuildErrorLogger;
     }
 
     /**
@@ -49,11 +43,11 @@ class WebhookEventBuilder
 
         /** @var UserInterface $user */
         $user = $context['user'];
-        $useUuid = $context['use_uuid'] ?? false;
+        $isUsingUuid = $context['is_using_uuid'] ?? false;
 
         $eventDataCollection = $eventDataBuilder->build(
             $pimEventBulk,
-            new Context($user->getUsername(), $user->getId(), $useUuid)
+            new Context($user->getUsername(), $user->getId(), $isUsingUuid)
         );
 
         return $this->buildWebhookEvents(
@@ -71,11 +65,11 @@ class WebhookEventBuilder
     private function resolveOptions(array $options): array
     {
         $resolver = new OptionsResolver();
-        $resolver->setRequired(['user', 'pim_source', 'connection_code', 'use_uuid']);
+        $resolver->setRequired(['user', 'pim_source', 'connection_code', 'is_using_uuid']);
         $resolver->setAllowedTypes('user', UserInterface::class);
         $resolver->setAllowedTypes('pim_source', 'string');
         $resolver->setAllowedTypes('connection_code', 'string');
-        $resolver->setAllowedTypes('use_uuid', 'bool');
+        $resolver->setAllowedTypes('is_using_uuid', 'bool');
 
         return $resolver->resolve($options);
     }

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
@@ -43,11 +43,10 @@ class WebhookEventBuilder
 
         /** @var UserInterface $user */
         $user = $context['user'];
-        $isUsingUuid = $context['is_using_uuid'] ?? false;
 
         $eventDataCollection = $eventDataBuilder->build(
             $pimEventBulk,
-            new Context($user->getUsername(), $user->getId(), $isUsingUuid)
+            new Context($user->getUsername(), $user->getId(), $context['is_using_uuid'])
         );
 
         return $this->buildWebhookEvents(

--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
@@ -49,10 +49,11 @@ class WebhookEventBuilder
 
         /** @var UserInterface $user */
         $user = $context['user'];
+        $useUuid = $context['use_uuid'] ?? false;
 
         $eventDataCollection = $eventDataBuilder->build(
             $pimEventBulk,
-            new Context($user->getUsername(), $user->getId())
+            new Context($user->getUsername(), $user->getId(), $useUuid)
         );
 
         return $this->buildWebhookEvents(
@@ -70,10 +71,11 @@ class WebhookEventBuilder
     private function resolveOptions(array $options): array
     {
         $resolver = new OptionsResolver();
-        $resolver->setRequired(['user', 'pim_source', 'connection_code']);
+        $resolver->setRequired(['user', 'pim_source', 'connection_code', 'use_uuid']);
         $resolver->setAllowedTypes('user', UserInterface::class);
         $resolver->setAllowedTypes('pim_source', 'string');
         $resolver->setAllowedTypes('connection_code', 'string');
+        $resolver->setAllowedTypes('use_uuid', 'bool');
 
         return $resolver->resolve($options);
     }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ActiveWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ActiveWebhook.php
@@ -16,7 +16,7 @@ class ActiveWebhook
         private int $userId,
         private string $secret,
         private string $url,
-        private bool $usesUuid,
+        private bool $isUsingUuid,
     ) {
     }
 
@@ -40,8 +40,8 @@ class ActiveWebhook
         return $this->url;
     }
 
-    public function usesUuid(): bool
+    public function isUsingUuid(): bool
     {
-        return $this->usesUuid;
+        return $this->isUsingUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ActiveWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ActiveWebhook.php
@@ -11,24 +11,13 @@ namespace Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read;
  */
 class ActiveWebhook
 {
-    private string $connectionCode;
-
-    private int $userId;
-
-    private string $secret;
-
-    private string $url;
-
     public function __construct(
-        string $connectionCode,
-        int $userId,
-        string $secret,
-        string $url
+        private string $connectionCode,
+        private int $userId,
+        private string $secret,
+        private string $url,
+        private bool $usesUuid,
     ) {
-        $this->connectionCode = $connectionCode;
-        $this->userId = $userId;
-        $this->secret = $secret;
-        $this->url = $url;
     }
 
     public function connectionCode(): string
@@ -49,5 +38,10 @@ class ActiveWebhook
     public function url(): string
     {
         return $this->url;
+    }
+
+    public function usesUuid(): bool
+    {
+        return $this->usesUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
@@ -11,24 +11,13 @@ namespace Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read;
  */
 class ConnectionWebhook
 {
-    private string $connectionCode;
-
-    private ?string $secret;
-
-    private ?string $url;
-
-    private bool $enabled;
-
     public function __construct(
-        string $connectionCode,
-        bool $enabled,
-        ?string $secret = null,
-        ?string $url = null
+        private string $connectionCode,
+        private bool $enabled,
+        private ?string $secret = null,
+        private ?string $url = null,
+        private bool $usesUuid = false,
     ) {
-        $this->enabled = $enabled;
-        $this->connectionCode = $connectionCode;
-        $this->secret = $secret;
-        $this->url = $url;
     }
 
     public function connectionCode(): string
@@ -51,12 +40,18 @@ class ConnectionWebhook
         return $this->enabled;
     }
 
+    public function usesUuid(): bool
+    {
+        return $this->usesUuid;
+    }
+
     /**
      * @return array{
      *  connectionCode: string,
      *  enabled: boolean,
      *  secret: ?string,
      *  url: ?string,
+     *  usesUuid: boolean,
      * }
      */
     public function normalize(): array
@@ -66,6 +61,7 @@ class ConnectionWebhook
             'enabled' => $this->enabled(),
             'secret' => $this->secret(),
             'url' => $this->url(),
+            'usesUuid' => $this->usesUuid(),
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/ConnectionWebhook.php
@@ -16,7 +16,7 @@ class ConnectionWebhook
         private bool $enabled,
         private ?string $secret = null,
         private ?string $url = null,
-        private bool $usesUuid = false,
+        private bool $isUsingUuid = false,
     ) {
     }
 
@@ -40,9 +40,9 @@ class ConnectionWebhook
         return $this->enabled;
     }
 
-    public function usesUuid(): bool
+    public function isUsingUuid(): bool
     {
-        return $this->usesUuid;
+        return $this->isUsingUuid;
     }
 
     /**
@@ -51,7 +51,7 @@ class ConnectionWebhook
      *  enabled: boolean,
      *  secret: ?string,
      *  url: ?string,
-     *  usesUuid: boolean,
+     *  isUsingUuid: boolean,
      * }
      */
     public function normalize(): array
@@ -61,7 +61,7 @@ class ConnectionWebhook
             'enabled' => $this->enabled(),
             'secret' => $this->secret(),
             'url' => $this->url(),
-            'usesUuid' => $this->usesUuid(),
+            'isUsingUuid' => $this->isUsingUuid(),
         ];
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
@@ -30,7 +30,8 @@ class EventSubscriptionFormData
      *      connectionCode: string,
      *      enabled: boolean,
      *      secret: ?string,
-     *      url: ?string
+     *      url: ?string,
+     *      usesUuid: boolean,
      *  },
      *  active_event_subscriptions_limit: array{
      *      limit: int,

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Read/EventSubscriptionFormData.php
@@ -10,18 +10,11 @@ namespace Akeneo\Connectivity\Connection\Domain\Webhook\Model\Read;
  */
 class EventSubscriptionFormData
 {
-    private ConnectionWebhook $eventSubscription;
-    private int $activeEventSubscriptionsLimit;
-    private int $activeEventSubscriptionsCount;
-
     public function __construct(
-        ConnectionWebhook $eventSubscription,
-        int $activeEventSubscriptionsLimit,
-        int $activeEventSubscriptionsCount
+        private ConnectionWebhook $eventSubscription,
+        private int $activeEventSubscriptionsLimit,
+        private int $activeEventSubscriptionsCount
     ) {
-        $this->eventSubscription = $eventSubscription;
-        $this->activeEventSubscriptionsLimit = $activeEventSubscriptionsLimit;
-        $this->activeEventSubscriptionsCount = $activeEventSubscriptionsCount;
     }
 
     /**
@@ -31,7 +24,7 @@ class EventSubscriptionFormData
      *      enabled: boolean,
      *      secret: ?string,
      *      url: ?string,
-     *      usesUuid: boolean,
+     *      isUsingUuid: boolean,
      *  },
      *  active_event_subscriptions_limit: array{
      *      limit: int,

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Write/ConnectionWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Write/ConnectionWebhook.php
@@ -18,7 +18,7 @@ class ConnectionWebhook
         private string $code,
         private bool $enabled,
         ?string $url = null,
-        private bool $usesUuid = false,
+        private bool $isUsingUuid = false,
     ) {
         $this->url = $url ? new Url($url) : null;
     }
@@ -38,8 +38,8 @@ class ConnectionWebhook
         return $this->url;
     }
 
-    public function usesUuid(): bool
+    public function isUsingUuid(): bool
     {
-        return $this->usesUuid;
+        return $this->isUsingUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Write/ConnectionWebhook.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Model/Write/ConnectionWebhook.php
@@ -12,16 +12,14 @@ use Akeneo\Connectivity\Connection\Domain\ValueObject\Url;
  */
 class ConnectionWebhook
 {
-    private string $code;
-
-    private bool $enabled;
-
     private ?Url $url = null;
 
-    public function __construct(string $code, bool $enabled, ?string $url = null)
-    {
-        $this->code = $code;
-        $this->enabled = $enabled;
+    public function __construct(
+        private string $code,
+        private bool $enabled,
+        ?string $url = null,
+        private bool $usesUuid = false,
+    ) {
         $this->url = $url ? new Url($url) : null;
     }
 
@@ -38,5 +36,10 @@ class ConnectionWebhook
     public function url(): ?Url
     {
         return $this->url;
+    }
+
+    public function usesUuid(): bool
+    {
+        return $this->usesUuid;
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Connections/Install/CreateConnectionTableQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Connections/Install/CreateConnectionTableQuery.php
@@ -30,7 +30,7 @@ final class CreateConnectionTableQuery
         webhook_url VARCHAR(255) NULL,
         webhook_secret VARCHAR(255) NULL,
         webhook_enabled TINYINT(1) DEFAULT 0 NOT NULL,
-        webhook_uses_uuid TINYINT(1) DEFAULT 0 NOT NULL,
+        webhook_is_using_uuid TINYINT(1) DEFAULT 0 NOT NULL,
         type VARCHAR(30) NOT NULL DEFAULT 'default',
         CONSTRAINT FK_CONNECTIVITY_CONNECTION_client_id FOREIGN KEY (client_id) REFERENCES pim_api_client (id),
         CONSTRAINT FK_CONNECTIVITY_CONNECTION_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id)

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Connections/Install/CreateConnectionTableQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Connections/Install/CreateConnectionTableQuery.php
@@ -17,7 +17,7 @@ final class CreateConnectionTableQuery
      * The anonymization script for cloned PIM instances must be updated after any change on the structure.
      * See `pim-enterprise-dev/deployments/bin/clone_serenity.sh`.
      */
-    const QUERY = <<<'SQL'
+    public const QUERY = <<<'SQL'
     CREATE TABLE IF NOT EXISTS akeneo_connectivity_connection(
         client_id INT NOT NULL UNIQUE,
         user_id INT NOT NULL,
@@ -30,6 +30,7 @@ final class CreateConnectionTableQuery
         webhook_url VARCHAR(255) NULL,
         webhook_secret VARCHAR(255) NULL,
         webhook_enabled TINYINT(1) DEFAULT 0 NOT NULL,
+        webhook_uses_uuid TINYINT(1) DEFAULT 0 NOT NULL,
         type VARCHAR(30) NOT NULL DEFAULT 'default',
         CONSTRAINT FK_CONNECTIVITY_CONNECTION_client_id FOREIGN KEY (client_id) REFERENCES pim_api_client (id),
         CONSTRAINT FK_CONNECTIVITY_CONNECTION_user_id FOREIGN KEY (user_id) REFERENCES oro_user (id)

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -483,7 +483,7 @@ akeneo_connectivity.connection:
             url: URL
             secret: Secret
             enabled: Event subscription activation
-            uses_uuid: Use product UUID instead of product identifier?
+            is_using_uuid: Use product UUID instead of product identifier?
             test: Test
         error:
             wrong_url: This value is not a valid URL.

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -483,6 +483,7 @@ akeneo_connectivity.connection:
             url: URL
             secret: Secret
             enabled: Event subscription activation
+            uses_uuid: Use product UUID instead of product identifier?
             test: Test
         error:
             wrong_url: This value is not a valid URL.

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Controller/Internal/UpdateWebhookAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Controller/Internal/UpdateWebhookAction.php
@@ -34,7 +34,8 @@ final class UpdateWebhookAction
                 new UpdateWebhookCommand(
                     $request->get('code', ''),
                     $request->get('enabled'),
-                    $request->get('url')
+                    $request->get('url'),
+                    $request->get('uses_uuid', false),
                 )
             );
         } catch (ConnectionWebhookNotFoundException $webhookNotFoundException) {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Controller/Internal/UpdateWebhookAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Controller/Internal/UpdateWebhookAction.php
@@ -35,7 +35,7 @@ final class UpdateWebhookAction
                     $request->get('code', ''),
                     $request->get('enabled'),
                     $request->get('url'),
-                    $request->get('uses_uuid', false),
+                    $request->get('is_using_uuid', false),
                 )
             );
         } catch (ConnectionWebhookNotFoundException $webhookNotFoundException) {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalGetAConnectionWebhookQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalGetAConnectionWebhookQuery.php
@@ -25,7 +25,7 @@ class DbalGetAConnectionWebhookQuery implements GetAConnectionWebhookQueryInterf
     public function execute(string $code): ?ConnectionWebhook
     {
         $query = <<<SQL
-            SELECT code, webhook_secret, webhook_url, webhook_enabled, webhook_uses_uuid
+            SELECT code, webhook_secret, webhook_url, webhook_enabled, webhook_is_using_uuid
             FROM akeneo_connectivity_connection
             WHERE code = :code
         SQL;
@@ -40,7 +40,7 @@ class DbalGetAConnectionWebhookQuery implements GetAConnectionWebhookQueryInterf
             (bool) $connectionWebhook['webhook_enabled'],
             $connectionWebhook['webhook_secret'],
             $connectionWebhook['webhook_url'],
-            (bool) $connectionWebhook['webhook_uses_uuid'],
+            (bool) $connectionWebhook['webhook_is_using_uuid'],
         );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalGetAConnectionWebhookQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalGetAConnectionWebhookQuery.php
@@ -25,10 +25,10 @@ class DbalGetAConnectionWebhookQuery implements GetAConnectionWebhookQueryInterf
     public function execute(string $code): ?ConnectionWebhook
     {
         $query = <<<SQL
-    SELECT code, webhook_secret, webhook_url, webhook_enabled
-    FROM akeneo_connectivity_connection
-    WHERE code = :code
-SQL;
+            SELECT code, webhook_secret, webhook_url, webhook_enabled, webhook_uses_uuid
+            FROM akeneo_connectivity_connection
+            WHERE code = :code
+        SQL;
         $connectionWebhook = $this->dbalConnection->executeQuery($query, ['code' => $code])->fetchAssociative();
 
         if (false === $connectionWebhook) {
@@ -39,7 +39,8 @@ SQL;
             $connectionWebhook['code'],
             (bool) $connectionWebhook['webhook_enabled'],
             $connectionWebhook['webhook_secret'],
-            $connectionWebhook['webhook_url']
+            $connectionWebhook['webhook_url'],
+            (bool) $connectionWebhook['webhook_uses_uuid'],
         );
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalSelectActiveWebhooksQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalSelectActiveWebhooksQuery.php
@@ -28,18 +28,19 @@ class DbalSelectActiveWebhooksQuery implements SelectActiveWebhooksQueryInterfac
     public function execute(): array
     {
         $sql = <<<SQL
-SELECT connection.code,
-connection.webhook_url,
-connection.webhook_secret,
-connection.user_id,
-access_group.name as group_name
-FROM akeneo_connectivity_connection as connection
-LEFT JOIN oro_user_access_group as user_access_group ON user_access_group.user_id = connection.user_id
-LEFT JOIN oro_user_access_role as user_access_role ON user_access_role.user_id = connection.user_id
-LEFT JOIN oro_access_group access_group ON user_access_group.group_id = access_group.id
-WHERE connection.webhook_url IS NOT NULL AND connection.webhook_enabled = 1
-ORDER BY code
-SQL;
+        SELECT connection.code,
+        connection.webhook_url,
+        connection.webhook_secret,
+        connection.user_id,
+        connection.webhook_uses_uuid,
+        access_group.name as group_name
+        FROM akeneo_connectivity_connection as connection
+        LEFT JOIN oro_user_access_group as user_access_group ON user_access_group.user_id = connection.user_id
+        LEFT JOIN oro_user_access_role as user_access_role ON user_access_role.user_id = connection.user_id
+        LEFT JOIN oro_access_group access_group ON user_access_group.group_id = access_group.id
+        WHERE connection.webhook_url IS NOT NULL AND connection.webhook_enabled = 1
+        ORDER BY code
+        SQL;
         $result = $this->dbalConnection->executeQuery($sql)->fetchAllAssociative();
 
         /*
@@ -66,7 +67,8 @@ SQL;
                 $row['code'],
                 (int) $row['user_id'],
                 $row['webhook_secret'],
-                $row['webhook_url']
+                $row['webhook_url'],
+                (bool) $row['webhook_uses_uuid'],
             );
         }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalSelectActiveWebhooksQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/DbalSelectActiveWebhooksQuery.php
@@ -32,7 +32,7 @@ class DbalSelectActiveWebhooksQuery implements SelectActiveWebhooksQueryInterfac
         connection.webhook_url,
         connection.webhook_secret,
         connection.user_id,
-        connection.webhook_uses_uuid,
+        connection.webhook_is_using_uuid,
         access_group.name as group_name
         FROM akeneo_connectivity_connection as connection
         LEFT JOIN oro_user_access_group as user_access_group ON user_access_group.user_id = connection.user_id
@@ -68,7 +68,7 @@ class DbalSelectActiveWebhooksQuery implements SelectActiveWebhooksQueryInterfac
                 (int) $row['user_id'],
                 $row['webhook_secret'],
                 $row['webhook_url'],
-                (bool) $row['webhook_uses_uuid'],
+                (bool) $row['webhook_is_using_uuid'],
             );
         }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/UpdateConnectionWebhookQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/UpdateConnectionWebhookQuery.php
@@ -23,7 +23,7 @@ class UpdateConnectionWebhookQuery implements UpdateConnectionWebhookQueryInterf
     {
         $query = <<<SQL
         UPDATE akeneo_connectivity_connection
-        SET webhook_url = :url, webhook_enabled = :enabled
+        SET webhook_url = :url, webhook_enabled = :enabled, webhook_uses_uuid = :uses_uuid
         WHERE code = :code
         SQL;
 
@@ -33,9 +33,11 @@ class UpdateConnectionWebhookQuery implements UpdateConnectionWebhookQueryInterf
                 'url' => $connectionWebhook->url(),
                 'enabled' => $connectionWebhook->enabled(),
                 'code' => $connectionWebhook->code(),
+                'uses_uuid' => $connectionWebhook->usesUuid(),
             ],
             [
                 'enabled' => Types::BOOLEAN,
+                'uses_uuid' => Types::BOOLEAN,
             ]
         );
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/UpdateConnectionWebhookQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Persistence/UpdateConnectionWebhookQuery.php
@@ -23,7 +23,7 @@ class UpdateConnectionWebhookQuery implements UpdateConnectionWebhookQueryInterf
     {
         $query = <<<SQL
         UPDATE akeneo_connectivity_connection
-        SET webhook_url = :url, webhook_enabled = :enabled, webhook_uses_uuid = :uses_uuid
+        SET webhook_url = :url, webhook_enabled = :enabled, webhook_is_using_uuid = :is_using_uuid
         WHERE code = :code
         SQL;
 
@@ -33,11 +33,11 @@ class UpdateConnectionWebhookQuery implements UpdateConnectionWebhookQueryInterf
                 'url' => $connectionWebhook->url(),
                 'enabled' => $connectionWebhook->enabled(),
                 'code' => $connectionWebhook->code(),
-                'uses_uuid' => $connectionWebhook->usesUuid(),
+                'is_using_uuid' => $connectionWebhook->isUsingUuid(),
             ],
             [
                 'enabled' => Types::BOOLEAN,
-                'uses_uuid' => Types::BOOLEAN,
+                'is_using_uuid' => Types::BOOLEAN,
             ]
         );
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
@@ -8,34 +8,31 @@ use Doctrine\DBAL\Types\Types;
 
 class WebhookLoader
 {
-    /** @var DbalConnection */
-    private $dbalConnection;
-
-    public function __construct(DbalConnection $dbalConnection)
+    public function __construct(private DbalConnection $dbalConnection)
     {
-        $this->dbalConnection = $dbalConnection;
     }
 
-    public function initWebhook(string $code): void
+    public function initWebhook(string $code, bool $usesUuid = false): void
     {
-        $this->updateConnection($code, true, 'http://test.com', 'secret');
+        $this->updateConnection($code, true, 'http://test.com', 'secret', $usesUuid);
     }
 
     public function updateConnection(
         string $code,
         bool $enabled = false,
         ?string $url = null,
-        ?string $secret = null
+        ?string $secret = null,
+        bool $usesUuid = false,
     ): int {
         if ($enabled && (null === $url || '' === $url)) {
             throw new \InvalidArgumentException('An enabled webhook required an url.');
         }
 
         $query = <<<SQL
-UPDATE akeneo_connectivity_connection
-SET webhook_url = :url, webhook_enabled = :enabled, webhook_secret = :secret
-WHERE code = :code
-SQL;
+        UPDATE akeneo_connectivity_connection
+        SET webhook_url = :url, webhook_enabled = :enabled, webhook_secret = :secret, webhook_uses_uuid = :usesUuid
+        WHERE code = :code
+        SQL;
 
         return $this->dbalConnection->executeUpdate(
             $query,
@@ -44,9 +41,11 @@ SQL;
                 'enabled' => $enabled,
                 'code' => $code,
                 'secret' => $secret,
+                'usesUuid' => $usesUuid,
             ],
             [
                 'enabled' => Types::BOOLEAN,
+                'usesUuid' => Types::BOOLEAN,
             ]
         );
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/CatalogBuilder/WebhookLoader.php
@@ -12,9 +12,9 @@ class WebhookLoader
     {
     }
 
-    public function initWebhook(string $code, bool $usesUuid = false): void
+    public function initWebhook(string $code, bool $isUsingUuid = false): void
     {
-        $this->updateConnection($code, true, 'http://test.com', 'secret', $usesUuid);
+        $this->updateConnection($code, true, 'http://test.com', 'secret', $isUsingUuid);
     }
 
     public function updateConnection(
@@ -22,7 +22,7 @@ class WebhookLoader
         bool $enabled = false,
         ?string $url = null,
         ?string $secret = null,
-        bool $usesUuid = false,
+        bool $isUsingUuid = false,
     ): int {
         if ($enabled && (null === $url || '' === $url)) {
             throw new \InvalidArgumentException('An enabled webhook required an url.');
@@ -30,7 +30,7 @@ class WebhookLoader
 
         $query = <<<SQL
         UPDATE akeneo_connectivity_connection
-        SET webhook_url = :url, webhook_enabled = :enabled, webhook_secret = :secret, webhook_uses_uuid = :usesUuid
+        SET webhook_url = :url, webhook_enabled = :enabled, webhook_secret = :secret, webhook_is_using_uuid = :isUsingUuid
         WHERE code = :code
         SQL;
 
@@ -41,11 +41,11 @@ class WebhookLoader
                 'enabled' => $enabled,
                 'code' => $code,
                 'secret' => $secret,
-                'usesUuid' => $usesUuid,
+                'isUsingUuid' => $isUsingUuid,
             ],
             [
                 'enabled' => Types::BOOLEAN,
-                'usesUuid' => Types::BOOLEAN,
+                'isUsingUuid' => Types::BOOLEAN,
             ]
         );
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/GetEventSubscriptionFormDataEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/GetEventSubscriptionFormDataEndToEnd.php
@@ -58,6 +58,7 @@ class GetEventSubscriptionFormDataEndToEnd extends WebTestCase
                     'enabled' => true,
                     'secret' => 'secret',
                     'url' => 'http://test.com',
+                    'usesUuid' => false,
                 ],
                 'active_event_subscriptions_limit' => [
                     'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/GetEventSubscriptionFormDataEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/GetEventSubscriptionFormDataEndToEnd.php
@@ -58,7 +58,7 @@ class GetEventSubscriptionFormDataEndToEnd extends WebTestCase
                     'enabled' => true,
                     'secret' => 'secret',
                     'url' => 'http://test.com',
-                    'usesUuid' => false,
+                    'isUsingUuid' => false,
                 ],
                 'active_event_subscriptions_limit' => [
                     'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/UpdateEventSubscriptionEndToEnd.php
@@ -44,7 +44,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $connection->code(),
             'enabled' => true,
-            'uses_uuid' => true,
+            'is_using_uuid' => true,
             'url' => 'http://example.test',
         ];
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/UpdateEventSubscriptionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/Controller/Internal/UpdateEventSubscriptionEndToEnd.php
@@ -44,6 +44,7 @@ class UpdateEventSubscriptionEndToEnd extends WebTestCase
         $data = [
             'code' => $connection->code(),
             'enabled' => true,
+            'uses_uuid' => true,
             'url' => 'http://example.test',
         ];
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalGetAConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalGetAConnectionWebhookQueryIntegration.php
@@ -37,7 +37,7 @@ class DbalGetAConnectionWebhookQueryIntegration extends TestCase
         Assert::assertInstanceOf(ConnectionWebhook::class, $webhook);
         Assert::assertEquals('magento', $webhook->connectionCode());
         Assert::assertTrue($webhook->enabled());
-        Assert::assertTrue($webhook->usesUuid());
+        Assert::assertTrue($webhook->isUsingUuid());
         Assert::assertEquals('secret', $webhook->secret());
         Assert::assertEquals('http://test.com', $webhook->url());
     }
@@ -52,7 +52,7 @@ class DbalGetAConnectionWebhookQueryIntegration extends TestCase
         Assert::assertInstanceOf(ConnectionWebhook::class, $webhook);
         Assert::assertEquals('erp', $webhook->connectionCode());
         Assert::assertFalse($webhook->enabled());
-        Assert::assertFalse($webhook->usesUuid());
+        Assert::assertFalse($webhook->isUsingUuid());
         Assert::assertNull($webhook->secret());
         Assert::assertNull($webhook->url());
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalGetAConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalGetAConnectionWebhookQueryIntegration.php
@@ -14,28 +14,30 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
 
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @covers \Akeneo\Connectivity\Connection\Infrastructure\Webhook\Persistence\DbalGetAConnectionWebhookQuery
+ */
 class DbalGetAConnectionWebhookQueryIntegration extends TestCase
 {
-    /** @var ConnectionLoader */
-    private $connectionLoader;
-
-    /** @var GetAConnectionWebhookQueryInterface */
-    private $getAConnectionWebhookQuery;
-
-    /** @var WebhookLoader */
-    private $webhookLoader;
+    private ?ConnectionLoader $connectionLoader;
+    private ?GetAConnectionWebhookQueryInterface $getAConnectionWebhookQuery;
+    private ?WebhookLoader $webhookLoader;
 
     public function test_it_gets_an_enabled_connection_webhook_for_a_given_code(): void
     {
         $magento = $this->connectionLoader->createConnection('magento', 'Magento Connector', FlowType::DATA_DESTINATION, false);
         $this->connectionLoader->createConnection('erp', 'ERP Connector', FlowType::DATA_SOURCE, false);
-        $this->webhookLoader->initWebhook($magento->code());
+        $this->webhookLoader->initWebhook($magento->code(), true);
 
         $webhook = $this->getAConnectionWebhookQuery->execute($magento->code());
 
         Assert::assertInstanceOf(ConnectionWebhook::class, $webhook);
         Assert::assertEquals('magento', $webhook->connectionCode());
         Assert::assertTrue($webhook->enabled());
+        Assert::assertTrue($webhook->usesUuid());
         Assert::assertEquals('secret', $webhook->secret());
         Assert::assertEquals('http://test.com', $webhook->url());
     }
@@ -50,6 +52,7 @@ class DbalGetAConnectionWebhookQueryIntegration extends TestCase
         Assert::assertInstanceOf(ConnectionWebhook::class, $webhook);
         Assert::assertEquals('erp', $webhook->connectionCode());
         Assert::assertFalse($webhook->enabled());
+        Assert::assertFalse($webhook->usesUuid());
         Assert::assertNull($webhook->secret());
         Assert::assertNull($webhook->url());
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
@@ -117,8 +117,8 @@ SQL;
             [
                 'webhook_url' => $url,
                 'webhook_secret' => $secret,
-                'webhook_enabled' => (int)$enabled,
-                'webhook_is_using_uuid' => (int)$isUsingUuid,
+                'webhook_enabled' => (int) $enabled,
+                'webhook_is_using_uuid' => (int) $isUsingUuid,
             ],
             ['code' => $connection->code()]
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
@@ -72,11 +72,11 @@ class DbalSelectActiveWebhooksQueryIntegration extends TestCase
         Assert::assertEquals('binder', $binder->connectionCode());
         Assert::assertEquals('secret_binder', $binder->secret());
         Assert::assertEquals('http://localhost/webhook_binder', $binder->url());
-        Assert::assertFalse($binder->usesUuid());
+        Assert::assertFalse($binder->isUsingUuid());
         Assert::assertEquals('erp', $erp->connectionCode());
         Assert::assertEquals('secret_erp', $erp->secret());
         Assert::assertEquals('http://localhost/webhook_erp', $erp->url());
-        Assert::assertTrue($erp->usesUuid());
+        Assert::assertTrue($erp->isUsingUuid());
     }
 
     public function test_it_does_not_find_anything_if_no_connection_webhook_is_configured(): void
@@ -110,7 +110,7 @@ SQL;
         string $secret,
         ?string $url,
         bool $enabled,
-        bool $usesUuid,
+        bool $isUsingUuid,
     ): void {
         $this->dbalConnection->update(
             'akeneo_connectivity_connection',
@@ -118,7 +118,7 @@ SQL;
                 'webhook_url' => $url,
                 'webhook_secret' => $secret,
                 'webhook_enabled' => (int)$enabled,
-                'webhook_uses_uuid' => (int)$usesUuid,
+                'webhook_is_using_uuid' => (int)$isUsingUuid,
             ],
             ['code' => $connection->code()]
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/DbalSelectActiveWebhooksQueryIntegration.php
@@ -23,10 +23,10 @@ use PHPUnit\Framework\Assert;
  */
 class DbalSelectActiveWebhooksQueryIntegration extends TestCase
 {
-    private ConnectionLoader $connectionLoader;
-    private SelectActiveWebhooksQueryInterface $selectActiveWebhooksQuery;
-    private DbalConnection $dbalConnection;
-    private UpdateConnectionHandler $updateConnectionHandler;
+    private ?ConnectionLoader $connectionLoader;
+    private ?SelectActiveWebhooksQueryInterface $selectActiveWebhooksQuery;
+    private ?DbalConnection $dbalConnection;
+    private ?UpdateConnectionHandler $updateConnectionHandler;
 
     protected function setUp(): void
     {
@@ -58,10 +58,10 @@ class DbalSelectActiveWebhooksQueryIntegration extends TestCase
             )
         );
 
-        $this->updateConnection($magento, 'secret_magento', null, true);
-        $this->updateConnection($binder, 'secret_binder', 'http://localhost/webhook_binder', true);
-        $this->updateConnection($erp, 'secret_erp', 'http://localhost/webhook_erp', true);
-        $this->updateConnection($sap, 'secret_sap', 'http://localhost/webhook_sap', false);
+        $this->updateConnection($magento, 'secret_magento', null, true, false);
+        $this->updateConnection($binder, 'secret_binder', 'http://localhost/webhook_binder', true, false);
+        $this->updateConnection($erp, 'secret_erp', 'http://localhost/webhook_erp', true, true);
+        $this->updateConnection($sap, 'secret_sap', 'http://localhost/webhook_sap', false, false);
 
         $connections = $this->selectActiveWebhooksQuery->execute();
 
@@ -72,9 +72,11 @@ class DbalSelectActiveWebhooksQueryIntegration extends TestCase
         Assert::assertEquals('binder', $binder->connectionCode());
         Assert::assertEquals('secret_binder', $binder->secret());
         Assert::assertEquals('http://localhost/webhook_binder', $binder->url());
+        Assert::assertFalse($binder->usesUuid());
         Assert::assertEquals('erp', $erp->connectionCode());
         Assert::assertEquals('secret_erp', $erp->secret());
         Assert::assertEquals('http://localhost/webhook_erp', $erp->url());
+        Assert::assertTrue($erp->usesUuid());
     }
 
     public function test_it_does_not_find_anything_if_no_connection_webhook_is_configured(): void
@@ -82,7 +84,7 @@ class DbalSelectActiveWebhooksQueryIntegration extends TestCase
         $this->connectionLoader->createConnection('erp', 'ERP', FlowType::DATA_SOURCE, false);
         $ecommerce = $this->connectionLoader->createConnection('ecommerce', 'eCommerce', FlowType::DATA_DESTINATION, false);
 
-        $this->updateConnection($ecommerce, 'secret', 'http://localhost/webhook', false);
+        $this->updateConnection($ecommerce, 'secret', 'http://localhost/webhook', false, true);
 
         $connections = $this->selectActiveWebhooksQuery->execute();
 
@@ -103,14 +105,20 @@ SQL;
         )->fetchOne();
     }
 
-    private function updateConnection(ConnectionWithCredentials $connection, string $secret, ?string $url, bool $enabled): void
-    {
+    private function updateConnection(
+        ConnectionWithCredentials $connection,
+        string $secret,
+        ?string $url,
+        bool $enabled,
+        bool $usesUuid,
+    ): void {
         $this->dbalConnection->update(
             'akeneo_connectivity_connection',
             [
                 'webhook_url' => $url,
                 'webhook_secret' => $secret,
                 'webhook_enabled' => (int)$enabled,
+                'webhook_uses_uuid' => (int)$usesUuid,
             ],
             ['code' => $connection->code()]
         );

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/UpdateConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/UpdateConnectionWebhookQueryIntegration.php
@@ -59,10 +59,10 @@ class UpdateConnectionWebhookQueryIntegration extends TestCase
         string $code,
         bool $enabled,
         ?string $url = null,
-        bool $usesUuid = false,
+        bool $isUsingUuid = false,
     ): void {
         $selectQuery = <<<SQL
-        SELECT webhook_enabled, webhook_url, webhook_uses_uuid
+        SELECT webhook_enabled, webhook_url, webhook_is_using_uuid
         FROM akeneo_connectivity_connection
         WHERE code = :code
         SQL;
@@ -70,6 +70,6 @@ class UpdateConnectionWebhookQueryIntegration extends TestCase
 
         Assert::assertEquals($enabled, (bool) $webhook['webhook_enabled']);
         Assert::assertEquals($url, $webhook['webhook_url']);
-        Assert::assertEquals($usesUuid, (bool) $webhook['webhook_uses_uuid']);
+        Assert::assertEquals($isUsingUuid, (bool) $webhook['webhook_is_using_uuid']);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/UpdateConnectionWebhookQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/Persistence/UpdateConnectionWebhookQueryIntegration.php
@@ -16,12 +16,14 @@ use PHPUnit\Framework\Assert;
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @covers \Akeneo\Connectivity\Connection\Infrastructure\Webhook\Persistence\UpdateConnectionWebhookQuery
  */
 class UpdateConnectionWebhookQueryIntegration extends TestCase
 {
-    private ConnectionLoader $connectionLoader;
-    private Connection $connection;
-    private UpdateConnectionWebhookQuery $query;
+    private ?ConnectionLoader $connectionLoader;
+    private ?Connection $connection;
+    private ?UpdateConnectionWebhookQuery $query;
 
     protected function getConfiguration(): Configuration
     {
@@ -42,16 +44,25 @@ class UpdateConnectionWebhookQueryIntegration extends TestCase
         $magento = $this->connectionLoader->createConnection('magento', 'Magento Connector', FlowType::DATA_DESTINATION, false);
         $this->assertWebhookIsInDatabase($magento->code(), false);
 
-        $numberOfUpdatedRows = $this->query->execute(new ConnectionWebhook($magento->code(), true, 'http://any-url.com'));
+        $numberOfUpdatedRows = $this->query->execute(new ConnectionWebhook(
+            $magento->code(),
+            true,
+            'http://any-url.com',
+            true
+        ));
 
         Assert::assertEquals(1, $numberOfUpdatedRows);
-        $this->assertWebhookIsInDatabase($magento->code(), true, 'http://any-url.com');
+        $this->assertWebhookIsInDatabase($magento->code(), true, 'http://any-url.com', true);
     }
 
-    private function assertWebhookIsInDatabase(string $code, bool $enabled, ?string $url = null): void
-    {
+    private function assertWebhookIsInDatabase(
+        string $code,
+        bool $enabled,
+        ?string $url = null,
+        bool $usesUuid = false,
+    ): void {
         $selectQuery = <<<SQL
-        SELECT webhook_enabled, webhook_url
+        SELECT webhook_enabled, webhook_url, webhook_uses_uuid
         FROM akeneo_connectivity_connection
         WHERE code = :code
         SQL;
@@ -59,5 +70,6 @@ class UpdateConnectionWebhookQueryIntegration extends TestCase
 
         Assert::assertEquals($enabled, (bool) $webhook['webhook_enabled']);
         Assert::assertEquals($url, $webhook['webhook_url']);
+        Assert::assertEquals($usesUuid, (bool) $webhook['webhook_uses_uuid']);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -90,7 +90,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'user' => $magentoUser,
                     'pim_source' => 'staging.akeneo.com',
                     'connection_code' => $webhook->connectionCode(),
-                    'use_uuid' => $webhook->usesUuid(),
+                    'is_using_uuid' => $webhook->isUsingUuid(),
                 ]
             )
             ->willReturn(
@@ -182,7 +182,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $magentoUser,
                     'connection_code' => $magentoWebhook->connectionCode(),
-                    'use_uuid' => $magentoWebhook->usesUuid(),
+                    'is_using_uuid' => $magentoWebhook->isUsingUuid(),
                 ]
             )
             ->willReturn(
@@ -265,7 +265,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $user,
                     'connection_code' => $webhook->connectionCode(),
-                    'use_uuid' => $webhook->usesUuid(),
+                    'is_using_uuid' => $webhook->isUsingUuid(),
                 ]
             )
             ->willThrow(\Exception::class);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/SendBusinessEventToWebhooksHandlerSpec.php
@@ -78,7 +78,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $this->createEvent($author, ['data'])
         ]);
         $command = new SendBusinessEventToWebhooksCommand($pimEventBulk);
-        $webhook = new ActiveWebhook('ecommerce', 42, 'a_secret', 'http://localhost/');
+        $webhook = new ActiveWebhook('ecommerce', 42, 'a_secret', 'http://localhost/', true);
 
         $selectActiveWebhooksQuery->execute()->willReturn([$webhook]);
 
@@ -90,6 +90,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'user' => $magentoUser,
                     'pim_source' => 'staging.akeneo.com',
                     'connection_code' => $webhook->connectionCode(),
+                    'use_uuid' => $webhook->usesUuid(),
                 ]
             )
             ->willReturn(
@@ -167,8 +168,8 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $this->createEvent($erpAuthor, ['data'])
         ]);
         $command = new SendBusinessEventToWebhooksCommand($pimEventBulk);
-        $erpWebhook = new ActiveWebhook('erp_source', 42, 'a_secret', 'http://localhost/');
-        $magentoWebhook = new ActiveWebhook('ecommerce_destination', 12, 'a_secret', 'http://localhost/');
+        $erpWebhook = new ActiveWebhook('erp_source', 42, 'a_secret', 'http://localhost/', true);
+        $magentoWebhook = new ActiveWebhook('ecommerce_destination', 12, 'a_secret', 'http://localhost/', false);
 
         $selectActiveWebhooksQuery->execute()->willReturn([$erpWebhook, $magentoWebhook]);
         $webhookUserAuthenticator->authenticate(12)->willReturn($magentoUser);
@@ -181,6 +182,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $magentoUser,
                     'connection_code' => $magentoWebhook->connectionCode(),
+                    'use_uuid' => $magentoWebhook->usesUuid(),
                 ]
             )
             ->willReturn(
@@ -252,7 +254,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
             $this->createEvent($author, ['data'])
         ]);
         $command = new SendBusinessEventToWebhooksCommand($pimEventBulk);
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/', false);
 
         $selectActiveWebhooksQuery->execute()->willReturn([$webhook]);
         $webhookUserAuthenticator->authenticate(0)->willReturn($user);
@@ -263,6 +265,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $user,
                     'connection_code' => $webhook->connectionCode(),
+                    'use_uuid' => $webhook->usesUuid(),
                 ]
             )
             ->willThrow(\Exception::class);
@@ -295,7 +298,7 @@ class SendBusinessEventToWebhooksHandlerSpec extends ObjectBehavior
         $user->setUsername('erp_0000');
         $user->defineAsApiUser();
 
-        $webhook = new ActiveWebhook('erp', $user->getId(), 'a_secret', 'http://localhost/');
+        $webhook = new ActiveWebhook('erp', $user->getId(), 'a_secret', 'http://localhost/', true);
         $selectActiveWebhooksQuery->execute()
             ->willReturn([$webhook]);
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookCommandSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookCommandSpec.php
@@ -41,12 +41,12 @@ class UpdateWebhookCommandSpec extends ObjectBehavior
     public function it_provides_the_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'any-url.com', true);
-        $this->usesUuid()->shouldReturn(true);
+        $this->isUsingUuid()->shouldReturn(true);
     }
 
     public function it_could_have_no_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'any-url.com');
-        $this->usesUuid()->shouldReturn(false);
+        $this->isUsingUuid()->shouldReturn(false);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookCommandSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookCommandSpec.php
@@ -37,4 +37,16 @@ class UpdateWebhookCommandSpec extends ObjectBehavior
         $this->beConstructedWith('magento', false);
         $this->url()->shouldReturn(null);
     }
+
+    public function it_provides_the_uuid_use_status(): void
+    {
+        $this->beConstructedWith('magento', true, 'any-url.com', true);
+        $this->usesUuid()->shouldReturn(true);
+    }
+
+    public function it_could_have_no_uuid_use_status(): void
+    {
+        $this->beConstructedWith('magento', true, 'any-url.com');
+        $this->usesUuid()->shouldReturn(false);
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookHandlerSpec.php
@@ -49,13 +49,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
         $code = 'magento';
         $url = 'http://valid-url.com';
         $enabled = true;
-        $useUuid = true;
+        $isUsingUuid = true;
         $secret = 'secret';
-        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $isUsingUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $isUsingUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
-                $webhook->usesUuid() === $useUuid &&
+                $webhook->isUsingUuid() === $isUsingUuid &&
                 $webhook->url() instanceof Url &&
                 (string) $webhook->url() === $url;
         };
@@ -87,13 +87,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
         $code = 'magento';
         $url = 'http://valid-url.com';
         $enabled = true;
-        $useUuid = true;
+        $isUsingUuid = true;
         $secret = 'secret';
-        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $isUsingUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $isUsingUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
-                $webhook->usesUuid() === $useUuid &&
+                $webhook->isUsingUuid() === $isUsingUuid &&
                 $webhook->url() instanceof Url &&
                 (string) $webhook->url() === $url;
         };
@@ -119,13 +119,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
     ): void {
         $code = 'magento';
         $enabled = true;
-        $useUuid = true;
+        $isUsingUuid = true;
         $url = null;
-        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $isUsingUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $isUsingUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
-                $webhook->usesUuid() === $useUuid &&
+                $webhook->isUsingUuid() === $isUsingUuid &&
                 $webhook->url() === null;
         };
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookHandlerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Command/UpdateWebhookHandlerSpec.php
@@ -49,11 +49,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
         $code = 'magento';
         $url = 'http://valid-url.com';
         $enabled = true;
+        $useUuid = true;
         $secret = 'secret';
-        $command = new UpdateWebhookCommand($code, $enabled, $url);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
+                $webhook->usesUuid() === $useUuid &&
                 $webhook->url() instanceof Url &&
                 (string) $webhook->url() === $url;
         };
@@ -85,11 +87,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
         $code = 'magento';
         $url = 'http://valid-url.com';
         $enabled = true;
+        $useUuid = true;
         $secret = 'secret';
-        $command = new UpdateWebhookCommand($code, $enabled, $url);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
+                $webhook->usesUuid() === $useUuid &&
                 $webhook->url() instanceof Url &&
                 (string) $webhook->url() === $url;
         };
@@ -115,11 +119,13 @@ class UpdateWebhookHandlerSpec extends ObjectBehavior
     ): void {
         $code = 'magento';
         $enabled = true;
+        $useUuid = true;
         $url = null;
-        $command = new UpdateWebhookCommand($code, $enabled, $url);
-        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url) {
+        $command = new UpdateWebhookCommand($code, $enabled, $url, $useUuid);
+        $isAValidWriteModel = function (ConnectionWebhook $webhook) use ($code, $enabled, $url, $useUuid) {
             return $webhook->code() === $code &&
                 $webhook->enabled() === $enabled &&
+                $webhook->usesUuid() === $useUuid &&
                 $webhook->url() === null;
         };
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Log/EventSubscriptionSendApiEventRequestLogSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Log/EventSubscriptionSendApiEventRequestLogSpec.php
@@ -19,7 +19,7 @@ class EventSubscriptionSendApiEventRequestLogSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false);
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $events = [
             new WebhookEvent(
@@ -68,7 +68,7 @@ class EventSubscriptionSendApiEventRequestLogSpec extends ObjectBehavior
 
     public function it_returns_the_webhook_requests(): void
     {
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false);
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $events = [
             new WebhookEvent(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/Logger/SendApiEventRequestLoggerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/Logger/SendApiEventRequestLoggerSpec.php
@@ -30,7 +30,7 @@ class SendApiEventRequestLoggerSpec extends ObjectBehavior
 
     public function it_logs_send_api_event_request_with_response(LoggerInterface $logger): void
     {
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false);
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $events = [
             new WebhookEvent(
@@ -110,7 +110,7 @@ class SendApiEventRequestLoggerSpec extends ObjectBehavior
 
     public function it_logs_send_api_event_request_without_response(LoggerInterface $logger): void
     {
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false);
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $events = [
             new WebhookEvent(
@@ -188,7 +188,7 @@ class SendApiEventRequestLoggerSpec extends ObjectBehavior
 
     public function it_returns_the_log_without_propagation_times(LoggerInterface $logger)
     {
-        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $webhook = new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false);
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $events = [
             new WebhookEvent(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/EventSubscriptionsLimitValidatorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Validation/EventSubscriptionsLimitValidatorSpec.php
@@ -96,9 +96,9 @@ class EventSubscriptionsLimitValidatorSpec extends ObjectBehavior
         ConstraintViolationBuilderInterface $constraintViolationBuilder
     ): void {
         $selectActiveWebhooksQuery->execute()->willReturn([
-            new ActiveWebhook('dam', 1, 'secret', 'http://localhost'),
-            new ActiveWebhook('ecommerce', 1, 'secret', 'http://localhost'),
-            new ActiveWebhook('translations', 1, 'secret', 'http://localhost'),
+            new ActiveWebhook('dam', 1, 'secret', 'http://localhost', false),
+            new ActiveWebhook('ecommerce', 1, 'secret', 'http://localhost', false),
+            new ActiveWebhook('translations', 1, 'secret', 'http://localhost', false),
         ]);
 
         $eventSubscription = new ConnectionWebhook('erp', true, 'http://localhost');
@@ -114,9 +114,9 @@ class EventSubscriptionsLimitValidatorSpec extends ObjectBehavior
     public function it_does_not_count_itself_in_the_limit_check($selectActiveWebhooksQuery, $context): void
     {
         $selectActiveWebhooksQuery->execute()->willReturn([
-            new ActiveWebhook('dam', 1, 'secret', 'http://localhost'),
-            new ActiveWebhook('ecommerce', 1, 'secret', 'http://localhost'),
-            new ActiveWebhook('erp', 1, 'secret', 'http://localhost'),
+            new ActiveWebhook('dam', 1, 'secret', 'http://localhost', false),
+            new ActiveWebhook('ecommerce', 1, 'secret', 'http://localhost', false),
+            new ActiveWebhook('erp', 1, 'secret', 'http://localhost', false),
         ]);
 
         $eventSubscription = new ConnectionWebhook('erp', true, 'http://localhost');

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
@@ -67,7 +67,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ]
         )->shouldBeLike(
             [
@@ -111,7 +111,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
-                'use_uuid' => false,
+                'is_using_uuid' => false,
             ]
         )->shouldBeLike(
             []
@@ -151,7 +151,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
-                'use_uuid' => false,
+                'is_using_uuid' => false,
             ]
         );
     }
@@ -177,7 +177,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $user,
                     'connection_code' => 'ecommerce',
-                    'use_uuid' => true,
+                    'is_using_uuid' => true,
                 ],
             ]
         );
@@ -196,7 +196,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'user' => $user,
                 'connection_code' => 'ecommerce',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ]
         ]);
     }
@@ -213,7 +213,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => $user,
                 'pim_source' => null,
                 'connection_code' => 'ecommerce',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ],
         ]);
     }
@@ -231,7 +231,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => 'ecommerce',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ],
         ]);
     }
@@ -248,7 +248,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => null,
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => 'ecommerce',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ],
         ]);
     }
@@ -264,7 +264,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'user' => $user,
                 'pim_source' => 'staging.akeneo.com',
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ],
         ]);
     }
@@ -281,12 +281,12 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => $user,
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => null,
-                'use_uuid' => true,
+                'is_using_uuid' => true,
             ],
         ]);
     }
 
-    public function it_throws_an_exception_if_there_is_no_use_uuid_in_context(UserInterface $user): void
+    public function it_throws_an_exception_if_there_is_no_is_using_uuid_in_context(UserInterface $user): void
     {
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $pimEvent = $this->createEvent($author, ['data'], 1599814161, 'a20832d1-a1e6-4f39-99ea-a1dd859faddb');

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
@@ -59,7 +59,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10, true))->willReturn($collection);
 
         $this->build(
             $pimEventBulk,
@@ -67,6 +67,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
+                'use_uuid' => true,
             ]
         )->shouldBeLike(
             [
@@ -102,7 +103,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10, false))->willReturn($collection);
 
         $this->build(
             $pimEventBulk,
@@ -110,6 +111,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
+                'use_uuid' => false,
             ]
         )->shouldBeLike(
             []
@@ -136,7 +138,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $notSupportedEventDataBuilder->supports($pimEventBulk)->willReturn(false);
         $supportedEventDataBuilder->supports($pimEventBulk)->willReturn(true);
 
-        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10))->willReturn($collection);
+        $supportedEventDataBuilder->build($pimEventBulk, new Context('ecommerce_0000', 10, false))->willReturn($collection);
 
         $apiEventBuildErrorLogger->logResourceNotFoundOrAccessDenied(
             'ecommerce',
@@ -149,6 +151,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'pim_source' => 'staging.akeneo.com',
                 'user' => $user,
                 'connection_code' => 'ecommerce',
+                'use_uuid' => false,
             ]
         );
     }
@@ -174,6 +177,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                     'pim_source' => 'staging.akeneo.com',
                     'user' => $user,
                     'connection_code' => 'ecommerce',
+                    'use_uuid' => true,
                 ],
             ]
         );
@@ -192,6 +196,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'user' => $user,
                 'connection_code' => 'ecommerce',
+                'use_uuid' => true,
             ]
         ]);
     }
@@ -208,6 +213,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => $user,
                 'pim_source' => null,
                 'connection_code' => 'ecommerce',
+                'use_uuid' => true,
             ],
         ]);
     }
@@ -225,6 +231,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => 'ecommerce',
+                'use_uuid' => true,
             ],
         ]);
     }
@@ -241,6 +248,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => null,
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => 'ecommerce',
+                'use_uuid' => true,
             ],
         ]);
     }
@@ -256,6 +264,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
             [
                 'user' => $user,
                 'pim_source' => 'staging.akeneo.com',
+                'use_uuid' => true,
             ],
         ]);
     }
@@ -272,9 +281,27 @@ class WebhookEventBuilderSpec extends ObjectBehavior
                 'user' => $user,
                 'pim_source' => 'staging.akeneo.com',
                 'connection_code' => null,
+                'use_uuid' => true,
             ],
         ]);
     }
+
+    public function it_throws_an_exception_if_there_is_no_use_uuid_in_context(UserInterface $user): void
+    {
+        $author = Author::fromNameAndType('julia', Author::TYPE_UI);
+        $pimEvent = $this->createEvent($author, ['data'], 1599814161, 'a20832d1-a1e6-4f39-99ea-a1dd859faddb');
+        $pimEventBulk = new BulkEvent([$pimEvent]);
+
+        $this->shouldThrow(\InvalidArgumentException::class)->during('build', [
+            $pimEventBulk,
+            [
+                'user' => $user,
+                'pim_source' => 'staging.akeneo.com',
+                'connection_code' => 'ecommerce',
+            ],
+        ]);
+    }
+
 
     private function createEvent(Author $author, array $data, int $timestamp, string $uuid): EventInterface
     {

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Client/WebhookRequestSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Client/WebhookRequestSpec.php
@@ -22,7 +22,7 @@ class WebhookRequestSpec extends ObjectBehavior
     {
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $this->beConstructedWith(
-            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook'),
+            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false),
             [
                 new WebhookEvent(
                     'product.created',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ActiveWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ActiveWebhookSpec.php
@@ -49,7 +49,7 @@ class ActiveWebhookSpec extends ObjectBehavior
 
     public function it_returns_uuid_usage_status(): void
     {
-        $this->usesUuid()
+        $this->isUsingUuid()
             ->shouldReturn(true);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ActiveWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ActiveWebhookSpec.php
@@ -15,7 +15,7 @@ class ActiveWebhookSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith('ecommerce', 0, 'a_secret', 'http://localhost/webhook');
+        $this->beConstructedWith('ecommerce', 0, 'a_secret', 'http://localhost/webhook', true);
     }
 
     public function it_is_initializable(): void
@@ -45,5 +45,11 @@ class ActiveWebhookSpec extends ObjectBehavior
     {
         $this->url()
             ->shouldReturn('http://localhost/webhook');
+    }
+
+    public function it_returns_uuid_usage_status(): void
+    {
+        $this->usesUuid()
+            ->shouldReturn(true);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
@@ -11,7 +11,7 @@ class ConnectionWebhookSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com');
+        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', true);
     }
 
     public function it_is_a_connection_webhook(): void
@@ -56,14 +56,27 @@ class ConnectionWebhookSpec extends ObjectBehavior
         $this->enabled()->shouldReturn(true);
     }
 
-    public function it_provides_a_normalized_format(): void
+    public function it_provides_the_uuid_use_status(): void
+    {
+        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', true);
+        $this->usesUuid()->shouldReturn(true);
+    }
+
+    public function it_could_have_no_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com');
+        $this->usesUuid()->shouldReturn(false);
+    }
+
+    public function it_provides_a_normalized_format(): void
+    {
+        $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', true);
         $this->normalize()->shouldReturn([
             'connectionCode' => 'magento',
             'enabled' => true,
             'secret' => 'secret_magento',
             'url' => 'any-url.com',
+            'usesUuid' => true,
         ]);
     }
 
@@ -75,6 +88,7 @@ class ConnectionWebhookSpec extends ObjectBehavior
             'enabled' => false,
             'secret' => null,
             'url' => null,
+            'usesUuid' => false,
         ]);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/ConnectionWebhookSpec.php
@@ -59,13 +59,13 @@ class ConnectionWebhookSpec extends ObjectBehavior
     public function it_provides_the_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com', true);
-        $this->usesUuid()->shouldReturn(true);
+        $this->isUsingUuid()->shouldReturn(true);
     }
 
     public function it_could_have_no_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'secret_magento', 'any-url.com');
-        $this->usesUuid()->shouldReturn(false);
+        $this->isUsingUuid()->shouldReturn(false);
     }
 
     public function it_provides_a_normalized_format(): void
@@ -76,7 +76,7 @@ class ConnectionWebhookSpec extends ObjectBehavior
             'enabled' => true,
             'secret' => 'secret_magento',
             'url' => 'any-url.com',
-            'usesUuid' => true,
+            'isUsingUuid' => true,
         ]);
     }
 
@@ -88,7 +88,7 @@ class ConnectionWebhookSpec extends ObjectBehavior
             'enabled' => false,
             'secret' => null,
             'url' => null,
-            'usesUuid' => false,
+            'isUsingUuid' => false,
         ]);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
@@ -32,7 +32,7 @@ class EventSubscriptionFormDataSpec extends ObjectBehavior
                 'enabled' => true,
                 'secret' => null,
                 'url' => null,
-                'usesUuid' => false,
+                'isUsingUuid' => false,
             ],
             'active_event_subscriptions_limit' => [
                 'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Read/EventSubscriptionFormDataSpec.php
@@ -32,6 +32,7 @@ class EventSubscriptionFormDataSpec extends ObjectBehavior
                 'enabled' => true,
                 'secret' => null,
                 'url' => null,
+                'usesUuid' => false,
             ],
             'active_event_subscriptions_limit' => [
                 'limit' => 3,

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Write/ConnectionWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Write/ConnectionWebhookSpec.php
@@ -46,4 +46,16 @@ class ConnectionWebhookSpec extends ObjectBehavior
         $this->beConstructedWith('magento', false);
         $this->url()->shouldReturn(null);
     }
+
+    public function it_provides_the_uuid_use_status(): void
+    {
+        $this->beConstructedWith('magento', true, 'any-url.com', true);
+        $this->usesUuid()->shouldReturn(true);
+    }
+
+    public function it_could_have_no_uuid_use_status(): void
+    {
+        $this->beConstructedWith('magento', true, 'any-url.com');
+        $this->usesUuid()->shouldReturn(false);
+    }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Write/ConnectionWebhookSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/Write/ConnectionWebhookSpec.php
@@ -50,12 +50,12 @@ class ConnectionWebhookSpec extends ObjectBehavior
     public function it_provides_the_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'any-url.com', true);
-        $this->usesUuid()->shouldReturn(true);
+        $this->isUsingUuid()->shouldReturn(true);
     }
 
     public function it_could_have_no_uuid_use_status(): void
     {
         $this->beConstructedWith('magento', true, 'any-url.com');
-        $this->usesUuid()->shouldReturn(false);
+        $this->isUsingUuid()->shouldReturn(false);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Webhook/Client/GuzzleWebhookClientSpec.php
@@ -89,7 +89,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $Request1pimEvent = $this->createEvent($author, ['data_1'], 1577836800, '7abae2fe-759a-4fce-aa43-f413980671b3');
         $request1 = new WebhookRequest(
-            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook1'),
+            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook1', false),
             [
                 new WebhookEvent(
                     'product.created',
@@ -105,7 +105,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
         $Request2pimEvent = $this->createEvent($author, ['data_2'], 1577836800, '7abae2fe-759a-4fce-aa43-f413980671b3');
         $request2 = new WebhookRequest(
-            new ActiveWebhook('erp', 1, 'a_secret', 'http://localhost/webhook2'),
+            new ActiveWebhook('erp', 1, 'a_secret', 'http://localhost/webhook2', false),
             [
                 new WebhookEvent(
                     'product.created',
@@ -222,7 +222,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $request1 = new WebhookRequest(
-            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook1'),
+            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook1', false),
             [
                 new WebhookEvent(
                     'product.created',
@@ -274,7 +274,7 @@ class GuzzleWebhookClientSpec extends ObjectBehavior
 
         $author = Author::fromNameAndType('julia', Author::TYPE_UI);
         $request = new WebhookRequest(
-            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook'),
+            new ActiveWebhook('ecommerce', 0, 'a_secret', 'http://localhost/webhook', false),
             [
                 new WebhookEvent(
                     'product.created',

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -85,6 +85,15 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                     disabled={false === webhook.enabled && isActiveEventSubscriptionsLimitReached()}
                 />
             </FormGroup>
+            <FormGroup
+                label='akeneo_connectivity.connection.webhook.form.uses_uuid'
+            >
+                <ToggleButton
+                    name='usesUuid'
+                    ref={register}
+                    defaultChecked={webhook.usesUuid}
+                />
+            </FormGroup>
 
             <FormGroup
                 controlId='url'

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -85,14 +85,8 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                     disabled={false === webhook.enabled && isActiveEventSubscriptionsLimitReached()}
                 />
             </FormGroup>
-            <FormGroup
-                label='akeneo_connectivity.connection.webhook.form.is_using_uuid'
-            >
-                <ToggleButton
-                    name='usesUuid'
-                    ref={register}
-                    defaultChecked={webhook.isUsingUuid}
-                />
+            <FormGroup label='akeneo_connectivity.connection.webhook.form.is_using_uuid'>
+                <ToggleButton name='isUsingUuid' ref={register} defaultChecked={webhook.isUsingUuid} />
             </FormGroup>
 
             <FormGroup

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/components/EditForm.tsx
@@ -86,12 +86,12 @@ export const EditForm: FC<Props> = ({webhook, activeEventSubscriptionsLimit}: Pr
                 />
             </FormGroup>
             <FormGroup
-                label='akeneo_connectivity.connection.webhook.form.uses_uuid'
+                label='akeneo_connectivity.connection.webhook.form.is_using_uuid'
             >
                 <ToggleButton
                     name='usesUuid'
                     ref={register}
-                    defaultChecked={webhook.usesUuid}
+                    defaultChecked={webhook.isUsingUuid}
                 />
             </FormGroup>
 

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
@@ -6,6 +6,7 @@ import {useRoute} from '../../../shared/router';
 export type EventSubscription = {
     connectionCode: string;
     enabled: boolean;
+    usesUuid: boolean;
     secret: string | null;
     url: string | null;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-fetch-event-subscription.ts
@@ -6,7 +6,7 @@ import {useRoute} from '../../../shared/router';
 export type EventSubscription = {
     connectionCode: string;
     enabled: boolean;
-    usesUuid: boolean;
+    isUsingUuid: boolean;
     secret: string | null;
     url: string | null;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-update-webhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-update-webhook.tsx
@@ -9,12 +9,13 @@ export type RequestData = {
     connectionCode: string;
     enabled: boolean;
     url: string | null;
+    usesUuid: boolean;
 };
 
 type ResultError = {
     message: string;
     errors: Array<{
-        field: 'connectionCode' | 'url' | 'enabled';
+        field: 'connectionCode' | 'url' | 'enabled' | 'usesUuid';
         message: string;
     }>;
 };
@@ -23,6 +24,7 @@ type ResultOk = {
     url: string | null;
     secret: string | null;
     enabled: boolean;
+    usesUuid: boolean;
 };
 
 export const useUpdateWebhook = (code: string) => {
@@ -38,6 +40,7 @@ export const useUpdateWebhook = (code: string) => {
                 code: data.connectionCode,
                 enabled: data.enabled,
                 url: data.url,
+                uses_uuid: data.usesUuid,
             }),
         });
         if (isErr(result)) {

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-update-webhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/hooks/api/use-update-webhook.tsx
@@ -9,13 +9,13 @@ export type RequestData = {
     connectionCode: string;
     enabled: boolean;
     url: string | null;
-    usesUuid: boolean;
+    isUsingUuid: boolean;
 };
 
 type ResultError = {
     message: string;
     errors: Array<{
-        field: 'connectionCode' | 'url' | 'enabled' | 'usesUuid';
+        field: 'connectionCode' | 'url' | 'enabled' | 'isUsingUuid';
         message: string;
     }>;
 };
@@ -24,7 +24,7 @@ type ResultOk = {
     url: string | null;
     secret: string | null;
     enabled: boolean;
-    usesUuid: boolean;
+    isUsingUuid: boolean;
 };
 
 export const useUpdateWebhook = (code: string) => {
@@ -40,7 +40,7 @@ export const useUpdateWebhook = (code: string) => {
                 code: data.connectionCode,
                 enabled: data.enabled,
                 url: data.url,
-                uses_uuid: data.usesUuid,
+                is_using_uuid: data.isUsingUuid,
             }),
         });
         if (isErr(result)) {

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
@@ -3,5 +3,5 @@ export type Webhook = {
     url: string | null;
     secret: string | null;
     enabled: boolean;
-    usesUuid: boolean;
+    isUsingUuid: boolean;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/model/Webhook.ts
@@ -3,4 +3,5 @@ export type Webhook = {
     url: string | null;
     secret: string | null;
     enabled: boolean;
+    usesUuid: boolean;
 };

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -23,7 +23,7 @@ export type FormInput = {
     url: string | null;
     enabled: boolean;
     secret: string | null;
-    usesUuid: boolean;
+    isUsingUuid: boolean;
 };
 
 export const EditConnectionWebhook: FC = () => {
@@ -107,7 +107,7 @@ const SaveButton: FC<SaveButtonProps> = ({webhook, onSaveSuccess}) => {
     const {formState, getValues, triggerValidation, handleSubmit, setError} = useFormContext<FormInput>();
     const updateWebhook = useUpdateWebhook(webhook.connectionCode);
     const handleSave = async () => {
-        const {enabled, url, usesUuid} = getValues();
+        const {enabled, url, isUsingUuid} = getValues();
 
         const isValid = await triggerValidation();
         if (isValid) {
@@ -115,7 +115,7 @@ const SaveButton: FC<SaveButtonProps> = ({webhook, onSaveSuccess}) => {
                 connectionCode: webhook.connectionCode,
                 enabled,
                 url: '' === url ? null : url,
-                usesUuid,
+                isUsingUuid,
             });
             if (isErr(result)) {
                 result.error.errors.forEach(error => {

--- a/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/webhook/pages/EditConnectionWebhook.tsx
@@ -23,6 +23,7 @@ export type FormInput = {
     url: string | null;
     enabled: boolean;
     secret: string | null;
+    usesUuid: boolean;
 };
 
 export const EditConnectionWebhook: FC = () => {
@@ -106,7 +107,7 @@ const SaveButton: FC<SaveButtonProps> = ({webhook, onSaveSuccess}) => {
     const {formState, getValues, triggerValidation, handleSubmit, setError} = useFormContext<FormInput>();
     const updateWebhook = useUpdateWebhook(webhook.connectionCode);
     const handleSave = async () => {
-        const {enabled, url} = getValues();
+        const {enabled, url, usesUuid} = getValues();
 
         const isValid = await triggerValidation();
         if (isValid) {
@@ -114,6 +115,7 @@ const SaveButton: FC<SaveButtonProps> = ({webhook, onSaveSuccess}) => {
                 connectionCode: webhook.connectionCode,
                 enabled,
                 url: '' === url ? null : url,
+                usesUuid,
             });
             if (isErr(result)) {
                 result.error.errors.forEach(error => {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/webhook.yml
@@ -4,6 +4,7 @@ services:
         arguments:
             - '@akeneo.pim.enrichment.product.connector.get_product_from_uuids'
             - '@pim_api.normalizer.connector_products'
+            - '@Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer'
         tags:
             - { name: akeneo_connectivity.connection.webhook.event_data_builder }
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Connector\ReadModel\ConnectorProduct
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductNormalizer;
+use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ConnectorProductWithUuidNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Query\GetConnectorProducts;
 use Akeneo\Pim\Enrichment\Component\Product\Webhook\Exception\ProductNotFoundException;
 use Akeneo\Platform\Component\EventQueue\BulkEventInterface;
@@ -25,7 +26,8 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
 {
     public function __construct(
         private GetConnectorProducts $getConnectorProductsQuery,
-        private ConnectorProductNormalizer $connectorProductNormalizer
+        private ConnectorProductNormalizer $connectorProductNormalizer,
+        private ConnectorProductWithUuidNormalizer $connectorProductWithUuidNormalizer,
     ) {
     }
 
@@ -66,8 +68,12 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
                 continue;
             }
 
+            $normalizer = $context->useUuid()
+                ? $this->connectorProductWithUuidNormalizer
+                : $this->connectorProductNormalizer;
+
             $data = [
-                'resource' => $this->connectorProductNormalizer->normalizeConnectorProduct($product),
+                'resource' => $normalizer->normalizeConnectorProduct($product),
             ];
             $collection->setEventData($event, $data);
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Webhook/ProductCreatedAndUpdatedEventDataBuilder.php
@@ -68,7 +68,7 @@ class ProductCreatedAndUpdatedEventDataBuilder implements EventDataBuilderInterf
                 continue;
             }
 
-            $normalizer = $context->useUuid()
+            $normalizer = $context->isUsingUuid()
                 ? $this->connectorProductWithUuidNormalizer
                 : $this->connectorProductNormalizer;
 

--- a/src/Akeneo/Platform/Component/Webhook/Context.php
+++ b/src/Akeneo/Platform/Component/Webhook/Context.php
@@ -10,13 +10,11 @@ namespace Akeneo\Platform\Component\Webhook;
  */
 final class Context
 {
-    private string $username;
-    private int $userId;
-
-    public function __construct(string $username, int $userId)
-    {
-        $this->username = $username;
-        $this->userId = $userId;
+    public function __construct(
+        private string $username,
+        private int $userId,
+        private bool $useUuid,
+    ) {
     }
 
     public function getUsername(): string
@@ -27,5 +25,10 @@ final class Context
     public function getUserId(): int
     {
         return $this->userId;
+    }
+
+    public function useUuid(): bool
+    {
+        return $this->useUuid;
     }
 }

--- a/src/Akeneo/Platform/Component/Webhook/Context.php
+++ b/src/Akeneo/Platform/Component/Webhook/Context.php
@@ -13,7 +13,7 @@ final class Context
     public function __construct(
         private string $username,
         private int $userId,
-        private bool $useUuid,
+        private bool $isUsingUuid = false,
     ) {
     }
 
@@ -27,8 +27,8 @@ final class Context
         return $this->userId;
     }
 
-    public function useUuid(): bool
+    public function isUsingUuid(): bool
     {
-        return $this->useUuid;
+        return $this->isUsingUuid;
     }
 }

--- a/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
+++ b/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
@@ -15,7 +15,7 @@ class ContextSpec extends ObjectBehavior
 {
     public function let(): void
     {
-        $this->beConstructedWith('username_0000', 10);
+        $this->beConstructedWith('username_0000', 10, true);
     }
 
     public function it_is_a_context(): void
@@ -31,5 +31,10 @@ class ContextSpec extends ObjectBehavior
     public function it_returns_a_user_id(): void
     {
         $this->getUserId()->shouldReturn(10);
+    }
+
+    public function it_returns_a_uuid_usage_status(): void
+    {
+        $this->useUuid()->shouldReturn(true);
     }
 }

--- a/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
+++ b/tests/back/Platform/Specification/Component/Webhook/ContextSpec.php
@@ -35,6 +35,6 @@ class ContextSpec extends ObjectBehavior
 
     public function it_returns_a_uuid_usage_status(): void
     {
-        $this->useUuid()->shouldReturn(true);
+        $this->isUsingUuid()->shouldReturn(true);
     }
 }

--- a/upgrades/schema/Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag.php
+++ b/upgrades/schema/Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag.php
@@ -7,11 +7,11 @@ namespace Pim\Upgrade\Schema;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-final class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag extends AbstractMigration
+final class Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag extends AbstractMigration
 {
     public function up(Schema $schema): void
     {
-        if ($schema->getTable('akeneo_connectivity_connection')->hasColumn('webhook_uses_uuid')) {
+        if ($schema->getTable('akeneo_connectivity_connection')->hasColumn('webhook_is_using_uuid')) {
             $this->disableMigrationWarning();
             return;
         }
@@ -19,7 +19,7 @@ final class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag ext
         $this->addSql(
             <<<SQL
             ALTER TABLE akeneo_connectivity_connection
-            ADD webhook_uses_uuid TINYINT(1) DEFAULT 0 NOT NULL AFTER webhook_enabled
+            ADD webhook_is_using_uuid TINYINT(1) DEFAULT 0 NOT NULL AFTER webhook_enabled
             SQL
         );
     }

--- a/upgrades/schema/Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag.php
+++ b/upgrades/schema/Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        if ($schema->getTable('akeneo_connectivity_connection')->hasColumn('webhook_uses_uuid')) {
+            $this->disableMigrationWarning();
+            return;
+        }
+
+        $this->addSql(
+            <<<SQL
+            ALTER TABLE akeneo_connectivity_connection
+            ADD webhook_uses_uuid TINYINT(1) DEFAULT 0 NOT NULL AFTER webhook_enabled
+            SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag_Integration.php
@@ -12,11 +12,11 @@ use Doctrine\DBAL\Connection;
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integration extends TestCase
+class Version_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag_Integration extends TestCase
 {
     use ExecuteMigrationTrait;
 
-    private const MIGRATION_LABEL = '_7_0_20220907143028_add_connection_webhook_uses_uuid_flag';
+    private const MIGRATION_LABEL = '_7_0_20220907143028_add_connection_webhook_is_using_uuid_flag';
     private ?Connection $connection = null;
 
     protected function getConfiguration(): ?Configuration
@@ -32,11 +32,11 @@ class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integrati
 
     public function test_it_adds_webhook_uses_uuid_column(): void
     {
-        $this->removeColumn('akeneo_connectivity_connection', 'webhook_uses_uuid');
+        $this->removeColumn('akeneo_connectivity_connection', 'webhook_is_using_uuid');
 
         $this->reExecuteMigration(self::MIGRATION_LABEL);
 
-        $this->assertTrue($this->hasColumn('akeneo_connectivity_connection', 'webhook_uses_uuid'));
+        $this->assertTrue($this->hasColumn('akeneo_connectivity_connection', 'webhook_is_using_uuid'));
     }
 
     private function removeColumn(string $table, string $column): void
@@ -50,6 +50,8 @@ class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integrati
                 ALTER TABLE $table DROP COLUMN $column;
             SQL
         );
+
+        $this->assertFalse($this->hasColumn($table, $column));
     }
 
     private function hasColumn(string $table, string $column): bool

--- a/upgrades/test_schema/Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integration.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_7_0_20220907143028_add_connection_webhook_uses_uuid_flag_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220907143028_add_connection_webhook_uses_uuid_flag';
+    private ?Connection $connection = null;
+
+    protected function getConfiguration(): ?Configuration
+    {
+        return null;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_adds_webhook_uses_uuid_column(): void
+    {
+        $this->removeColumn('akeneo_connectivity_connection', 'webhook_uses_uuid');
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertTrue($this->hasColumn('akeneo_connectivity_connection', 'webhook_uses_uuid'));
+    }
+
+    private function removeColumn(string $table, string $column): void
+    {
+        if (!$this->hasColumn($table, $column)) {
+            return;
+        }
+
+        $this->connection->executeQuery(
+            <<<SQL
+                ALTER TABLE $table DROP COLUMN $column;
+            SQL
+        );
+    }
+
+    private function hasColumn(string $table, string $column): bool
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<SQL
+                SHOW COLUMNS FROM $table LIKE '$column';
+            SQL,
+        );
+
+        return count($rows) >= 1;
+    }
+}


### PR DESCRIPTION
Added a toggle to use UUID instead of identifiers
If true, generated events will produce products payload using the UUID normalizer
Example
set to false
![image](https://user-images.githubusercontent.com/7101819/189347562-f9b7446f-9bf1-4c3a-b3f1-c8212368d83d.png)
set to true:
![image](https://user-images.githubusercontent.com/7101819/189347481-ad278947-ad80-4206-9254-1b1c121b421f.png)
