### PR TITLE
Fix error during migration test does not display revelant message

### DIFF
--- a/upgrades/test_schema/ExecuteMigrationTrait.php
+++ b/upgrades/test_schema/ExecuteMigrationTrait.php
@@ -42,6 +42,7 @@ trait ExecuteMigrationTrait
 
         Assert::assertEquals(1, $status, 'Migration should be irreversible.');
 
+        $output = [];
         exec(
             sprintf(
                 "%s %s/bin/console doctrine:migrations:execute 'Pim\Upgrade\Schema\Version%s' --up -n",


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an error occurred during a migration test the error displayed do not show the error message it display 
(https://app.circleci.com/pipelines/github/akeneo/pim-enterprise-dev/80249/workflows/2df6ab9d-145b-4b77-ac5e-ce0937432d93/jobs/515176) :

```
This migration is irreversible and cannot be reverted .....
```

Because the output is not cleared after the migration down test. In this PR, i just clear the output before launching migration up

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
