### PR TITLE
OCT-128: deduplicate ES indices

### DIFF
--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Client.php
@@ -334,6 +334,10 @@ class Client
      */
     public function createIndex()
     {
+        if ($this->hasIndexForAlias()) {
+            throw new \LogicException(sprintf('Index %s already exists', $this->indexName));
+        }
+
         $configuration = $this->configurationLoader->load();
         $body = $configuration->buildAggregated();
         $body['aliases'] = [$this->indexName => (object) []];

--- a/upgrades/schema/Version_7_0_20220920000000_deduplicate_elasticsearch_indices.php
+++ b/upgrades/schema/Version_7_0_20220920000000_deduplicate_elasticsearch_indices.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Elasticsearch\Client;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_7_0_20220920000000_deduplicate_elasticsearch_indices extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container;
+    private ?Client $client;
+
+    public function up(Schema $schema): void
+    {
+        $aliases = [
+            $this->container->getParameter('events_api_debug_index_name'),
+            $this->container->getParameter('connection_error_index_name'),
+        ];
+
+        foreach ($aliases as $alias) {
+            $this->removeDuplicatedIndices($alias);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function removeDuplicatedIndices(string $alias): void
+    {
+        $esClient = $this->getEsClient();
+        $indices = $esClient->indices()->getAlias(['name' => $alias]);
+
+        if (\count($indices) <= 1) {
+            return;
+        }
+
+        /** @var array<string> $duplicates */
+        $duplicates = \array_slice(\array_keys($indices), 1);
+
+        foreach ($duplicates as $duplicate) {
+            $esClient->indices()->delete(['index' => $duplicate]);
+        }
+    }
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    private function getEsClient(): Client
+    {
+        return $this->client ??= $this->buildEsClient();
+    }
+
+    private function buildEsClient(): Client
+    {
+        $builder = $this->container->get('akeneo_elasticsearch.client_builder');
+        $builder->setHosts([$this->container->getParameter('index_hosts')]);
+
+        return $builder->build();
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220920000000_deduplicate_elasticsearch_indices_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220920000000_deduplicate_elasticsearch_indices_Integration.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
+use Elasticsearch\Client;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+final class Version_7_0_20220920000000_deduplicate_elasticsearch_indices_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_NAME = '_7_0_20220920000000_deduplicate_elasticsearch_indices';
+
+    private ?Client $client;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    public function testItRemovesDuplicatedIndices(): void
+    {
+        $this->removeEventsApiDebugIndices();
+        $this->createEventsApiDebugIndice();
+        $this->createEventsApiDebugIndice();
+
+        $this->assertCount(2, $this->getEventsApiDebugIndices());
+
+        $this->reExecuteMigration(self::MIGRATION_NAME);
+
+        $this->assertCount(1, $this->getEventsApiDebugIndices());
+    }
+
+    private function removeEventsApiDebugIndices(): void
+    {
+        $esClient = $this->getEsClient();
+
+        $alias = self::getContainer()->getParameter('events_api_debug_index_name');
+        $indices = $esClient->indices()->getAlias(['name' => $alias]);
+
+        foreach (\array_keys($indices) as $indice) {
+            $esClient->indices()->delete(['index' => $indice]);
+        }
+    }
+
+    private function createEventsApiDebugIndice(): void
+    {
+        $esClient = $this->getEsClient();
+
+        $alias = self::getContainer()->getParameter('events_api_debug_index_name');
+        $configurationLoader = new Loader(
+            self::getContainer()->getParameter('events_api_debug_elasticsearch_index_configuration_file'),
+            new ParameterBag()
+        );
+
+        $configuration = $configurationLoader->load();
+        $body = $configuration->buildAggregated();
+        $body['aliases'] = [$alias => (object) []];
+
+        $params = [
+            'index' => \strtolower($alias.'_'.Uuid::uuid4()->toString()),
+            'body' => $body,
+        ];
+
+        $esClient->indices()->create($params);
+    }
+
+    private function getEventsApiDebugIndices(): array
+    {
+        $esClient = $this->getEsClient();
+
+        $alias = self::getContainer()->getParameter('events_api_debug_index_name');
+
+        return $esClient->indices()->getAlias(['name' => $alias]);
+    }
+
+    private function getEsClient(): Client
+    {
+        return $this->client ??= $this->buildEsClient();
+    }
+
+    private function buildEsClient(): Client
+    {
+        $builder = self::getContainer()->get('akeneo_elasticsearch.client_builder');
+        $builder->setHosts([self::getContainer()->getParameter('index_hosts')]);
+
+        return $builder->build();
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

`Client::createIndex` did not prevent the PIM from creating multiple indices with the same alias.

We have, on some customers environments, the following error:
```
{"type":"illegal_argument_exception","reason":"no write index is defined for alias [akeneo_connectivity_connection_events_api_debug]. The write index may be explicitly disabled using is_write_index=false or the alias points to multiple indices without one being designated as a write index"}
```

In this PR:
1) I prevent createIndex to duplicate indices
2) I add a migration that will remove duplicated indices

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
