### PR TITLE
PH-268: Allow to purge  job executions older than 1 hour

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
@@ -30,12 +30,12 @@ class PurgeJobExecutions implements TaskletInterface
         $days = (int) $this->stepExecution->getJobParameters()->get('days');
 
         if (0 === $days) {
-            $this->purgeJobExecution->all();
-            $this->logger->info('All jobs execution deleted');
+            $numberOfDeletedJobExecutions = $this->purgeJobExecution->olderThanHours(1);
+            $this->logger->info('Purged jobs execution older than 1 hour');
         } else {
             $numberOfDeletedJobExecutions = $this->purgeJobExecution->olderThanDays($days);
             $this->logger->info(sprintf('Purged jobs execution older than %d days', $days));
-            $this->logger->info(sprintf('%d jobs execution deleted', $numberOfDeletedJobExecutions));
         }
+        $this->logger->info(sprintf('%d jobs execution deleted', $numberOfDeletedJobExecutions));
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Purge/PurgeJobExecution.php
@@ -37,10 +37,21 @@ final class PurgeJobExecution
         return $numberOfDeletedJobExecutions;
     }
 
-    public function all(): void
+    public function olderThanHours(int $hours): int
+    {
+        $this->deleteJobExecutionLogs->olderThanHours($hours);
+        $numberOfDeletedJobExecutions = $this->deleteJobExecution->olderThanHours($hours);
+        $this->deleteOrphansJobExecutionDirectories->execute();
+
+        return $numberOfDeletedJobExecutions;
+    }
+
+    public function all(): int
     {
         $this->deleteJobExecutionLogs->all();
-        $this->deleteJobExecution->all();
+        $numberOfDeletedJobExecutions = $this->deleteJobExecution->all();
         $this->deleteOrphansJobExecutionDirectories->execute();
+
+        return $numberOfDeletedJobExecutions;
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
@@ -16,8 +16,7 @@ services:
 
     Akeneo\Platform\Bundle\ImportExportBundle\Command\PurgeJobExecutionCommand:
         arguments:
-            - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\ExecuteJobExecutionHandler'
-            - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandler'
+            - '@akeneo.platform.import_export.purge_job_execution'
         tags:
             - { name: console.command }
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/GetJobExecutionIds.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Persistence/Sql/GetJobExecutionIds.php
@@ -7,9 +7,10 @@ namespace Akeneo\Tool\Bundle\BatchBundle\Persistence\Sql;
 use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use DateTime;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Driver\ResultStatement;
+use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Types\Types;
 use InvalidArgumentException;
+use Webmozart\Assert\Assert;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -17,14 +18,11 @@ use InvalidArgumentException;
  */
 final class GetJobExecutionIds
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
-    public function olderThanDays(int $days): ResultStatement
+    public function olderThanDays(int $days): Result
     {
         if ($days < 1) {
             throw new InvalidArgumentException(
@@ -35,6 +33,35 @@ final class GetJobExecutionIds
         $endTime = new DateTime();
         $endTime->modify(sprintf('- %d days', $days));
 
+        return $this->fetchOlderThanTime($endTime);
+    }
+
+    public function olderThanHours(int $hours): Result
+    {
+        Assert::greaterThanEq(
+            $hours,
+            1,
+            sprintf('Number of hours should be at least 1, "%s given', $hours)
+        );
+
+        $endTime = new DateTime();
+        $endTime->modify(sprintf('- %d hours', $hours));
+
+        return $this->fetchOlderThanTime($endTime);
+    }
+
+    public function all(): Result
+    {
+        $query = <<<SQL
+            SELECT id
+            FROM akeneo_batch_job_execution
+        SQL;
+
+        return $this->connection->executeQuery($query);
+    }
+
+    private function fetchOlderThanTime(DateTime $timeLimit): Result
+    {
         $query = <<<SQL
             SELECT id
             FROM akeneo_batch_job_execution
@@ -48,18 +75,8 @@ final class GetJobExecutionIds
 
         return $this->connection->executeQuery(
             $query,
-            ['create_time' => $endTime, 'status' => BatchStatus::COMPLETED],
+            ['create_time' => $timeLimit, 'status' => BatchStatus::COMPLETED],
             ['create_time' => Types::DATETIME_MUTABLE]
         );
-    }
-
-    public function all(): ResultStatement
-    {
-        $query = <<<SQL
-            SELECT id
-            FROM akeneo_batch_job_execution
-        SQL;
-
-        return $this->connection->executeQuery($query);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Storage/DeleteJobExecutionLogs.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Storage/DeleteJobExecutionLogs.php
@@ -14,29 +14,25 @@ use Symfony\Component\Filesystem\Filesystem;
  */
 final class DeleteJobExecutionLogs
 {
-    /** @var GetJobExecutionIds */
-    private $getJobExecutionIds;
-
-    /** @var Filesystem */
-    private $filesystem;
-
-    /** @var string */
-    private $logDir;
-
     public function __construct(
-        GetJobExecutionIds $getJobExecutionIds,
-        Filesystem $filesystem,
-        string $logDir
+        private GetJobExecutionIds $getJobExecutionIds,
+        private Filesystem $filesystem,
+        private string $logDir
     ) {
-        $this->getJobExecutionIds = $getJobExecutionIds;
-        $this->filesystem = $filesystem;
-        $this->logDir = $logDir;
     }
 
     public function olderThanDays(int $days): void
     {
         $statement = $this->getJobExecutionIds->olderThanDays($days);
-        while ($id = $statement->fetch(FetchMode::COLUMN)) {
+        while ($id = $statement->fetchOne()) {
+            $this->filesystem->remove($this->getJobExecutionLogDirectory($id));
+        }
+    }
+
+    public function olderThanHours(int $hours): void
+    {
+        $statement = $this->getJobExecutionIds->olderThanHours($hours);
+        while ($id = $statement->fetchOne()) {
             $this->filesystem->remove($this->getJobExecutionLogDirectory($id));
         }
     }
@@ -44,7 +40,7 @@ final class DeleteJobExecutionLogs
     public function all(): void
     {
         $statement = $this->getJobExecutionIds->all();
-        while ($id = $statement->fetch(FetchMode::COLUMN)) {
+        while ($id = $statement->fetchOne()) {
             $this->filesystem->remove($this->getJobExecutionLogDirectory($id));
         }
     }


### PR DESCRIPTION
### The issue
When running the purge job execution, we first create a job execution.
If we set the purge limit to 0, all executions are purged, included the purge itself.
At the end of the job, we try to update the execution status of this purge, but the execution does not exist anymore.

### The solution
When running the purge as a job, we will have a new hard limit to one hour and we will not purge job executions of the last hour.
But we  will keep the possibility to purge all with a CLI command. Do do that, the CLI command will not launch a job anymore, but use the purger directly.