### PR TITLE
PIM-10644: Fix identifier format check on multiple product update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - PIM-10667: Fix product import when measurement contains line break
 - PIM-10669: Fix the attribute list does not update if we don't scroll
 - PIM-10655: Fix format of empty completeness in API
+- PIM-10644: Fix identifier format check on multiple product update
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -73,6 +73,9 @@ final class StreamResourceResponse
                     if (null === $data) {
                         throw new BadRequestHttpException('Invalid json message received');
                     }
+                    if (isset($data[$this->identifierKey]) && !is_string($data[$this->identifierKey])) {
+                        throw new UnprocessableEntityHttpException(\sprintf('%s must be of type string.', $this->identifierKey));
+                    }
                     if (!isset($data[$this->identifierKey]) || '' === trim($data[$this->identifierKey])) {
                         throw new UnprocessableEntityHttpException(sprintf('%s is missing.', ucfirst($this->identifierKey)));
                     }

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductEndToEnd.php
@@ -214,7 +214,7 @@ JSON;
 {"line":8,"status_code":413,"message":"Line is too long."}
 {"line":9,"status_code":413,"message":"Line is too long."}
 {"line":10,"status_code":400,"message":"Invalid json message received"}
-{"line":11,"identifier":123456,"status_code":422,"message":"The identifier field requires a string. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products__code_"}}}
+{"line":11,"status_code":422,"message":"identifier must be of type string."}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
@@ -243,6 +243,27 @@ JSON;
 {"line":3,"status_code":422,"message":"Identifier is missing."}
 {"line":4,"status_code":422,"message":"Identifier is missing."}
 {"line":5,"status_code":422,"message":"Identifier is missing."}
+JSON;
+
+        $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);
+        $httpResponse = $response['http_response'];
+
+        $this->assertSame(Response::HTTP_OK, $httpResponse->getStatusCode());
+        $this->assertSame($expectedContent, $response['content']);
+    }
+
+    public function testErrorWhenIdentifierIsWrongType()
+    {
+        $data =
+            <<<JSON
+    {"identifier": []}
+    {"identifier": true}
+JSON;
+
+        $expectedContent =
+            <<<JSON
+{"line":1,"status_code":422,"message":"identifier must be of type string."}
+{"line":2,"status_code":422,"message":"identifier must be of type string."}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
@@ -192,7 +192,7 @@ JSON;
             'line_too_long_5' => str_repeat('a', $this->getBufferSize() * 2),
             'line_too_long_6' => str_repeat('a', $this->getBufferSize() * 5),
             'invalid_json_4'  => str_repeat('a', $this->getBufferSize()),
-            'invalid_uuid_datatype' => '{"uuid": 122345, "family": "familyA2", "values": {"sku": [{"locale": null, "scope": null, "data": "123456" }]}}',
+            'invalid_uuid_datatype' => '{"uuid": "122345", "family": "familyA2", "values": {"sku": [{"locale": null, "scope": null, "data": "123456" }]}}',
         ];
 
         $data =
@@ -222,7 +222,7 @@ JSON;
 {"line":8,"status_code":413,"message":"Line is too long."}
 {"line":9,"status_code":413,"message":"Line is too long."}
 {"line":10,"status_code":400,"message":"Invalid json message received"}
-{"line":11,"uuid":122345,"code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
+{"line":11,"uuid":"122345","code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products-uuid', [], [], [], $data);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/ProductModel/ExternalApi/PartialUpdateListProductModelEndToEnd.php
@@ -314,7 +314,7 @@ JSON;
 {"line":3,"status_code":422,"message":"Code is missing."}
 {"line":4,"status_code":422,"message":"Code is missing."}
 {"line":5,"status_code":422,"message":"Code is missing."}
-{"line":6,"code":123456,"status_code":422,"message":"The code field requires a string. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_product_models__code_"}}}
+{"line":6,"status_code":422,"message":"code must be of type string."}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/product-models', [], [], [], $data);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When value from identifierCode was not a string, an error 500 was thrown. Now we throw 2.. type error

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
