### PR TITLE
PIM-10631: increase the FOS OAuth scope column to VARCHAR(1000)

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -27,6 +27,7 @@ PIM-10679: Fix out of sort memory on ProductModelImagesFromCodes
 
 ## Bug fixes
 
+- PIM-10631: increase the FOS OAuth scope column to VARCHAR(1000)
 - PIM-10435: [Backport] Fix search_after requests with codes using uppercase accented characters
 
 # 6.0.43 (2022-09-20)

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/IncreaseScopeLengthQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Persistence/Query/IncreaseScopeLengthQuery.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Pull-up master: do not pull this class: a migration handles the length's increase.
+ */
+final class IncreaseScopeLengthQuery
+{
+    public function __construct(
+        private Connection $connection
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+        if (!is_string($databaseName)) {
+            return;
+        }
+
+        $this->increaseAccessTokenScopeLength($databaseName);
+        $this->increaseRefreshTokenScopeLength($databaseName);
+        $this->increaseAuthCodeScopeLength($databaseName);
+    }
+
+    private function increaseAccessTokenScopeLength(string $databaseName): void
+    {
+        $findAccessTokenScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_access_token' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $scopeLength = $this->connection->executeQuery($findAccessTokenScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        if ('1000' === $scopeLength) {
+            return;
+        }
+
+        $this->connection->executeQuery('ALTER TABLE pim_api_access_token MODIFY scope VARCHAR(1000) DEFAULT NULL');
+    }
+
+    private function increaseRefreshTokenScopeLength(string $databaseName): void
+    {
+        $findRefreshTokenScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_refresh_token' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $scopeLength = $this->connection->executeQuery($findRefreshTokenScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        if ('1000' === $scopeLength) {
+            return;
+        }
+
+        $this->connection->executeQuery('ALTER TABLE pim_api_refresh_token MODIFY scope VARCHAR(1000) DEFAULT NULL');
+    }
+
+    private function increaseAuthCodeScopeLength(string $databaseName): void
+    {
+        $findAuthCodeScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_auth_code' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $scopeLength = $this->connection->executeQuery($findAuthCodeScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        if ('1000' === $scopeLength) {
+            return;
+        }
+
+        $this->connection->executeQuery('ALTER TABLE pim_api_auth_code MODIFY scope VARCHAR(1000) DEFAULT NULL');
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/apps.yml
@@ -98,6 +98,8 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetUserConsentedAuthenticationUuidQuery'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetUserConsentedAuthenticationScopesQuery'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetAccessTokenQuery'
+            # Pull-up master: do not inject
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseScopeLengthQuery'
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\OAuth\CreateJsonWebToken:
         arguments:
@@ -173,5 +175,10 @@ services:
             - '@akeneo_connectivity.connection.clock'
 
     Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\GetAccessTokenQuery:
+        arguments:
+            - '@database_connection'
+
+    # Pull-up master: do not declare this service
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseScopeLengthQuery:
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/IncreaseScopeLengthQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Persistence/Query/IncreaseScopeLengthQueryIntegration.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\Integration\Apps\Persistence\Query;
+
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\Query\IncreaseScopeLengthQuery;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Pull-up master: do not pull this class: a migration handles the length's increase.
+ */
+class IncreaseScopeLengthQueryIntegration extends TestCase
+{
+    private IncreaseScopeLengthQuery $query;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->query = $this->get(IncreaseScopeLengthQuery::class);
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_updates_scope_column_length(): void
+    {
+        if ('255' !== $this->getAccessTokenScopeLength()) {
+            $this->resetDefaultScopeColumnsLength();
+        }
+
+        $this->assertEquals('255', $this->getAccessTokenScopeLength());
+        $this->assertEquals('255', $this->getRefreshTokenScopeLength());
+        $this->assertEquals('255', $this->getAuthCodeScopeLength());
+
+        $this->query->execute();
+
+        $this->assertEquals('1000', $this->getAccessTokenScopeLength());
+        $this->assertEquals('1000', $this->getRefreshTokenScopeLength());
+        $this->assertEquals('1000', $this->getAuthCodeScopeLength());
+    }
+
+    private function getAccessTokenScopeLength(): string
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+
+        $findAccessTokenScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_access_token' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $accessTokenScopeLength = $this->connection->executeQuery($findAccessTokenScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        return $accessTokenScopeLength;
+    }
+
+    private function getRefreshTokenScopeLength(): string
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+
+        $findRefreshTokenScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_refresh_token' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $refreshTokenScopeLength = $this->connection->executeQuery($findRefreshTokenScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        return $refreshTokenScopeLength;
+    }
+
+    private function getAuthCodeScopeLength(): string
+    {
+        $databaseNameSql = 'SELECT database()';
+        $databaseName = $this->connection->executeQuery($databaseNameSql)->fetchOne();
+
+        $findAuthCodeScopeLengthSql = <<< SQL
+        SELECT CHARACTER_MAXIMUM_LENGTH 
+        FROM information_schema.COLUMNS 
+        WHERE TABLE_SCHEMA = :database_name AND TABLE_NAME = 'pim_api_auth_code' AND COLUMN_NAME = 'scope';
+        SQL;
+
+        $authCodeScopeLength = $this->connection->executeQuery($findAuthCodeScopeLengthSql, [
+            'database_name' => $databaseName,
+        ])->fetchOne();
+
+        return $authCodeScopeLength;
+    }
+
+    private function resetDefaultScopeColumnsLength(): void
+    {
+        $this->connection->executeQuery('ALTER TABLE pim_api_access_token MODIFY scope VARCHAR(255) DEFAULT NULL');
+        $this->connection->executeQuery('ALTER TABLE pim_api_refresh_token MODIFY scope VARCHAR(255) DEFAULT NULL');
+        $this->connection->executeQuery('ALTER TABLE pim_api_auth_code MODIFY scope VARCHAR(255) DEFAULT NULL');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an app ask too many scopes (like all available scopes in EE), the database columns from FOS Oauth lib where these scopes are stored are too small.

We fixed this issue on master by doing a migration but on 6.0 we need to update the column structure on runtime as creating new migrations is forbidden.

We only use scopes in the app authorization process so we add the sql query right before creating the access token.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
