### PR TITLE
PH-276: Fix AttributeOptionInterface typing

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
@@ -3,46 +3,29 @@
 namespace Akeneo\Pim\Structure\Component\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Webmozart\Assert\Assert;
 
 /**
- * Attribute option
- *
  * @author    Nicolas Dupont <nicolas@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 class AttributeOption implements AttributeOptionInterface
 {
-    /** @var int */
-    protected $id;
-
-    /** @var string $code */
-    protected $code;
+    protected ?int $id;
+    protected ?string $code;
+    protected ArrayCollection $optionValues;
+    protected ?int $sortOrder;
 
     /**
      * Overrided to change target entity name
-     *
-     * @var AttributeInterface
      */
-    protected $attribute;
-
-    /** @var ArrayCollection */
-    protected $optionValues;
+    protected ?AttributeInterface $attribute;
 
     /**
      * Not persisted, allows to define the value locale
-     *
-     * @var string
      */
-    protected $locale;
+    protected ?string $locale;
 
-    /** @var int */
-    protected $sortOrder;
-
-    /**
-     * Constructor
-     */
     public function __construct()
     {
         $this->optionValues = new ArrayCollection();
@@ -51,7 +34,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
@@ -59,7 +42,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setId($id)
+    public function setId($id): static
     {
         $this->id = $id;
 
@@ -69,7 +52,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttribute()
+    public function getAttribute(): AttributeInterface
     {
         return $this->attribute;
     }
@@ -77,7 +60,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setAttribute(AttributeInterface $attribute = null)
+    public function setAttribute(AttributeInterface $attribute = null): static
     {
         $this->attribute = $attribute;
 
@@ -87,7 +70,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getOptionValues()
+    public function getOptionValues(): ArrayCollection
     {
         return $this->optionValues;
     }
@@ -95,7 +78,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getLocale()
+    public function getLocale(): ?string
     {
         return $this->locale;
     }
@@ -103,7 +86,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setLocale($locale)
+    public function setLocale($locale): static
     {
         $this->locale = $locale;
 
@@ -113,7 +96,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setSortOrder($sortOrder)
+    public function setSortOrder($sortOrder): static
     {
         if ($sortOrder !== null) {
             $this->sortOrder = $sortOrder;
@@ -125,7 +108,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getSortOrder()
+    public function getSortOrder(): ?int
     {
         return $this->sortOrder;
     }
@@ -133,7 +116,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function setCode($code)
+    public function setCode($code): static
     {
         $this->code = (string) $code;
 
@@ -143,7 +126,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getCode()
+    public function getCode(): ?string
     {
         return $this->code;
     }
@@ -153,17 +136,17 @@ class AttributeOption implements AttributeOptionInterface
      *
      * {@inheritdoc}
      */
-    public function __toString()
+    public function __toString(): string
     {
         $value = $this->getOptionValue();
 
-        return ($value && $value->getValue()) ? $value->getValue() : '['.$this->getCode().']';
+        return ($value && $value->getValue()) ? $value->getValue() : '[' . $this->getCode() . ']';
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getReference()
+    public function getReference(): ?string
     {
         if (null === $this->code) {
             return null;
@@ -175,7 +158,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getTranslation()
+    public function getTranslation(): ?AttributeOptionValueInterface
     {
         $value = $this->getOptionValue();
 
@@ -191,7 +174,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function addOptionValue(AttributeOptionValueInterface $value)
+    public function addOptionValue(AttributeOptionValueInterface $value): static
     {
         $this->optionValues[] = $value;
         $value->setOption($this);
@@ -202,7 +185,7 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function removeOptionValue(AttributeOptionValueInterface $value)
+    public function removeOptionValue(AttributeOptionValueInterface $value): static
     {
         $this->optionValues->removeElement($value);
 
@@ -212,14 +195,12 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * {@inheritdoc}
      */
-    public function getOptionValue()
+    public function getOptionValue(): ?AttributeOptionValueInterface
     {
         $locale = $this->locale;
         $values = $this->optionValues->filter(
-            function ($value) use ($locale) {
-                if ($value->getLocale() === $locale) {
-                    return true;
-                }
+            function ($value) use ($locale): bool {
+                return $value->getLocale() === $locale;
             }
         );
 

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
@@ -20,12 +20,12 @@ class AttributeOption implements AttributeOptionInterface
     /**
      * Overrided to change target entity name
      */
-    protected ?AttributeInterface $attribute;
+    protected ?AttributeInterface $attribute = null;
 
     /**
      * Not persisted, allows to define the value locale
      */
-    protected ?string $locale;
+    protected ?string $locale = null;
 
     public function __construct()
     {
@@ -47,7 +47,7 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    public function getAttribute(): AttributeInterface
+    public function getAttribute(): ?AttributeInterface
     {
         return $this->attribute;
     }

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
@@ -13,7 +13,7 @@ class AttributeOption implements AttributeOptionInterface
 {
     protected ?int $id = null;
     protected ?string $code = null;
-    protected ArrayCollection $optionValues;
+    protected \ArrayAccess $optionValues;
     protected ?int $sortOrder = null;
 
     /**
@@ -39,9 +39,6 @@ class AttributeOption implements AttributeOptionInterface
         return $this->id;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setId($id): static
     {
         $this->id = $id;
@@ -49,17 +46,11 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAttribute(): AttributeInterface
     {
         return $this->attribute;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setAttribute(AttributeInterface $attribute = null): static
     {
         $this->attribute = $attribute;
@@ -67,25 +58,16 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getOptionValues(): ArrayCollection
+    public function getOptionValues(): \ArrayAccess
     {
         return $this->optionValues;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getLocale(): ?string
     {
         return $this->locale;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setLocale($locale): static
     {
         $this->locale = $locale;
@@ -93,9 +75,6 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setSortOrder($sortOrder): static
     {
         if ($sortOrder !== null) {
@@ -105,17 +84,11 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSortOrder(): ?int
     {
         return $this->sortOrder;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setCode($code): static
     {
         $this->code = (string) $code;
@@ -123,19 +96,11 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCode(): ?string
     {
         return $this->code;
     }
 
-    /**
-     * Override to use default value
-     *
-     * {@inheritdoc}
-     */
     public function __toString(): string
     {
         $value = $this->getOptionValue();
@@ -143,9 +108,6 @@ class AttributeOption implements AttributeOptionInterface
         return ($value && $value->getValue()) ? $value->getValue() : '[' . $this->getCode() . ']';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getReference(): ?string
     {
         if (null === $this->code) {
@@ -155,9 +117,6 @@ class AttributeOption implements AttributeOptionInterface
         return ($this->attribute ? $this->attribute->getCode() : '') . '.' . $this->code;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTranslation(): ?AttributeOptionValueInterface
     {
         $value = $this->getOptionValue();
@@ -171,9 +130,6 @@ class AttributeOption implements AttributeOptionInterface
         return $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addOptionValue(AttributeOptionValueInterface $value): static
     {
         $this->optionValues[] = $value;
@@ -182,9 +138,6 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeOptionValue(AttributeOptionValueInterface $value): static
     {
         $this->optionValues->removeElement($value);
@@ -192,9 +145,6 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getOptionValue(): ?AttributeOptionValueInterface
     {
         $locale = $this->locale;

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Pim\Structure\Component\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 
 /**
  * @author    Nicolas Dupont <nicolas@akeneo.com>
@@ -13,7 +14,7 @@ class AttributeOption implements AttributeOptionInterface
 {
     protected ?int $id = null;
     protected ?string $code = null;
-    protected \ArrayAccess $optionValues;
+    protected Collection $optionValues;
     protected ?int $sortOrder = null;
 
     /**
@@ -58,7 +59,7 @@ class AttributeOption implements AttributeOptionInterface
         return $this;
     }
 
-    public function getOptionValues(): \ArrayAccess
+    public function getOptionValues(): Collection
     {
         return $this->optionValues;
     }

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOption.php
@@ -11,10 +11,10 @@ use Doctrine\Common\Collections\ArrayCollection;
  */
 class AttributeOption implements AttributeOptionInterface
 {
-    protected ?int $id;
-    protected ?string $code;
+    protected ?int $id = null;
+    protected ?string $code = null;
     protected ArrayCollection $optionValues;
-    protected ?int $sortOrder;
+    protected ?int $sortOrder = null;
 
     /**
      * Overrided to change target entity name

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
@@ -14,127 +14,35 @@ use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
  */
 interface AttributeOptionInterface extends ReferableInterface, VersionableInterface
 {
-    /**
-     * Get id
-     *
-     * @return int
-     */
-    public function getId();
+    public function getId(): ?int;
 
-    /**
-     * Set id
-     *
-     * @param int $id
-     *
-     * @return AttributeOptionInterface
-     */
-    public function setId($id);
+    public function setId(int $id): AttributeOptionInterface;
 
-    /**
-     * Get attribute
-     *
-     * @return AttributeInterface
-     */
-    public function getAttribute();
+    public function getAttribute(): AttributeInterface;
 
-    /**
-     * Set attribute
-     *
-     * @param AttributeInterface $attribute
-     *
-     * @return AttributeOptionInterface
-     */
-    public function setAttribute(AttributeInterface $attribute = null);
+    public function setAttribute(?AttributeInterface $attribute = null): AttributeOptionInterface;
 
-    /**
-     * Get values
-     *
-     * @return \ArrayAccess
-     */
-    public function getOptionValues();
+    public function getOptionValues(): \ArrayAccess;
 
-    /**
-     * Get used locale
-     *
-     * @return string $locale
-     */
-    public function getLocale();
+    public function getLocale(): ?string;
 
-    /**
-     * Set used locale
-     *
-     * @param string $locale
-     *
-     * @return AttributeOptionInterface
-     */
-    public function setLocale($locale);
+    public function setLocale(string $locale): AttributeOptionInterface;
 
-    /**
-     * Set sort order
-     *
-     * @param string $sortOrder
-     *
-     * @return AttributeOptionInterface
-     */
-    public function setSortOrder($sortOrder);
+    public function setSortOrder(int $sortOrder): AttributeOptionInterface;
 
-    /**
-     * Get sort order
-     *
-     * @return int
-     */
-    public function getSortOrder();
+    public function getSortOrder(): ?int;
 
-    /**
-     * Set code
-     *
-     * @param string $code
-     *
-     * @return AttributeOptionInterface
-     */
-    public function setCode($code);
+    public function setCode(string $code): AttributeOptionInterface;
 
-    /**
-     * Get code
-     *
-     * @return string
-     */
-    public function getCode();
+    public function getCode(): ?string;
 
-    /**
-     * Returns the current translation
-     *
-     * @return AttributeOptionValueInterface
-     */
-    public function getTranslation();
+    public function getTranslation(): ?AttributeOptionValueInterface;
 
-    /**
-     * Add option value
-     *
-     * @param AttributeOptionValueInterface $value
-     *
-     * @return AttributeOptionInterface
-     */
-    public function addOptionValue(AttributeOptionValueInterface $value);
+    public function addOptionValue(AttributeOptionValueInterface $value): AttributeOptionInterface;
 
-    /**
-     * Remove value
-     *
-     * @param AttributeOptionValueInterface $value
-     *
-     * @return AttributeOptionInterface
-     */
-    public function removeOptionValue(AttributeOptionValueInterface $value);
+    public function removeOptionValue(AttributeOptionValueInterface $value): AttributeOptionInterface;
 
-    /**
-     * Get localized value
-     *
-     * @return ?AttributeOptionValueInterface
-     */
-    public function getOptionValue();
+    public function getOptionValue(): ?AttributeOptionValueInterface;
 
-    /**
-     * @return string
-     */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
+++ b/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php
@@ -18,11 +18,11 @@ interface AttributeOptionInterface extends ReferableInterface, VersionableInterf
 
     public function setId(int $id): AttributeOptionInterface;
 
-    public function getAttribute(): AttributeInterface;
+    public function getAttribute(): ?AttributeInterface;
 
     public function setAttribute(?AttributeInterface $attribute = null): AttributeOptionInterface;
 
-    public function getOptionValues(): \ArrayAccess;
+    public function getOptionValues(): \ArrayAccess|array;
 
     public function getLocale(): ?string;
 

--- a/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriberSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriberSpec.php
@@ -127,6 +127,10 @@ class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
     ) {
         $color = new Attribute();
         $color->setCode('color');
+
+        $blue->setAttribute($color)->shouldBeCalled()->willReturn($blue);
+        $red->setAttribute($color)->shouldBeCalled()->willReturn($red);
+
         $color->addOption($blue->getWrappedObject());
         $color->addOption($red->getWrappedObject());
 
@@ -137,8 +141,8 @@ class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
 
         $getAttributeOptionsMaxSortOrder->forAttributeCodes(['color'])->willReturn(['color' => 12]);
 
-        $blue->setSortOrder(13)->shouldBeCalled();
-        $red->setSortOrder(14)->shouldBeCalled();
+        $blue->setSortOrder(13)->shouldBeCalled()->willReturn($blue);
+        $red->setSortOrder(14)->shouldBeCalled()->willReturn($red);
 
         $this->onPreSave(new GenericEvent($color, ['unitary' => true]));
     }
@@ -152,6 +156,10 @@ class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
     ) {
         $color = new Attribute();
         $color->setCode('color');
+
+        $blue->setAttribute($color)->shouldBeCalled()->willReturn($blue);
+        $red->setAttribute($color)->shouldBeCalled()->willReturn($red);
+
         $color->addOption($blue->getWrappedObject());
         $color->addOption($red->getWrappedObject());
 
@@ -162,6 +170,10 @@ class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
 
         $size = new Attribute();
         $size->setCode('size');
+
+        $xl->setAttribute($size)->shouldBeCalled()->willReturn($xl);
+        $xxl->setAttribute($size)->shouldBeCalled()->willReturn($xxl);
+
         $size->addOption($xl->getWrappedObject());
         $size->addOption($xxl->getWrappedObject());
 
@@ -177,9 +189,9 @@ class SetAttributeOptionSortOrderSubscriberSpec extends ObjectBehavior
             ['color' => 12, 'size' => 41]
         );
 
-        $blue->setSortOrder(13)->shouldBeCalled();
-        $red->setSortOrder(14)->shouldBeCalled();
-        $xl->setSortOrder(42)->shouldBeCalled();
+        $blue->setSortOrder(13)->shouldBeCalled()->willReturn($blue);
+        $red->setSortOrder(14)->shouldBeCalled()->willReturn($red);
+        $xl->setSortOrder(42)->shouldBeCalled()->willReturn($xl);
         $xxl->setSortOrder(Argument::any())->shouldNotBeCalled();
 
         $this->onPreSaveAll(new GenericEvent([$color, $size, $name]));

--- a/tests/back/Pim/Structure/Specification/Component/Manager/AttributeOptionsSorterSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Manager/AttributeOptionsSorterSpec.php
@@ -32,8 +32,8 @@ class AttributeOptionsSorterSpec extends ObjectBehavior
 
         $attribute->getOptions()->willReturn([$size, $width]);
 
-        $size->setSortOrder(2)->shouldBeCalled();
-        $width->setSortOrder(1)->shouldBeCalled();
+        $size->setSortOrder(2)->shouldBeCalled()->willReturn($size);
+        $width->setSortOrder(1)->shouldBeCalled()->willReturn($width);
 
         $optionSaver->saveAll([0 => $size, 1 => $width])->shouldBeCalled();
 

--- a/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AttributeOptionNormalizerSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Normalizer/Standard/AttributeOptionNormalizerSpec.php
@@ -37,12 +37,13 @@ class AttributeOptionNormalizerSpec extends ObjectBehavior
 
     function it_normalizes_an_attribute_option_without_label(
         AttributeOptionInterface $attributeOption,
-        AttributeInterface $attribute
+        AttributeInterface $attribute,
+        \ArrayAccess $optionValues,
     ) {
         $attributeOption->getAttribute()->willReturn($attribute);
         $attribute->getCode()->willReturn('color');
         $attributeOption->getCode()->willReturn('red');
-        $attributeOption->getOptionValues()->willReturn([]);
+        $attributeOption->getOptionValues()->willReturn($optionValues);
         $attributeOption->getSortOrder()->willReturn(1);
 
         $this->normalize($attributeOption, 'standard')->shouldReturn([


### PR DESCRIPTION
Started to fix this incorrect test: https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Enrichment/Bundle/EventSubscriber/AttributeOption/SetAttributeOptionSortOrderSubscriber.php#L88

`AttributeOptionInterface::getSortOrder()` was typed `int` strict [in phpDoc](https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/Pim/Structure/Component/Model/AttributeOptionInterface.php#L84) when it is in fact nullable

I'm typing all the stuff by the way...