### PR TITLE
CPM-594: Update Product creation modal

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -76,7 +76,7 @@ use Webmozart\Assert\Assert;
  */
 class ProductController
 {
-    const NO_IDENTIFIER_MESSAGE = 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.';
+    private const NO_IDENTIFIER_MESSAGE = 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.';
 
     public function __construct(
         protected NormalizerInterface $normalizer,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -76,6 +76,8 @@ use Webmozart\Assert\Assert;
  */
 class ProductController
 {
+    const NO_IDENTIFIER_MESSAGE = 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.';
+
     public function __construct(
         protected NormalizerInterface $normalizer,
         protected IdentifiableObjectRepositoryInterface $channelRepository,
@@ -252,6 +254,14 @@ class ProductController
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
         $data = $this->getDecodedContent($request->getContent());
+
+        if (!isset($data['identifier']) || $data['identifier'] === '') {
+            throw new DocumentedHttpException(
+                Documentation::URL . 'post_products_uuid',
+                sprintf(self::NO_IDENTIFIER_MESSAGE)
+            );
+        }
+
         $violations = $this->validator->validate($data, new PayloadFormat());
         if (0 < $violations->count()) {
             $firstViolation = $violations->get(0);
@@ -303,6 +313,15 @@ class ProductController
     {
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
+        $data = $this->getDecodedContent($request->getContent());
+
+        if (!isset($data['identifier']) || $data['identifier'] === '') {
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products_uuid__uuid_',
+                sprintf(self::NO_IDENTIFIER_MESSAGE)
+            );
+        }
+
         if (!\is_string($code)) {
             $message = 'The identifier field requires a string.';
             throw new DocumentedHttpException(
@@ -310,8 +329,6 @@ class ProductController
                 sprintf('%s Check the expected format on the API documentation.', $message)
             );
         }
-
-        $data = $this->getDecodedContent($request->getContent());
 
         $violations = $this->validator->validate($data, new PayloadFormat());
         if (0 < $violations->count()) {

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -323,7 +323,7 @@ class ProductController
 
         $data = $this->getDecodedContent($request->getContent());
 
-        if (!isset($data['identifier']) || $data['identifier'] === '') {
+        if (array_key_exists('identifier', $data) && (null === $data['identifier'] || '' === $data['identifier'])) {
             throw new DocumentedHttpException(
                 Documentation::URL . 'patch_products_uuid__uuid_',
                 sprintf(self::NO_IDENTIFIER_MESSAGE)

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -313,13 +313,20 @@ class ProductController
     {
         $this->denyAccessUnlessAclIsGranted('pim_api_product_edit');
 
-        $data = $this->getDecodedContent($request->getContent());
-
         if (!\is_string($code)) {
             $message = 'The identifier field requires a string.';
             throw new DocumentedHttpException(
                 Documentation::URL . 'patch_products__code_',
                 sprintf('%s Check the expected format on the API documentation.', $message)
+            );
+        }
+
+        $data = $this->getDecodedContent($request->getContent());
+
+        if (!isset($data['identifier']) || $data['identifier'] === '') {
+            throw new DocumentedHttpException(
+                Documentation::URL . 'patch_products_uuid__uuid_',
+                sprintf(self::NO_IDENTIFIER_MESSAGE)
             );
         }
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/ExternalApi/ProductController.php
@@ -315,13 +315,6 @@ class ProductController
 
         $data = $this->getDecodedContent($request->getContent());
 
-        if (!isset($data['identifier']) || $data['identifier'] === '') {
-            throw new DocumentedHttpException(
-                Documentation::URL . 'patch_products_uuid__uuid_',
-                sprintf(self::NO_IDENTIFIER_MESSAGE)
-            );
-        }
-
         if (!\is_string($code)) {
             $message = 'The identifier field requires a string.';
             throw new DocumentedHttpException(

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductPdfController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductPdfController.php
@@ -72,7 +72,7 @@ class ProductPdfController
                 'content-type'        => 'application/pdf',
                 'content-disposition' => sprintf(
                     'attachment; filename=%s-%s.pdf',
-                    $product->getIdentifier() ?? $product->getUuid(),
+                    $product->getIdentifier() ?? $product->getUuid()->toString(),
                     $renderingDate->format('Y-m-d_H-i-s')
                 ),
             ]

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductPdfController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductPdfController.php
@@ -72,7 +72,7 @@ class ProductPdfController
                 'content-type'        => 'application/pdf',
                 'content-disposition' => sprintf(
                     'attachment; filename=%s-%s.pdf',
-                    $product->getIdentifier(),
+                    $product->getIdentifier() ?? $product->getUuid(),
                     $renderingDate->format('Y-m-d_H-i-s')
                 ),
             ]

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/validation/product.yml
@@ -20,8 +20,6 @@ Akeneo\Pim\Enrichment\Component\Product\Model\Product:
         uuid:
             - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsUuid4: ~
         identifier:
-            - Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\NotBlank:
-                attributeCode: 'identifier'
             - Regex:
                 pattern: '/^(?!\s)[^,;]+(?<!\s)$/'
                 message: 'regex.comma_or_semicolon_or_surrounding_space.message'

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -42,6 +42,7 @@ pim_enrich.entity.product:
             title: Select your action
             choose_family: Choose a family
             choose_family_variant: Choose a family variant
+            helper: The identifier is now an optional field. <a href="{{ link }}" target="_blank">Read more</a> about this change and the possible impacts for your products.
         variant_navigation:
             common: Common
         status:

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/UpsertProductIntegration.php
@@ -176,14 +176,6 @@ final class UpsertProductIntegration extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_deleting_the_identifier_value()
-    {
-        $this->expectException(LegacyViolationsException::class);
-        $this->expectExceptionMessage('The identifier attribute cannot be empty.');
-        $this->updateProduct(new SetIdentifierValue('sku', ''));
-    }
-
-    /** @test */
     public function it_throws_an_exception_for_a_duplicate_identifier_value(): void
     {
         $this->messageBus->dispatch(UpsertProductCommand::createWithIdentifier(
@@ -1433,21 +1425,6 @@ final class UpsertProductIntegration extends TestCase
         $product = $this->productRepository->findOneByIdentifier('product_sku');
         Assert::assertNotNull($product);
         Assert::assertSame('product_sku', $product->getIdentifier());
-    }
-
-    /**
-     * @test
-     * @TODO: remove this test once the identifier is rendered optional
-     */
-    public function it_cannot_create_a_product_without_identifier_value(): void
-    {
-        $this->expectException(LegacyViolationsException::class);
-        $this->expectDeprecationMessageMatches('/The identifier attribute cannot be empty/');
-
-        $this->messageBus->dispatch(UpsertProductCommand::createWithoutUuidNorIdentifier(
-            userId: $this->getUserId('admin'),
-            userIntents: [new SetEnabled(false)]
-        ));
     }
 
     private function getUserId(string $username): int

--- a/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
+++ b/src/Akeneo/Pim/Structure/Component/Updater/FamilyUpdater.php
@@ -189,7 +189,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
                 $this->setAttributeRequirements($family, $data);
                 break;
             case 'attributes':
-                $this->addAttributes($family, $data);
+                $this->setAttributes($family, $data);
                 break;
             case 'attribute_as_label':
                 $this->setAttributeAsLabel($family, $data);
@@ -346,7 +346,7 @@ class FamilyUpdater implements ObjectUpdaterInterface
      *
      * @throws InvalidPropertyException
      */
-    protected function addAttributes(FamilyInterface $family, array $data)
+    protected function setAttributes(FamilyInterface $family, array $data)
     {
         $newAttributes = [];
         foreach ($data as $attributeCode) {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
@@ -12,11 +12,21 @@ extensions:
            routerKey: uuid
            entityIdentifierParamName: meta.id
 
+    pim-product-create-helper:
+        module: pim/common/simple-view
+        parent: pim-product-create-modal
+        targetZone: fields
+        position: 10
+        config:
+            template: pim/template/product/create-helper
+            templateParams:
+                link: "https://help.akeneo.com/pim/serenity/articles/about-product-identifiers.html"
+
     pim-product-create-family:
         module: pim/form/common/fields/simple-select-async
         parent: pim-product-create-modal
         targetZone: fields
-        position: 10
+        position: 20
         config:
             fieldName: family
             label: pim_enrich.entity.family.uppercase_label
@@ -26,6 +36,6 @@ extensions:
         module: pim/product-edit-form/creation/identifier-regarding-family
         parent: pim-product-create-modal
         targetZone: fields
-        position: 20
+        position: 30
         config:
             identifier: identifier

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
@@ -32,7 +32,7 @@ extensions:
             label: pim_enrich.entity.family.uppercase_label
             choiceRoute: pim_enrich_family_rest_index
 
-    pim-product-create-sku:
+    pim-product-create-identifier:
         module: pim/product-edit-form/creation/identifier-regarding-family
         parent: pim-product-create-modal
         targetZone: fields

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/create.yml
@@ -12,20 +12,20 @@ extensions:
            routerKey: uuid
            entityIdentifierParamName: meta.id
 
-    pim-product-create-sku:
-        module: pim/product-edit-form/creation/identifier
-        parent: pim-product-create-modal
-        targetZone: fields
-        position: 10
-        config:
-            identifier: identifier
-
     pim-product-create-family:
         module: pim/form/common/fields/simple-select-async
         parent: pim-product-create-modal
         targetZone: fields
-        position: 20
+        position: 10
         config:
             fieldName: family
             label: pim_enrich.entity.family.uppercase_label
             choiceRoute: pim_enrich_family_rest_index
+
+    pim-product-create-sku:
+        module: pim/product-edit-form/creation/identifier-regarding-family
+        parent: pim-product-create-modal
+        targetZone: fields
+        position: 20
+        config:
+            identifier: identifier

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
@@ -8,7 +8,7 @@ extensions:
         targetZone: breadcrumbs
         config:
             tab: pim-menu-products
-            itemPath: identifier
+            itemPath: [identifier, "meta.id"]
 
     pim-product-edit-form-user-navigation:
         module: pim/menu/user-navigation
@@ -19,7 +19,6 @@ extensions:
             logout: pim_menu.user.logout
 
     pim-product-edit-form-main-image:
-        #module: pim/form/common/product/product-main-image
         module: pim/product-edit-form/main-image
         parent: pim-product-edit-form
         targetZone: main-image

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -705,6 +705,7 @@ config:
     pim/product-edit-form/download-pdf:                      pimui/js/product/form/download-pdf
     pim/product-edit-form/attributes:                        pimui/js/product/form/attributes
     pim/product-edit-form/creation/identifier:               pimui/js/product/form/creation/identifier
+    pim/product-edit-form/creation/identifier-regarding-family: pimui/js/product/form/creation/identifier-regarding-family
     pim/product-edit-form/free-trial-start-copy:             pimui/js/product/form/free-trial-start-copy
     pim/product-edit-form/start-copy:                        pimui/js/product/form/start-copy
     pim/product-edit-form/convert-to-simple-product:         pimui/js/product/form/convert-to-simple-product.ts

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/requirejs.yml
@@ -1142,6 +1142,7 @@ config:
     pim/template/product-create-error:                   pimui/templates/product/create-error.html
     pim/template/product/create-button:                  pimui/templates/product/create-button.html
     pim/template/product/create-modal-content:           pimui/templates/product/create-modal-content.html
+    pim/template/product/create-helper:                  pimui/templates/product/create-helper.html
     pim/template/product/add-select/attribute/line:      pimui/templates/product/form/add-select/attribute/line.html
     pim/template/product/form/total-missing-required-attributes: pimui/templates/product/form/total-missing-required-attributes.html
     pim/template/product/form/variant-navigation/navigation: pimui/templates/product/form/variant-navigation/navigation.html

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/breadcrumbs.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/breadcrumbs.js
@@ -65,11 +65,8 @@ define([
             if (!Array.isArray(itemPaths)) {
               itemPaths = [itemPaths];
             }
-            itemPaths.forEach((itemPath) => {
-              if (
-                breadcrumbItem === null &&
-                null !== propertyAccessor.accessProperty(this.getFormData(), itemPath)
-              ) {
+            itemPaths.forEach(itemPath => {
+              if (breadcrumbItem === null && null !== propertyAccessor.accessProperty(this.getFormData(), itemPath)) {
                 const item = propertyAccessor.accessProperty(this.getFormData(), itemPath);
 
                 breadcrumbItem = {code: item, label: item, active: false};

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/breadcrumbs.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/common/breadcrumbs.js
@@ -60,13 +60,21 @@ define([
           if (undefined !== metaItem) {
             breadcrumbItem = {code: this.config.item, label: __(metaItem.config.title), active: true};
           }
-          if (
-            undefined !== this.config.itemPath &&
-            null !== propertyAccessor.accessProperty(this.getFormData(), this.config.itemPath)
-          ) {
-            const item = propertyAccessor.accessProperty(this.getFormData(), this.config.itemPath);
+          if (this.config.itemPath) {
+            let itemPaths = this.config.itemPath;
+            if (!Array.isArray(itemPaths)) {
+              itemPaths = [itemPaths];
+            }
+            itemPaths.forEach((itemPath) => {
+              if (
+                breadcrumbItem === null &&
+                null !== propertyAccessor.accessProperty(this.getFormData(), itemPath)
+              ) {
+                const item = propertyAccessor.accessProperty(this.getFormData(), itemPath);
 
-            breadcrumbItem = {code: item, label: item, active: false};
+                breadcrumbItem = {code: item, label: item, active: false};
+              }
+            });
           }
 
           const tab = React.createElement(Breadcrumb.Step, {className: 'breadcrumb-tab'}, breadcrumbTab.label);

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/family/form/attributes/attributes.js
@@ -43,7 +43,6 @@ define([
     collapsedClass: 'AknGrid-bodyContainer--collapsed',
     requiredLabel: __('pim_enrich.entity.family.module.attributes.required_label'),
     notRequiredLabel: __('pim_enrich.entity.family.module.attributes.not_required_label'),
-    identifierAttributeType: 'pim_catalog_identifier',
     template: _.template(template),
     errors: [],
     catalogLocale: UserContext.get('catalogLocale'),

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * This compoonent allows to display an identifier field.
+ * It is only displayed when the family contains the identifier attribute.
+ *
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+define([
+  'pim/product-edit-form/creation/identifier',
+  'pim/fetcher-registry',
+], function (Identifier, FetcherRegistry) {
+  return Identifier.extend({
+    shouldDisplay: async function () {
+      const familyCode = this.getFormData()?.family;
+      if (familyCode) {
+        return FetcherRegistry.getFetcher('family')
+          .fetch(familyCode)
+          .then((family) => {
+              return !!family.attributes.find((attribute) => attribute.type === 'pim_catalog_identifier');
+            }
+          );
+      } else {
+        return new Promise(resolve => resolve(false));
+      }
+    },
+  });
+});

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
@@ -7,20 +7,16 @@
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-define([
-  'pim/product-edit-form/creation/identifier',
-  'pim/fetcher-registry',
-], function (Identifier, FetcherRegistry) {
+define(['pim/product-edit-form/creation/identifier', 'pim/fetcher-registry'], function (Identifier, FetcherRegistry) {
   return Identifier.extend({
     shouldDisplay: async function () {
       const familyCode = this.getFormData()?.family;
       if (familyCode) {
         return FetcherRegistry.getFetcher('family')
           .fetch(familyCode)
-          .then((family) => {
-              return !!family.attributes.find((attribute) => attribute.type === 'pim_catalog_identifier');
-            }
-          );
+          .then(family => {
+            return !!family.attributes.find(attribute => attribute.type === 'pim_catalog_identifier');
+          });
       } else {
         return new Promise(resolve => resolve(false));
       }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier-regarding-family.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * This compoonent allows to display an identifier field.
+ * This component allows to display an identifier field.
  * It is only displayed when the family contains the identifier attribute.
  *
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -42,7 +42,6 @@ define([
                 this.template({
                   identifier: this.identifier,
                   label: i18n.getLabel(identifier.labels, UserContext.get('catalogLocale'), identifier.code),
-                  requiredLabel: __('pim_common.required_label'),
                   errors: this.getRoot().validationErrors,
                   value: this.getFormData()[this.identifier],
                 })

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -25,8 +25,7 @@ define([
      * @return {Promise}
      */
     render: function () {
-      return this.shouldDisplay()
-        .then((shouldDisplay) => {
+      return this.shouldDisplay().then(shouldDisplay => {
         if (!shouldDisplay) {
           this.$el.html('');
           this.updateModel({target: {value: undefined}});
@@ -61,6 +60,6 @@ define([
 
     shouldDisplay: async function () {
       return new Promise(resolve => resolve(true));
-    }
+    },
   });
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -29,6 +29,7 @@ define([
         .then((shouldDisplay) => {
         if (!shouldDisplay) {
           this.$el.html('');
+          this.updateModel({target: {value: undefined}});
 
           return this;
         }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -25,28 +25,41 @@ define([
      * @return {Promise}
      */
     render: function () {
-      return FetcherRegistry.getFetcher('attribute')
-        .getIdentifierAttribute()
-        .then(
-          function (identifier) {
-            this.$el.html(
-              this.template({
-                identifier: this.identifier,
-                label: i18n.getLabel(identifier.labels, UserContext.get('catalogLocale'), identifier.code),
-                requiredLabel: __('pim_common.required_label'),
-                errors: this.getRoot().validationErrors,
-                value: this.getFormData()[this.identifier],
-              })
-            );
+      return this.shouldDisplay()
+        .then((shouldDisplay) => {
+        if (!shouldDisplay) {
+          this.$el.html('');
 
-            this.delegateEvents();
+          return this;
+        }
 
-            return this;
-          }.bind(this)
-        )
-        .fail(() => {
-          this.$el.html(this.errorTemplate({message: __('pim_enrich.entity.product.flash.create.fail')}));
-        });
+        return FetcherRegistry.getFetcher('attribute')
+          .getIdentifierAttribute()
+          .then(
+            function (identifier) {
+              this.$el.html(
+                this.template({
+                  identifier: this.identifier,
+                  label: i18n.getLabel(identifier.labels, UserContext.get('catalogLocale'), identifier.code),
+                  requiredLabel: __('pim_common.required_label'),
+                  errors: this.getRoot().validationErrors,
+                  value: this.getFormData()[this.identifier],
+                })
+              );
+
+              this.delegateEvents();
+
+              return this;
+            }.bind(this)
+          )
+          .fail(() => {
+            this.$el.html(this.errorTemplate({message: __('pim_enrich.entity.product.flash.create.fail')}));
+          });
+      });
     },
+
+    shouldDisplay: async function () {
+      return new Promise(resolve => resolve(true));
+    }
   });
 });

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -42,6 +42,7 @@ define([
                 this.template({
                   identifier: this.identifier,
                   label: i18n.getLabel(identifier.labels, UserContext.get('catalogLocale'), identifier.code),
+                  requiredLabel: '',
                   errors: this.getRoot().validationErrors,
                   value: this.getFormData()[this.identifier],
                 })

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/MessageBox.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/components/MessageBox.less
@@ -10,6 +10,10 @@
   flex-direction: column;
   margin-bottom: 8px;
 
+  &--inline {
+    display: inline-block;
+  }
+
   &-title {
     display: inline;
     font-weight: bold;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/create-helper.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/create-helper.html
@@ -1,0 +1,1 @@
+<div class="AknMessageBox AknMessageBox--inline"><%= __('pim_enrich.entity.product.module.create.helper', {link}) %></div>

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductEndToEnd.php
@@ -749,13 +749,12 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Validation failed.',
-            'errors'  => [
-                [
-                    'property'   => 'identifier',
-                    'message' => 'The identifier attribute cannot be empty.',
-                ],
-            ],
+            'message' => 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_products_uuid'
+                ]
+            ]
         ];
 
         $response = $client->getResponse();
@@ -774,13 +773,12 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Validation failed.',
-            'errors'  => [
-                [
-                    'property' => 'identifier',
-                    'message'  => 'The identifier attribute cannot be empty.',
-                ],
-            ],
+            'message' => 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#post_products_uuid'
+                ]
+            ]
         ];
 
         $response = $client->getResponse();
@@ -826,6 +824,7 @@ JSON;
         $data =
             <<<JSON
     {
+        "identifier": "new_product",
         "extra_property": "foo"
     }
 JSON;

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductEndToEnd.php
@@ -406,13 +406,12 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Validation failed.',
-            'errors'  => [
-                [
-                    'property' => 'identifier',
-                    'message'  => 'The identifier attribute cannot be empty.',
-                ],
-            ],
+            'message' => 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.',
+            '_links'  => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#patch_products_uuid__uuid_'
+                ]
+            ]
         ];
 
         $response = $client->getResponse();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/CreateVariantProductWithUuidEndToEnd.php
@@ -11,7 +11,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\IntegrationTestsBundle\Messenger\AssertEventCountTrait;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
-use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -148,46 +147,6 @@ JSON;
         $this->assertSameProducts($expectedProduct, 'product_variant_creation_family');
 
         $this->assertEventCount(1, ProductCreated::class);
-    }
-
-    public function testProductVariantCreationWithFamilyAndWithoutIdentifier()
-    {
-        $client = $this->createAuthenticatedClient();
-
-        $data =
-            <<<JSON
-    {
-        "family": "familyA",
-        "parent": "amor",
-        "values": {
-          "a_yes_no": [
-            {
-              "locale": null,
-              "scope": null,
-              "data": true
-            }
-          ]
-        }
-    }
-JSON;
-
-        $client->request('POST', 'api/rest/v1/products-uuid', [], [], [], $data);
-
-        $expectedContent = [
-            'code'    => 422,
-            'message' => 'Validation failed.',
-            'errors'  => [
-                [
-                    'property'   => 'identifier',
-                    'message' => 'The identifier attribute cannot be empty.',
-                ],
-            ],
-        ];
-
-        $response = $client->getResponse();
-
-        $this->assertSame($expectedContent, json_decode($response->getContent(), true));
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
     }
 
     public function testProductVariantCreationWithFamilyNotSpecifiedInSentData()

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/VariantProduct/ExternalApi/PartialUpdateVariantProductEndToEnd.php
@@ -255,12 +255,11 @@ JSON;
 
         $expectedContent = [
             'code'    => 422,
-            'message' => 'Validation failed.',
-            'errors'  => [
-                [
-                    'property' => 'identifier',
-                    'message'  => 'The identifier attribute cannot be empty.',
-                ],
+            'message' => 'Validation failed. The identifier field is required for this endpoint. If you want to manipulate products without identifiers, please use products-uuid endpoints.',
+            '_links' => [
+                'documentation' => [
+                    'href' => 'http://api.akeneo.com/api-reference.html#patch_products_uuid__uuid_'
+                ]
             ],
         ];
 

--- a/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Validation/ProductIdentifierValidationIntegration.php
@@ -81,17 +81,15 @@ class ProductIdentifierValidationIntegration extends TestCase
         );
     }
 
-    public function testNotBlankValidation()
+    public function testItCanCreateProductWithoutIdentifier()
     {
         $correctProduct = $this->createProduct('sku-001');
         $violations = $this->validateProduct($correctProduct);
         $this->assertCount(0, $violations);
 
-        $wrongProduct = $this->createProduct('');
-        $violations = $this->validateProduct($wrongProduct);
-        $this->assertCount(1, $violations);
-        $this->assertSame($violations->get(0)->getMessage(), 'The identifier attribute cannot be empty.');
-        $this->assertSame($violations->get(0)->getPropertyPath(), 'identifier');
+        $productWithoutIdentifier = $this->createProduct('');
+        $violations = $this->validateProduct($productWithoutIdentifier);
+        $this->assertCount(0, $violations);
     }
 
     /**

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Controller/InternalApi/ProductPdfControllerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Controller/InternalApi/ProductPdfControllerSpec.php
@@ -28,11 +28,9 @@ class ProductPdfControllerSpec extends ObjectBehavior
         $request->get('dataLocale', null)->willReturn('fr_FR');
         $request->get('dataScope', null)->willReturn('mobile');
 
-        $now = new \DateTime('now');
-
         $rendererRegistry->render($blender, 'pdf', Argument::type('array'))->shouldBeCalled();
 
-        $blender->getIdentifier()->shouldBeCalled();
+        $blender->getIdentifier()->shouldBeCalled()->willReturn('productIdentifier');
 
         $this->downloadPdfAction($request, 'df470d52-7723-4890-85a0-e79be625e2ed');
     }
@@ -61,8 +59,6 @@ class ProductPdfControllerSpec extends ObjectBehavior
 
     function it_throws_an_exception_if_the_product_doesnt_exist(
         Request $request,
-        ProductInterface $blender,
-        $rendererRegistry,
         $productRepository
     ) {
         $productRepository->find('df470d52-7723-4890-85a0-e79be625e2ed')->willReturn(null);

--- a/tests/legacy/features/pim/enrichment/product-model/add_product_model_children.feature
+++ b/tests/legacy/features/pim/enrichment/product-model/add_product_model_children.feature
@@ -152,16 +152,6 @@ Feature: Add children to product model
     And I confirm the child creation
     Then I should see the text "The product model code must not be empty."
 
-  Scenario: I cannot add a variant product without identifier
-    Given I am on the "apollon_blue" product model page
-    When I open the variant navigation children selector for level 2
-    And I press the "Add new" button and wait for modal
-    Then I should see the text "Add a new size"
-    When I fill in the following child information:
-      | Size (variant axis) | XL |
-    And I confirm the child creation
-    Then I should see the text "The identifier attribute cannot be empty."
-
   Scenario: I cannot add a sub product model without axis value
     Given I am on the "apollon" product model page
     When I open the variant navigation children selector for level 1

--- a/tests/legacy/features/pim/enrichment/product/create_product_and_save_added_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/create_product_and_save_added_attributes.feature
@@ -18,8 +18,8 @@ Feature: Create product and save a new product value
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | gladiator       |
       | Family | [super_sandals] |
+      | SKU    | gladiator       |
     And I press the "Save" button in the popin
     And I wait to be on the "gladiator" product page
     And I visit the "Product information" group

--- a/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_and_update_attribute_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-edit/edit-common-attribute/mass_edit_and_update_attribute_history.feature
@@ -11,24 +11,24 @@ Feature: Update product history when mass editing products
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
     And I save the product
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | sneakers |
       | Family | Sneakers |
+      | SKU    | sneakers |
     And I press the "Save" button in the popin
     And I wait to be on the "sneakers" product page
     And I save the product
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | sandals |
       | Family | Sandals |
+      | SKU    | sandals |
     And I press the "Save" button in the popin
     And I wait to be on the "sandals" product page
     And I save the product

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_and_display_all_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_and_display_all_attributes.feature
@@ -10,8 +10,8 @@ Feature: Edit and see all attributes
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
     And I visit the "Sizes" group

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_and_remove_a_product.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_and_remove_a_product.feature
@@ -13,8 +13,8 @@ Feature: Edit and remove a product
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
     And I visit the "Sizes" group

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_boolean_value.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_boolean_value.feature
@@ -10,8 +10,8 @@ Feature: Edit a boolean value
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | gladiator |
       | Family | T-shirts  |
+      | SKU    | gladiator |
     And I press the "Save" button in the popin
     And I wait to be on the "gladiator" product page
     And I visit the "Additional information" group

--- a/tests/legacy/features/pim/enrichment/product/pef/edit_product_and_filter_attributes.feature
+++ b/tests/legacy/features/pim/enrichment/product/pef/edit_product_and_filter_attributes.feature
@@ -10,8 +10,8 @@ Feature: Edit product and filter attributes
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
 

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_history.feature
@@ -10,7 +10,8 @@ Feature: Display the product history
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU | sandals-001 |
+      | Family | Boots       |
+      | SKU    | sandals-001 |
     And I press the "Save" button in the popin
     And I wait to be on the "sandals-001" product page
     And the history of the product "sandals-001" has been built

--- a/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
+++ b/tests/legacy/features/pim/enrichment/product/versioning/display_removed_value_history.feature
@@ -11,8 +11,8 @@ Feature: Display the product history
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
     And I visit the "Product information" group

--- a/tests/legacy/features/pim/enrichment/reference-data/product/display_history.feature
+++ b/tests/legacy/features/pim/enrichment/reference-data/product/display_history.feature
@@ -10,8 +10,8 @@ Feature: Display the product history
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | heels |
       | Family | Heels |
+      | SKU    | heels |
     And I press the "Save" button in the popin
     And I wait to be on the "heels" product page
 

--- a/tests/legacy/features/pim/structure/attribute/option/sort_attribute_options.feature
+++ b/tests/legacy/features/pim/structure/attribute/option/sort_attribute_options.feature
@@ -29,8 +29,8 @@ Feature: Sort attribute options
     And I am on the products grid
     And I create a product
     And I fill in the following information in the popin:
-      | SKU    | boots |
       | Family | Boots |
+      | SKU    | boots |
     And I press the "Save" button in the popin
     And I wait to be on the "boots" product page
     When I visit the "Colors" group


### PR DESCRIPTION
This PR:
- Removes the validation saying identifier should be filled for a product
- Updates the former API endpoints to have a dedicated message when user try to remove identifier / create a product without identifier ; the message links to the new endpoints usage
- Updates the new API endpoints to create products without identifiers
- Updates the filename of a PDF when it has no identifier (uuid-date.pdf instead of identifier-date.pdf)
- Adds a helper in the create product modal
- Puts family first in the create product modal, then display the identifier field if it's part of the family attributes
- Displays the UUID in the PEF breadcrumbs if product has no identifier