### PR TITLE
CPM-754: Add Uuid filter in list products endpoints

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/UuidFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/UuidFilter.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterHelper;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class UuidFilter extends AbstractFieldFilter
+{
+    public function __construct(private string $prefix)
+    {
+        $this->supportedFields = ['uuid'];
+        $this->supportedOperators = [Operators::IN_LIST];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFieldFilter(
+        $field,
+        $operator,
+        $value,
+        $locale = null,
+        $channel = null,
+        $options = []
+    ) {
+        if (null === $this->searchQueryBuilder) {
+            throw new \LogicException('The search query builder is not initialized in the filter.');
+        }
+        $this->checkValue($operator, $value);
+
+        switch ($operator) {
+            case Operators::IN_LIST:
+                $clause = [
+                    'terms' => [
+                        'id' => \array_map(
+                            fn (string $uuid): string => \sprintf('%s%s', $this->prefix, $uuid),
+                            $value
+                        ),
+                    ],
+                ];
+
+                $this->searchQueryBuilder->addFilter($clause);
+                break;
+            default:
+                throw InvalidOperatorException::notSupported($operator, static::class);
+        }
+
+        return $this;
+    }
+
+    private function checkValue($operator, $value): void
+    {
+        if (Operators::IN_LIST === $operator) {
+            FieldFilterHelper::checkArrayOfStrings('uuid', $value, self::class);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -300,6 +300,12 @@ services:
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
 
+    Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\UuidFilter:
+        arguments:
+            - 'product_'
+        tags:
+            - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
+
     pim_catalog.query.elasticsearch.product_model.filter.id:
         class: '%pim_catalog.query.elasticsearch.filter.id.class%'
         arguments:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
@@ -18,6 +18,7 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 final class ValidateProperties
 {
     private static $productFields = [
+        'uuid',
         'family',
         'categories',
         'completeness',

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -1021,6 +1021,46 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected);
     }
 
+    public function testListProductsWithUuidNotInFilter(): void
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+
+        $search = \json_encode([
+            'uuid' => [
+                [
+                    'operator' => 'NOT IN',
+                    'value' => [
+                        self::PRODUCT_UUIDS['simple'],
+                        self::PRODUCT_UUIDS['localizable'],
+                        self::PRODUCT_UUIDS['product_with_parent'],
+                    ],
+                ],
+            ],
+        ]);
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['product_china']},
+            {$standardizedProducts['product_without_category']},
+            {$standardizedProducts['scopable']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
+    }
+
     public function testListProductsWithoutParent()
     {
         $standardizedProducts = $this->getStandardizedProducts();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -20,6 +20,7 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Akeneo\Test\Integration\Configuration;
 use AkeneoTest\Pim\Enrichment\EndToEnd\Product\Product\ExternalApi\AbstractProductTestCase;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -978,6 +979,46 @@ JSON;
 
             $this->assertListResponse($client->getResponse(), $expected);
         }
+    }
+
+    public function testListProductsWithUuidFilter(): void
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+
+        $search = \json_encode([
+            'uuid' => [
+                [
+                    'operator' => 'IN',
+                    'value' => [
+                        self::PRODUCT_UUIDS['simple'],
+                        self::PRODUCT_UUIDS['localizable'],
+                        Uuid::uuid4()->toString(),
+                        self::PRODUCT_UUIDS['product_with_parent'],
+                    ],
+                ],
+            ],
+        ]);
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products?search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['localizable']},
+            {$standardizedProducts['product_with_parent']},
+            {$standardizedProducts['simple']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected);
     }
 
     public function testListProductsWithoutParent()

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
@@ -913,6 +913,46 @@ JSON;
         $this->assertListResponse($client->getResponse(), $expected, true);
     }
 
+    public function testListProductsWithUuidNotInFilter(): void
+    {
+        $standardizedProducts = $this->getStandardizedProducts();
+
+        $search = \json_encode([
+            'uuid' => [
+                [
+                    'operator' => 'NOT IN',
+                    'value' => [
+                        $this->products['simple']->getUuid()->toString(),
+                        $this->products['localizable']->getUuid()->toString(),
+                        $this->products['with_parent']->getUuid()->toString(),
+                    ],
+                ],
+            ],
+        ]);
+        $client = $this->createAuthenticatedClient();
+        $client->request('GET', 'api/rest/v1/products-uuid?search=' . $search);
+        $searchEncoded = $this->encodeStringWithSymfonyUrlGeneratorCompatibility($search);
+        $expected = <<<JSON
+{
+    "_links": {
+        "self"  : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"},
+        "first" : {"href" : "http://localhost/api/rest/v1/products-uuid?page=1&with_count=false&pagination_type=page&limit=10&search=${searchEncoded}"}
+    },
+    "current_page" : 1,
+    "_embedded"    : {
+        "items" : [
+            {$standardizedProducts['scopable']},
+            {$standardizedProducts['localizable_and_scopable']},
+            {$standardizedProducts['china']},
+            {$standardizedProducts['without_category']}
+        ]
+    }
+}
+JSON;
+
+        $this->assertListResponse($client->getResponse(), $expected, true);
+    }
+
     public function testListProductsWithoutParent()
     {
         $standardizedProducts = $this->getStandardizedProducts();

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/UuidFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/UuidFilterIntegration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Enrichment\Integration\PQB\Filter\Field\Product;
+
+use Akeneo\Pim\Enrichment\Component\Product\Exception\UnsupportedFilterException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use AkeneoTest\Pim\Enrichment\Integration\PQB\AbstractProductQueryBuilderTestCase;
+
+/**
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UuidFilterIntegration extends AbstractProductQueryBuilderTestCase
+{
+    private array $uuids = [];
+
+    protected function setUp(): void
+    {
+        foreach (['foo', 'bar', 'baz'] as $identifier) {
+            $this->uuids[$identifier] = $this->createProduct($identifier, [])->getUuid()->toString();
+        }
+    }
+
+    public function testOperatorInList(): void
+    {
+        $result = $this->executeFilter([['uuid', Operators::IN_LIST, [$this->uuids['bar'], $this->uuids['baz']]]]);
+        $this->assert($result, ['bar', 'baz']);
+    }
+
+    public function testEmptyList(): void
+    {
+        $result = $this->executeFilter([['uuid', Operators::IN_LIST, []]]);
+        $this->assert($result, []);
+    }
+
+    public function testInvalidOperator(): void
+    {
+        $this->expectException(UnsupportedFilterException::class);
+        $this->executeFilter([['uuid', '=', ['toto']]]);
+    }
+
+    public function testInvalidValue(): void
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->executeFilter([['uuid', 'IN', 'abc']]);
+    }
+
+    public function testInvalidArrayItemValue(): void
+    {
+        $this->expectException(InvalidPropertyTypeException::class);
+        $this->executeFilter([['uuid', 'IN', [123]]]);
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/UuidFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/Product/UuidFilterIntegration.php
@@ -26,8 +26,14 @@ class UuidFilterIntegration extends AbstractProductQueryBuilderTestCase
 
     public function testOperatorInList(): void
     {
-        $result = $this->executeFilter([['uuid', Operators::IN_LIST, [$this->uuids['bar'], $this->uuids['baz']]]]);
-        $this->assert($result, ['bar', 'baz']);
+        $result = $this->executeFilter([['uuid', Operators::IN_LIST, [$this->uuids['foo'], $this->uuids['baz']]]]);
+        $this->assert($result, ['foo', 'baz']);
+    }
+
+    public function testOperatorNotInList(): void
+    {
+        $result = $this->executeFilter([['uuid', Operators::NOT_IN_LIST, [$this->uuids['foo'], $this->uuids['baz']]]]);
+        $this->assert($result, ['bar']);
     }
 
     public function testEmptyList(): void

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/UuidFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/UuidFilterSpec.php
@@ -23,7 +23,7 @@ class UuidFilterSpec extends ObjectBehavior
         $this->shouldHaveType(UuidFilter::class);
     }
 
-    function it_only_supports_in_list_operator()
+    function it_only_supports_in_list_and_not_in_list_operators()
     {
         $this->shouldThrow(InvalidOperatorException::class)->during(
             'addFieldFilter',
@@ -84,6 +84,23 @@ class UuidFilterSpec extends ObjectBehavior
         $this->addFieldFilter(
             'uuid',
             'IN',
+            ['ca4787d5-36fd-4893-ba46-f4edd71b7186', 'dc832a6d-b2fb-4918-b169-eadb92242b85']
+        )->shouldReturn($this);
+    }
+
+    function it_adds_a_not_in_list_filter(SearchQueryBuilder $queryBuilder)
+    {
+        $queryBuilder->addMustNot([
+            'terms' => [
+                'id' => [
+                    'product_ca4787d5-36fd-4893-ba46-f4edd71b7186',
+                    'product_dc832a6d-b2fb-4918-b169-eadb92242b85',
+                ],
+            ],
+        ])->shouldBeCalled();
+        $this->addFieldFilter(
+            'uuid',
+            'NOT IN',
             ['ca4787d5-36fd-4893-ba46-f4edd71b7186', 'dc832a6d-b2fb-4918-b169-eadb92242b85']
         )->shouldReturn($this);
     }

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/UuidFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/UuidFilterSpec.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
+
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\UuidFilter;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
+
+class UuidFilterSpec extends ObjectBehavior
+{
+    function let(SearchQueryBuilder $queryBuilder)
+    {
+        $this->beConstructedWith('product_');
+        $this->setQueryBuilder($queryBuilder);
+    }
+
+    function it_is_a_query_filter()
+    {
+        $this->shouldImplement(FieldFilterInterface::class);
+        $this->shouldHaveType(UuidFilter::class);
+    }
+
+    function it_only_supports_in_list_operator()
+    {
+        $this->shouldThrow(InvalidOperatorException::class)->during(
+            'addFieldFilter',
+            [
+                'uuid',
+                '=',
+                ['ca4787d5-36fd-4893-ba46-f4edd71b7186', 'dc832a6d-b2fb-4918-b169-eadb92242b85'],
+            ]
+        );
+    }
+
+    function it_throws_an_error_if_value_is_not_an_array()
+    {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayExpected(
+                'uuid',
+                UuidFilter::class,
+                'ca4787d5-36fd-4893-ba46-f4edd71b7186'
+            )
+        )->during(
+            'addFieldFilter',
+            [
+                'uuid',
+                'IN',
+                'ca4787d5-36fd-4893-ba46-f4edd71b7186',
+            ]
+        );
+    }
+
+    function it_throws_an_error_if_value_is_not_an_array_of_strings()
+    {
+        $this->shouldThrow(
+            InvalidPropertyTypeException::arrayOfStringsExpected(
+                'uuid',
+                UuidFilter::class,
+                [123, false]
+            )
+        )->during(
+            'addFieldFilter',
+            [
+                'uuid',
+                'IN',
+                [123, false],
+            ]
+        );
+    }
+
+    function it_adds_an_in_list_filter(SearchQueryBuilder $queryBuilder)
+    {
+        $queryBuilder->addFilter([
+            'terms' => [
+                'id' => [
+                    'product_ca4787d5-36fd-4893-ba46-f4edd71b7186',
+                    'product_dc832a6d-b2fb-4918-b169-eadb92242b85',
+                ],
+            ],
+        ])->shouldBeCalled();
+        $this->addFieldFilter(
+            'uuid',
+            'IN',
+            ['ca4787d5-36fd-4893-ba46-f4edd71b7186', 'dc832a6d-b2fb-4918-b169-eadb92242b85']
+        )->shouldReturn($this);
+    }
+}


### PR DESCRIPTION
Adds a filter on product uuids, usable in the external API. The filter only accepts the "IN" operator

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
