### PR TITLE
OCT-126: Broken link to the marketplace in the PIM app store

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/services.yml
@@ -1,11 +1,12 @@
 parameters:
-    akeneo_pim_marketplace_url: 'https://api.apps.akeneo.cloud'
+    akeneo_pim_app_store_url: 'https://apps.akeneo.com'
+    akeneo_pim_app_store_api_url: 'https://api.apps.akeneo.cloud'
     akeneo_pim_marketplace_api_pagination_size: 100
 
 services:
     Akeneo\Connectivity\Connection\Application\Marketplace\MarketplaceUrlGenerator:
         arguments:
-            - '%akeneo_pim_marketplace_url%'
+            - '%akeneo_pim_app_store_url%'
             - '@pim_catalog.version_provider'
             - '%env(AKENEO_PIM_URL)%'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Marketplace\Persistence\GetUserProfileQuery'
@@ -24,7 +25,7 @@ services:
         class: GuzzleHttp\Client
         arguments:
             -
-                base_uri: '%akeneo_pim_marketplace_url%'
+                base_uri: '%akeneo_pim_app_store_api_url%'
                 headers: {User-Agent: ~}
 
     Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceApi:

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/Controller/Internal/GetWebMarketplaceUrlEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Marketplace/Controller/Internal/GetWebMarketplaceUrlEndToEnd.php
@@ -33,7 +33,7 @@ class GetWebMarketplaceUrlEndToEnd extends WebTestCase
 
         Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertMatchesRegularExpression(
-            '/https:\/\/api\.apps\.akeneo\.cloud\/.*/',
+            '/https:\/\/apps\.akeneo\.com\/.*/',
             $result,
         );
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

There are now 2 separated hosts for the app store:
- website: https://apps.akeneo.com
- api: https://api.apps.akeneo.cloud

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
