### PR TITLE
RAB-1114: Rectorize Griffins domains to be Symfony 6 compliant

### DIFF
--- a/config/packages/security.yml
+++ b/config/packages/security.yml
@@ -8,7 +8,7 @@ security:
         pim_user_api:
             id: pim_user.provider.user_api
 
-    encoders:
+    password_hashers:
         Akeneo\UserManagement\Component\Model\User: sha512
         Symfony\Component\Security\Core\User\User: plaintext
 

--- a/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/ExternalApi/CategoryNormalizer.php
+++ b/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/ExternalApi/CategoryNormalizer.php
@@ -44,7 +44,7 @@ class CategoryNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CategoryInterface && 'external_api' === $format;
     }

--- a/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/InternalApi/CategoryNormalizer.php
+++ b/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/InternalApi/CategoryNormalizer.php
@@ -45,7 +45,7 @@ class CategoryNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CategoryInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/Standard/CategoryNormalizer.php
+++ b/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/Standard/CategoryNormalizer.php
@@ -45,7 +45,7 @@ class CategoryNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CategoryInterface && 'standard' === $format;
     }

--- a/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/Versioning/CategoryNormalizer.php
+++ b/src/Akeneo/Category/back/Infrastructure/Component/Normalizer/Versioning/CategoryNormalizer.php
@@ -57,7 +57,7 @@ class CategoryNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CategoryInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Category/back/Infrastructure/EventSubscriber/InitCategoryDbSchemaSubscriber.php
+++ b/src/Akeneo/Category/back/Infrastructure/EventSubscriber/InitCategoryDbSchemaSubscriber.php
@@ -15,7 +15,7 @@ class InitCategoryDbSchemaSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => 'initDbSchema'

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Form/Type/CategoryType.php
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Form/Type/CategoryType.php
@@ -91,7 +91,7 @@ class CategoryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_category';
     }

--- a/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/CategoryAuthorization.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/CategoryAuthorization.php
@@ -25,7 +25,7 @@ class CategoryAuthorizationEndToEnd extends ApiTestCase
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -53,7 +53,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -81,7 +81,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -98,7 +98,7 @@ JSON;
         $client->request('POST', '/api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
     }
 
     public function testAccessDeniedForCreatingACategory(): void
@@ -121,7 +121,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -134,7 +134,7 @@ JSON;
         $client->request('PATCH', '/api/rest/v1/categories/master', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
     }
 
     public function testAccessDeniedForPartialUpdatingACategory(): void
@@ -153,7 +153,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -198,7 +198,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 

--- a/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/CreateCategoryEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/CreateCategoryEndToEnd.php
@@ -23,7 +23,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertArrayHasKey('location', $response->headers->all());
         $this->assertSame('http://localhost/api/rest/v1/categories/new_category_headers', $response->headers->get('location'));
         $this->assertSame('', $response->getContent());
@@ -56,7 +56,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryNormalized);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $categoryNormalized);
     }
 
@@ -97,7 +97,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryNormalized);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $categoryNormalized);
     }
 
@@ -135,7 +135,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryNormalized);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $categoryNormalized);
     }
 
@@ -152,7 +152,7 @@ JSON;
 
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -169,7 +169,7 @@ JSON;
 
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -198,7 +198,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -227,7 +227,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -256,7 +256,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -284,7 +284,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -316,7 +316,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -348,7 +348,7 @@ JSON;
         $client->request('POST', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 

--- a/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/GetCategoryEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/GetCategoryEndToEnd.php
@@ -60,7 +60,7 @@ class GetCategoryEndToEnd extends ApiTestCase
         $client->request('GET', 'api/rest/v1/categories/not_found');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $content = json_decode($response->getContent(), true);
         $this->assertCount(2, $content, 'response contains 2 items');
         $this->assertSame(Response::HTTP_NOT_FOUND, $content['code']);
@@ -98,7 +98,7 @@ class GetCategoryEndToEnd extends ApiTestCase
 
         $response = $client->getResponse();
 
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame(
             [
                 'code' => 400,

--- a/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/PartialUpdateCategoryEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/PartialUpdateCategoryEndToEnd.php
@@ -23,7 +23,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/categoryA1', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
         $this->assertArrayHasKey('location', $response->headers->all());
         $this->assertSame('http://localhost/api/rest/v1/categories/categoryA1', $response->headers->get('location'));
         $this->assertSame('', $response->getContent());
@@ -44,7 +44,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/new_category_headers', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertArrayHasKey('location', $response->headers->all());
         $this->assertSame('http://localhost/api/rest/v1/categories/new_category_headers', $response->headers->get('location'));
         $this->assertSame(null, json_decode($response->getContent(), true));
@@ -77,7 +77,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryStandard);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -103,7 +103,7 @@ JSON;
         NormalizedCategoryCleaner::clean($normalizedCategory);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -145,7 +145,7 @@ JSON;
         NormalizedCategoryCleaner::clean($normalizedCategory);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -182,7 +182,7 @@ JSON;
         NormalizedCategoryCleaner::clean($normalizedCategory);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -211,7 +211,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryStandard);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -248,7 +248,7 @@ JSON;
         NormalizedCategoryCleaner::clean($categoryStandard);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -284,7 +284,7 @@ JSON;
         NormalizedCategoryCleaner::clean($normalizedCategory);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -317,7 +317,7 @@ JSON;
         NormalizedCategoryCleaner::clean($normalizedCategory);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
         $this->assertSame($categoryStandard, $normalizedCategory);
     }
 
@@ -334,7 +334,7 @@ JSON;
 
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -351,7 +351,7 @@ JSON;
 
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -380,7 +380,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -408,7 +408,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -436,7 +436,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -459,7 +459,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/inconsistent_code1', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 
@@ -473,7 +473,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories/categoryA', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 
@@ -494,7 +494,7 @@ JSON;
         ];
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame($expectedContent, json_decode($response->getContent(), true));
     }
 

--- a/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/PartialUpdateListCategoryEndToEnd.php
+++ b/src/Akeneo/Category/back/tests/EndToEnd/ExternalApi/PartialUpdateListCategoryEndToEnd.php
@@ -124,7 +124,7 @@ JSON;
 
         $response = $client->getResponse();
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
-        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
     }
 
     public function testPartialUpdateListWithInvalidAndTooLongLines(): void
@@ -262,7 +262,7 @@ JSON;
         $client->request('PATCH', 'api/rest/v1/categories', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 

--- a/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
+++ b/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\back\tests\Integration\Helper;
 
+use Doctrine\DBAL\Driver\Exception;
 use Akeneo\Category\Application\Storage\Save\Query\UpsertCategoryBase;
 use Akeneo\Category\Application\Storage\Save\Query\UpsertCategoryTranslations;
 use Akeneo\Category\Domain\Model\Category;
@@ -23,7 +24,7 @@ class CategoryTestCase extends TestCase
     /**
      * @param array<string, string>|null $labels
      *
-     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws Exception
      * @throws \Doctrine\DBAL\Exception
      */
     protected function createOrUpdateCategory(

--- a/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
+++ b/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\back\tests\Integration\Helper;
 
-use Doctrine\DBAL\Driver\Exception;
 use Akeneo\Category\Application\Storage\Save\Query\UpsertCategoryBase;
 use Akeneo\Category\Application\Storage\Save\Query\UpsertCategoryTranslations;
 use Akeneo\Category\Domain\Model\Category;
@@ -18,6 +17,7 @@ use Akeneo\Category\Domain\ValueObject\CategoryId;
 use Akeneo\Category\Domain\ValueObject\Code;
 use Akeneo\Category\Domain\ValueObject\LabelCollection;
 use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Driver\Exception;
 
 class CategoryTestCase extends TestCase
 {

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Model/ChannelInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Model/ChannelInterface.php
@@ -2,12 +2,12 @@
 
 namespace Akeneo\Channel\Infrastructure\Component\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Akeneo\Channel\Infrastructure\Component\Event\ChannelEvent;
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
 use Akeneo\Tool\Component\StorageUtils\Model\ReferableInterface;
 use Akeneo\Tool\Component\Versioning\Model\VersionableInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Channel interface

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Model/ChannelInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Model/ChannelInterface.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Channel\Infrastructure\Component\Model;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Akeneo\Channel\Infrastructure\Component\Event\ChannelEvent;
 use Akeneo\Tool\Component\Localization\Model\TranslatableInterface;
@@ -59,7 +60,7 @@ interface ChannelInterface extends ReferableInterface, VersionableInterface, Tra
     public function setCategory(CategoryInterface $category);
 
     /**
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return ArrayCollection
      */
     public function getCurrencies();
 
@@ -90,7 +91,7 @@ interface ChannelInterface extends ReferableInterface, VersionableInterface, Tra
     public function hasCurrency(CurrencyInterface $currency);
 
     /**
-     * @return \Doctrine\Common\Collections\ArrayCollection
+     * @return ArrayCollection
      */
     public function getLocales();
 

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/ChannelNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/ChannelNormalizer.php
@@ -45,7 +45,7 @@ class ChannelNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ChannelInterface && 'external_api' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/CurrencyNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/CurrencyNormalizer.php
@@ -35,7 +35,7 @@ class CurrencyNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CurrencyInterface && 'external_api' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/LocaleNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/ExternalApi/LocaleNormalizer.php
@@ -35,7 +35,7 @@ class LocaleNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof LocaleInterface && 'external_api' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/InternalApi/ChannelNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/InternalApi/ChannelNormalizer.php
@@ -99,7 +99,7 @@ class ChannelNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ChannelInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/InternalApi/LocaleNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/InternalApi/LocaleNormalizer.php
@@ -47,7 +47,7 @@ class LocaleNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof LocaleInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/ChannelNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/ChannelNormalizer.php
@@ -42,7 +42,7 @@ class ChannelNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ChannelInterface && 'standard' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/CurrencyNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/CurrencyNormalizer.php
@@ -27,7 +27,7 @@ class CurrencyNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof CurrencyInterface && 'standard' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/LocaleNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Standard/LocaleNormalizer.php
@@ -27,7 +27,7 @@ class LocaleNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof LocaleInterface && 'standard' === $format;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Versioning/ChannelNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Versioning/ChannelNormalizer.php
@@ -42,7 +42,7 @@ class ChannelNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      *
-     * @param \Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface $channel
+     * @param ChannelInterface $channel
      *
      * @return array
      */
@@ -69,7 +69,7 @@ class ChannelNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ChannelInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Versioning/LocaleNormalizer.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Normalizer/Versioning/LocaleNormalizer.php
@@ -50,7 +50,7 @@ class LocaleNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof LocaleInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/ConversionUnits.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/ConversionUnits.php
@@ -22,7 +22,7 @@ class ConversionUnits extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_conversion_units_validator';
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/IsCurrencyActivated.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/IsCurrencyActivated.php
@@ -17,7 +17,7 @@ class IsCurrencyActivated extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_is_currency_activated_validator';
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/IsRootCategory.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/IsRootCategory.php
@@ -17,7 +17,7 @@ class IsRootCategory extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_is_root_category_validator';
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/LocaleCode.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Validator/Constraint/LocaleCode.php
@@ -10,12 +10,12 @@ final class LocaleCode extends Constraint
 {
     public $message = 'pim_enrich.entity.locale.constraint.invalid_locale_code';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::PROPERTY_CONSTRAINT;
     }
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_locale_code_validator';
     }

--- a/src/Akeneo/Channel/back/Infrastructure/EventListener/ChannelLocaleSubscriber.php
+++ b/src/Akeneo/Channel/back/Infrastructure/EventListener/ChannelLocaleSubscriber.php
@@ -55,7 +55,7 @@ class ChannelLocaleSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             StorageEvents::PRE_REMOVE => 'removeChannel',
@@ -142,7 +142,7 @@ class ChannelLocaleSubscriber implements EventSubscriberInterface
             [
                 'locales_identifier' => $localesCodes,
                 'channel_code' => $channelCode,
-                'username' => $user->getUsername(),
+                'username' => $user->getUserIdentifier(),
             ]
         );
     }

--- a/src/Akeneo/Channel/back/Infrastructure/EventListener/CurrencyDisablingSubscriber.php
+++ b/src/Akeneo/Channel/back/Infrastructure/EventListener/CurrencyDisablingSubscriber.php
@@ -32,7 +32,7 @@ class CurrencyDisablingSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [StorageEvents::PRE_SAVE => 'checkChannelLink'];
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/DependencyInjection/AkeneoChannelExtension.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/DependencyInjection/AkeneoChannelExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Infrastructure\Symfony\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -21,7 +22,7 @@ class AkeneoChannelExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('array_converters.yml');
         $loader->load('controllers.yml');
         $loader->load('processors.yml');

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/DependencyInjection/AkeneoChannelExtension.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/DependencyInjection/AkeneoChannelExtension.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Infrastructure\Symfony\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Channel/back/Infrastructure/Twig/LocaleExtension.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Twig/LocaleExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\Channel\Infrastructure\Twig;
 
-use Symfony\Component\Intl\Currencies;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Symfony\Component\Intl;
+use Symfony\Component\Intl\Currencies;
 use Symfony\Component\Intl\Exception\MissingResourceException;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;

--- a/src/Akeneo/Channel/back/Infrastructure/Twig/LocaleExtension.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Twig/LocaleExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Channel\Infrastructure\Twig;
 
+use Symfony\Component\Intl\Currencies;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Symfony\Component\Intl;
 use Symfony\Component\Intl\Exception\MissingResourceException;
@@ -94,7 +95,7 @@ class LocaleExtension extends AbstractExtension
         $translateIn = $translateIn ?: $this->getCurrentLocaleCode();
         $language = \Locale::getPrimaryLanguage($translateIn);
 
-        return Intl\Currencies::getSymbol($code, $language);
+        return Currencies::getSymbol($code, $language);
     }
 
     public function currencyLabel(string $code, ?string $translateIn = null): ?string
@@ -103,7 +104,7 @@ class LocaleExtension extends AbstractExtension
         $language = \Locale::getPrimaryLanguage($translateIn);
 
         try {
-            return Intl\Currencies::getName($code, $language);
+            return Currencies::getName($code, $language);
         } catch (MissingResourceException) {
             return null;
         }

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -81,6 +81,7 @@ $rules = [
         // PLG-692: use email notification from Notification bundle
         'Akeneo\Platform\Bundle\NotificationBundle\Email\MailNotifierInterface',
         'Twig\Environment',
+        'Twig\Extension\AbstractExtension',
         'Throwable',
         'Psr\Log\LoggerInterface',
 

--- a/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
+++ b/src/Akeneo/UserManagement/Bundle/Command/CreateUserCommand.php
@@ -130,7 +130,7 @@ DESC
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$input->isInteractive()) {
             $this->gatherArgumentsForNonInteractiveMode($input);

--- a/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
+++ b/src/Akeneo/UserManagement/Bundle/Context/UserContext.php
@@ -310,7 +310,7 @@ class UserContext
     /**
      * Get authenticated user
      *
-     * @return \Akeneo\UserManagement\Component\Model\UserInterface|null
+     * @return UserInterface|null
      */
     public function getUser()
     {

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -56,7 +56,7 @@ class ResetController extends AbstractController
                 'The password for this user has already been requested within the last 24 hours.'
             );
 
-            return $this->redirect($this->generateUrl('pim_user_reset_request'));
+            return $this->redirectToRoute('pim_user_reset_request');
         }
 
         if (null === $user->getConfirmationToken()) {
@@ -86,7 +86,7 @@ class ResetController extends AbstractController
 
         if (empty($email)) {
             // the user does not come from the sendEmail action
-            return $this->redirect($this->generateUrl('pim_user_reset_request'));
+            return $this->redirectToRoute('pim_user_reset_request');
         }
 
         return [
@@ -115,7 +115,7 @@ class ResetController extends AbstractController
                 'The password for this user has already been requested within the last 24 hours.'
             );
 
-            return $this->redirect($this->generateUrl('pim_user_reset_request'));
+            return $this->redirectToRoute('pim_user_reset_request');
         }
 
         if ($this->resetHandler->process($user)) {
@@ -125,7 +125,7 @@ class ResetController extends AbstractController
             $this->session->invalidate();
             $this->tokenStorage->setToken(null);
 
-            return $this->redirect($this->generateUrl('pim_user_security_login'));
+            return $this->redirectToRoute('pim_user_security_login');
         }
 
         return [
@@ -138,7 +138,7 @@ class ResetController extends AbstractController
      * Get the truncated email displayed when requesting the resetting.
      * The default implementation only keeps the part following @ in the address.
      *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      *
      * @return string
      */

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\UserManagement\Bundle\Controller\Rest;
 
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Akeneo\Tool\Component\Localization\Factory\NumberFactory;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
@@ -26,7 +27,6 @@ use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -54,7 +54,7 @@ class UserController
     protected SaverInterface $saver;
     protected NormalizerInterface $constraintViolationNormalizer;
     protected SimpleFactoryInterface $factory;
-    protected UserPasswordEncoderInterface $encoder;
+    protected UserPasswordHasherInterface $encoder;
     private EventDispatcherInterface $eventDispatcher;
     private Session $session;
     private ObjectManager $objectManager;
@@ -72,7 +72,7 @@ class UserController
         SaverInterface $saver,
         NormalizerInterface $constraintViolationNormalizer,
         SimpleFactoryInterface $factory,
-        UserPasswordEncoderInterface $encoder,
+        UserPasswordHasherInterface $encoder,
         EventDispatcherInterface $eventDispatcher,
         Session $session,
         ObjectManager $objectManager,

--- a/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/Rest/UserController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\UserManagement\Bundle\Controller\Rest;
 
-use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Akeneo\Tool\Component\Localization\Factory\NumberFactory;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
@@ -26,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use Symfony\Component\Validator\ConstraintViolation;

--- a/src/Akeneo/UserManagement/Bundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/UserManagement/Bundle/DependencyInjection/Configuration.php
@@ -11,7 +11,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('pim_user');
         $builder

--- a/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
+++ b/src/Akeneo/UserManagement/Bundle/Doctrine/ORM/Repository/GroupRepository.php
@@ -57,7 +57,7 @@ class GroupRepository extends EntityRepository implements GroupRepositoryInterfa
     /**
      * Create a QB to find all groups but the default one
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function getAllButDefaultQB()
     {

--- a/src/Akeneo/UserManagement/Bundle/EventListener/GroupSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/GroupSubscriber.php
@@ -20,7 +20,7 @@ class GroupSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             UserEvents::PRE_DELETE_GROUP => 'preDeleteGroup',

--- a/src/Akeneo/UserManagement/Bundle/EventListener/LocaleSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/LocaleSubscriber.php
@@ -86,7 +86,7 @@ class LocaleSubscriber implements EventSubscriberInterface
     /**
      * @return array
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             UserEvent::POST_UPDATE => [['onPostUpdate']],

--- a/src/Akeneo/UserManagement/Bundle/EventListener/RoleListener.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/RoleListener.php
@@ -10,7 +10,7 @@ use Oro\Bundle\SecurityBundle\DependencyInjection\Utils\ServiceLink;
 class RoleListener
 {
     /**
-     * @var \Oro\Bundle\SecurityBundle\DependencyInjection\Utils\ServiceLink
+     * @var ServiceLink
      */
     protected $aclSidManagerLink;
 

--- a/src/Akeneo/UserManagement/Bundle/Form/Handler/AclRoleHandler.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Handler/AclRoleHandler.php
@@ -2,7 +2,6 @@
 
 namespace Akeneo\UserManagement\Bundle\Form\Handler;
 
-use Symfony\Component\Form\FormView;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Bundle\Form\Type\AclRoleType;
 use Akeneo\UserManagement\Component\Model\Role;
@@ -14,6 +13,7 @@ use Oro\Bundle\SecurityBundle\Acl\Persistence\AclPrivilegeRepository;
 use Oro\Bundle\SecurityBundle\Model\AclPrivilege;
 use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 

--- a/src/Akeneo/UserManagement/Bundle/Form/Handler/AclRoleHandler.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Handler/AclRoleHandler.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle\Form\Handler;
 
+use Symfony\Component\Form\FormView;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Bundle\Form\Type\AclRoleType;
 use Akeneo\UserManagement\Component\Model\Role;
@@ -125,7 +126,7 @@ class AclRoleHandler
     /**
      * Create form view for current form
      *
-     * @return \Symfony\Component\Form\FormView
+     * @return FormView
      */
     public function createView()
     {

--- a/src/Akeneo/UserManagement/Bundle/Form/Handler/RoleHandler.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Handler/RoleHandler.php
@@ -71,7 +71,7 @@ class RoleHandler
      * "Success" form handler
      *
      * @param Role                                      $entity
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface[] $appendUsers
+     * @param UserInterface[] $appendUsers
      * @param UserInterface[]                           $removeUsers
      */
     protected function onSuccess(Role $entity, array $appendUsers, array $removeUsers)

--- a/src/Akeneo/UserManagement/Bundle/Form/Subscriber/PatchSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Subscriber/PatchSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormInterface;
  */
 class PatchSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [FormEvents::PRE_SUBMIT => 'preBind'];
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Subscriber/UserSubscriber.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Subscriber/UserSubscriber.php
@@ -38,7 +38,7 @@ class UserSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'preSetData',
@@ -85,7 +85,7 @@ class UserSubscriber implements EventSubscriberInterface
     /**
      * Returns true if passed user is currently authenticated
      *
-     * @param  \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      *
      * @return bool
      */

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/AclAccessLevelSelectorType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/AclAccessLevelSelectorType.php
@@ -32,7 +32,7 @@ class AclAccessLevelSelectorType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CheckboxType::class;
     }
@@ -40,7 +40,7 @@ class AclAccessLevelSelectorType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_acl_access_level_selector';
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/AclRoleType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/AclRoleType.php
@@ -90,7 +90,7 @@ class AclRoleType extends AbstractType
         foreach ($this->privilegeConfig as $fieldName => $config) {
             $builder->add(
                 $fieldName,
-                new PrivilegeCollectionType(),
+                PrivilegeCollectionType::class,
                 [
                     'entry_type' => new AclPrivilegeType(),
                     'allow_add' => true,
@@ -144,7 +144,7 @@ class AclRoleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_user_role_form';
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/GroupApiType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/GroupApiType.php
@@ -29,7 +29,7 @@ class GroupApiType extends GroupType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'group';
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/GroupType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/GroupType.php
@@ -82,7 +82,7 @@ class GroupType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_user_group';
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/ResetType.php
@@ -66,7 +66,7 @@ class ResetType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_user_reset';
     }

--- a/src/Akeneo/UserManagement/Bundle/Form/Type/RoleApiType.php
+++ b/src/Akeneo/UserManagement/Bundle/Form/Type/RoleApiType.php
@@ -76,7 +76,7 @@ class RoleApiType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'role';
     }

--- a/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
+++ b/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\UserManagement\Bundle\Manager;
 
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\User;
@@ -11,7 +9,9 @@ use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ObjectManager;
 use Doctrine\Persistence\ObjectRepository;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 

--- a/src/Akeneo/UserManagement/Bundle/Model/LockedAccountException.php
+++ b/src/Akeneo/UserManagement/Bundle/Model/LockedAccountException.php
@@ -4,7 +4,6 @@
 namespace Akeneo\UserManagement\Bundle\Model;
 
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
@@ -3,10 +3,10 @@
 
 namespace Akeneo\UserManagement\Bundle\Provider;
 
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Bundle\Model\LockedAccountException;
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;

--- a/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
@@ -26,9 +26,17 @@ class CustomDaoAuthenticationProvider extends DaoAuthenticationProvider
 
     private int $accountMaxConsecutiveFailure;
 
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, PasswordHasherFactoryInterface $encoderFactory, UserManager $userManager, int $accountLockDuration, int $accountMaxConsecutiveFailure, bool $hideUserNotFoundExceptions = true)
-    {
-        parent::__construct($userProvider, $userChecker, $providerKey, $encoderFactory, $hideUserNotFoundExceptions);
+    public function __construct(
+        UserProviderInterface $userProvider,
+        UserCheckerInterface $userChecker,
+        string $providerKey,
+        PasswordHasherFactoryInterface $hasherFactory,
+        UserManager $userManager,
+        int $accountLockDuration,
+        int $accountMaxConsecutiveFailure,
+        bool $hideUserNotFoundExceptions = true
+    ) {
+        parent::__construct($userProvider, $userChecker, $providerKey, $hasherFactory, $hideUserNotFoundExceptions);
         $this->userManager = $userManager;
         $this->accountLockDuration = $accountLockDuration;
         $this->accountMaxConsecutiveFailure = $accountMaxConsecutiveFailure;

--- a/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Provider/CustomDaoAuthenticationProvider.php
@@ -3,12 +3,12 @@
 
 namespace Akeneo\UserManagement\Bundle\Provider;
 
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Bundle\Model\LockedAccountException;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
@@ -26,7 +26,7 @@ class CustomDaoAuthenticationProvider extends DaoAuthenticationProvider
 
     private int $accountMaxConsecutiveFailure;
 
-    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, EncoderFactoryInterface $encoderFactory, UserManager $userManager, int $accountLockDuration, int $accountMaxConsecutiveFailure, bool $hideUserNotFoundExceptions = true)
+    public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, string $providerKey, PasswordHasherFactoryInterface $encoderFactory, UserManager $userManager, int $accountLockDuration, int $accountMaxConsecutiveFailure, bool $hideUserNotFoundExceptions = true)
     {
         parent::__construct($userProvider, $userChecker, $providerKey, $encoderFactory, $hideUserNotFoundExceptions);
         $this->userManager = $userManager;

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -16,7 +16,7 @@ services:
             - '@pim_user.saver.user'
             - '@pim_enrich.normalizer.violation'
             - '@pim_user.factory.user'
-            - '@security.password_encoder'
+            - '@security.password_hasher'
             - '@event_dispatcher'
             - '@session'
             - '@doctrine.orm.entity_manager'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
@@ -43,7 +43,7 @@ services:
             - ''
             - ''
             - ''
-            - '@security.encoder_factory'
+            - '@security.password_hasher_factory'
             - '@pim_user.manager'
             - '%pim_user.account_lock.duration%'
             - '%pim_user.account_lock.max_consecutive_failures%'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/services.yml
@@ -8,7 +8,7 @@ services:
         arguments:
             - '%pim_user.entity.user.class%'
             - "@doctrine.orm.entity_manager"
-            - "@security.encoder_factory"
+            - "@security.password_hasher_factory"
             - "@pim_user.saver.user"
 
     pim_user.security.login:

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -19,7 +19,7 @@ class JobUserProvider implements UserProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @TODO: Remove this function when symfony will be in 6.0
      */
     public function loadUserByUsername(string $username)
     {
@@ -29,11 +29,11 @@ class JobUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByIdentifier($username)
+    public function loadUserByIdentifier(string $identifier): UserInterface
     {
-        $user = $this->userRepository->findOneByIdentifier($username);
+        $user = $this->userRepository->findOneByIdentifier($identifier);
         if (!$user || $user->isApiUser()) {
-            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Job user.', $username));
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Job user.', $identifier));
         }
 
         if (!$user->isEnabled()) {

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -21,7 +21,7 @@ class JobUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByUsername($username)
+    public function loadUserByIdentifier($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);
         if (!$user || $user->isApiUser()) {
@@ -38,7 +38,7 @@ class JobUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         if (!$this->supportsClass($user::class)) {
             throw new UnsupportedUserException(sprintf('User object of class "%s" is not supported.', $user::class));
@@ -55,7 +55,7 @@ class JobUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return is_subclass_of($class, 'Akeneo\UserManagement\Component\Model\UserInterface');
     }

--- a/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/JobUserProvider.php
@@ -21,6 +21,14 @@ class JobUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function loadUserByUsername(string $username)
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadUserByIdentifier($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -35,7 +35,7 @@ class UserApiProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByUsername($username)
+    public function loadUserByIdentifier($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);
         if (!$user || $user->isJobUser()) {
@@ -52,7 +52,7 @@ class UserApiProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user): UserInterface
     {
         $userClass = ClassUtils::getClass($user);
         if (!$this->supportsClass($userClass)) {
@@ -70,7 +70,7 @@ class UserApiProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsClass($class)
+    public function supportsClass($class): bool
     {
         return is_subclass_of($class, 'Akeneo\UserManagement\Component\Model\UserInterface');
     }

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -10,6 +10,7 @@ use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -33,7 +34,7 @@ class UserApiProvider implements UserProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @TODO: Remove this function when symfony will be in 6.0
      */
     public function loadUserByUsername(string $username)
     {
@@ -43,11 +44,11 @@ class UserApiProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByIdentifier($username)
+    public function loadUserByIdentifier(string $identifier): SecurityUserInterface
     {
-        $user = $this->userRepository->findOneByIdentifier($username);
+        $user = $this->userRepository->findOneByIdentifier($identifier);
         if (!$user || $user->isJobUser()) {
-            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Api user.', $username));
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist or is not a Api user.', $identifier));
         }
 
         if (!$user->isEnabled()) {

--- a/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserApiProvider.php
@@ -35,6 +35,14 @@ class UserApiProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function loadUserByUsername(string $username)
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadUserByIdentifier($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);

--- a/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\UserManagement\Bundle\Security;
 
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
 use Doctrine\Common\Util\ClassUtils;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 

--- a/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
@@ -32,6 +32,14 @@ class UserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
+    public function loadUserByUsername(string $username)
+    {
+        return $this->loadUserByIdentifier($username);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function loadUserByIdentifier($username)
     {
         $user = $this->userRepository->findOneByIdentifier($username);

--- a/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
+++ b/src/Akeneo/UserManagement/Bundle/Security/UserProvider.php
@@ -30,7 +30,7 @@ class UserProvider implements UserProviderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @TODO: Remove this function when symfony will be in 6.0
      */
     public function loadUserByUsername(string $username)
     {
@@ -40,11 +40,11 @@ class UserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function loadUserByIdentifier($username)
+    public function loadUserByIdentifier(string $identifier): UserInterface
     {
-        $user = $this->userRepository->findOneByIdentifier($username);
+        $user = $this->userRepository->findOneByIdentifier($identifier);
         if (!$user || $user->isApiUser() || $user->isJobUser()) {
-            throw new UserNotFoundException(sprintf('User with username "%s" does not exist.', $username));
+            throw new UserNotFoundException(sprintf('User with username "%s" does not exist.', $identifier));
         }
 
         if (!$user->isEnabled()) {

--- a/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
+++ b/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\UserManagement\Bundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use Symfony\Component\Yaml\Yaml;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
+++ b/src/Akeneo/UserManagement/Bundle/Twig/AclGroupsExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use Symfony\Component\Yaml\Yaml;
 use Twig\TwigFunction;
@@ -13,7 +14,7 @@ use Twig\TwigFunction;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AclGroupsExtension extends \Twig\Extension\AbstractExtension
+class AclGroupsExtension extends AbstractExtension
 {
     public function __construct(
         protected array $bundles,

--- a/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUser.php
+++ b/src/Akeneo/UserManagement/Bundle/Validator/Constraints/CreateUser.php
@@ -19,7 +19,7 @@ class CreateUser extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/UserManagement/Bundle/Validator/Constraints/UserPreferences.php
+++ b/src/Akeneo/UserManagement/Bundle/Validator/Constraints/UserPreferences.php
@@ -41,7 +41,7 @@ class UserPreferences extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/UserManagement/Bundle/Validator/Constraints/UserPreferencesValidator.php
+++ b/src/Akeneo/UserManagement/Bundle/Validator/Constraints/UserPreferencesValidator.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle\Validator\Constraints;
 
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -17,7 +18,7 @@ class UserPreferencesValidator extends ConstraintValidator
     /**
      * Validate the user preferences
      *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      * @param Constraint                              $constraint
      */
     public function validate($user, Constraint $constraint)
@@ -30,7 +31,7 @@ class UserPreferencesValidator extends ConstraintValidator
     /**
      * Validate catalog locale
      *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      * @param Constraint                              $constraint
      */
     protected function validateCatalogLocale($user, Constraint $constraint)
@@ -50,7 +51,7 @@ class UserPreferencesValidator extends ConstraintValidator
     /**
      * Validate catalog Scope
      *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      * @param Constraint                              $constraint
      */
     protected function validateCatalogScope($user, Constraint $constraint)
@@ -66,7 +67,7 @@ class UserPreferencesValidator extends ConstraintValidator
     /**
      * Validate default tree
      *
-     * @param \Akeneo\UserManagement\Component\Model\UserInterface $user
+     * @param UserInterface $user
      * @param Constraint                              $constraint
      */
     protected function validateDefaultTree($user, Constraint $constraint)

--- a/src/Akeneo/UserManagement/Component/Model/User.php
+++ b/src/Akeneo/UserManagement/Component/Model/User.php
@@ -341,7 +341,7 @@ class User implements UserInterface, EquatableInterface
     /**
      * {@inheritdoc}
      */
-    public function getSalt()
+    public function getSalt(): ?string
     {
         return $this->salt;
     }
@@ -349,7 +349,7 @@ class User implements UserInterface, EquatableInterface
     /**
      * {@inheritdoc}
      */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }

--- a/src/Akeneo/UserManagement/Component/Model/UserInterface.php
+++ b/src/Akeneo/UserManagement/Component/Model/UserInterface.php
@@ -10,6 +10,7 @@ use Akeneo\UserManagement\Component\EntityUploadedImageInterface;
 use Doctrine\Common\Collections\Collection;
 use Oro\Bundle\PimDataGridBundle\Entity\DatagridView;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 
 /**
@@ -19,7 +20,7 @@ use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface UserInterface extends BaseUserInterface, \Serializable, EntityUploadedImageInterface
+interface UserInterface extends LegacyPasswordAuthenticatedUserInterface, BaseUserInterface, \Serializable, EntityUploadedImageInterface
 {
     public const SYSTEM_USER_NAME = 'system';
 

--- a/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
+++ b/src/Akeneo/UserManagement/Component/Normalizer/UserNormalizer.php
@@ -123,7 +123,7 @@ class UserNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof UserInterface && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/UserManagement/Component/Repository/UserRepositoryInterface.php
+++ b/src/Akeneo/UserManagement/Component/Repository/UserRepositoryInterface.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\UserManagement\Component\Repository;
 
-use Akeneo\UserManagement\Component\Model\UserInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\CountableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\Persistence\ObjectRepository;
 
 /**

--- a/src/Akeneo/UserManagement/Component/Repository/UserRepositoryInterface.php
+++ b/src/Akeneo/UserManagement/Component/Repository/UserRepositoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Component\Repository;
 
+use Akeneo\UserManagement\Component\Model\UserInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\CountableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Doctrine\Persistence\ObjectRepository;
@@ -20,7 +21,7 @@ interface UserRepositoryInterface extends IdentifiableObjectRepositoryInterface,
      *
      * @param array $groupIds
      *
-     * @return \Akeneo\UserManagement\Component\Model\UserInterface[]
+     * @return UserInterface[]
      */
     public function findByGroupIds(array $groupIds);
 }

--- a/tests/back/Channel/Specification/Infrastructure/EventListener/ChannelLocaleSubscriberSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/EventListener/ChannelLocaleSubscriberSpec.php
@@ -111,7 +111,7 @@ class ChannelLocaleSubscriberSpec extends ObjectBehavior
 
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
 
         $jobInstanceRepository
             ->findOneByIdentifier('remove_completeness_for_channel_and_locale')

--- a/tests/back/UserManagement/Specification/Bundle/Provider/CustomDaoAuthenticationProviderSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Provider/CustomDaoAuthenticationProviderSpec.php
@@ -88,7 +88,7 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
 
         $this->initUsernamePasswordToken($usernamePasswordToken);
         $userProvider->loadUserByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn($user);
-        $passwordHasher->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
+        $passwordHasher->verify(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
         $hasherFactory->getPasswordHasher(Argument::any())->willReturn($passwordHasher);
 
         $this->shouldThrow(LockedAccountException::class)
@@ -111,7 +111,7 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
 
         $this->initUsernamePasswordToken($usernamePasswordToken);
         $userProvider->loadUserByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn($user);
-        $passwordHasher->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
+        $passwordHasher->verify(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
         $hasherFactory->getPasswordHasher(Argument::any())->willReturn($passwordHasher);
         $this->shouldThrow(BadCredentialsException::class)
             ->duringAuthenticate($usernamePasswordToken);

--- a/tests/back/UserManagement/Specification/Bundle/Provider/CustomDaoAuthenticationProviderSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Provider/CustomDaoAuthenticationProviderSpec.php
@@ -8,6 +8,8 @@ use Akeneo\UserManagement\Bundle\Provider\CustomDaoAuthenticationProvider;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface;
@@ -22,9 +24,9 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
     const PROVIDER_KEY = "providerKey";
     const USERNAME = "username";
 
-    public function let(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, EncoderFactoryInterface $encoderFactory, UserManager $userManager)
+    public function let(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, PasswordHasherFactoryInterface $hasherFactory, UserManager $userManager)
     {
-        $this->beConstructedWith($userProvider, $userChecker, self::PROVIDER_KEY, $encoderFactory, $userManager, self::ACCOUNT_LOCK_DURATION, self::ALLOWED_FAILED_ATTEMPTS, false);
+        $this->beConstructedWith($userProvider, $userChecker, self::PROVIDER_KEY, $hasherFactory, $userManager, self::ACCOUNT_LOCK_DURATION, self::ALLOWED_FAILED_ATTEMPTS, false);
     }
 
     public function it_is_initializable()
@@ -71,8 +73,8 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
         UserInterface $user,
         UserProviderInterface $userProvider,
         UsernamePasswordToken $usernamePasswordToken,
-        PasswordEncoderInterface $passwordEncoder,
-        EncoderFactoryInterface $encoderFactory
+        PasswordHasherInterface $passwordHasher,
+        PasswordHasherFactoryInterface $hasherFactory
     ) {
         $this->initUser(
             $user,
@@ -86,18 +88,18 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
 
         $this->initUsernamePasswordToken($usernamePasswordToken);
         $userProvider->loadUserByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn($user);
-        $passwordEncoder->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
-        $encoderFactory->getEncoder(Argument::any())->willReturn($passwordEncoder);
+        $passwordHasher->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
+        $hasherFactory->getPasswordHasher(Argument::any())->willReturn($passwordHasher);
 
         $this->shouldThrow(LockedAccountException::class)
             ->duringAuthenticate($usernamePasswordToken);
     }
 
     public function it_increase_failed_attempts_counter(
-        EncoderFactoryInterface $encoderFactory,
+        PasswordHasherFactoryInterface $hasherFactory,
         UserManager $userManager,
         UserProviderInterface $userProvider,
-        PasswordEncoderInterface $passwordEncoder,
+        PasswordHasherInterface $passwordHasher,
         UserInterface $user,
         UsernamePasswordToken $usernamePasswordToken
     ) {
@@ -109,15 +111,15 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
 
         $this->initUsernamePasswordToken($usernamePasswordToken);
         $userProvider->loadUserByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn($user);
-        $passwordEncoder->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
-        $encoderFactory->getEncoder(Argument::any())->willReturn($passwordEncoder);
+        $passwordHasher->isPasswordValid(Argument::any(), Argument::any(), Argument::any())->willReturn(false);
+        $hasherFactory->getPasswordHasher(Argument::any())->willReturn($passwordHasher);
         $this->shouldThrow(BadCredentialsException::class)
             ->duringAuthenticate($usernamePasswordToken);
 
         $this->checkLockStateUpdated($userManager, $user, self::ALLOWED_FAILED_ATTEMPTS);
     }
 
-    public function it_initialize_failed_attempts_after_reset(UserManager $userManager, UserProviderInterface $userProvider, EncoderFactoryInterface $encoderFactory, PasswordEncoderInterface $passwordEncoder, UserInterface $user, UsernamePasswordToken $usernamePasswordToken)
+    public function it_initialize_failed_attempts_after_reset(UserManager $userManager, UserProviderInterface $userProvider, PasswordHasherFactoryInterface $hasherFactory, PasswordHasherInterface $passwordHasher, UserInterface $user, UsernamePasswordToken $usernamePasswordToken)
     {
         $this->initUser(
             $user,
@@ -127,7 +129,7 @@ class CustomDaoAuthenticationProviderSpec extends ObjectBehavior
         $user->getConsecutiveAuthenticationFailureCounter()->willReturn(0);
         $this->initUsernamePasswordToken($usernamePasswordToken);
         $userProvider->loadUserByIdentifier(self::USERNAME)->willReturn($user);
-        $encoderFactory->getEncoder(Argument::any())->willReturn($passwordEncoder);
+        $hasherFactory->getPasswordHasher(Argument::any())->willReturn($passwordHasher);
 
         $this->shouldThrow(BadCredentialsException::class)
             ->duringAuthenticate($usernamePasswordToken);

--- a/tests/back/UserManagement/Specification/Bundle/Security/UserProviderSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Security/UserProviderSpec.php
@@ -7,6 +7,7 @@ use Akeneo\UserManagement\Component\Repository\UserRepositoryInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\User;
 
@@ -23,14 +24,14 @@ class UserProviderSpec extends ObjectBehavior
         $julia->isJobUser()->willReturn(false);
         $julia->isEnabled()->willReturn(true);
         $userRepository->findOneByIdentifier('julia')->willReturn($julia);
-        $this->loadUserByUsername('julia')->shouldReturn($julia);
+        $this->loadUserByIdentifier('julia')->shouldReturn($julia);
     }
 
     function it_throws_an_exception_if_username_does_not_exist(UserRepositoryInterface $userRepository)
     {
         $userRepository->findOneByIdentifier('jean-pacôme')->willReturn(null);
         $this->shouldThrow(UsernameNotFoundException::class)
-            ->during('loadUserByUsername', ['jean-pacôme']);
+            ->during('loadUserByIdentifier', ['jean-pacôme']);
     }
 
     function it_throws_an_exception_if_user_is_disabled(UserRepositoryInterface $userRepository, UserInterface $disabledGuy)
@@ -39,8 +40,8 @@ class UserProviderSpec extends ObjectBehavior
         $disabledGuy->isApiUser()->willReturn(false);
         $disabledGuy->isEnabled()->willReturn(false);
         $userRepository->findOneByIdentifier('disabled-guy')->willReturn($disabledGuy);
-        $this->shouldThrow(UsernameNotFoundException::class)
-            ->during('loadUserByUsername', ['disabled-guy']);
+        $this->shouldThrow(UserNotFoundException::class)
+            ->during('loadUserByIdentifier', ['disabled-guy']);
     }
 
     function it_throws_an_exception_if_user_is_job_user(UserRepositoryInterface $userRepository, UserInterface $jobUser)
@@ -48,8 +49,8 @@ class UserProviderSpec extends ObjectBehavior
         $jobUser->isJobUser()->willReturn(true);
         $jobUser->isApiUser()->willReturn(false);
         $userRepository->findOneByIdentifier('job-user')->willReturn($jobUser);
-        $this->shouldThrow(UsernameNotFoundException::class)
-            ->during('loadUserByUsername', ['job-user']);
+        $this->shouldThrow(UserNotFoundException::class)
+            ->during('loadUserByIdentifier', ['job-user']);
     }
 
     function it_refreshes_a_user($userRepository, UserInterface $julia)
@@ -74,7 +75,7 @@ class UserProviderSpec extends ObjectBehavior
         $julia->getId()->willReturn(42);
         $userRepository->find(42)->willReturn(null);
 
-        $this->shouldThrow(UsernameNotFoundException::class)
+        $this->shouldThrow(UserNotFoundException::class)
             ->during('refreshUser', [$julia]);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

 In this PR, we upgraded the griffin maintenance domain to Symfony 6. For V7 release we should make your code compliant with Symfony6. In order to keep ownership to user we migrate code by maintenance domain. All change have been made by rector (committed for now).

TLDR:

- Symfony make her code more strict (return type)
- getUsername have been replaced by getUserIdentifier => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L353-L354
- loadByUsername have been replaced by loadUserByIdentifier => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L12
- EncoderFactoryInterface have been replaced by PasswordHasherFactoryInterface => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L455-L456
- EncoderInterface have been replaced by PasswordHasherInterface => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L457-L458
- encoders have been replaced by password_hasher => https://symfony.com/blog/new-in-symfony-5-3-passwordhasher-component
- Kernel.php now use RoutingConfigurator on configureRoute function => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L99

Domains covered :
- Structure (Attribute, Family, Channel, Category)
- FreeTrial
- UserManagement

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
