### PR TITLE
GRF-349 fix DSM InputTextArea : richtext : selected dropdown items in…

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/TextAreaInput/TextAreaInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/TextAreaInput/TextAreaInput.tsx
@@ -29,6 +29,10 @@ const CommonStyle = css<{readOnly: boolean; invalid: boolean} & AkeneoThemedProp
   &:focus-within {
     box-shadow: 0 0 0 2px ${getColor('blue', 40)};
   }
+
+  a.rdw-dropdown-selectedtext > span {
+    color: ${({readOnly}) => (readOnly ? getColor('grey', 100) : getColor('grey', 140))};
+  }
 `;
 
 const RichTextEditorContainer = styled.div<{readOnly: boolean; invalid: boolean} & AkeneoThemedProps>`


### PR DESCRIPTION
… toolbar where styled link links in PIM (purple)

**Description (for Contributor and Core Developer)**

When embedded in PIM,
an InputTextArea from DSM havingprop isRichText set to true
had some purple texts in the wysiwyg toolbar UI because the style of the link in PIM was applied.

A dedicated specific selector prevents the color of element being set by the PIM above.

**Definition Of Done (for Core Developer only)**

- [ ] PM Validation (Story)
