### PR TITLE
[migration uuid] Add option to remove the algorithm inplace

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/Context.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/Context.php
@@ -17,7 +17,7 @@ final class Context
     public function __construct(
         private bool $dryRun,
         private bool $withStats,
-        private bool $algorithmInplace
+        private bool $lockTables
     ) {
     }
 
@@ -31,8 +31,8 @@ final class Context
         return $this->withStats;
     }
 
-    public function algorithmInplace(): bool
+    public function lockTables(): bool
     {
-        return $this->algorithmInplace;
+        return $this->lockTables;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/Context.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/Context.php
@@ -14,8 +14,11 @@ final class Context
 {
     public LogContext $logContext;
 
-    public function __construct(private bool $dryRun, private bool $withStats)
-    {
+    public function __construct(
+        private bool $dryRun,
+        private bool $withStats,
+        private bool $algorithmInplace
+    ) {
     }
 
     public function dryRun(): bool
@@ -26,5 +29,10 @@ final class Context
     public function withStats(): bool
     {
         return $this->withStats;
+    }
+
+    public function algorithmInplace(): bool
+    {
+        return $this->algorithmInplace;
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidAddConstraints.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidAddConstraints.php
@@ -66,6 +66,7 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
     public function addMissing(Context $context): bool
     {
         $logContext = $context->logContext;
+        $algorithmInplace = $context->algorithmInplace();
         $updatedItems = 0;
 
         foreach (MigrateToUuidStep::TABLES as $tableName => $tableProperties) {
@@ -74,14 +75,14 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
                 if (null !== $tableProperties[MigrateToUuidStep::PRIMARY_KEY_UUID_INDEX] && !$this->hasPrimaryKey($tableName, $tableProperties[MigrateToUuidStep::PRIMARY_KEY_UUID_INDEX])) {
                     $this->logger->notice(sprintf('Will add %s primary key', $tableName), $logContext->toArray());
                     if (!$context->dryRun()) {
-                        $this->setPrimaryKey($tableName, $tableProperties);
+                        $this->setPrimaryKey($tableName, $tableProperties, $algorithmInplace);
                         $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                     }
                 }
                 if (null !== $tableProperties[MigrateToUuidStep::FOREIGN_KEY_INDEX] && !$this->constraintExists($tableName, $tableProperties[MigrateToUuidStep::FOREIGN_KEY_INDEX])) {
                     $this->logger->notice(sprintf('Will add %s foreign key', $tableName), $logContext->toArray());
                     if (!$context->dryRun()) {
-                        $this->addForeignKey($tableName, $tableProperties);
+                        $this->addForeignKey($tableName, $tableProperties, $algorithmInplace);
                         $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                     }
                 }
@@ -89,7 +90,7 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
                     if (!$this->constraintExists($tableName, $constraintName)) {
                         $this->logger->notice(sprintf('Will add %s constraint %s', $tableName, $constraintName), $logContext->toArray());
                         if (!$context->dryRun()) {
-                            $this->addUniqueConstraint($tableName, $constraintName, $constraintColumns);
+                            $this->addUniqueConstraint($tableName, $constraintName, $constraintColumns, $algorithmInplace);
                             $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                         }
                     }
@@ -98,7 +99,7 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
                     if (null == $this->getIndexName($tableName, $indexColumns)) {
                         $this->logger->notice(sprintf('Will add %s constraint %s', $tableName, $indexName), $logContext->toArray());
                         if (!$context->dryRun()) {
-                            $this->addIndex($tableName, $indexName, $indexColumns);
+                            $this->addIndex($tableName, $indexName, $indexColumns, $algorithmInplace);
                             $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                         }
                     }
@@ -122,15 +123,13 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
      * To keep performance, we add a temporary index named `migrate_to_uuid_temp_index_to_delete`.
      * This index has to be dropped once everything is migrated.
      */
-    private function setPrimaryKey(string $tableName, array $tableProperties): void
+    private function setPrimaryKey(string $tableName, array $tableProperties, bool $algorithmInplace): void
     {
         $sql = <<<SQL
             ALTER TABLE {tableName}
                 ADD CONSTRAINT migrate_to_uuid_temp_index_to_delete UNIQUE ({formerColumnNames}),
                 DROP PRIMARY KEY,
-                ADD PRIMARY KEY ({newColumnNames}),
-                ALGORITHM=INPLACE,
-                LOCK=NONE
+                ADD PRIMARY KEY ({newColumnNames}){algorithmInplace};
         SQL;
 
         $newColumnNames = $tableProperties[MigrateToUuidStep::PRIMARY_KEY_UUID_INDEX];
@@ -142,23 +141,23 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
             '{tableName}' => $tableName,
             '{formerColumnNames}' => \implode(', ', array_map(fn (string $columnName): string => sprintf('`%s`', $columnName), $formerColumnNames)),
             '{newColumnNames}' => \implode(', ', array_map(fn (string $columnName): string => sprintf('`%s`', $columnName), $newColumnNames)),
+            '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
         ]);
 
         $this->connection->executeQuery($query);
     }
 
-    private function addForeignKey(string $tableName, array $tableProperties): void
+    private function addForeignKey(string $tableName, array $tableProperties, bool $algorithmInplace): void
     {
         $sql = <<<SQL
-            ALTER TABLE {tableName} ADD CONSTRAINT {constraintName} FOREIGN KEY ({uuidColumnName}) REFERENCES `pim_catalog_product` (`uuid`) ON DELETE CASCADE,
-            ALGORITHM=INPLACE,
-            LOCK=NONE; 
+            ALTER TABLE {tableName} ADD CONSTRAINT {constraintName} FOREIGN KEY ({uuidColumnName}) REFERENCES `pim_catalog_product` (`uuid`) ON DELETE CASCADE{algorithmInplace};
         SQL;
 
         $query = \strtr($sql, [
             '{tableName}' => $tableName,
             '{constraintName}' => $tableProperties[MigrateToUuidStep::FOREIGN_KEY_INDEX],
             '{uuidColumnName}' => $tableProperties[MigrateToUuidStep::UUID_COLUMN_INDEX],
+            '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
         ]);
 
         $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
@@ -169,36 +168,42 @@ final class MigrateToUuidAddConstraints implements MigrateToUuidStep
         }
     }
 
-    private function addUniqueConstraint(string $tableName, string $constraintName, array $columnNames): void
-    {
+    private function addUniqueConstraint(
+        string $tableName,
+        string $constraintName,
+        array $columnNames,
+        bool $algorithmInplace
+    ): void {
         $sql = <<<SQL
-            ALTER TABLE {tableName} ADD CONSTRAINT {constraintName} UNIQUE ({columnNames}),
-            ALGORITHM=INPLACE,
-            LOCK=NONE
+            ALTER TABLE {tableName} ADD CONSTRAINT {constraintName} UNIQUE ({columnNames}){algorithmInplace}
         SQL;
 
         $query = \strtr($sql, [
             '{tableName}' => $tableName,
             '{constraintName}' => $constraintName,
             '{columnNames}' => \implode(', ', array_map(fn (string $columnName): string => sprintf('`%s`', $columnName), $columnNames)),
+            '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
         ]);
 
         $this->connection->executeQuery($query);
     }
 
-    private function addIndex(string $tableName, string $indexName, array $columnNames): void
-    {
+    private function addIndex(
+        string $tableName,
+        string $indexName,
+        array $columnNames,
+        bool $algorithmInplace
+    ): void {
         $sql = <<<SQL
             ALTER TABLE {tableName}
-                ADD INDEX {indexName} ({columnNames}),
-                ALGORITHM=INPLACE,
-                LOCK=NONE
+                ADD INDEX {indexName} ({columnNames}){algorithmInplace}
         SQL;
 
         $query = \strtr($sql, [
             '{tableName}' => $tableName,
             '{indexName}' => $indexName,
             '{columnNames}' => \implode(', ', array_map(fn (string $columnName): string => sprintf('`%s`', $columnName), $columnNames)),
+            '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
         ]);
 
         $this->connection->executeQuery($query);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
@@ -60,6 +60,7 @@ class MigrateToUuidCommand extends Command
         $this->addOption('dry-run', 'd', InputOption::VALUE_NEGATABLE, 'dry run', false);
         $this->addOption('with-stats', 's', InputOption::VALUE_NEGATABLE, 'Display stats (be careful the command is way too slow)', false);
         $this->addOption('wait-for-dqi', 'w', InputOption::VALUE_NEGATABLE, 'Wait for DQI job before starting', true);
+        $this->addOption('algorithm-inplace', 'a', InputOption::VALUE_NEGATABLE, 'Use ALGORITHM=INPLACE for table migrations. This option does not lock the tables during migration.', true);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -72,7 +73,8 @@ class MigrateToUuidCommand extends Command
 
         $withStats = $input->getOption('with-stats');
         $waitForDQI = $input->getOption('wait-for-dqi');
-        $context = new Context($input->getOption('dry-run'), $withStats);
+        $algorithInplace = $input->getOption('algorithm-inplace');
+        $context = new Context($input->getOption('dry-run'), $withStats, $algorithInplace);
 
         if (!$this->isDatabaseReady()) {
             // As the migration can be run with a cron, the database can be not ready.

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
@@ -60,7 +60,7 @@ class MigrateToUuidCommand extends Command
         $this->addOption('dry-run', 'd', InputOption::VALUE_NEGATABLE, 'dry run', false);
         $this->addOption('with-stats', 's', InputOption::VALUE_NEGATABLE, 'Display stats (be careful the command is way too slow)', false);
         $this->addOption('wait-for-dqi', 'w', InputOption::VALUE_NEGATABLE, 'Wait for DQI job before starting', true);
-        $this->addOption('algorithm-inplace', 'a', InputOption::VALUE_NEGATABLE, 'Use ALGORITHM=INPLACE for table migrations. This option does not lock the tables during migration.', true);
+        $this->addOption('lock-tables', 'a', InputOption::VALUE_NEGATABLE, 'Locks table during migration. This option speeds up migration.', false);
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -73,7 +73,7 @@ class MigrateToUuidCommand extends Command
 
         $withStats = $input->getOption('with-stats');
         $waitForDQI = $input->getOption('wait-for-dqi');
-        $algorithInplace = $input->getOption('algorithm-inplace');
+        $algorithInplace = $input->getOption('lock-tables');
         $context = new Context($input->getOption('dry-run'), $withStats, $algorithInplace);
 
         if (!$this->isDatabaseReady()) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCreateIndexes.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCreateIndexes.php
@@ -63,6 +63,7 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
     public function addMissing(Context $context): bool
     {
         $logContext = $context->logContext;
+        $algorithmInplace = $context->algorithmInplace();
 
         $updatedItems = 0;
         foreach (MigrateToUuidStep::TABLES as $tableName => $tableProperties) {
@@ -78,7 +79,8 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
                     $this->addIndexOnUuid(
                         $tableName,
                         $tableProperties[self::UUID_COLUMN_INDEX],
-                        $indexName
+                        $indexName,
+                        $algorithmInplace
                     );
                     $this->logger->notice(
                         \sprintf('index on uuid added for %s', $tableName),
@@ -94,7 +96,8 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
                         $this->addAdditionalIndex(
                             $tableName,
                             $additionalIndexName,
-                            $columns
+                            $columns,
+                            $algorithmInplace
                         );
                         $this->logger->notice(
                             \sprintf('additional indexes added for %s', $tableName),
@@ -112,12 +115,14 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
         return true;
     }
 
-    private function addIndexOnUuid(string $tableName, string $uuidColumName, string $indexName): void
-    {
+    private function addIndexOnUuid(
+        string $tableName,
+        string $uuidColumName,
+        string $indexName,
+        bool $algorithmInplace
+    ): void {
         $addUuidColumnAndIndexOnUuidSql = <<<SQL
-            ALTER TABLE `{table_name}` ADD {unique} INDEX `{index_name}` (`{uuid_column_name}`),
-                ALGORITHM=INPLACE,
-                LOCK=NONE;
+            ALTER TABLE `{table_name}` ADD {unique} INDEX `{index_name}` (`{uuid_column_name}`){algorithmInplace};
         SQL;
 
         $addUuidColumnAndIndexOnUuidQuery = \strtr(
@@ -127,6 +132,7 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
                 '{table_name}' => $tableName,
                 '{uuid_column_name}' => $uuidColumName,
                 '{index_name}' => $indexName,
+                '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
             ]
         );
 
@@ -136,19 +142,22 @@ class MigrateToUuidCreateIndexes implements MigrateToUuidStep
     /**
      * @param string[] $columns
      */
-    private function addAdditionalIndex(string $tableName, string $indexName, array $columns): void
-    {
+    private function addAdditionalIndex(
+        string $tableName,
+        string $indexName,
+        array $columns,
+        bool $algorithmInplace
+    ): void {
         $this->connection->executeQuery(\strtr(
             <<<SQL
             ALTER TABLE `{tableName}`
-            ADD INDEX `{indexName}` (`{columnNames}`),
-            ALGORITHM=INPLACE,
-            LOCK=NONE;
+            ADD INDEX `{indexName}` (`{columnNames}`){algorithmInplace};
             SQL,
             [
                 '{tableName}' => $tableName,
                 '{indexName}' => $indexName,
-                '{columnNames}' => \implode('`, `', $columns)
+                '{columnNames}' => \implode('`, `', $columns),
+                '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
             ]
         ));
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidSetNotNullableUuidColumns.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidSetNotNullableUuidColumns.php
@@ -84,7 +84,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
     public function addMissing(Context $context): bool
     {
         $logContext = $context->logContext;
-        $algorithmInplace = $context->algorithmInplace();
+        $lockTables = $context->lockTables();
 
         $updatedItems = 0;
         foreach ($this->getTablesToMigrate() as $tableName => $columnNames) {
@@ -95,7 +95,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
                     $this->setUuidColumnNotNullable(
                         $tableName,
                         $columnNames[self::UUID_COLUMN_INDEX],
-                        $algorithmInplace
+                        $lockTables
                     );
                     $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                 }
@@ -111,7 +111,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
                     SQL,
                     [
                         '{table_name}' => $tableName,
-                        '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
+                        '{algorithmInplace}' => $lockTables ? '' : ', ALGORITHM=INPLACE, LOCK=NONE',
                     ]
                 ));
                 $this->logger->notice('Substep done', $logContext->toArray([
@@ -124,7 +124,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
         return true;
     }
 
-    private function setUuidColumnNotNullable(string $tableName, string $uuidColumnName, bool $algorithmInplace): void
+    private function setUuidColumnNotNullable(string $tableName, string $uuidColumnName, bool $lockTables): void
     {
         $sql = <<<SQL
             ALTER TABLE `{table_name}`
@@ -136,7 +136,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
             [
                 '{table_name}' => $tableName,
                 '{uuid_column_name}' => $uuidColumnName,
-                '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
+                '{algorithmInplace}' => $lockTables ? '' : ', ALGORITHM=INPLACE, LOCK=NONE',
             ]
         );
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidSetNotNullableUuidColumns.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidSetNotNullableUuidColumns.php
@@ -84,6 +84,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
     public function addMissing(Context $context): bool
     {
         $logContext = $context->logContext;
+        $algorithmInplace = $context->algorithmInplace();
 
         $updatedItems = 0;
         foreach ($this->getTablesToMigrate() as $tableName => $columnNames) {
@@ -93,7 +94,8 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
                 if (!$context->dryRun()) {
                     $this->setUuidColumnNotNullable(
                         $tableName,
-                        $columnNames[self::UUID_COLUMN_INDEX]
+                        $columnNames[self::UUID_COLUMN_INDEX],
+                        $algorithmInplace
                     );
                     $this->logger->notice('Substep done', $logContext->toArray(['updated_items_count' => $updatedItems+=1]));
                 }
@@ -105,11 +107,12 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
                 $this->connection->executeQuery(\strtr(
                     <<<SQL
                     ALTER TABLE {table_name}
-                    MODIFY resource_id varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-                    ALGORITHM=INPLACE,
-                    LOCK=NONE;
+                    MODIFY resource_id varchar(24) COLLATE utf8mb4_unicode_ci DEFAULT NULL{algorithmInplace};
                     SQL,
-                    ['{table_name}' => $tableName]
+                    [
+                        '{table_name}' => $tableName,
+                        '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
+                    ]
                 ));
                 $this->logger->notice('Substep done', $logContext->toArray([
                     'updated_items_count' => $updatedItems+=1,
@@ -121,13 +124,11 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
         return true;
     }
 
-    private function setUuidColumnNotNullable(string $tableName, string $uuidColumnName): void
+    private function setUuidColumnNotNullable(string $tableName, string $uuidColumnName, bool $algorithmInplace): void
     {
         $sql = <<<SQL
             ALTER TABLE `{table_name}`
-            MODIFY {uuid_column_name} BINARY(16) NOT NULL,
-            ALGORITHM=INPLACE,
-            LOCK=NONE;
+            MODIFY {uuid_column_name} BINARY(16) NOT NULL{algorithmInplace};
         SQL;
 
         $query = \strtr(
@@ -135,6 +136,7 @@ class MigrateToUuidSetNotNullableUuidColumns implements MigrateToUuidStep
             [
                 '{table_name}' => $tableName,
                 '{uuid_column_name}' => $uuidColumnName,
+                '{algorithmInplace}' => $algorithmInplace ? ', ALGORITHM=INPLACE, LOCK=NONE' : '',
             ]
         );
 

--- a/upgrades/schema/Version_7_0_20220429131804_execute_uuid_migration.php
+++ b/upgrades/schema/Version_7_0_20220429131804_execute_uuid_migration.php
@@ -29,6 +29,7 @@ final class Version_7_0_20220429131804_execute_uuid_migration extends AbstractMi
         $input = new ArrayInput([
             'command' => 'pim:product:migrate-to-uuid',
             '--wait-for-dqi' => false,
+            '--algorithm-inplace' => false,
         ]);
         $output = new BufferedOutput();
         $exitCode = $application->run($input, $output);

--- a/upgrades/schema/Version_7_0_20220429131804_execute_uuid_migration.php
+++ b/upgrades/schema/Version_7_0_20220429131804_execute_uuid_migration.php
@@ -29,7 +29,7 @@ final class Version_7_0_20220429131804_execute_uuid_migration extends AbstractMi
         $input = new ArrayInput([
             'command' => 'pim:product:migrate-to-uuid',
             '--wait-for-dqi' => false,
-            '--algorithm-inplace' => false,
+            '--lock-tables' => true,
         ]);
         $output = new BufferedOutput();
         $exitCode = $application->run($input, $output);


### PR DESCRIPTION
The UUID migration was designed to be SAAS-compliant, so every ALTER TABLE methods use ALGORITHM INPLACE and LOCK NONE.
Today, some users want to run this migration with the server down.
We hope to speed up the migration by removing this inplace algorithm.

We added a new option '--lock-tables', set to true on the doctrine migrations.