### PR TITLE
CXP-1300: Adds first product meta schema

### DIFF
--- a/components/catalogs/back/.php_cd.php
+++ b/components/catalogs/back/.php_cd.php
@@ -37,6 +37,7 @@ $rules = [
             'Akeneo\Catalogs\Application',
             'Akeneo\Catalogs\Infrastructure',
 
+            // Allowed dependencies in Infrastructure
             'Symfony\Component\Config',
             'Symfony\Component\Console',
             'Symfony\Component\DependencyInjection',
@@ -50,24 +51,31 @@ $rules = [
             'Symfony\Component\Validator',
             'Doctrine\DBAL',
             'Ramsey\Uuid\Uuid',
+            'League\Flysystem\Filesystem',
+            'Opis\JsonSchema',
+            'Psr\Log\LoggerInterface',
             'Akeneo\Platform\Bundle\InstallerBundle',
             'Akeneo\Platform\Bundle\FrameworkBundle\Security\SecurityFacadeInterface',
             'Akeneo\Tool\Component\Api',
-            'Akeneo\UserManagement\Component\Model\UserInterface',
-            'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
             'Akeneo\Connectivity\Connection\ServiceApi',
-            'League\Flysystem\Filesystem',
+            'Akeneo\Tool\Bundle\MeasureBundle\ServiceApi',
+
+            /**********************************************************************************************************/
+            /* Below are dependencies that we have, but we shouldn't rely on them.
+            /* They are coupling exceptions that should be replaced by better alternatives, like ServiceAPIs.
+            /**********************************************************************************************************/
+
+            // This class is not clearly identified as public API
             'Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperInterface',
 
-            // used in Persistence\Measurement
-            'Akeneo\Tool\Bundle\MeasureBundle\ServiceApi\FindMeasurementFamilies',
+            // used in GetCurrentUsernameTrait
+            'Akeneo\UserManagement\Component\Model\UserInterface',
+            'Akeneo\UserManagement\Component\Repository\UserRepositoryInterface',
 
             // used in TemporaryEnrichmentBridge
             'Akeneo\Tool\Bundle\ElasticsearchBundle\Client',
             'Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface',
             'Symfony\Component\OptionsResolver',
-
-            // @todo replace next ones with the ones from service API when available
 
             // used in Persistence\Attribute
             'Akeneo\Pim\Structure\Component\Model\AttributeInterface',

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/meta-schemas/product-0.0.1.json
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/meta-schemas/product-0.0.1.json
@@ -18,11 +18,9 @@
   },
   "$defs": {
     "$id": {
-      "$ref": "#/$defs/uriReferenceString",
       "$comment": "Non-empty fragments not allowed.",
       "pattern": "^[^#]*#?$"
     },
-    "$ref": { "$ref": "#/$defs/uriReferenceString" },
     "$schema": { "$ref": "#/$defs/uriString" },
     "$comment": {
       "type": "string"
@@ -47,18 +45,14 @@
       "properties": {
         "title": { "$ref": "#/$defs/title" },
         "description": { "$ref": "#/$defs/description" },
-        "type": { "$ref": "#/$defs/propertyType" },
-        "$ref": { "$ref": "#/$defs/$ref" }
+        "type": { "$ref": "#/$defs/propertyType" }
       },
-      "additionalProperties": false
+      "additionalProperties": false,
+      "required": ["type"]
     },
     "uriString": {
       "type": "string",
       "format": "uri"
-    },
-    "uriReferenceString": {
-      "type": "string",
-      "format": "uri-reference"
     }
   },
   "additionalProperties": false

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/schemas/product-0.0.1.json
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/schemas/product-0.0.1.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://api.akeneo.com/mapping/product/0.0.1/schema",
+  "type": "object",
+  "properties": {
+    "$id": { "$ref": "#/$defs/$id" },
+    "$schema": { "$ref": "#/$defs/$schema" },
+    "$comment": { "$ref": "#/$defs/$comment" },
+    "$defs": { "$ref": "#/$defs/$defs" },
+    "title": { "$ref": "#/$defs/title" },
+    "description": { "$ref": "#/$defs/description" },
+    "type": { "const": "object" },
+    "properties": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/property" },
+      "default": {}
+    }
+  },
+  "$defs": {
+    "$id": {
+      "$ref": "#/$defs/uriReferenceString",
+      "$comment": "Non-empty fragments not allowed.",
+      "pattern": "^[^#]*#?$"
+    },
+    "$ref": { "$ref": "#/$defs/uriReferenceString" },
+    "$schema": { "$ref": "#/$defs/uriString" },
+    "$comment": {
+      "type": "string"
+    },
+    "$defs": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/property" }
+    },
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "propertyType": {
+      "enum": [
+        "string"
+      ]
+    },
+    "property": {
+      "type": "object",
+      "properties": {
+        "title": { "$ref": "#/$defs/title" },
+        "description": { "$ref": "#/$defs/description" },
+        "type": { "$ref": "#/$defs/propertyType" },
+        "$ref": { "$ref": "#/$defs/$ref" }
+      },
+      "additionalProperties": false
+    },
+    "uriString": {
+      "type": "string",
+      "format": "uri"
+    },
+    "uriReferenceString": {
+      "type": "string",
+      "format": "uri-reference"
+    }
+  },
+  "additionalProperties": false
+}

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSchema.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSchema.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Infrastructure\Validation;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+final class ProductSchema extends Constraint
+{
+}

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
@@ -35,7 +35,7 @@ final class ProductSchemaValidator extends ConstraintValidator
         }
 
         $metaSchemaId = $value->{'$schema'} ?? null;
-        if (null === $metaSchemaId) {
+        if (null === $metaSchemaId || !\is_string($metaSchemaId)) {
             $this->context
                 ->buildViolation('You must provide a $schema reference.')
                 ->addViolation();
@@ -53,7 +53,9 @@ final class ProductSchemaValidator extends ConstraintValidator
         }
 
         $validator = new Validator();
-        $validator->resolver()->registerFile($metaSchemaId, $metaSchemaPath);
+        $resolver = $validator->resolver();
+        \assert(null !== $resolver);
+        $resolver->registerFile($metaSchemaId, $metaSchemaPath);
 
         $result = $validator->validate($value, $metaSchemaId);
 

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
@@ -73,7 +73,7 @@ final class ProductSchemaValidator extends ConstraintValidator
     private function getMetaSchemaLocalPath(string $id): ?string
     {
         return match ($id) {
-            'https://api.akeneo.com/mapping/product/0.0.1/schema' => __DIR__.'/../Symfony/Resources/schemas/product-0.0.1.json',
+            'https://api.akeneo.com/mapping/product/0.0.1/schema' => __DIR__.'/../Symfony/Resources/meta-schemas/product-0.0.1.json',
             default => null,
         };
     }

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSchemaValidator.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Infrastructure\Validation;
+
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Validator;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+final class ProductSchemaValidator extends ConstraintValidator
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ProductSchema) {
+            throw new UnexpectedTypeException($constraint, ProductSchema::class);
+        }
+
+        if (!\is_object($value)) {
+            throw new UnexpectedValueException($value, 'object');
+        }
+
+        $metaSchemaId = $value->{'$schema'} ?? null;
+        if (null === $metaSchemaId) {
+            $this->context
+                ->buildViolation('You must provide a $schema reference.')
+                ->addViolation();
+
+            return;
+        }
+
+        $metaSchemaPath = $this->getMetaSchemaLocalPath($metaSchemaId);
+        if (null === $metaSchemaPath) {
+            $this->context
+                ->buildViolation('You must provide a valid $schema reference.')
+                ->addViolation();
+
+            return;
+        }
+
+        $validator = new Validator();
+        $validator->resolver()->registerFile($metaSchemaId, $metaSchemaPath);
+
+        $result = $validator->validate($value, $metaSchemaId);
+
+        if ($result->hasError()) {
+            $this->context
+                ->buildViolation('You must provide a valid schema.')
+                ->addViolation();
+
+            $formatter = new ErrorFormatter();
+            $this->logger->debug(
+                'A Product Mapping Schema validation failed',
+                $formatter->formatOutput($result->error(), 'verbose')
+            );
+        }
+    }
+
+    private function getMetaSchemaLocalPath(string $id): ?string
+    {
+        return match ($id) {
+            'https://api.akeneo.com/mapping/product/0.0.1/schema' => __DIR__.'/../Symfony/Resources/schemas/product-0.0.1.json',
+            default => null,
+        };
+    }
+}

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Test\Integration\Infrastructure\Validation;
+
+use Akeneo\Catalogs\Infrastructure\Validation\ProductSchema;
+use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * @covers \Akeneo\Catalogs\Infrastructure\Validation\ProductSchema
+ * @covers \Akeneo\Catalogs\Infrastructure\Validation\ProductSchemaValidator
+ */
+class ProductSchemaValidatorTest extends IntegrationTestCase
+{
+    private ?ValidatorInterface $validator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = self::getContainer()->get(ValidatorInterface::class);
+    }
+
+    /**
+     * @dataProvider validSchemaDataProvider
+     */
+    public function testItAcceptsTheSchema(string $schema): void
+    {
+        $violations = $this->validator->validate(
+            \json_decode($schema, false, 512, JSON_THROW_ON_ERROR),
+            new ProductSchema()
+        );
+
+        $this->assertEmpty($violations);
+    }
+
+    /**
+     * @dataProvider invalidSchemaDataProvider
+     */
+    public function testItRejectsTheSchema(string $schema): void
+    {
+        $violations = $this->validator->validate(
+            \json_decode($schema, false, 512, JSON_THROW_ON_ERROR),
+            new ProductSchema()
+        );
+
+        $this->assertNotEmpty($violations);
+    }
+
+    public function validSchemaDataProvider(): array
+    {
+        return [
+            '0.0.1 with valid schema' => [
+                'schema' => <<<'JSON'
+{
+  "$id": "https://example.com/product",
+  "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
+  "$comment": "My first schema !",
+  "title": "Product Mapping",
+  "description": "JSON Schema describing the structure of products expected by our application",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "body_html": {
+      "title": "Description",
+      "description": "Product description in raw HTML",
+      "type": "string"
+    },
+    "url": { "$ref": "#/$defs/url" }
+  },
+  "$defs": {
+    "url": {
+      "title": "Url",
+      "type": "string"
+    }
+  }
+}
+JSON,
+            ],
+        ];
+    }
+
+    public function invalidSchemaDataProvider(): array
+    {
+        return [
+            '0.0.1 with invalid type number' => [
+                'schema' => <<<'JSON'
+{
+  "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
+  "properties": {
+    "price": {
+      "type": "number"
+    }
+  }
+}
+JSON,
+            ],
+        ];
+    }
+}

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
@@ -72,13 +72,6 @@ class ProductSchemaValidatorTest extends IntegrationTestCase
       "title": "Description",
       "description": "Product description in raw HTML",
       "type": "string"
-    },
-    "url": { "$ref": "#/$defs/url" }
-  },
-  "$defs": {
-    "url": {
-      "title": "Url",
-      "type": "string"
     }
   }
 }
@@ -98,6 +91,16 @@ JSON,
     "price": {
       "type": "number"
     }
+  }
+}
+JSON,
+            ],
+            '0.0.1 with missing target type' => [
+                'schema' => <<<'JSON'
+{
+  "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
+  "properties": {
+    "price": {}
   }
 }
 JSON,

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSchemaValidatorTest.php
@@ -56,7 +56,7 @@ class ProductSchemaValidatorTest extends IntegrationTestCase
     {
         return [
             '0.0.1 with valid schema' => [
-                'schema' => <<<'JSON'
+                'schema' => <<<'JSON_WRAP'
 {
   "$id": "https://example.com/product",
   "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
@@ -75,7 +75,7 @@ class ProductSchemaValidatorTest extends IntegrationTestCase
     }
   }
 }
-JSON,
+JSON_WRAP,
             ],
         ];
     }
@@ -84,7 +84,7 @@ JSON,
     {
         return [
             '0.0.1 with invalid type number' => [
-                'schema' => <<<'JSON'
+                'schema' => <<<'JSON_WRAP'
 {
   "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
   "properties": {
@@ -93,17 +93,17 @@ JSON,
     }
   }
 }
-JSON,
+JSON_WRAP,
             ],
             '0.0.1 with missing target type' => [
-                'schema' => <<<'JSON'
+                'schema' => <<<'JSON_WRAP'
 {
   "$schema": "https://api.akeneo.com/mapping/product/0.0.1/schema",
   "properties": {
     "price": {}
   }
 }
-JSON,
+JSON_WRAP,
             ],
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -105,6 +105,7 @@
         "monolog/monolog": "1.25.5",
         "ocramius/proxy-manager": "2.11.1",
         "oneup/flysystem-bundle": "^4.0.0",
+        "opis/json-schema": "^2.3",
         "phpseclib/phpseclib": "2.0.31",
         "psr/event-dispatcher": "^1.0.0",
         "ramsey/uuid": "^3.7",
@@ -205,7 +206,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "symfony/flex": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb9bfb75cf6fd78bf25a5501f5ceded9",
+    "content-hash": "0b32b6dbc05e48f738dce5c7e6a70db2",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -4593,6 +4593,196 @@
                 "source": "https://github.com/1up-lab/OneupFlysystemBundle/tree/4.4.2"
             },
             "time": "2022-07-13T07:10:37+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/c48df6d7089a45f01e1c82432348f2d5976f9bfb",
+                "reference": "c48df6d7089a45f01e1c82432348f2d5976f9bfb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.0",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.3.0"
+            },
+            "time": "2022-01-08T20:38:03+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
+                "reference": "9ebf1a1f873f502f6859d11210b25a4bf5d141e7",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.0.1"
+            },
+            "time": "2022-01-14T15:42:23+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -18382,5 +18572,5 @@
         "ext-zip": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Repository/CurrencyRepositoryInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Repository/CurrencyRepositoryInterface.php
@@ -25,7 +25,7 @@ interface CurrencyRepositoryInterface extends IdentifiableObjectRepositoryInterf
     /**
      * Return an array of currency codes
      *
-     * @return array
+     * @return array<string>
      */
     public function getActivatedCurrencyCodes();
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Why a new dependency ?**

The current JSON Schema library we use in the PIM stopped updating the spec at the Draft-4. It does not support all the features we have in the meta schema.
https://github.com/justinrainbow/json-schema/issues/658 :tada: 

2 new alternatives emerged in the community, and after trying both, I went with `opis/json-schema` because the API is similar and it supports `draft-2020-12, draft-2019-09, draft-07 and draft-06`.

**yes**, we need an ADR.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
