### PR TITLE
OCT-121: Fix first failing test with empty cache

### DIFF
--- a/components/catalogs/back/phpunit.xml.dist
+++ b/components/catalogs/back/phpunit.xml.dist
@@ -19,7 +19,7 @@
         <ini name="intl.error_level" value="0"/>
         <ini name="memory_limit" value="-1"/>
         <ini name="zend.enable_gc" value="1"/>
-        <server name="KERNEL_CLASS" value="Kernel" force="true" />
+        <server name="KERNEL_CLASS" value="Akeneo\Catalogs\Test\Integration\Kernel" force="true" />
     </php>
 
     <groups>

--- a/components/catalogs/back/tests/Integration/Fakes/TimestampableSubscriber.php
+++ b/components/catalogs/back/tests/Integration/Fakes/TimestampableSubscriber.php
@@ -15,9 +15,17 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
  */
 final class TimestampableSubscriber implements EventSubscriber
 {
+    private Clock $clock;
+
     public function __construct(
-        private Clock $clock
+        ?Clock $clock = null,
     ) {
+        $this->clock = $clock ?? new Clock();
+    }
+
+    public function setClock(Clock $clock): void
+    {
+        $this->clock = $clock;
     }
 
     public function getSubscribedEvents()

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -48,14 +48,13 @@ abstract class IntegrationTestCase extends WebTestCase
         static::bootKernel(['environment' => 'test', 'debug' => false]);
 
         $this->clock = new Clock();
-        self::getContainer()->set(
-            'pim_catalog.event_subscriber.timestampable',
-            new TimestampableSubscriber($this->clock)
-        );
-        self::getContainer()->set(
-            'pim_versioning.event_subscriber.timestampable',
-            new TimestampableSubscriber($this->clock)
-        );
+
+        self::getContainer()
+            ->get('pim_catalog.event_subscriber.timestampable')
+            ->setClock($this->clock);
+        self::getContainer()
+            ->get('pim_versioning.event_subscriber.timestampable')
+            ->setClock($this->clock);
 
         self::getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
 

--- a/components/catalogs/back/tests/Integration/Kernel.php
+++ b/components/catalogs/back/tests/Integration/Kernel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Test\Integration;
+
+use Akeneo\Catalogs\Test\Integration\Fakes\TimestampableSubscriber;
+use Kernel as AppKernel;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class Kernel extends AppKernel
+{
+    protected function build(ContainerBuilder $container): void
+    {
+        $pimCatalogTimestampableSubscriber = new Definition(TimestampableSubscriber::class, []);
+        $pimCatalogTimestampableSubscriber->setDecoratedService('pim_catalog.event_subscriber.timestampable');
+
+        $pimVersioningTimestampableSubscriber = new Definition(TimestampableSubscriber::class, []);
+        $pimVersioningTimestampableSubscriber->setDecoratedService('pim_versioning.event_subscriber.timestampable');
+
+        $container->addDefinitions([
+            'test.pim_catalog.event_subscriber.timestampable' => $pimCatalogTimestampableSubscriber,
+            'test.pim_versioning.event_subscriber.timestampable' => $pimVersioningTimestampableSubscriber,
+        ]);
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In integration tests, we should use decorated service to override ones we need. As we can't use a global `config_test.yaml` file because it would impact all the PIM, we declare a dedicated Kernel class to our integration tests and manually decorate services in it.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
