### PR TITLE
PIM-10652: [Backport PIM-10646] Fix export with label from a select attribute containing uppercase in its code exports code and not labels

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+- PIM-10652: [Backport PIM-10646] Fix export with label from a select attribute containing uppercase in its code exports code and not labels
+
 # 6.0.44 (2022-09-23)
 
 ## Bug fixes

--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+## Bug fixes
+
 - PIM-10652: [Backport PIM-10646] Fix export with label from a select attribute containing uppercase in its code exports code and not labels
 
 # 6.0.44 (2022-09-23)

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
@@ -47,7 +47,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionCodes = explode(',', $value);
             $labelizedOptions = array_map(
                 function ($optionCode) use ($attributeCode, $locale, $attributeOptionTranslations) {
-                    $optionKey = sprintf('%s.%s', $attributeCode, $optionCode);
+                    $optionKey = self::generateOptionKey($attributeCode, $optionCode);
 
                     return $attributeOptionTranslations[$optionKey][$locale] ?? sprintf(FlatTranslatorInterface::FALLBACK_PATTERN, $optionCode);
                 },
@@ -69,9 +69,7 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             }
             $optionCodes = explode(',', $value);
             $currentOptionKeys = array_map(
-                function ($optionCode) use ($attributeCode) {
-                    return sprintf('%s.%s', $attributeCode, $optionCode);
-                },
+                static fn ($optionCode) => self::generateOptionKey($attributeCode, $optionCode),
                 $optionCodes
             );
 
@@ -79,5 +77,10 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
         }
 
         return $optionKeys;
+    }
+
+    private static function generateOptionKey(string $attributeCode, string $optionCode): string
+    {
+        return sprintf('%s.%s', strtolower($attributeCode), strtolower($optionCode));
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslator.php
@@ -35,6 +35,8 @@ class MultiSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionKeys
         );
 
+        $attributeOptionTranslations = array_change_key_case($attributeOptionTranslations, CASE_LOWER);
+
         $result = [];
         foreach ($values as $valueIndex => $value) {
             if (null === $value || '' === $value) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
@@ -40,6 +40,8 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
             $optionKeys
         );
 
+        $attributeOptionTranslations = array_change_key_case($attributeOptionTranslations, CASE_LOWER);
+
         $result = [];
         foreach ($values as $valueIndex => $value) {
             if (null === $value || '' === $value) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslator.php
@@ -29,13 +29,7 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
 
     public function translate(string $attributeCode, array $properties, array $values, string $locale): array
     {
-        $optionKeys = array_map(
-            function ($value) use ($attributeCode) {
-                return sprintf('%s.%s', $attributeCode, $value);
-            },
-            $values
-        );
-
+        $optionKeys = $this->generateOptionKeys($attributeCode, $values);
         $attributeOptionTranslations = $this->getExistingAttributeOptionsWithValues->fromAttributeCodeAndOptionCodes(
             $optionKeys
         );
@@ -49,11 +43,30 @@ class SimpleSelectTranslator implements FlatAttributeValueTranslatorInterface
                 continue;
             }
 
-            $optionKey = sprintf('%s.%s', $attributeCode, $value);
+            $optionKey = self::generateOptionKey($attributeCode, $value);
             $attributeOptionTranslation = $attributeOptionTranslations[$optionKey][$locale] ?? sprintf(FlatTranslatorInterface::FALLBACK_PATTERN, $value);
             $result[$valueIndex] = $attributeOptionTranslation;
         }
 
         return $result;
+    }
+
+    private function generateOptionKeys(string $attributeCode, array $values): array
+    {
+        $optionKeys = [];
+        foreach ($values as $optionCode) {
+            if (null === $optionCode || '' === $optionCode) {
+                continue;
+            }
+
+            $optionKeys[] = self::generateOptionKey($attributeCode, $optionCode);
+        }
+
+        return array_values(array_unique($optionKeys));
+    }
+
+    private static function generateOptionKey(string $attributeCode, string $optionCode): string
+    {
+        return sprintf('%s.%s', strtolower($attributeCode), strtolower($optionCode));
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/MultiSelectTranslatorSpec.php
@@ -47,6 +47,25 @@ class MultiSelectTranslatorSpec extends ObjectBehavior
             ->shouldReturn(['rouge,jaune', 'purple', '']);
     }
 
+    function it_is_attribute_code_case_insensitive_to_find_option_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                'color.red',
+                'color.yellow',
+                'color.purple'
+            ])
+            ->willReturn([
+                'Color.red' => ['fr_FR' => 'rouge'],
+                'Color.yellow' => ['fr_FR' => 'jaune'],
+                'Color.purple' => ['fr_FR' => 'purple']
+            ]);
+
+        $this->translate('Color', [], ['ReD', 'YeLLoW', 'PURPle', ''], 'fr_FR')
+            ->shouldReturn(['rouge', 'jaune', 'purple', '']);
+    }
+
     function it_translates_multi_select_value_with_numeric_label(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/FlatTranslator/AttributeValue/SimpleSelectTranslatorSpec.php
@@ -61,6 +61,25 @@ class SimpleSelectTranslatorSpec extends ObjectBehavior
         )->shouldReturn([$redTranslation, $yellowTranslation, $optionWithoutTranslation]);
     }
 
+    function it_is_attribute_code_case_insensitive_to_find_option_labels(
+        GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
+    ) {
+        $getExistingAttributeOptionsWithValues
+            ->fromAttributeCodeAndOptionCodes([
+                'color.red',
+                'color.yellow',
+                'color.purple'
+            ])
+            ->willReturn([
+                'Color.red' => ['fr_FR' => 'rouge'],
+                'Color.yellow' => ['fr_FR' => 'jaune'],
+                'Color.purple' => ['fr_FR' => 'purple']
+            ]);
+
+        $this->translate('Color', [], ['ReD', 'YeLLoW', 'PURPle', ''], 'fr_FR')
+            ->shouldReturn(['rouge', 'jaune', 'purple', '']);
+    }
+
     function it_translates_simple_select_value_with_numeric_label(
         GetExistingAttributeOptionsWithValues $getExistingAttributeOptionsWithValues
     ) {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport https://github.com/akeneo/pim-community-dev/pull/17972
