### PR TITLE
PIM-10649: Fix wrong attributes displayed when selecting attribute group in export profile filter when there is too much attribute selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PIM-10646: Fix export with label from a select attribute containing uppercase in its code exports code and not labels
 - PIM-10622: Fix save options labels when using the automatic correction in Firefox
 - PIM-10634: Fix media filter values normalizer to be case insensitive
+- PIM-10649: Fix wrong attributes displayed when selecting attribute group in export profile filter when there is too many attributes selected
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/attribute-fetcher.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/fetcher/attribute-fetcher.js
@@ -52,6 +52,19 @@ define(['jquery', 'underscore', 'pim/base-fetcher', 'routing'], function ($, _, 
       return this.fetchByTypesPromises[cacheKey];
     },
 
+    search: function (searchOptions) {
+      const url = Routing.generate(this.options.urls.list);
+
+      return $.ajax({
+        data: JSON.stringify(searchOptions),
+        contentType: 'application/json',
+        type: 'POST',
+        url: url,
+      })
+        .then(_.identity)
+        .promise();
+    },
+
     /**
      * This method overrides the base method, to send a POST query instead of a GET query, because the request
      * URI can be too long.


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Actually when the user have move than 1000 attribute in the product export attribute selector the filtering does not work correctly => attribute are not part of the requested attribute group for example


**Why we have this problem ?** 
 Because there is a FPM configuration named `max_input_vars` filled with the environment variable PHP_CONF_MAX_INPUT_VARS. In production the value of this configuration is 1000. So FPM silently truncate the inputs to 1000.

**How we resolve it ?**
Instead of updating the `max_input_vars` and having another problem after I decided to send search query into json content, to do this we need to use `$.ajax` instead of `$.post`.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
