### PR TITLE
OCT-149: catch unavailable mysql or ES errors and log warnings

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
@@ -3,6 +3,7 @@ services:
         arguments:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persistence\PurgeEventsApiSuccessLogsQuery'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persistence\PurgeEventsApiErrorLogsQuery'
+            - '@logger'
         tags:
             - {name: 'console.command'}
 
@@ -11,6 +12,7 @@ services:
             - '@Akeneo\Platform\Component\EventQueue\BulkEventNormalizer'
             - '@Akeneo\Connectivity\Connection\Application\Webhook\Command\SendBusinessEventToWebhooksHandler'
             - '@event_dispatcher'
+            - '@logger'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This 2 commands are launched by kubes before the database & ES are ready.
I'm downgrading the error level from critical to warning.
Then, in datadog, we will dedicate a new monitoring that will notify us if the amount of warnings is too high. (we will basically ignore it if this error happens less than 10 times a day, for example)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
