### PR TITLE
PIM-10646: Fix export with label from a select attribute containing uppercase in its code exports code and not labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - PIM-10624: Fix very slow query when counting variants for mass delete
 - PIM-10566: Fix wrong namespace for categories in resource_name column in pim_versioning_version table
 - PIM-10568: Fix error when running Version_7_0_20220629142647_dqi_update_pk_on_product_score during On-Premise/Flex to Serenity migration
+- PIM-10646: Fix export with label from a select attribute containing uppercase in its code exports code and not labels
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
@@ -35,6 +35,8 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionKeys
         );
 
+        $attributeOptionTranslations = array_change_key_case($attributeOptionTranslations, CASE_LOWER);
+
         $result = [];
         foreach ($values as $valueIndex => $value) {
             if (null === $value || '' === $value) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
@@ -34,6 +34,8 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionKeys
         );
 
+        $attributeOptionTranslations = array_change_key_case($attributeOptionTranslations, CASE_LOWER);
+
         $result = [];
         foreach ($values as $valueIndex => $value) {
             if (null === $value || '' === $value) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
@@ -47,6 +47,25 @@ class MultiSelectTranslatorSpec extends ObjectBehavior
             ->shouldReturn(['rouge,jaune', 'purple', '']);
     }
 
+    function it_is_attribute_code_case_insensitive_to_find_option_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                'color.red',
+                'color.yellow',
+                'color.purple'
+            ])
+            ->willReturn([
+                'Color.red' => ['fr_FR' => 'rouge'],
+                'Color.yellow' => ['fr_FR' => 'jaune'],
+                'Color.purple' => ['fr_FR' => 'purple']
+            ]);
+
+        $this->translate('Color', [], ['ReD', 'YeLLoW', 'PURPle', ''], 'fr_FR')
+            ->shouldReturn(['rouge', 'jaune', 'purple', '']);
+    }
+
     function it_translates_multi_select_value_with_numeric_label(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
@@ -81,6 +81,25 @@ class SimpleSelectTranslatorSpec extends ObjectBehavior
             ->shouldReturn(['rouge', 'jaune', 'purple', '']);
     }
 
+    function it_is_attribute_code_case_insensitive_to_find_option_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                'color.red',
+                'color.yellow',
+                'color.purple'
+            ])
+            ->willReturn([
+                'Color.red' => ['fr_FR' => 'rouge'],
+                'Color.yellow' => ['fr_FR' => 'jaune'],
+                'Color.purple' => ['fr_FR' => 'purple']
+            ]);
+
+        $this->translate('Color', [], ['ReD', 'YeLLoW', 'PURPle', ''], 'fr_FR')
+            ->shouldReturn(['rouge', 'jaune', 'purple', '']);
+    }
+
     function it_translates_simple_select_value_with_numeric_label(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I fixed the fact that code is returned when there is an uppercase in the attribute code when exporting with label. The option key generated is always in lowercase that why we can't find the option label

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
