### PR TITLE
Use APP_DEBUG env var for test Kernel

### DIFF
--- a/tests/back/Integration/TestCase.php
+++ b/tests/back/Integration/TestCase.php
@@ -37,7 +37,7 @@ abstract class TestCase extends KernelTestCase
      */
     protected function setUp(): void
     {
-        $this->testKernel = static::bootKernel(['debug' => false]);
+        $this->testKernel = static::bootKernel(['debug' => (bool)($_SERVER['APP_DEBUG'] ?? false)]);
 
         /** @var FilePersistedFeatureFlags $featureFlags*/
         $featureFlags = $this->get('feature_flags');


### PR DESCRIPTION
This PR allows you to run integration tests without using the cache container.
It can be useful when working on services DI definition by launching the integration test. Without this PR, you have to clear the cache each time you modify the DI, which is a real pain... :cry: 

You can activate the debug several ways:

By adding the env var in the Docker command line:

```bash
APP_ENV=test docker-compose run --rm -e APP_DEBUG=1 php vendor/bin/phpunit src/Akeneo/..../MyTestIntegration.php
```

Or by adding the APP_DEBUG in a local test env file named `.env.test.local`