### PR TITLE
PIM-10655: Fix format of empty completeness in external API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@
 - PIM-10633: Fix no DQI dashboard average rankings if code case changed
 - PIM-10667: Fix product import when measurement contains line break
 - PIM-10669: Fix the attribute list does not update if we don't scroll
+- PIM-10655: Fix format of empty completeness in API
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizer.php
@@ -66,8 +66,7 @@ final class ConnectorProductNormalizer
             $normalizedProduct['quality_scores'] = $this->normalizeQualityScores($qualityScores);
         }
         if ($completenesses !== null) {
-            $normalizedCompletenesses = $this->normalizeCompletenesses($completenesses);
-            $normalizedProduct['completenesses'] = empty($normalizedCompletenesses) ? (object) [] : $normalizedCompletenesses;
+            $normalizedProduct['completenesses'] = $this->normalizeCompletenesses($completenesses);
         }
 
         if (!empty($connectorProduct->metadata())) {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductWithUuidNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ConnectorProductWithUuidNormalizer.php
@@ -65,8 +65,7 @@ final class ConnectorProductWithUuidNormalizer
             $normalizedProduct['quality_scores'] = $this->normalizeQualityScores($qualityScores);
         }
         if ($completenesses !== null) {
-            $normalizedCompletenesses = $this->normalizeCompletenesses($completenesses);
-            $normalizedProduct['completenesses'] = empty($normalizedCompletenesses) ? (object) [] : $normalizedCompletenesses;
+            $normalizedProduct['completenesses'] = $this->normalizeCompletenesses($completenesses);
         }
 
         if (!empty($connectorProduct->metadata())) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductNormalizerSpec.php
@@ -247,12 +247,12 @@ class ConnectorProductNormalizerSpec extends ObjectBehavior
                 'associations' => (object) [],
                 'quantified_associations' => (object) [],
                 'metadata' => ['a_metadata' => 'viande'],
-                'completenesses' => (object) [],
+                'completenesses' => [],
             ],
         ]);
     }
 
-    function it_normalize_a_single_connection_product(
+    function it_normalizes_a_single_connector_product(
         ProductValueNormalizer $productValueNormalizer
     ) {
         $identifier = ScalarValue::value('sku', 'identifier_1');

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductWithUuidNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/ExternalApi/ConnectorProductWithUuidNormalizerSpec.php
@@ -16,7 +16,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Normalizer\ExternalApi\ValuesNormali
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\DateTimeNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Normalizer\Standard\Product\ProductValueNormalizer;
 use Akeneo\Pim\Enrichment\Component\Product\Value\ScalarValue;
-use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Routing\RouterInterface;
@@ -213,7 +212,7 @@ class ConnectorProductWithUuidNormalizerSpec extends ObjectBehavior
                 'associations' => (object) [],
                 'quantified_associations' => (object) [],
                 'metadata' => ['a_metadata' => 'viande'],
-                'completenesses' => (object) [],
+                'completenesses' => [],
             ],
         ]);
     }


### PR DESCRIPTION
Fixes the format of empty completenesses (for a product without family) in the external API (it is actually an array, and not an object)

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
