### PR TITLE
RAB-1046: Remove fallback to user_to_notify

### DIFF
--- a/src/Akeneo/Platform/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifier.php
@@ -60,20 +60,11 @@ class JobExecutionNotifier implements EventSubscriberInterface
      */
     private function getUsersToNotify(?JobParameters $jobParameters): array
     {
-        if (null === $jobParameters) {
+        if (null === $jobParameters || !$jobParameters->has('users_to_notify')) {
             return [];
         }
 
-        if ($jobParameters->has('users_to_notify')) {
-            return $jobParameters->get('users_to_notify');
-        }
-
-        //TODO RAB-1046: remove this condition
-        if ($jobParameters->has('user_to_notify')) {
-            return [$jobParameters->get('user_to_notify')];
-        }
-
-        return [];
+        return $jobParameters->get('users_to_notify');
     }
 
     private function createNotification(JobExecution $jobExecution): NotificationInterface

--- a/tests/back/Platform/Specification/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
+++ b/tests/back/Platform/Specification/Bundle/NotificationBundle/EventSubscriber/JobExecutionNotifierSpec.php
@@ -40,8 +40,6 @@ class JobExecutionNotifierSpec extends ObjectBehavior
 
         $jobParameters->has('users_to_notify')->willReturn(true);
         $jobParameters->get('users_to_notify')->willReturn(['julia']);
-        //TODO RAB-1046: Remove this line
-        $jobParameters->has('user_to_notify')->willReturn(false);
 
         $stepExecution->getWarnings()->willReturn($warnings);
         $jobExecution->getId()->willReturn(5);
@@ -243,41 +241,5 @@ class JobExecutionNotifierSpec extends ObjectBehavior
 
         $this->shouldThrow(new \LogicException('No notification factory found for the "export" job type'))
             ->during('afterJobExecution', [$event]);
-    }
-
-    /**
-     * TODO RAB-1046: Remove this test
-     */
-    public function it_falls_back_on_user_to_notify_when_users_to_notify_does_not_exist(
-        $event,
-        $notifier,
-        $factoryRegistry,
-        $jobExecution,
-        JobParameters $jobParameters,
-        NotificationInterface $notification,
-        NotificationFactoryInterface $notificationFactory,
-        ExitStatus $exitStatus
-    ): void {
-        $factoryRegistry->get('export')->willReturn($notificationFactory);
-        $notificationFactory->create($jobExecution)->willReturn($notification);
-
-        $notification->setMessage('pim_import_export.notification.export.success')->willReturn($notification);
-        $notification->setMessageParams(['%label%' => 'Product export'])->willReturn($notification);
-        $notification->setRoute('pim_importexport_export_execution_show')->willReturn($notification);
-        $notification->setRouteParams(['id' => 5])->willReturn($notification);
-        $notification->setContext(['actionType' => 'export'])->willReturn($notification);
-
-        $jobExecution->getExitStatus()->willReturn($exitStatus);
-        $exitStatus->getExitCode()->willReturn(ExitStatus::COMPLETED);
-
-
-        $jobParameters->has('users_to_notify')->willReturn(false);
-        $jobParameters->get('users_to_notify')->shouldNotBeCalled();
-        $jobParameters->has('user_to_notify')->willReturn(true);
-        $jobParameters->get('user_to_notify')->willReturn('julia');
-
-        $notifier->notify($notification, ['julia'])->shouldBeCalled();
-
-        $this->afterJobExecution($event);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Following, `user_to_notify` migration, we add this falback for pending jobs. We can remove it now because migration is done and pending jobs are completed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
