### PR TITLE
CXP-1313: Move Catalog DTO & QueryInterface

### DIFF
--- a/components/catalogs/back/src/Application/Persistence/Catalog/GetCatalogQueryInterface.php
+++ b/components/catalogs/back/src/Application/Persistence/Catalog/GetCatalogQueryInterface.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Catalogs\Domain\Catalog;
+namespace Akeneo\Catalogs\Application\Persistence\Catalog;
+
+use Akeneo\Catalogs\Domain\Catalog;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)

--- a/components/catalogs/back/src/Domain/Catalog.php
+++ b/components/catalogs/back/src/Domain/Catalog.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Akeneo\Catalogs\Domain\Catalog;
+namespace Akeneo\Catalogs\Domain;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)

--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/GetCatalogQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/GetCatalogQuery.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Catalogs\Infrastructure\Persistence\Catalog;
 
-use Akeneo\Catalogs\Domain\Catalog\Catalog;
-use Akeneo\Catalogs\Domain\Catalog\GetCatalogQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\Catalog\GetCatalogQueryInterface;
+use Akeneo\Catalogs\Domain\Catalog;
 use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\Uuid;
 

--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/GetCatalogQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/GetCatalogQueryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Catalogs\Test\Integration\Infrastructure\Persistence\Catalog;
 
-use Akeneo\Catalogs\Domain\Catalog\Catalog;
+use Akeneo\Catalogs\Domain\Catalog;
 use Akeneo\Catalogs\Infrastructure\Persistence\Catalog\GetCatalogQuery;
 use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
 use Doctrine\DBAL\Connection;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Having query interfaces in Domain is a reasonable option.

But I think this is not the way to go for us.
- We already have all persistence interfaces in Application/Persistence. => As usual, if we put similar patterns in different directories without an obvious explanation on the case-by-case situation, it doesn't scale well. How do you guess which query belong to Domain and the other to Application ? How do you trace the line ?
- We cannot autowire interfaces that are in Domain. The Domain directory is excluded on purpose https://github.com/akeneo/pim-community-dev/blob/master/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml#L17 => Why ? If you don't, Symfony tries to convert all classes in it into services, including DTOs. It will complains about unknown constructor arguments. That's why Symfony always recommend to exclude directories containing DTOs from the autowiring feature. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
