### PR TITLE
OCT-136: Migrate from `justinrainbow/json-schema` to `opis/json-schema` the MeasureBundle

### DIFF
--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchema/MeasurementFamilyCommonStructureValidator.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchema;
 
-use JsonSchema\Validator;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Errors\ValidationError;
+use Opis\JsonSchema\Helper;
+use Opis\JsonSchema\Validator;
 
 /**
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
@@ -15,10 +18,27 @@ class MeasurementFamilyCommonStructureValidator
     public function validate(array $normalizedMeasurementFamily): array
     {
         $validator = new Validator();
-        $normalizedMeasurementFamilyObject = Validator::arrayToObjectRecursive($normalizedMeasurementFamily);
-        $validator->validate($normalizedMeasurementFamilyObject, $this->getJsonSchema());
+        $validator->setMaxErrors(50);
 
-        return $validator->getErrors();
+        $result = $validator->validate(
+            Helper::toJSON($normalizedMeasurementFamily),
+            Helper::toJSON($this->getJsonSchema()),
+        );
+
+        if (!$result->hasError()) {
+            return [];
+        }
+
+        $errorFormatter = new ErrorFormatter();
+
+        $customFormatter = function (ValidationError $error) use ($errorFormatter) {
+            return [
+                'property' => $errorFormatter->formatErrorKey($error),
+                'message' => $errorFormatter->formatErrorMessage($error),
+            ];
+        };
+
+        return $errorFormatter->formatFlat($result->error(), $customFormatter);
     }
 
     private function getJsonSchema(): array

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchemaErrorsFormatter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchemaErrorsFormatter.php
@@ -28,7 +28,7 @@ class JsonSchemaErrorsFormatter
 
         $explodedOpisPropertyPath = explode('/', ltrim($opisPropertyPath, '/'));
         $explodedAkeneoPropertyPath = array_map(
-            static fn($propertyPath) => sprintf(is_numeric($propertyPath) ? '[%d]' : '.%s', $propertyPath),
+            static fn ($propertyPath) => sprintf(is_numeric($propertyPath) ? '[%d]' : '.%s', $propertyPath),
             $explodedOpisPropertyPath
         );
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchemaErrorsFormatter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Controller/ExternalApi/JsonSchemaErrorsFormatter.php
@@ -15,8 +15,23 @@ class JsonSchemaErrorsFormatter
     public static function format(array $errors): array
     {
         return array_map(static fn (array $error) => [
-            'property' => $error['property'] ?? '',
+            'property' => isset($error['property']) ? self::convertOpisPropertyPath($error['property']) : '',
             'message'  => $error['message'] ?? '',
         ], $errors);
+    }
+
+    private static function convertOpisPropertyPath(string $opisPropertyPath): string
+    {
+        if ($opisPropertyPath === '/') {
+            return '';
+        }
+
+        $explodedOpisPropertyPath = explode('/', ltrim($opisPropertyPath, '/'));
+        $explodedAkeneoPropertyPath = array_map(
+            static fn($propertyPath) => sprintf(is_numeric($propertyPath) ? '[%d]' : '.%s', $propertyPath),
+            $explodedOpisPropertyPath
+        );
+
+        return ltrim(implode('', $explodedAkeneoPropertyPath), '.');
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyListValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyListValidatorSpec.php
@@ -20,7 +20,7 @@ class MeasurementFamilyListValidatorSpec extends ObjectBehavior
 
         $errors = $this->validate($measurementFamilyList);
         $errors->shouldBeArray();
-        $errors->shouldHaveCount(2);
+        $errors->shouldHaveCount(3);
     }
 
     function it_returns_an_empty_array_if_the_list_of_measurement_families_is_valid()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchema/MeasurementFamilyValidatorSpec.php
@@ -19,11 +19,14 @@ class MeasurementFamilyValidatorSpec extends ObjectBehavior
         $measurement = [
             'values' => null,
             'foo' => 'bar',
+            'code' => 1,
+            'units' => true,
+            'standard_unit_code' => [],
         ];
 
         $errors = $this->validate($measurement);
         $errors->shouldBeArray();
-        $errors->shouldHaveCount(5);
+        $errors->shouldHaveCount(4);
     }
 
     function it_returns_an_empty_array_if_all_the_measurement_family_properties_are_valid()

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchemaErrorsFormatterSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Controller/ExternalApi/JsonSchemaErrorsFormatterSpec.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi;
+
+use Akeneo\Tool\Bundle\MeasureBundle\Controller\ExternalApi\JsonSchemaErrorsFormatter;
+use PhpSpec\ObjectBehavior;
+
+class JsonSchemaErrorsFormatterSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(JsonSchemaErrorsFormatter::class);
+    }
+
+    function it_maps_only_mandatory_properties()
+    {
+        $errors = [
+            [
+                'property' => '/property1',
+                'message' => 'wrong type',
+                'additionalProperty' => 'some additional error description',
+            ],
+        ];
+
+        $formattedErrors = $this::format($errors);
+        $formattedErrors->shouldBeArray();
+        $formattedErrors->shouldHaveCount(1);
+        $formattedErrors[0]->shouldHaveKey('property');
+        $formattedErrors[0]->shouldHaveKey('message');
+        $formattedErrors[0]->shouldNotHaveKey('additionalProperty');
+    }
+
+    function it_maps_properties_with_default_values()
+    {
+        $errors = [
+            [
+                'property' => '/property1',
+            ],
+            [
+                'message' => 'wrong type',
+            ]
+        ];
+
+        $formattedErrors = $this::format($errors);
+        $formattedErrors->shouldBeArray();
+        $formattedErrors->shouldHaveCount(2);
+        $formattedErrors[0]->shouldHaveKeyWithValue('property', 'property1');
+        $formattedErrors[0]->shouldHaveKeyWithValue('message', '');
+        $formattedErrors[1]->shouldHaveKeyWithValue('property', '');
+        $formattedErrors[1]->shouldHaveKeyWithValue('message', 'wrong type');
+    }
+
+    function it_converts_opis_property_paths()
+    {
+        $errors = [
+            [
+                'property' => '/property1/property2/1/property3',
+            ]
+        ];
+
+        $formattedErrors = $this::format($errors);
+        $formattedErrors[0]->shouldHaveKeyWithValue('property', 'property1.property2[1].property3');
+    }
+}

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
@@ -80,8 +80,8 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
                 'message' => 'The measurement family has an invalid format.',
                 'errors' => [
                     [
-                        'property' => 'code',
-                        'message' => 'The property code is required',
+                        'property' => '',
+                        'message' => 'The required properties (code) are missing',
                     ]
                 ],
             ]
@@ -507,7 +507,7 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
                 'errors' => [
                     [
                         'property' => '',
-                        'message' => 'Object value found, but an array is required',
+                        'message' => 'The data (object) must match the type: array',
                     ],
                 ]
             ],
@@ -535,13 +535,9 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
                 'errors' =>
                     [
                         [
-                            'property' => 'units',
-                            'message' => 'The property units is required',
-                        ],
-                        [
-                            'property' => 'standard_unit_code',
-                            'message' => 'The property standard_unit_code is required',
-                        ],
+                            'property' => '',
+                            'message' => 'The required properties (units, standard_unit_code) are missing'
+                        ]
                     ],
             ]
         ], json_decode($response->getContent(), true));
@@ -591,7 +587,7 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
                     [
                         [
                             'property' => '',
-                            'message' => 'The property foo is not defined and the definition does not allow additional properties',
+                            'message' => 'Additional object properties are not allowed: foo',
                         ],
                     ],
             ]


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

We added the new `opis/json-schema` library to validate JSON-schema because `justinrainbow/json-schema` is nor up-to-date neither maintained anymore.

This PR aims to migrate the use of the old one to the new one in `MeasureBundle`. 

There are some changes about error formatting but to minimize them and avoid BC breaks in the external API, we convert `opis` property path syntax to the `justinrainbow` one.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
