### PR TITLE
PIM-10648: Migrate all job conf which contains old user_to_notify param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - PIM-10620: Fix export product options values with label to be case insensitive with codes
 - PIM-10606: Fix computeFamilyVariantStructureChange on attribute removal
 - PIM-10624: Fix very slow query when counting variants for mass delete
+- PIM-10648: Migrate all job conf which contains old user_to_notify param
 - PIM-10566: Fix wrong namespace for categories in resource_name column in pim_versioning_version table
 - PIM-10568: Fix error when running Version_7_0_20220629142647_dqi_update_pk_on_product_score during On-Premise/Flex to Serenity migration
 

--- a/upgrades/schema/Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs.php
+++ b/upgrades/schema/Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+final class Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs extends AbstractMigration implements ContainerAwareInterface
+{
+    private ?ContainerInterface $container;
+
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $jobInstancesToMigrate = $this->getJobInstancesToMigrate();
+
+        $this->skipIf(empty($jobInstancesToMigrate), 'No remaining job instance to migrate');
+
+        foreach ($jobInstancesToMigrate as $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            $migratedRawParameters = $this->migrateRawParameters($rawParameters);
+
+            $this->updateJobInstance($jobInstance['id'], serialize($migratedRawParameters));
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function getJobInstancesToMigrate(): array
+    {
+        $connection = $this->container->get('database_connection');
+        $sql = <<<SQL
+SELECT id, raw_parameters
+FROM akeneo_batch_job_instance
+WHERE raw_parameters LIKE '%user_to_notify%'
+SQL;
+
+        $stmt = $connection->executeQuery($sql);
+        $jobInstances = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        return array_filter($jobInstances, function (array $jobInstance) {
+            $rawParameters = unserialize($jobInstance['raw_parameters']);
+            return array_key_exists('user_to_notify', $rawParameters);
+        });
+    }
+
+    private function migrateRawParameters(array $rawParameters): array
+    {
+        $rawParameters['users_to_notify'] = null !== $rawParameters['user_to_notify'] ? [$rawParameters['user_to_notify']] : [];
+        unset($rawParameters['user_to_notify']);
+
+        return $rawParameters;
+    }
+
+    private function updateJobInstance(string $jobInstanceId, string $serializedRawParameters)
+    {
+        $sql = <<<SQL
+UPDATE akeneo_batch_job_instance
+SET raw_parameters = :raw_parameters
+WHERE id = :job_instance_id
+SQL;
+
+        $this->addSql($sql, ['job_instance_id' => $jobInstanceId, 'raw_parameters' => $serializedRawParameters]);
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs_Integration.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\LocalStorage;
+use Akeneo\Platform\Bundle\ImportExportBundle\Domain\Model\NoneStorage;
+use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+use Doctrine\DBAL\Connection;
+
+final class Version_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_7_0_20220921104755_update_job_instance_parameter_user_to_notify_for_jobs';
+
+    private Connection $connection;
+    private JobInstanceRepository $jobInstanceRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+        $this->jobInstanceRepository = $this->get('akeneo_batch.job.job_instance_repository');
+    }
+
+    public function test_it_is_idempotent(): void {
+        $this->createJob('a_mass_edit', 'mass_edit', 'admin');
+        $this->createJob('a_mass_edit_rule', 'mass_edit_rule', 'greg');
+        $this->createJob('a_mass_upload', 'mass_upload', null);
+
+        $this->assertFalse($this->jobIsMigrated('a_mass_edit', ['admin']));
+        $this->assertFalse($this->jobIsMigrated('a_mass_edit_rule', ['greg']));
+        $this->assertFalse($this->jobIsMigrated('a_mass_upload', []));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertTrue($this->jobIsMigrated('a_mass_edit', ['admin']));
+        $this->assertTrue($this->jobIsMigrated('a_mass_edit_rule', ['greg']));
+        $this->assertTrue($this->jobIsMigrated('a_mass_upload', []));
+    }
+
+    public function test_it_changes_user_to_notify_for_job_instance(): void
+    {
+        $this->createJob('a_mass_edit', 'mass_edit', 'admin');
+        $this->createJob('a_mass_edit_rule', 'mass_edit_rule', 'greg');
+        $this->createJob('a_mass_upload', 'mass_upload', null);
+
+        $this->assertFalse($this->jobIsMigrated('a_mass_edit', ['admin']));
+        $this->assertFalse($this->jobIsMigrated('a_mass_edit_rule', ['greg']));
+        $this->assertFalse($this->jobIsMigrated('a_mass_upload', []));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $this->assertTrue($this->jobIsMigrated('a_mass_edit', ['admin']));
+        $this->assertTrue($this->jobIsMigrated('a_mass_edit_rule', ['greg']));
+        $this->assertTrue($this->jobIsMigrated('a_mass_upload', []));
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createJob(string $jobCode, string $type, ?string $userToNotify): void
+    {
+        $rawParameters = [
+            'storage' => [
+                'type' => 'local',
+                'file_path' => '/tmp/product.xlsx',
+            ],
+            'withHeader' => true,
+            'uploadAllowed' => true,
+            'invalid_items_file_format' => 'xlsx',
+            'user_to_notify' => $userToNotify,
+            'is_user_authenticated' => false,
+            'decimalSeparator' => '.',
+            'dateFormat' => 'yyyy-MM-dd',
+            'enabled' => true,
+            'categoriesColumn' => 'categories',
+            'familyColumn' => 'family',
+            'groupsColumn' => 'groups',
+            'enabledComparison' => true,
+            'realTimeVersioning' => true,
+            'convertVariantToSimple' => false,
+        ];
+
+        $this->connection->executeStatement(
+            'DELETE FROM akeneo_batch_job_instance WHERE code = :job_code',
+            [
+                'job_code' => $jobCode,
+            ]
+        );
+
+        $sql = <<<SQL
+INSERT INTO `akeneo_batch_job_instance` (`code`, `label`, `job_name`, `status`, `connector`, `raw_parameters`, `type`)
+VALUES
+	(:job_code, :job_code, :job_code, 0, 'Akeneo CSV Connector', :raw_parameters, :type);
+SQL;
+
+        $this->connection->executeStatement($sql, [
+            'job_code' => $jobCode,
+            'raw_parameters' => serialize($rawParameters),
+            'type' => $type,
+        ]);
+    }
+
+    private function jobIsMigrated(string $jobCode, array $usersToNotify): bool
+    {
+        $this->jobInstanceRepository->clear();
+
+        /** @var JobInstance $jobInstance */
+        $jobInstance = $this->jobInstanceRepository->findOneByCode($jobCode);
+        $rawParameters = $jobInstance->getRawParameters();
+
+        return !array_key_exists('user_to_notify', $rawParameters)
+            && array_key_exists('users_to_notify', $rawParameters)
+            && $rawParameters['users_to_notify'] === $usersToNotify;
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I added a db migration to migrate user_to_notify job parameter.

ZDD compliancy : 
![Screenshot from 2022-09-06 11-24-42](https://user-images.githubusercontent.com/35272857/188599146-ad16c5da-735a-4a8e-aa51-83e6fa8040b4.png)

As we can see on this screenshot, the maximum lines for job instances table is 1780. We fetch them to update a value inside each lines so it should be quick and ZDD compliant.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
