### PR TITLE
RAB-1112: Launch rector on raccoons and global bounded context

### DIFF
--- a/src/Acme/Bundle/AppBundle/DependencyInjection/AcmeAppExtension.php
+++ b/src/Acme/Bundle/AppBundle/DependencyInjection/AcmeAppExtension.php
@@ -2,6 +2,7 @@
 
 namespace Acme\Bundle\AppBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -21,7 +22,7 @@ class AcmeAppExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('entities.yml');
         $loader->load('savers.yml');
     }

--- a/src/Acme/Bundle/AppBundle/DependencyInjection/AcmeAppExtension.php
+++ b/src/Acme/Bundle/AppBundle/DependencyInjection/AcmeAppExtension.php
@@ -2,10 +2,10 @@
 
 namespace Acme\Bundle\AppBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/WebhookEventSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/Webhook/Model/WebhookEventSpec.php
@@ -19,7 +19,7 @@ class WebhookEventSpec extends ObjectBehavior
 {
     public function let(UserInterface $user): void
     {
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $user->getFirstName()->willReturn('Julia');
         $user->getLastName()->willReturn('Doe');
         $user->isApiUser()->willReturn(false);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Form/Type/CommentType.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Form/Type/CommentType.php
@@ -82,7 +82,7 @@ class CommentType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_comment_comment';
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionType.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionType.php
@@ -96,7 +96,7 @@ class AttributeOptionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_enrich_attribute_option';
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionValueType.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionValueType.php
@@ -84,7 +84,7 @@ class AttributeOptionValueType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_enrich_attribute_option_value';
     }

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pim_notification');
         $rootNode = $treeBuilder->getRootNode()

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\AnalyticsBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
 use Twig\TwigFunction;
@@ -13,7 +14,7 @@ use Twig\TwigFunction;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class UpdateExtension extends \Twig\Extension\AbstractExtension
+class UpdateExtension extends AbstractExtension
 {
     /** @var ConfigManager */
     protected $configManager;

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Twig/UpdateExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\Platform\Bundle\AnalyticsBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Controller;
 
 use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer;
-use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,11 +17,11 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class VolumeMonitoringController
 {
-    private Volumes $volumesNormalizer;
+    private Normalizer\Volumes $volumesNormalizer;
 
     private SecurityFacade $securityFacade;
 
-    public function __construct(Volumes $volumesNormalizer, SecurityFacade $securityFacade)
+    public function __construct(Normalizer\Volumes $volumesNormalizer, SecurityFacade $securityFacade)
     {
         $this->volumesNormalizer = $volumesNormalizer;
         $this->securityFacade = $securityFacade;

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Controller;
 
-use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
 use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer;
+use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/Controller/VolumeMonitoringController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\CatalogVolumeMonitoringBundle\Controller;
 
+use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer\Volumes;
 use Akeneo\Platform\Component\CatalogVolumeMonitoring\Volume\Normalizer;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,11 +18,11 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 class VolumeMonitoringController
 {
-    private Normalizer\Volumes $volumesNormalizer;
+    private Volumes $volumesNormalizer;
 
     private SecurityFacade $securityFacade;
 
-    public function __construct(Normalizer\Volumes $volumesNormalizer, SecurityFacade $securityFacade)
+    public function __construct(Volumes $volumesNormalizer, SecurityFacade $securityFacade)
     {
         $this->volumesNormalizer = $volumesNormalizer;
         $this->securityFacade = $securityFacade;

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/InstallerSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/Infrastructure/Framework/Symfony/Installer/InstallerSubscriber.php
@@ -23,7 +23,7 @@ class InstallerSubscriber implements EventSubscriberInterface
         $this->dbalConnection = $dbalConnection;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['createCommunicationChannelTable'],

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\DashboardBundle;
 
-use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler\RegisterWidgetsPass;
 use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler;
+use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler\RegisterWidgetsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
@@ -3,7 +3,6 @@
 namespace Akeneo\Platform\Bundle\DashboardBundle;
 
 use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler;
-use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler\RegisterWidgetsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,6 +20,6 @@ class PimDashboardBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new RegisterWidgetsPass());
+        $container->addCompilerPass(new Compiler\RegisterWidgetsPass());
     }
 }

--- a/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
+++ b/src/Akeneo/Platform/Bundle/DashboardBundle/PimDashboardBundle.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\DashboardBundle;
 
+use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler\RegisterWidgetsPass;
 use Akeneo\Platform\Bundle\DashboardBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -20,6 +21,6 @@ class PimDashboardBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $container->addCompilerPass(new Compiler\RegisterWidgetsPass());
+        $container->addCompilerPass(new RegisterWidgetsPass());
     }
 }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\FeatureFlagBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\FeatureFlagBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -20,7 +21,7 @@ class AkeneoFeatureFlagExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
 
         $this->registerFlags($configs, $container);

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('akeneo_feature_flag');
 

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/FilterRoutesSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/FilterRoutesSubscriber.php
@@ -47,7 +47,7 @@ class FilterRoutesSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'filterRoutesFromDisabledFeatureFlags',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -454,7 +454,7 @@ class JobInstanceController
 
         $configuration = $jobInstance->getRawParameters();
         $configuration['send_email'] = true;
-        $configuration['users_to_notify'][] = $user->getUsername();
+        $configuration['users_to_notify'][] = $user->getUserIdentifier();
 
         return $this->jobLauncher->launch($jobInstance, $user, $configuration);
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pim_import_export');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Job;
 
-use Psr\Log\LoggerInterface;
 use Akeneo\Platform\Bundle\ImportExportBundle\Purge\PurgeJobExecution;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Job/PurgeJobExecutions.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Job;
 
+use Psr\Log\LoggerInterface;
 use Akeneo\Platform\Bundle\ImportExportBundle\Purge\PurgeJobExecution;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
-use Symfony\Bridge\Monolog\Logger;
 
 /**
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
@@ -16,7 +16,7 @@ class PurgeJobExecutions implements TaskletInterface
 {
     protected StepExecution $stepExecution;
 
-    public function __construct(private PurgeJobExecution $purgeJobExecution, private Logger $logger)
+    public function __construct(private PurgeJobExecution $purgeJobExecution, private LoggerInterface $logger)
     {
     }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/JobExecutionNormalizer.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/JobExecutionNormalizer.php
@@ -87,7 +87,7 @@ class JobExecutionNormalizer implements NormalizerInterface, NormalizerAwareInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof JobExecution;
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/StepExecutionNormalizer.php
@@ -61,7 +61,7 @@ class StepExecutionNormalizer implements NormalizerInterface, CacheableSupportsM
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof StepExecution;
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizer.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizer.php
@@ -42,7 +42,7 @@ class JobInstanceNormalizer implements NormalizerInterface, CacheableSupportsMet
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof JobInstance && in_array($format, $this->supportedFormats);
     }

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/AssetsCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/AssetsCommand.php
@@ -99,7 +99,7 @@ class AssetsCommand extends Command
                 $output->writeln(sprintf('<error>Error during PIM installation. %s</error>', $e->getMessage()));
                 $output->writeln('');
 
-                return $e->getCode();
+                return (int) $e->getCode();
             }
         }
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -87,7 +87,7 @@ class InstallCommand extends Command
             $output->writeln(sprintf('<error>Error during PIM installation. %s</error>', $e->getMessage()));
             $output->writeln('');
 
-            return $e->getCode();
+            return (int) $e->getCode();
         }
 
         $output->writeln('');

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\InstallerBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -19,7 +20,7 @@ class PimInstallerExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('fixture_loader.yml');
         $loader->load('job_constraints.yml');
         $loader->load('job_defaults.yml');

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/DependencyInjection/PimInstallerExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\InstallerBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Email/MailNotifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Email/MailNotifier.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle\Email;
 
-use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Component\Email\SenderAddress;
+use Psr\Log\LoggerInterface;
 use Swift_Mailer;
 use Swift_Mime_SimpleMessage;
 

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Email/MailNotifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Email/MailNotifier.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle\Email;
 
+use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Component\Email\SenderAddress;
 use Swift_Mailer;
 use Swift_Mime_SimpleMessage;
-use Symfony\Bridge\Monolog\Logger;
 
 /**
  * Notify by email
@@ -19,7 +19,7 @@ class MailNotifier implements MailNotifierInterface
     public function __construct(
         protected Swift_Mailer $mailer,
         protected string $mailerUrl,
-        private Logger $logger,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
@@ -2,12 +2,12 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle;
 
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\NotificationInterface;
 use Akeneo\Platform\Bundle\NotificationBundle\Factory\UserNotificationFactory;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -59,9 +59,9 @@ class Notifier implements NotifierInterface
 
         foreach ($users as $user) {
             try {
-                $user = is_object($user) ? $user : $this->userProvider->loadUserByUsername($user);
+                $user = is_object($user) ? $user : $this->userProvider->loadUserByIdentifier($user);
                 $userNotifications[] = $this->userNotifFactory->createUserNotification($notification, $user);
-            } catch (UsernameNotFoundException $e) {
+            } catch (UserNotFoundException $e) {
                 continue;
             }
         }

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
@@ -87,7 +87,7 @@ class Notifier implements NotifierInterface
                 if (is_string($user) && UserInterface::SYSTEM_USER_NAME === $user) {
                     return false;
                 }
-                if (is_object($user) && UserInterface::SYSTEM_USER_NAME === $user->getUsername()) {
+                if (is_object($user) && UserInterface::SYSTEM_USER_NAME === $user->getUserIdentifier()) {
                     return false;
                 }
 

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Notifier.php
@@ -2,12 +2,12 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle;
 
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\NotificationInterface;
 use Akeneo\Platform\Bundle\NotificationBundle\Factory\UserNotificationFactory;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\Repository\UserNotificationRepositoryInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
 use Twig\TwigFunction;
@@ -13,7 +14,7 @@ use Twig\TwigFunction;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class NotificationExtension extends \Twig\Extension\AbstractExtension
+class NotificationExtension extends AbstractExtension
 {
     /** @var UserNotificationRepositoryInterface */
     protected $repository;

--- a/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
+++ b/src/Akeneo/Platform/Bundle/NotificationBundle/Twig/NotificationExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\Platform\Bundle\NotificationBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\Repository\UserNotificationRepositoryInterface;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/PimVersionBundle/DependencyInjection/PimVersionExtension.php
+++ b/src/Akeneo/Platform/Bundle/PimVersionBundle/DependencyInjection/PimVersionExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\PimVersionBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Platform/Bundle/PimVersionBundle/DependencyInjection/PimVersionExtension.php
+++ b/src/Akeneo/Platform/Bundle/PimVersionBundle/DependencyInjection/PimVersionExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\PimVersionBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -18,7 +19,7 @@ class PimVersionExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pim_ui');
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/CloseSessionListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/CloseSessionListener.php
@@ -29,7 +29,7 @@ class CloseSessionListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => ['closeSession', -100]

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ExceptionListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ExceptionListener.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\EventListener;
 
-use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener as BaseExceptionListener;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ExceptionListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/ExceptionListener.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\EventListener;
 
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\ExceptionListener as BaseExceptionListener;
 
@@ -21,11 +21,11 @@ class ExceptionListener extends BaseExceptionListener
     /**
      * Handles security related exceptions.
      *
-     * @param GetResponseForExceptionEvent $event An GetResponseForExceptionEvent instance
+     * @param ExceptionEvent $event An GetResponseForExceptionEvent instance
      */
-    public function onKernelException(GetResponseForExceptionEvent $event)
+    public function onKernelException(ExceptionEvent $event)
     {
-        $exception = $event->getException();
+        $exception = $event->getThrowable();
         $request = $event->getRequest();
         if (!$request->isXmlHttpRequest() || !($exception instanceof AuthenticationException)) {
             return parent::onKernelException($event);

--- a/src/Akeneo/Platform/Bundle/UIBundle/EventListener/UserContextListener.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/EventListener/UserContextListener.php
@@ -64,7 +64,7 @@ class UserContextListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest'
@@ -73,7 +73,7 @@ class UserContextListener implements EventSubscriberInterface
 
     public function onKernelRequest(RequestEvent $event)
     {
-        if (HttpKernel::MASTER_REQUEST !== $event->getRequestType() || null === $this->tokenStorage->getToken()) {
+        if (HttpKernel::MAIN_REQUEST !== $event->getRequestType() || null === $this->tokenStorage->getToken()) {
             return;
         }
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Subscriber/AddTranslatableFieldSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Subscriber/AddTranslatableFieldSubscriber.php
@@ -77,7 +77,7 @@ class AddTranslatableFieldSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::PRE_SET_DATA => 'preSetData',

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Subscriber/DisableFieldSubscriber.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Subscriber/DisableFieldSubscriber.php
@@ -41,7 +41,7 @@ class DisableFieldSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             FormEvents::POST_SET_DATA => 'postSetData'

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Transformer/TransformerFactoryInterface.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Transformer/TransformerFactoryInterface.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Platform\Bundle\UIBundle\Form\Transformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+
 interface TransformerFactoryInterface
 {
     /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Transformer/TransformerFactoryInterface.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Transformer/TransformerFactoryInterface.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Form\Transformer;
 
+use Symfony\Component\Form\DataTransformerInterface;
 interface TransformerFactoryInterface
 {
     /**
@@ -9,7 +10,7 @@ interface TransformerFactoryInterface
      *
      * @param array $options
      *
-     * @return \Symfony\Component\Form\DataTransformerInterface
+     * @return DataTransformerInterface
      */
     public function create(array $options);
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AjaxEntityType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AjaxEntityType.php
@@ -66,7 +66,7 @@ class AjaxEntityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_ajax_entity';
     }
@@ -74,7 +74,7 @@ class AjaxEntityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AjaxReferenceDataType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AjaxReferenceDataType.php
@@ -14,7 +14,7 @@ class AjaxReferenceDataType extends AjaxEntityType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_ajax_reference_data';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AsyncSelectType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/AsyncSelectType.php
@@ -45,7 +45,7 @@ class AsyncSelectType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_async_select';
     }
@@ -53,7 +53,7 @@ class AsyncSelectType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/DateType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/DateType.php
@@ -88,7 +88,7 @@ class DateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return BaseDateType::class;
     }
@@ -96,7 +96,7 @@ class DateType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_date';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/EntityIdentifierType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/EntityIdentifierType.php
@@ -128,7 +128,7 @@ class EntityIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -136,7 +136,7 @@ class EntityIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LightEntityType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LightEntityType.php
@@ -31,6 +31,14 @@ class LightEntityType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getBlockPrefix(): string
+    {
+        return 'light_entity';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->addViewTransformer(

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LightEntityType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LightEntityType.php
@@ -23,17 +23,9 @@ class LightEntityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
-    {
-        return 'light_entity';
     }
 
     /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LocaleType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LocaleType.php
@@ -32,7 +32,7 @@ class LocaleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return SymfonyLocaleType::class;
     }
@@ -40,7 +40,7 @@ class LocaleType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_locale';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LocalizedCollectionType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/LocalizedCollectionType.php
@@ -52,7 +52,7 @@ class LocalizedCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CollectionType::class;
     }
@@ -60,7 +60,7 @@ class LocalizedCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_enrich_localized_collection';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/MediaType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/MediaType.php
@@ -38,7 +38,7 @@ class MediaType extends FileInfoType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_enrich_media';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/NumberType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/NumberType.php
@@ -86,7 +86,7 @@ class NumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_number';
     }
@@ -94,7 +94,7 @@ class NumberType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return TextType::class;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/ObjectIdentifierType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/ObjectIdentifierType.php
@@ -22,7 +22,7 @@ class ObjectIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }
@@ -30,7 +30,7 @@ class ObjectIdentifierType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_object_identifier';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/SwitchType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/SwitchType.php
@@ -50,4 +50,12 @@ class SwitchType extends AbstractType
     {
         return CheckboxType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix(): string
+    {
+        return 'switch';
+    }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/SwitchType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/SwitchType.php
@@ -46,16 +46,8 @@ class SwitchType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CheckboxType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
-    {
-        return 'switch';
     }
 }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/TranslatableFieldType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/TranslatableFieldType.php
@@ -94,7 +94,7 @@ class TranslatableFieldType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_translatable_field';
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Form\Type;
 
-use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -17,17 +18,9 @@ class UploadType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getParent(): ?string
     {
-        return 'upload';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return 'form';
+        return FormType::class;
     }
 
     /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Form/Type/UploadType.php
@@ -18,6 +18,14 @@ class UploadType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getBlockPrefix(): string
+    {
+        return 'upload';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getParent(): ?string
     {
         return FormType::class;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\UIBundle\Http;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Http/FormAuthenticationEntryPoint.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\UIBundle\Http;
 
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -40,7 +41,7 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
     /**
      * {@inheritdoc}
      */
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null): Response
     {
         if ($this->useForward) {
             //This is the added code

--- a/src/Akeneo/Platform/Bundle/UIBundle/Normalizer/ConstraintViolationListNormalizer.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Normalizer/ConstraintViolationListNormalizer.php
@@ -35,7 +35,7 @@ class ConstraintViolationListNormalizer implements NormalizerInterface, Cacheabl
     /**
      * @inheritDoc
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ConstraintViolationListInterface;
     }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Translator/TranslatorDecorator.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Translator/TranslatorDecorator.php
@@ -28,7 +28,7 @@ class TranslatorDecorator implements TranslatorInterface, LocaleAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function trans(string $id, array $parameters = [], $domain = null, $locale = null)
+    public function trans(?string $id, array $parameters = [], string $domain = null, string $locale = null)
     {
         return $this->symfonyTranslator->trans($id, $parameters, $domain, $locale);
     }
@@ -51,7 +51,7 @@ class TranslatorDecorator implements TranslatorInterface, LocaleAwareInterface, 
     /**
      * {@inheritdoc}
      */
-    public function setLocale($locale)
+    public function setLocale(string $locale)
     {
         Assert::implementsInterface($this->symfonyTranslator, LocaleAwareInterface::class);
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Resolver\LocaleResolver;
 use Akeneo\Tool\Component\Localization\Presenter\PresenterInterface;
 use Twig\TwigFilter;
@@ -13,7 +14,7 @@ use Twig\TwigFilter;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AttributeExtension extends \Twig\Extension\AbstractExtension
+class AttributeExtension extends AbstractExtension
 {
     /** @var PresenterInterface */
     protected $datePresenter;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/AttributeExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Resolver\LocaleResolver;
 use Akeneo\Tool\Component\Localization\Presenter\PresenterInterface;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
 use Twig\TwigFunction;
 
@@ -14,7 +15,7 @@ use Twig\TwigFunction;
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ContentSecurityPolicyExtension extends \Twig\Extension\AbstractExtension
+class ContentSecurityPolicyExtension extends AbstractExtension
 {
     /** @var ScriptNonceGenerator */
     private $scriptNonceGenerator;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ContentSecurityPolicyExtension.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\EventListener\ScriptNonceGenerator;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Provider\ExternalJavascriptDependenciesProvider;
 use Twig\TwigFunction;
 
-final class ExternalJavascriptDependenciesExtension extends \Twig\Extension\AbstractExtension
+final class ExternalJavascriptDependenciesExtension extends AbstractExtension
 {
     private ExternalJavascriptDependenciesProvider $dependenciesProvider;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ExternalJavascriptDependenciesExtension.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Provider\ExternalJavascriptDependenciesProvider;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 final class ExternalJavascriptDependenciesExtension extends AbstractExtension

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/LocaleExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/LocaleExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**
@@ -11,7 +12,7 @@ use Twig\TwigFilter;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class LocaleExtension extends \Twig\Extension\AbstractExtension
+class LocaleExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Doctrine\Common\Util\ClassUtils;
 use Twig\TwigFilter;
 
@@ -12,7 +13,7 @@ use Twig\TwigFilter;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ObjectClassExtension extends \Twig\Extension\AbstractExtension
+class ObjectClassExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ObjectClassExtension.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Doctrine\Common\Util\ClassUtils;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/StyleExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/StyleExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 /**
@@ -11,7 +12,7 @@ use Twig\TwigFilter;
  * @copyright 2016 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class StyleExtension extends \Twig\Extension\AbstractExtension
+class StyleExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
@@ -2,9 +2,9 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Tool\Component\Console\CommandLauncher;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/TranslationsExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Tool\Component\Console\CommandLauncher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\TwigFunction;
@@ -16,7 +17,7 @@ use Twig\TwigFunction;
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class TranslationsExtension extends \Twig\Extension\AbstractExtension
+class TranslationsExtension extends AbstractExtension
 {
     /** @var CommandLauncher */
     protected $commandLauncher;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Twig\Parser\PlaceholderTokenParser;
+use Twig\Extension\AbstractExtension;
 
 class UiExtension extends AbstractExtension
 {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/UiExtension.php
@@ -2,9 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\Twig\Parser\PlaceholderTokenParser;
 
-class UiExtension extends \Twig\Extension\AbstractExtension
+class UiExtension extends AbstractExtension
 {
     protected $placeholders;
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
@@ -2,8 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/VersionExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Twig\TwigFunction;
 
@@ -12,7 +13,7 @@ use Twig\TwigFunction;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class VersionExtension extends \Twig\Extension\AbstractExtension
+class VersionExtension extends AbstractExtension
 {
     /** @var VersionProviderInterface */
     private $versionProvider;

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementInterface;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementRegistry;
 use Twig\Environment;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 /**

--- a/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Twig/ViewElementExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Platform\Bundle\UIBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementInterface;
 use Akeneo\Platform\Bundle\UIBundle\ViewElement\ViewElementRegistry;
 use Twig\Environment;
@@ -14,7 +15,7 @@ use Twig\TwigFunction;
  * @copyright 2014 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class ViewElementExtension extends \Twig\Extension\AbstractExtension
+class ViewElementExtension extends AbstractExtension
 {
     protected ViewElementRegistry $registry;
     protected Environment $templating;

--- a/src/Akeneo/Platform/Component/EventQueue/Author.php
+++ b/src/Akeneo/Platform/Component/EventQueue/Author.php
@@ -35,7 +35,7 @@ class Author
     {
         $type = $user->isApiUser() ? self::TYPE_API : self::TYPE_UI;
 
-        return new self($user->getUsername(), $type);
+        return new self($user->getUserIdentifier(), $type);
     }
 
     public static function fromNameAndType(string $name, string $type): Author

--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Configuration.php
@@ -15,7 +15,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pim_api');
         $rootNode = $treeBuilder->getRootNode()

--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\ApiBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/PimApiExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ApiBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -24,7 +25,7 @@ class PimApiExtension extends Extension
 
         $container->setParameter('pim_api.configuration', $config);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('checkers.yml');
         $loader->load('converters.yml');

--- a/src/Akeneo/Tool/Bundle/ApiBundle/EventSubscriber/ApiRequestLogSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/EventSubscriber/ApiRequestLogSubscriber.php
@@ -21,7 +21,7 @@ class ApiRequestLogSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/Akeneo/Tool/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/EventSubscriber/CheckHeadersRequestSubscriber.php
@@ -45,7 +45,7 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest'
@@ -63,7 +63,7 @@ class CheckHeadersRequestSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
 
         if (!$request->attributes->has(FOSRestBundle::ZONE_ATTRIBUTE) ||
-            $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST
+            $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST
         ) {
             return;
         }

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Security/ActionAclVoter.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Security/ActionAclVoter.php
@@ -61,7 +61,7 @@ class ActionAclVoter extends Voter implements VoterInterface
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $object, array $attributes): int
     {
         foreach ($attributes as $attribute) {
             if (!$this->supports($attribute, $object)) {

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Security/OAuth2.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Security/OAuth2.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\ApiBundle\Security;
 
+use OAuth2\OAuth2ServerException;
 use Akeneo\Tool\Component\Api\Event\ApiAuthenticationEvent;
 use Akeneo\Tool\Component\Api\Event\ApiAuthenticationFailedEvent;
 use Akeneo\UserManagement\Component\Model\User;
@@ -60,7 +61,7 @@ class OAuth2 extends BaseOAuth2
      *
      * @return Response
      *
-     * @throws \OAuth2\OAuth2ServerException
+     * @throws OAuth2ServerException
      */
     public function grantAccessToken(Request $request = null): Response
     {

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Security/OAuth2.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Security/OAuth2.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\ApiBundle\Security;
 
-use OAuth2\OAuth2ServerException;
 use Akeneo\Tool\Component\Api\Event\ApiAuthenticationEvent;
 use Akeneo\Tool\Component\Api\Event\ApiAuthenticationFailedEvent;
 use Akeneo\UserManagement\Component\Model\User;
@@ -11,6 +10,7 @@ use OAuth2\IOAuth2Storage;
 use OAuth2\Model\IOAuth2AccessToken;
 use OAuth2\OAuth2 as BaseOAuth2;
 use OAuth2\OAuth2AuthenticateException;
+use OAuth2\OAuth2ServerException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/GetAccessTokenIntegration.php
@@ -98,7 +98,7 @@ class GetAccessTokenIntegration extends ApiTestCase
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 
@@ -124,7 +124,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -153,7 +153,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -182,7 +182,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('This grant type is not authorized for this client', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -211,7 +211,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "client_id" is missing or does not match any client, or secret is invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -240,7 +240,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "client_id" is missing or does not match any client, or secret is invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -268,7 +268,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -296,7 +296,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "grant_type", "username" or "password" is missing, empty or invalid', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -325,7 +325,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('No user found for the given username and password', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -344,7 +344,7 @@ JSON;
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
         $this->assertSame('The access token provided is invalid.', $responseBody['message']);
     }
 
@@ -372,7 +372,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_REQUEST_ENTITY_TOO_LARGE);
         $this->assertJsonStringEqualsJsonString($expectedContent, $response->getContent());
     }
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Controller/Token/RefreshTokenIntegration.php
@@ -106,7 +106,7 @@ class RefreshTokenIntegration extends ApiTestCase
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Parameter "grant_type" or "refresh_token" is missing or empty', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);
@@ -132,7 +132,7 @@ class RefreshTokenIntegration extends ApiTestCase
         $response = $client->getResponse();
         $responseBody = json_decode($response->getContent(), true);
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $this->assertSame('Refresh token is invalid or has expired', $responseBody['message']);
         $this->assertArrayNotHasKey('access_token', $responseBody);
         $this->assertArrayNotHasKey('refresh_token', $responseBody);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/CheckHeadersRequestSubscriberIntegration.php
@@ -15,7 +15,7 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         $client->request('GET', 'api/rest/v1/categories/master', [], [], ['HTTP_ACCEPT' => 'application/xml']);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'Header is not acceptable');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_ACCEPTABLE);
         $content = json_decode($response->getContent(), true);
         $this->assertCount(2, $content, 'Error response contains 2 items');
         $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $content['code']);
@@ -51,7 +51,7 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         ], '{"code": "my_category"}');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), 'Header is not acceptable');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
         $content = json_decode($response->getContent(), true);
         $this->assertCount(2, $content, 'Error response contains 2 items');
         $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $content['code']);
@@ -67,7 +67,7 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         ], '{"code": "my_category"}');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode(), 'Header is acceptable');
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
     }
 
     public function testErrorIfContentTypeHeaderIsJsonOnListPatch()
@@ -79,7 +79,7 @@ class CheckHeadersRequestSubscriberIntegration extends ApiTestCase
         ], '{"code": "my_category"}');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE, $response->getStatusCode(), 'Header is not acceptable');
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNSUPPORTED_MEDIA_TYPE);
         $expected = <<<JSON
 {
     "code": 415,
@@ -111,7 +111,7 @@ JSON;
         ], '{"code": "master"}');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode(), 'Header is acceptable');
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/ValidateApiRequestQueryParametersSubscriberIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/EventSubscriber/ValidateApiRequestQueryParametersSubscriberIntegration.php
@@ -20,7 +20,7 @@ class ValidateApiRequestQueryParametersSubscriberIntegration extends ApiTestCase
         $client->request('GET', 'api/rest/v1/categories?array_parameter[]=bad');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), 'Bracket syntax is not supported in query parameters.');
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $expected = <<<JSON
             {
                 "code": 400,

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/ChannelAuthorizationIntegration.php
@@ -23,7 +23,7 @@ class ChannelAuthorizationIntegration extends ApiTestCase
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -51,7 +51,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -79,7 +79,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -99,7 +99,7 @@ JSON;
         $client->request('POST', '/api/rest/v1/channels', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_CREATED);
     }
 
     public function testAccessDeniedForCreatingAChannel()
@@ -122,7 +122,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -135,7 +135,7 @@ JSON;
         $client->request('PATCH', '/api/rest/v1/channels/ecommerce', [], [], [], $data);
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NO_CONTENT);
     }
 
     public function testAccessDeniedForPartialUpdatingAChannel()
@@ -155,7 +155,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -200,7 +200,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/CurrencyAuthorizationIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/CurrencyAuthorizationIntegration.php
@@ -22,7 +22,7 @@ class CurrencyAuthorizationIntegration extends ApiTestCase
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -50,7 +50,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -78,7 +78,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/tests/integration/Security/LocaleAuthorizationIntegration.php
@@ -22,7 +22,7 @@ class LocaleAuthorizationIntegration extends ApiTestCase
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -50,7 +50,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 
@@ -78,7 +78,7 @@ JSON;
 JSON;
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_FORBIDDEN);
         $this->assertJsonStringEqualsJsonString($expectedResponse, $response->getContent());
     }
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
@@ -2,6 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle;
 
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterNotifiersPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\PushBatchLogHandlerPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobsPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobParametersPass;
 use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,11 +29,11 @@ class AkeneoBatchBundle extends Bundle
             realpath(__DIR__ . '/Resources/config/model/doctrine') => 'Akeneo\Tool\Component\Batch\Model'
         ];
         $container
-            ->addCompilerPass(new Compiler\RegisterNotifiersPass())
-            ->addCompilerPass(new Compiler\PushBatchLogHandlerPass())
-            ->addCompilerPass(new Compiler\RegisterJobsPass())
-            ->addCompilerPass(new Compiler\RegisterJobParametersPass('default_values_provider'))
-            ->addCompilerPass(new Compiler\RegisterJobParametersPass('constraint_collection_provider'))
+            ->addCompilerPass(new RegisterNotifiersPass())
+            ->addCompilerPass(new PushBatchLogHandlerPass())
+            ->addCompilerPass(new RegisterJobsPass())
+            ->addCompilerPass(new RegisterJobParametersPass('default_values_provider'))
+            ->addCompilerPass(new RegisterJobParametersPass('constraint_collection_provider'))
             ->addCompilerPass(
                 DoctrineOrmMappingsPass::createYamlMappingDriver(
                     $mappings,

--- a/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
@@ -3,10 +3,6 @@
 namespace Akeneo\Tool\Bundle\BatchBundle;
 
 use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\PushBatchLogHandlerPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobParametersPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobsPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterNotifiersPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -29,11 +25,11 @@ class AkeneoBatchBundle extends Bundle
             realpath(__DIR__ . '/Resources/config/model/doctrine') => 'Akeneo\Tool\Component\Batch\Model'
         ];
         $container
-            ->addCompilerPass(new RegisterNotifiersPass())
-            ->addCompilerPass(new PushBatchLogHandlerPass())
-            ->addCompilerPass(new RegisterJobsPass())
-            ->addCompilerPass(new RegisterJobParametersPass('default_values_provider'))
-            ->addCompilerPass(new RegisterJobParametersPass('constraint_collection_provider'))
+            ->addCompilerPass(new Compiler\RegisterNotifiersPass())
+            ->addCompilerPass(new Compiler\PushBatchLogHandlerPass())
+            ->addCompilerPass(new Compiler\RegisterJobsPass())
+            ->addCompilerPass(new Compiler\RegisterJobParametersPass('default_values_provider'))
+            ->addCompilerPass(new Compiler\RegisterJobParametersPass('constraint_collection_provider'))
             ->addCompilerPass(
                 DoctrineOrmMappingsPass::createYamlMappingDriver(
                     $mappings,

--- a/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/AkeneoBatchBundle.php
@@ -2,11 +2,11 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle;
 
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterNotifiersPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\PushBatchLogHandlerPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobsPass;
-use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobParametersPass;
 use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\PushBatchLogHandlerPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobParametersPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterJobsPass;
+use Akeneo\Tool\Bundle\BatchBundle\DependencyInjection\Compiler\RegisterNotifiersPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/BatchCommand.php
@@ -198,7 +198,7 @@ class BatchCommand extends Command
             $exitCode = self::EXIT_ERROR_CODE;
         }
 
-        return $exitCode;
+        return (int) $exitCode;
     }
 
     /**

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/ListJobsCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/ListJobsCommand.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle\Command;
 
+use Symfony\Component\Console\Helper\HelperInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Symfony\Component\Console\Command\Command;
@@ -75,7 +76,7 @@ class ListJobsCommand extends Command
      * @param array           $jobs
      * @param OutputInterface $output
      *
-     * @return \Symfony\Component\Console\Helper\HelperInterface
+     * @return HelperInterface
      */
     protected function buildTable(array $jobs, OutputInterface $output)
     {

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Command/ListJobsCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Command/ListJobsCommand.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle\Command;
 
-use Symfony\Component\Console\Helper\HelperInterface;
 use Akeneo\Tool\Component\Batch\Job\JobRepositoryInterface;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/AkeneoBatchExtension.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/AkeneoBatchExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -24,7 +25,7 @@ class AkeneoBatchExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('entities.yml');
         $loader->load('jobs.yml');
         $loader->load('queries.yml');

--- a/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/AkeneoBatchExtension.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/AkeneoBatchExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\BatchBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('akeneo_batch');
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/LoggerSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/LoggerSubscriber.php
@@ -40,7 +40,7 @@ class LoggerSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             EventInterface::JOB_EXECUTION_CREATED => 'jobExecutionCreated',

--- a/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/SetJobExecutionLogFileSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/SetJobExecutionLogFileSubscriber.php
@@ -32,7 +32,7 @@ class SetJobExecutionLogFileSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EventInterface::BEFORE_JOB_EXECUTION => 'setJobExecutionLogFile',

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Launcher/SimpleJobLauncher.php
@@ -153,7 +153,7 @@ class SimpleJobLauncher implements JobLauncherInterface
 
         $jobExecution = $this->jobRepository->createJobExecution($job, $jobInstance, $jobParameters);
         if ($user) {
-            $jobExecution->setUser($user->getUsername());
+            $jobExecution->setUser($user->getUserIdentifier());
         }
         $this->jobRepository->updateJobExecution($jobExecution);
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Validator/Constraints/JobInstance.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Validator/Constraints/JobInstance.php
@@ -27,7 +27,7 @@ class JobInstance extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_job_instance_validator';
     }
@@ -35,7 +35,7 @@ class JobInstance extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/spec/Launcher/SimpleJobLauncherSpec.php
@@ -53,7 +53,7 @@ class SimpleJobLauncherSpec extends ObjectBehavior
         $jobInstance->getJobName()->willReturn('job_instance_name');
         $jobInstance->getCode()->willReturn('job_instance_code');
         $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $jobExecution->getId()->willReturn(1);
         $constraintViolationList->count()->willReturn(0);
 
@@ -85,7 +85,7 @@ class SimpleJobLauncherSpec extends ObjectBehavior
         $jobInstance->getJobName()->willReturn('job_instance_name');
         $jobInstance->getCode()->willReturn('job_instance_code');
         $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $jobExecution->getId()->willReturn(1);
         $constraintViolationList->count()->willReturn(1);
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\BatchQueueBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/DependencyInjection/AkeneoBatchQueueExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\BatchQueueBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -21,7 +22,7 @@ class AkeneoBatchQueueExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
 
         if ('test' === $container->getParameter('kernel.environment')) {

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Launcher/QueueJobLauncher.php
@@ -118,7 +118,7 @@ class QueueJobLauncher implements JobLauncherInterface
 
         $jobExecution = $this->jobRepository->createJobExecution($job, $jobInstance, $jobParameters);
         if ($user) {
-            $jobExecution->setUser($user->getUsername());
+            $jobExecution->setUser($user->getUserIdentifier());
         }
 
         $this->jobRepository->updateJobExecution($jobExecution);

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
@@ -104,7 +104,7 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $jobInstance->getJobName()->willReturn('job_instance_name');
         $jobInstance->getType()->willReturn('export');
         $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $jobExecution->getId()->willReturn(1);
         $constraintViolationList->count()->willReturn(0);
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Launcher/QueueJobLauncherSpec.php
@@ -64,7 +64,7 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $jobInstance->getJobName()->willReturn('job_instance_name');
         $jobInstance->getType()->willReturn('export');
         $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $jobExecution->getId()->willReturn(1);
         $constraintViolationList->count()->willReturn(0);
 
@@ -145,7 +145,7 @@ class QueueJobLauncherSpec extends ObjectBehavior
         $jobInstance->getType()->willReturn('export');
         $jobInstance->getCode()->willReturn('job_instance_code');
         $jobInstance->getRawParameters()->willReturn(['foo' => 'bar']);
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $jobExecution->getId()->willReturn(1);
         $constraintViolationList->count()->willReturn(1);
 

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\ConnectorBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -21,7 +22,7 @@ class PimConnectorExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('archiving.yml');
         $loader->load('array_converters.yml');
         $loader->load('doctrine.yml');

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/DependencyInjection/PimConnectorExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\ConnectorBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/InvalidItemsCollector.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/InvalidItemsCollector.php
@@ -22,7 +22,7 @@ class InvalidItemsCollector implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EventInterface::INVALID_ITEM => 'collect'

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
@@ -2,12 +2,12 @@
 
 namespace Akeneo\Tool\Bundle\ConnectorBundle\EventListener;
 
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\Batch\Event\EventInterface;
 use Akeneo\Tool\Component\Batch\Event\JobExecutionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**
@@ -38,7 +38,7 @@ class JobExecutionAuthenticator implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EventInterface::BEFORE_JOB_EXECUTION => 'authenticate'
@@ -49,7 +49,7 @@ class JobExecutionAuthenticator implements EventSubscriberInterface
      * Authenticate or not the job execution with the user that launched the job,
      * according to the parameters of the job execution.
      *
-     * @throws UsernameNotFoundException
+     * @throws UserNotFoundException
      *
      * @param JobExecutionEvent $event
      */
@@ -67,7 +67,7 @@ class JobExecutionAuthenticator implements EventSubscriberInterface
             return;
         }
 
-        $user = $this->userProvider->loadUserByUsername($username);
+        $user = $this->userProvider->loadUserByIdentifier($username);
 
         $token = new UsernamePasswordToken($user, null, 'main', $user->getRoles());
         $this->tokenStorage->setToken($token);

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/EventListener/JobExecutionAuthenticator.php
@@ -2,12 +2,12 @@
 
 namespace Akeneo\Tool\Bundle\ConnectorBundle\EventListener;
 
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\Batch\Event\EventInterface;
 use Akeneo\Tool\Component\Batch\Event\JobExecutionEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
 /**

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Tool\Bundle\ConnectorBundle\EventListener;
 
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\Batch\Event\EventInterface;
 use Akeneo\Tool\Component\Batch\Event\JobExecutionEvent;
 use Akeneo\Tool\Component\Batch\Job\JobParameters;
@@ -11,7 +12,6 @@ use Akeneo\Tool\Bundle\ConnectorBundle\EventListener\JobExecutionAuthenticator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -149,11 +149,11 @@ class JobExecutionAuthenticatorSpec extends ObjectBehavior
         $jobParameters->has('is_user_authenticated')->willReturn(true);
         $jobParameters->get('is_user_authenticated')->willReturn(true);
 
-        $userProvider->loadUserByUsername('julia')->willThrow(UsernameNotFoundException::class);
+        $userProvider->loadUserByUsername('julia')->willThrow(UserNotFoundException::class);
 
         $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
         $tokenStorage->setToken($token)->shouldNotBeCalled();
 
-        $this->shouldThrow(UsernameNotFoundException::class)->during('authenticate', [$event]);
+        $this->shouldThrow(UserNotFoundException::class)->during('authenticate', [$event]);
     }
 }

--- a/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
+++ b/src/Akeneo/Tool/Bundle/ConnectorBundle/spec/EventListener/JobExecutionAuthenticatorSpec.php
@@ -52,7 +52,7 @@ class JobExecutionAuthenticatorSpec extends ObjectBehavior
         $jobParameters->has('is_user_authenticated')->willReturn(true);
         $jobParameters->get('is_user_authenticated')->willReturn(true);
 
-        $userProvider->loadUserByUsername('julia')->willReturn($user);
+        $userProvider->loadUserByIdentifier('julia')->willReturn($user);
 
         $user->getRoles()->willReturn(['role']);
 
@@ -149,7 +149,7 @@ class JobExecutionAuthenticatorSpec extends ObjectBehavior
         $jobParameters->has('is_user_authenticated')->willReturn(true);
         $jobParameters->get('is_user_authenticated')->willReturn(true);
 
-        $userProvider->loadUserByUsername('julia')->willThrow(UserNotFoundException::class);
+        $userProvider->loadUserByIdentifier('julia')->willThrow(UserNotFoundException::class);
 
         $token  = new UsernamePasswordToken($user->getWrappedObject(), null, 'main', ['role']);
         $tokenStorage->setToken($token)->shouldNotBeCalled();

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateMappingIndexCommand.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateMappingIndexCommand.php
@@ -52,7 +52,7 @@ class UpdateMappingIndexCommand extends Command
         $this->addOption('all', 'a', InputOption::VALUE_NONE, "Use --all if you want to update all mappings of all indices", null);
     }
 
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $indices = $input->getOption('all') ? [] : $input->getArgument('indices');
 

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('akeneo_elasticsearch');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Install/InstallSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Install/InstallSubscriber.php
@@ -17,7 +17,7 @@ class InstallSubscriber implements EventSubscriberInterface
         $this->dbalConnection = $dbalConnection;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => 'createIndexMigrationTable',

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Form/Type/FileInfoType.php
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Form/Type/FileInfoType.php
@@ -50,7 +50,7 @@ class FileInfoType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'akeneo_file_storage_file_info';
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Normalizer/ExternalMeasurementFamilyNormalizer.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Normalizer/ExternalMeasurementFamilyNormalizer.php
@@ -30,7 +30,7 @@ final class ExternalMeasurementFamilyNormalizer implements NormalizerInterface
         return $normalizedMeasurementFamily;
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, string $format = null): bool
     {
         return $data instanceof MeasurementFamily;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
+use Doctrine\DBAL\DBALException;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -187,7 +188,7 @@ SQL;
     /**
      * @return array
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     private function loadMeasurementFamiliesIndexByCodes(): array
     {

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Persistence/MeasurementFamilyRepository.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Persistence;
 
-use Doctrine\DBAL\DBALException;
 use Akeneo\Tool\Bundle\MeasureBundle\Exception\MeasurementFamilyNotFoundException;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\LabelCollection;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\MeasurementFamily;
@@ -13,6 +12,7 @@ use Akeneo\Tool\Bundle\MeasureBundle\Model\Operation;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\Unit;
 use Akeneo\Tool\Bundle\MeasureBundle\Model\UnitCode;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Types\Types;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -19,10 +23,10 @@ class CodeValidator extends ConstraintValidator
         $violations = $validator->validate(
             $code,
             [
-                new Constraints\NotBlank(),
-                new Constraints\Type(['type' => 'string']),
-                new Constraints\Length(['max' => self::MAX_CODE_LENGTH]),
-                new Constraints\Regex(
+                new NotBlank(),
+                new Type(['type' => 'string']),
+                new Length(['max' => self::MAX_CODE_LENGTH]),
+                new Regex(
                     [
                         'pattern' => '/^[a-zA-Z0-9_]+$/',
                         'message' => 'pim_measurements.validation.common.code.pattern',

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Common/CodeValidator.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Bundle\MeasureBundle\Validation\Common;
 
-use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Type;
-use Symfony\Component\Validator\Constraints\Length;
-use Symfony\Component\Validator\Constraints\Regex;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
+use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Validation;
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/Count.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/Count.php
@@ -14,12 +14,12 @@ class Count extends Constraint
 {
     public const MAX_MESSAGE = 'pim_measurements.validation.measurement_family.should_contain_max_elements';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.create_measurement_family.count';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChanged.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeCannotBeChanged.php
@@ -15,12 +15,12 @@ class StandardUnitCodeCannotBeChanged extends Constraint
 {
     public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.cannot_be_changed';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.create_measurement_family.standard_unit_code_cannot_be_changed';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return Constraint::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
@@ -15,7 +15,7 @@ class StandardUnitCodeOperationShouldBeMultiplyByOne extends Constraint
 {
     public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.operation_should_be_multiply_by_one';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return Constraint::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/StandardUnitCodeShouldExist.php
@@ -15,7 +15,7 @@ class StandardUnitCodeShouldExist extends Constraint
     public const STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS = 'pim_measurements.validation.measurement_family.standard_unit_code.should_be_in_the_list_of_units';
     public const STANDARD_UNIT_CODE_IS_REQUIRED = 'pim_measurements.validation.measurement_family.standard_unit_code.is_required';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/CreateMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -16,7 +16,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
     public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_units_is_locked_for_updates';
     public const MEASUREMENT_FAMILY_OPERATION_UPDATE_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_unit_operations_locked_for_updates';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttribute.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/DeleteMeasurementFamily/ShouldNotBeUsedByProductAttribute.php
@@ -14,7 +14,7 @@ class ShouldNotBeUsedByProductAttribute extends Constraint
 {
     public const MEASUREMENT_FAMILY_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_cannot_be_removed';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUnique.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/CodeMustBeUnique.php
@@ -14,7 +14,7 @@ class CodeMustBeUnique extends Constraint
 {
     public string $message = 'pim_measurements.validation.measurement_family.code.must_be_unique';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measure.validation.measurement_family.code_must_be_unique';
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCount.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationCount.php
@@ -10,7 +10,7 @@ class OperationCount extends Constraint
     public string $minMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_min_elements';
     public string $maxMessage = 'pim_measurements.validation.measurement_family.convert.should_contain_max_elements';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.measurement_family.operation_count';
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/OperationValue.php
@@ -9,7 +9,7 @@ class OperationValue extends Constraint
 {
     public const VALUE_SHOULD_BE_A_NUMBER_IN_A_STRING = 'pim_measurements.validation.measurement_family.convert.value_should_be_a_number_in_a_string';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return [self::PROPERTY_CONSTRAINT, self::CLASS_CONSTRAINT];
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCount.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/MeasurementFamily/UnitCount.php
@@ -10,7 +10,7 @@ class UnitCount extends Constraint
     public const MAX_MESSAGE = 'pim_measurements.validation.measurement_family.units.should_contain_max_elements';
     public const MIN_MESSAGE = 'pim_measurements.validation.measurement_family.units.should_contain_at_least_one_unit';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.measurement_family.unit_count';
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/Count.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/Count.php
@@ -9,12 +9,12 @@ class Count extends Constraint
 {
     public const MAX_MESSAGE = 'pim_measurements.validation.measurement_family.should_contain_max_elements';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.save_measurement_family.count';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChanged.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeCannotBeChanged.php
@@ -15,12 +15,12 @@ class StandardUnitCodeCannotBeChanged extends Constraint
 {
     public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.cannot_be_changed';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.save_measurement_family.standard_unit_code_cannot_be_changed';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return Constraint::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeOperationShouldBeMultiplyByOne.php
@@ -15,7 +15,7 @@ class StandardUnitCodeOperationShouldBeMultiplyByOne extends Constraint
 {
     public const ERROR_MESSAGE = 'pim_measurements.validation.measurement_family.standard_unit_code.operation_should_be_multiply_by_one';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return Constraint::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExist.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/StandardUnitCodeShouldExist.php
@@ -10,7 +10,7 @@ class StandardUnitCodeShouldExist extends Constraint
     public const STANDARD_UNIT_CODE_SHOULD_EXIST_IN_THE_LIST_OF_UNITS = 'pim_measurements.validation.measurement_family.standard_unit_code.should_be_in_the_list_of_units';
     public const STANDARD_UNIT_CODE_IS_REQUIRED = 'pim_measurements.validation.measurement_family.standard_unit_code.is_required';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/SaveMeasurementFamily/WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUnits.php
@@ -16,7 +16,7 @@ class WhenUsedInAProductAttributeShouldBeAbleToUpdateOnlyLabelsAndSymbolAndAddUn
     public const MEASUREMENT_FAMILY_UNIT_REMOVAL_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_units_is_locked_for_updates';
     public const MEASUREMENT_FAMILY_OPERATION_UPDATE_NOT_ALLOWED = 'pim_measurements.validation.measurement_family.measurement_family_unit_operations_locked_for_updates';
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUnique.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Validation/Unit/CodeMustBeUnique.php
@@ -14,12 +14,12 @@ class CodeMustBeUnique extends Constraint
 {
     public string $message = 'pim_measurements.validation.unit.code.must_be_unique';
 
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'akeneo_measurement.validation.unit.code_must_be_unique';
     }
 
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/Acceptance/DeleteMeasurementFamilyTest.php
@@ -134,8 +134,7 @@ class DeleteMeasurementFamilyTest extends AcceptanceTestCase
     }
 
     /**
-     * @param \Symfony\Component\Validator\ConstraintViolationListInterface $violations
-     *
+     * @param ConstraintViolationListInterface $violations
      */
     private function assertCannotRemoveTheMeasurementFamily(
         ConstraintViolationListInterface $violations

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Legacy/GetMeasureFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Legacy/GetMeasureFamilyEndToEnd.php
@@ -159,7 +159,7 @@ JSON;
         $client->request('GET', 'api/rest/v1/measure-families/not_found');
 
         $response = $client->getResponse();
-        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
         $expected = '{"code":404,"message":"Measure family with code \"not_found\" does not exist."}';
         $this->assertSame($expected, $response->getContent());
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Legacy/ListMeasureFamilyEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/Legacy/ListMeasureFamilyEndToEnd.php
@@ -1855,7 +1855,7 @@ JSON;
 
         $response = $client->getResponse();
 
-        $this->assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
         $expected = '{"code":422,"message":"Pagination type is not supported."}';
         $this->assertEquals($response->getContent(), $expected);
     }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/tests/EndToEnd/ExternalApi/SaveMeasurementFamiliesActionEndToEnd.php
@@ -499,7 +499,7 @@ class SaveMeasurementFamiliesActionEndToEnd extends ApiTestCase
     {
         $response = $this->request(['values' => null]);
 
-        $this->assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertResponseStatusCodeSame(Response::HTTP_BAD_REQUEST);
         $this->assertSame(
             [
                 'code' => 400,

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Command/PurgeMessengerCommand.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Command/PurgeMessengerCommand.php
@@ -51,7 +51,7 @@ class PurgeMessengerCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $retentionTime = $input->getOption('retention-time');
         $tableName = $input->getArgument('table-name');

--- a/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Tool/Bundle/StorageUtilsBundle/DependencyInjection/Configuration.php
@@ -17,7 +17,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('akeneo_storage_utils');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/DependencyInjection/AkeneoVersioningExtension.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/DependencyInjection/AkeneoVersioningExtension.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -20,7 +21,7 @@ class AkeneoVersioningExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('builders.yml');
         $loader->load('entities.yml');
         $loader->load('event_subscribers.yml');
@@ -49,7 +50,7 @@ class AkeneoVersioningExtension extends Extension
      */
     protected function loadSerializerConfig(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/serializer'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/serializer'));
         $loader->load('serializer.yml');
     }
 }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/DependencyInjection/AkeneoVersioningExtension.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/DependencyInjection/AkeneoVersioningExtension.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Yaml\Yaml;
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Doctrine\ORM;
 
+use Doctrine\ORM\QueryBuilder;
+use Akeneo\Tool\Component\Versioning\Model\Version;
 use Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
@@ -90,7 +92,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
     /**
      * @param array $parameters
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      */
     public function createDatagridQueryBuilder(array $parameters = [])
     {
@@ -197,7 +199,7 @@ class VersionRepository extends EntityRepository implements VersionRepositoryInt
      * @param bool|null $pending
      * @param string    $sort
      *
-     * @return \Akeneo\Tool\Component\Versioning\Model\Version|null
+     * @return Version|null
      */
     protected function getOneLogEntry($resourceName, $resourceId, ?UuidInterface $resourceUuid, $pending, $sort)
     {

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Doctrine/ORM/VersionRepository.php
@@ -2,15 +2,15 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Doctrine\ORM;
 
-use Doctrine\ORM\QueryBuilder;
-use Akeneo\Tool\Component\Versioning\Model\Version;
 use Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\ORM\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Repository\VersionRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorFactoryInterface;
+use Akeneo\Tool\Component\Versioning\Model\Version;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\NoResultException;
+use Doctrine\ORM\QueryBuilder;
 use Ramsey\Uuid\UuidInterface;
 
 /**

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddContextSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddContextSubscriber.php
@@ -35,7 +35,7 @@ class AddContextSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EventInterface::BEFORE_JOB_EXECUTION => 'addContext'

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddRemoveVersionSubscriber.php
@@ -61,7 +61,7 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             StorageEvents::POST_REMOVE => 'addRemoveVersion',
@@ -83,7 +83,7 @@ class AddRemoveVersionSubscriber implements EventSubscriberInterface
         if (null !== ($token = $this->tokenStorage->getToken()) &&
             $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')
         ) {
-            $author = $token->getUser()->getUsername();
+            $author = $token->getUser()->getUserIdentifier();
         }
 
         $resourceId = $this->shouldUseUuid($subject) ? null : ($subject->getId() ?? $event->getSubjectId());

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddUserSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/AddUserSubscriber.php
@@ -38,7 +38,7 @@ class AddUserSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             BuildVersionEvents::PRE_BUILD => 'preBuild',
@@ -58,7 +58,7 @@ class AddUserSubscriber implements EventSubscriberInterface
 
         $token = $this->tokenStorage->getToken();
         if (null !== $token && $this->authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')) {
-            $event->setUsername($token->getUser()->getUsername());
+            $event->setUsername($token->getUser()->getUserIdentifier());
         }
 
         return $event;

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/PurgeProgressBarAdvancerSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/EventSubscriber/PurgeProgressBarAdvancerSubscriber.php
@@ -26,7 +26,7 @@ class PurgeProgressBarAdvancerSubscriber implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [PurgeVersionEvents::PRE_ADVISEMENT  => 'advanceProgressbar'];
     }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Job/RefreshVersioning.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Job/RefreshVersioning.php
@@ -2,13 +2,13 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Job;
 
-use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Manager\VersionManager;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Tool\Component\Versioning\Model\Version;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Refresh versioning data

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Job/RefreshVersioning.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Job/RefreshVersioning.php
@@ -2,13 +2,13 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Job;
 
+use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Manager\VersionManager;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Detacher\BulkObjectDetacherInterface;
 use Akeneo\Tool\Component\Versioning\Model\Version;
 use Doctrine\ORM\EntityManagerInterface;
-use Symfony\Bridge\Monolog\Logger;
 
 /**
  * Refresh versioning data
@@ -22,7 +22,7 @@ class RefreshVersioning implements TaskletInterface
     private StepExecution $stepExecution;
 
     public function __construct(
-        private Logger $logger,
+        private LoggerInterface $logger,
         private VersionManager $versionManager,
         private BulkObjectDetacherInterface $bulkObjectDetacher,
         private EntityManagerInterface $entityManager

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Purger;
 
+use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlDeleteVersionsByIdsQuery;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlGetAllResourceNamesQuery;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlGetPurgeableVersionListQuery;
-use Symfony\Bridge\Monolog\Logger;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -25,7 +25,7 @@ class VersionPurger implements VersionPurgerInterface
         private SqlDeleteVersionsByIdsQuery $deleteVersionsByIdsQuery,
         private SqlGetAllResourceNamesQuery $getAllResourceNamesQuery,
         private SqlGetPurgeableVersionListQuery $getPurgeableVersionListQuery,
-        private Logger $logger,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Purger/VersionPurger.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Tool\Bundle\VersioningBundle\Purger;
 
-use Psr\Log\LoggerInterface;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlDeleteVersionsByIdsQuery;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlGetAllResourceNamesQuery;
 use Akeneo\Tool\Bundle\VersioningBundle\Doctrine\Query\SqlGetPurgeableVersionListQuery;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddRemoveVersionSubscriberSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddRemoveVersionSubscriberSpec.php
@@ -56,7 +56,7 @@ class AddRemoveVersionSubscriberSpec extends ObjectBehavior
     ) {
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($admin);
-        $admin->getUsername()->willReturn('admin');
+        $admin->getUserIdentifier()->willReturn('admin');
         $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')->willReturn(true);
 
         $versionRepository->getNewestLogEntry(Argument::any(), 12, null)->willReturn($previousVersion);
@@ -92,7 +92,7 @@ class AddRemoveVersionSubscriberSpec extends ObjectBehavior
     ) {
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($admin);
-        $admin->getUsername()->willReturn('admin');
+        $admin->getUserIdentifier()->willReturn('admin');
         $authorizationChecker->isGranted('IS_AUTHENTICATED_REMEMBERED')->willReturn(true);
 
         $versionSaver->save($removeVersion, Argument::any())->shouldNotBeCalled();

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddUserSubscriberSpec.php
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/spec/EventSubscriber/AddUserSubscriberSpec.php
@@ -41,7 +41,7 @@ class AddUserSubscriberSpec extends ObjectBehavior
     ) {
         $tokenStorage->getToken()->willReturn($token);
         $token->getUser()->willReturn($user);
-        $user->getUsername()->willReturn('foo');
+        $user->getUserIdentifier()->willReturn('foo');
 
         $this->preBuild($event);
     }

--- a/src/Akeneo/Tool/Component/Api/Normalizer/CollectionNormalizer.php
+++ b/src/Akeneo/Tool/Component/Api/Normalizer/CollectionNormalizer.php
@@ -37,7 +37,7 @@ class CollectionNormalizer implements NormalizerInterface, SerializerAwareInterf
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return ($data instanceof \Traversable || is_array($data)) && 'external_api' === $format;
     }

--- a/src/Akeneo/Tool/Component/Api/Normalizer/Exception/DocumentedNormalizer.php
+++ b/src/Akeneo/Tool/Component/Api/Normalizer/Exception/DocumentedNormalizer.php
@@ -35,7 +35,7 @@ class DocumentedNormalizer implements NormalizerInterface, CacheableSupportsMeth
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($exception, $format = null)
+    public function supportsNormalization($exception, $format = null): bool
     {
         return $exception instanceof DocumentedHttpException;
     }

--- a/src/Akeneo/Tool/Component/Api/Normalizer/Exception/ViolationNormalizer.php
+++ b/src/Akeneo/Tool/Component/Api/Normalizer/Exception/ViolationNormalizer.php
@@ -52,7 +52,7 @@ class ViolationNormalizer implements NormalizerInterface, CacheableSupportsMetho
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($exception, $format = null)
+    public function supportsNormalization($exception, $format = null): bool
     {
         return $exception instanceof ViolationHttpException;
     }

--- a/src/Akeneo/Tool/Component/Api/Normalizer/FileNormalizer.php
+++ b/src/Akeneo/Tool/Component/Api/Normalizer/FileNormalizer.php
@@ -53,7 +53,7 @@ class FileNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof FileInfoInterface && 'external_api' === $format;
     }

--- a/src/Akeneo/Tool/Component/Batch/Normalizer/Standard/JobInstanceNormalizer.php
+++ b/src/Akeneo/Tool/Component/Batch/Normalizer/Standard/JobInstanceNormalizer.php
@@ -39,7 +39,7 @@ class JobInstanceNormalizer implements NormalizerInterface, CacheableSupportsMet
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof JobInstance && 'standard' === $format;
     }

--- a/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
+++ b/src/Akeneo/Tool/Component/Connector/spec/Reader/File/Xlsx/ReaderSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Akeneo\Tool\Component\Connector\Reader\File\Xlsx;
 
+use PhpSpec\Wrapper\Collaborator;
 use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
 use Akeneo\Tool\Component\Connector\Exception\BusinessArrayConversionException;
 use Akeneo\Tool\Component\Connector\Exception\InvalidItemFromViolationsException;
@@ -126,10 +127,10 @@ class ReaderSpec extends ObjectBehavior
     }
 
     /**
-     * @param \PhpSpec\Wrapper\Collaborator $stepExecution
+     * @param Collaborator $stepExecution
      * @param $jobParameters
      */
-    private function initStepExecution(\PhpSpec\Wrapper\Collaborator $stepExecution, $jobParameters): void
+    private function initStepExecution(Collaborator $stepExecution, $jobParameters): void
     {
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $jobParameters->has('storage')->willReturn(true);
@@ -140,10 +141,10 @@ class ReaderSpec extends ObjectBehavior
     }
 
     /**
-     * @param \PhpSpec\Wrapper\Collaborator $fileIteratorFactory
+     * @param Collaborator $fileIteratorFactory
      * @param $fileIterator
      */
-    private function initFileIterator(\PhpSpec\Wrapper\Collaborator $fileIteratorFactory, $fileIterator): void
+    private function initFileIterator(Collaborator $fileIteratorFactory, $fileIterator): void
     {
         $fileIteratorFactory->create($this->initFilePath(), [])->willReturn($fileIterator);
 

--- a/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
+++ b/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
@@ -2,13 +2,13 @@
 
 namespace Akeneo\Tool\Component\Localization;
 
-use Symfony\Component\Translation\TranslatorBagInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class LabelTranslator implements LabelTranslatorInterface
 {
     private $translator;
 
-    public function __construct(TranslatorBagInterface $translator)
+    public function __construct(TranslatorInterface $translator)
     {
         $this->translator = $translator;
     }

--- a/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
+++ b/src/Akeneo/Tool/Component/Localization/LabelTranslator.php
@@ -2,13 +2,13 @@
 
 namespace Akeneo\Tool\Component\Localization;
 
-use Symfony\Component\Translation\Translator;
+use Symfony\Component\Translation\TranslatorBagInterface;
 
 class LabelTranslator implements LabelTranslatorInterface
 {
     private $translator;
 
-    public function __construct(Translator $translator)
+    public function __construct(TranslatorBagInterface $translator)
     {
         $this->translator = $translator;
     }

--- a/src/Akeneo/Tool/Component/Localization/Validator/Constraints/DateFormat.php
+++ b/src/Akeneo/Tool/Component/Localization/Validator/Constraints/DateFormat.php
@@ -25,7 +25,7 @@ class DateFormat extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_localization_date_format';
     }

--- a/src/Akeneo/Tool/Component/Localization/Validator/Constraints/NumberFormat.php
+++ b/src/Akeneo/Tool/Component/Localization/Validator/Constraints/NumberFormat.php
@@ -25,7 +25,7 @@ class NumberFormat extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_localization_number_format';
     }

--- a/src/Akeneo/Tool/Component/Localization/spec/LabelTranslatorSpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/LabelTranslatorSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Akeneo\Tool\Component\Localization;
 
-use Symfony\Component\Translation\TranslatorBagInterface;
 use Akeneo\Tool\Component\Localization\LabelTranslator;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Translation\MessageCatalogueInterface;
+use Symfony\Component\Translation\Translator;
 
 class LabelTranslatorSpec extends ObjectBehavior
 {
-    function let(TranslatorBagInterface $translator)
+    function let(Translator $translator)
     {
         $this->beConstructedWith($translator);
     }
@@ -19,7 +19,7 @@ class LabelTranslatorSpec extends ObjectBehavior
         $this->shouldHaveType(LabelTranslator::class);
     }
 
-    function it_translates_labels_and_returns_fallback_if_not_found(TranslatorBagInterface $translator, MessageCatalogueInterface $catalogue)
+    function it_translates_labels_and_returns_fallback_if_not_found(Translator $translator, MessageCatalogueInterface $catalogue)
     {
         $translator->getCatalogue('fr_FR')->willReturn($catalogue);
         $catalogue->defines('some.key')->willReturn(true);

--- a/src/Akeneo/Tool/Component/Localization/spec/LabelTranslatorSpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/LabelTranslatorSpec.php
@@ -2,14 +2,14 @@
 
 namespace spec\Akeneo\Tool\Component\Localization;
 
+use Symfony\Component\Translation\TranslatorBagInterface;
 use Akeneo\Tool\Component\Localization\LabelTranslator;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\Translation\MessageCatalogueInterface;
-use Symfony\Component\Translation\Translator;
 
 class LabelTranslatorSpec extends ObjectBehavior
 {
-    function let(Translator $translator)
+    function let(TranslatorBagInterface $translator)
     {
         $this->beConstructedWith($translator);
     }
@@ -19,7 +19,7 @@ class LabelTranslatorSpec extends ObjectBehavior
         $this->shouldHaveType(LabelTranslator::class);
     }
 
-    function it_translates_labels_and_returns_fallback_if_not_found(Translator $translator, MessageCatalogueInterface $catalogue)
+    function it_translates_labels_and_returns_fallback_if_not_found(TranslatorBagInterface $translator, MessageCatalogueInterface $catalogue)
     {
         $translator->getCatalogue('fr_FR')->willReturn($catalogue);
         $catalogue->defines('some.key')->willReturn(true);

--- a/src/Akeneo/Tool/Component/StorageUtils/Validator/Constraints/Immutable.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Validator/Constraints/Immutable.php
@@ -30,7 +30,7 @@ class Immutable extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function getTargets()
+    public function getTargets(): string|array
     {
         return self::CLASS_CONSTRAINT;
     }
@@ -38,7 +38,7 @@ class Immutable extends Constraint
     /**
      * {@inheritdoc}
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return 'pim_immutable_validator';
     }

--- a/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
+++ b/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\UserManagement\Bundle\Manager;
 
-use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\User;

--- a/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
+++ b/src/Akeneo/UserManagement/Bundle/Manager/UserManager.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\UserManagement\Bundle\Manager;
 
+use Symfony\Component\PasswordHasher\Hasher\PasswordHasherFactoryInterface;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Model\User;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,13 +1,13 @@
 <?php
 
 declare(strict_types=1);
-use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
-
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
 /**

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
@@ -50,7 +51,7 @@ class Kernel extends BaseKernel
         $loader->load($confDir.'/{services}/'.$this->environment.'/**/*.yml', 'glob');
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes): void
+    protected function configureRoutes(RoutingConfigurator $routes): void
     {
         $confDir = $this->getProjectDir().'/config';
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -55,8 +55,8 @@ class Kernel extends BaseKernel
     {
         $confDir = $this->getProjectDir().'/config';
 
-        $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*.yml', '/', 'glob');
-        $routes->import($confDir.'/{routes}/*.yml', '/', 'glob');
+        $routes->import($confDir.'/{routes}/'.$this->environment.'/**/*.yml', 'glob');
+        $routes->import($confDir.'/{routes}/*.yml', 'glob');
     }
 
     /**

--- a/src/Oro/Bundle/ConfigBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/ConfigBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('oro_config');
         $builder->getRootNode()

--- a/src/Oro/Bundle/ConfigBundle/DependencyInjection/OroConfigExtension.php
+++ b/src/Oro/Bundle/ConfigBundle/DependencyInjection/OroConfigExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\ConfigBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -23,7 +24,7 @@ class OroConfigExtension extends Extension
 
         $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('controllers.yml');
         $loader->load('services.yml');
     }

--- a/src/Oro/Bundle/ConfigBundle/DependencyInjection/OroConfigExtension.php
+++ b/src/Oro/Bundle/ConfigBundle/DependencyInjection/OroConfigExtension.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\ConfigBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
+++ b/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
@@ -2,10 +2,11 @@
 
 namespace Oro\Bundle\ConfigBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
 use Twig\TwigFunction;
 
-class ConfigExtension extends \Twig\Extension\AbstractExtension
+class ConfigExtension extends AbstractExtension
 {
     /**
      * @var ConfigManager

--- a/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
+++ b/src/Oro/Bundle/ConfigBundle/Twig/ConfigExtension.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\ConfigBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Oro\Bundle\ConfigBundle\Config\ConfigManager;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class ConfigExtension extends AbstractExtension

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/QueryConfiguration.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/QueryConfiguration.php
@@ -12,7 +12,7 @@ class QueryConfiguration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('query');
 
@@ -68,8 +68,8 @@ class QueryConfiguration implements ConfigurationInterface
     /**
      * @param  string $name Join type ('left', 'inner')
      *
-     * @throws \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     * @throws InvalidConfigurationException
+     * @return ArrayNodeDefinition
      */
     protected function addJoinNode($name)
     {

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
@@ -3,7 +3,6 @@
 namespace Oro\Bundle\DataGridBundle\Datasource\Orm\QueryConverter;
 
 use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Yaml;
@@ -33,7 +32,7 @@ class YamlConverter implements QueryConverterInterface
 
         if (isset($value['select'])) {
             foreach ($value['select'] as $select) {
-                $qb->add('select', new Select($select), true);
+                $qb->add('select', new Expr\Select($select), true);
             }
         }
 

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Datasource\Orm\QueryConverter;
 
-use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Yaml;

--- a/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
+++ b/src/Oro/Bundle/DataGridBundle/Datasource/Orm/QueryConverter/YamlConverter.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\DataGridBundle\Datasource\Orm\QueryConverter;
 
+use Doctrine\ORM\Query\Expr\Select;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Component\Config\Definition\Processor;
@@ -32,7 +33,7 @@ class YamlConverter implements QueryConverterInterface
 
         if (isset($value['select'])) {
             foreach ($value['select'] as $select) {
-                $qb->add('select', new Expr\Select($select), true);
+                $qb->add('select', new Select($select), true);
             }
         }
 

--- a/src/Oro/Bundle/DataGridBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oro_data_grid');
         $treeBuilder->getRootNode();

--- a/src/Oro/Bundle/DataGridBundle/DependencyInjection/OroDataGridExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/DependencyInjection/OroDataGridExtension.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\DataGridBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class OroDataGridExtension extends Extension

--- a/src/Oro/Bundle/DataGridBundle/DependencyInjection/OroDataGridExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/DependencyInjection/OroDataGridExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\DataGridBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -17,7 +18,7 @@ class OroDataGridExtension extends Extension
         $configuration = new Configuration();
         $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('extensions.yml');
         $loader->load('data_sources.yml');

--- a/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder($this->root);
 

--- a/src/Oro/Bundle/DataGridBundle/Extension/Sorter/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Sorter/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('sorters');
 

--- a/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Toolbar/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('toolbarOptions');
 

--- a/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
+++ b/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
@@ -2,10 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\ORM\Query;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
-use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 
@@ -18,7 +16,7 @@ class QueryCountCalculator
      * Calculates total count of query records
      *
      * @param Query $query
-     * @param ArrayCollection|array|null $parameters Query parameters.
+     * @param \Doctrine\Common\Collections\ArrayCollection|array|null $parameters Query parameters.
      * @return integer
      */
     public static function calculateCount(Query $query, $parameters = null)
@@ -32,7 +30,7 @@ class QueryCountCalculator
      * Calculates total count of query records
      *
      * @param Query $query
-     * @param ArrayCollection|array|null $parameters Query parameters.
+     * @param \Doctrine\Common\Collections\ArrayCollection|array|null $parameters Query parameters.
      * @return integer
      */
     public function getCount(Query $query, $parameters = null)
@@ -59,7 +57,7 @@ class QueryCountCalculator
     /**
      * @param Query                              $query
      * @param array                              $paramMappings
-     * @throws QueryException
+     * @throws \Doctrine\ORM\Query\QueryException
      * @return array
      */
     protected function processParameterMappings(Query $query, $paramMappings)
@@ -78,7 +76,7 @@ class QueryCountCalculator
             $value = $query->processParameterValue($parameter->getValue());
             $type = ($parameter->getValue() === $value)
                 ? $parameter->getType()
-                : ParameterTypeInferer::inferType($value);
+                : Query\ParameterTypeInferer::inferType($value);
 
             foreach ($paramMappings[$key] as $position) {
                 $types[$position] = $type;

--- a/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
+++ b/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
@@ -2,6 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\ORM\Query;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
 use Doctrine\ORM\Query\Parser;
@@ -16,7 +18,7 @@ class QueryCountCalculator
      * Calculates total count of query records
      *
      * @param Query $query
-     * @param \Doctrine\Common\Collections\ArrayCollection|array|null $parameters Query parameters.
+     * @param ArrayCollection|array|null $parameters Query parameters.
      * @return integer
      */
     public static function calculateCount(Query $query, $parameters = null)
@@ -30,7 +32,7 @@ class QueryCountCalculator
      * Calculates total count of query records
      *
      * @param Query $query
-     * @param \Doctrine\Common\Collections\ArrayCollection|array|null $parameters Query parameters.
+     * @param ArrayCollection|array|null $parameters Query parameters.
      * @return integer
      */
     public function getCount(Query $query, $parameters = null)
@@ -57,7 +59,7 @@ class QueryCountCalculator
     /**
      * @param Query                              $query
      * @param array                              $paramMappings
-     * @throws \Doctrine\ORM\Query\QueryException
+     * @throws QueryException
      * @return array
      */
     protected function processParameterMappings(Query $query, $paramMappings)
@@ -76,7 +78,7 @@ class QueryCountCalculator
             $value = $query->processParameterValue($parameter->getValue());
             $type = ($parameter->getValue() === $value)
                 ? $parameter->getType()
-                : Query\ParameterTypeInferer::inferType($value);
+                : ParameterTypeInferer::inferType($value);
 
             foreach ($paramMappings[$key] as $position) {
                 $types[$position] = $type;

--- a/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
+++ b/src/Oro/Bundle/DataGridBundle/ORM/Query/QueryCountCalculator.php
@@ -3,9 +3,9 @@
 namespace Oro\Bundle\DataGridBundle\ORM\Query;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\Query\Parameter;
+use Doctrine\ORM\Query\ParameterTypeInferer;
 use Doctrine\ORM\Query\Parser;
 use Doctrine\ORM\Query\QueryException;
 

--- a/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
@@ -3,10 +3,9 @@
 namespace Oro\Bundle\DataGridBundle\Twig;
 
 use Oro\Bundle\DataGridBundle\Datagrid\MetadataParser;
-use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
-class MetadataExtension extends AbstractExtension
+class MetadataExtension extends \Twig\Extension\AbstractExtension
 {
     /**
      * @param ContainerInterface $container

--- a/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\DataGridBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Oro\Bundle\DataGridBundle\Datagrid\MetadataParser;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class MetadataExtension extends AbstractExtension

--- a/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Twig/MetadataExtension.php
@@ -2,10 +2,11 @@
 
 namespace Oro\Bundle\DataGridBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Oro\Bundle\DataGridBundle\Datagrid\MetadataParser;
 use Twig\TwigFunction;
 
-class MetadataExtension extends \Twig\Extension\AbstractExtension
+class MetadataExtension extends AbstractExtension
 {
     /**
      * @param ContainerInterface $container

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
+use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr;
 use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
 
@@ -35,7 +36,7 @@ class OrmExpressionBuilder implements ExpressionBuilderInterface
      */
     public function comparison($x, $operator, $y, $withParam = false)
     {
-        return new Expr\Comparison($x, $operator, $withParam ? ':' . $y : $y);
+        return new Comparison($x, $operator, $withParam ? ':' . $y : $y);
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
@@ -3,7 +3,6 @@
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
 use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\Query\Expr\Comparison;
 use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
 
 class OrmExpressionBuilder implements ExpressionBuilderInterface
@@ -36,7 +35,7 @@ class OrmExpressionBuilder implements ExpressionBuilderInterface
      */
     public function comparison($x, $operator, $y, $withParam = false)
     {
-        return new Comparison($x, $operator, $withParam ? ':' . $y : $y);
+        return new Expr\Comparison($x, $operator, $withParam ? ':' . $y : $y);
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
-use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\Comparison;
 use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
 
 class OrmExpressionBuilder implements ExpressionBuilderInterface

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
+use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
@@ -127,7 +128,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
      */
     protected function fixComparison($restriction, $condition)
     {
-        if ($restriction instanceof Expr\Comparison
+        if ($restriction instanceof Comparison
             && ($restriction->getOperator() === 'LIKE' || $restriction->getOperator() === 'NOT LIKE')
         ) {
             return $this->tryApplyWhereRestriction($restriction, $condition);
@@ -146,7 +147,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
      */
     protected function tryApplyWhereRestriction($restriction, $condition)
     {
-        if (!($restriction instanceof Expr\Comparison)) {
+        if (!($restriction instanceof Comparison)) {
             return false;
         }
 
@@ -165,7 +166,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
             return false;
         }
 
-        $restriction = new Expr\Comparison(
+        $restriction = new Comparison(
             $extraSelect,
             $restriction->getOperator(),
             $restriction->getRightExpr()

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
-use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility;

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmFilterDatasourceAdapter.php
@@ -3,7 +3,6 @@
 namespace Oro\Bundle\FilterBundle\Datasource\Orm;
 
 use Doctrine\ORM\Query\Expr;
-use Doctrine\ORM\Query\Expr\Comparison;
 use Doctrine\ORM\QueryBuilder;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\FilterUtility;
@@ -128,7 +127,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
      */
     protected function fixComparison($restriction, $condition)
     {
-        if ($restriction instanceof Comparison
+        if ($restriction instanceof Expr\Comparison
             && ($restriction->getOperator() === 'LIKE' || $restriction->getOperator() === 'NOT LIKE')
         ) {
             return $this->tryApplyWhereRestriction($restriction, $condition);
@@ -147,7 +146,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
      */
     protected function tryApplyWhereRestriction($restriction, $condition)
     {
-        if (!($restriction instanceof Comparison)) {
+        if (!($restriction instanceof Expr\Comparison)) {
             return false;
         }
 
@@ -166,7 +165,7 @@ class OrmFilterDatasourceAdapter implements FilterDatasourceAdapterInterface
             return false;
         }
 
-        $restriction = new Comparison(
+        $restriction = new Expr\Comparison(
             $extraSelect,
             $restriction->getOperator(),
             $restriction->getRightExpr()

--- a/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oro_filter');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/BooleanFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/BooleanFilterType.php
@@ -13,7 +13,7 @@ class BooleanFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -21,7 +21,7 @@ class BooleanFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/ChoiceFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/ChoiceFilterType.php
@@ -16,7 +16,7 @@ class ChoiceFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -24,7 +24,7 @@ class ChoiceFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DateRangeFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DateRangeFilterType.php
@@ -27,7 +27,7 @@ class DateRangeFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -35,7 +35,7 @@ class DateRangeFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DateTimeRangeFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DateTimeRangeFilterType.php
@@ -17,7 +17,7 @@ class DateTimeRangeFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -25,7 +25,7 @@ class DateTimeRangeFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return DateRangeFilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/EntityFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/EntityFilterType.php
@@ -13,7 +13,7 @@ class EntityFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -21,7 +21,7 @@ class EntityFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/FilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/FilterType.php
@@ -28,7 +28,7 @@ class FilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/NumberFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/NumberFilterType.php
@@ -31,7 +31,7 @@ class NumberFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -39,7 +39,7 @@ class NumberFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/SelectRowFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/SelectRowFilterType.php
@@ -33,7 +33,7 @@ class SelectRowFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -41,7 +41,7 @@ class SelectRowFilterType extends AbstractChoiceType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/TextFilterType.php
@@ -27,7 +27,7 @@ class TextFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -35,7 +35,7 @@ class TextFilterType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return FilterType::class;
     }

--- a/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
+++ b/src/Oro/Bundle/FilterBundle/Grid/Extension/Configuration.php
@@ -27,7 +27,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('filters');
 

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Fixtures/CustomFormExtension.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Fixtures/CustomFormExtension.php
@@ -23,7 +23,7 @@ class CustomFormExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    protected function loadTypes()
+    protected function loadTypes(): array
     {
         return $this->initialTypes;
     }

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/AbstractTypeTestCase.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/AbstractTypeTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\FilterBundle\Tests\Unit\Form\Type;
 
+use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -9,7 +10,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 abstract class AbstractTypeTestCase extends FormIntegrationTestCase
 {
     /**
-     * @var \Symfony\Component\Form\FormFactory
+     * @var FormFactory
      */
     protected $factory;
 

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/BooleanFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/BooleanFilterTypeTest.php
@@ -48,7 +48,7 @@ class BooleanFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(BooleanFilterType::NAME, $this->type->getName());
+        $this->assertEquals(BooleanFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/ChoiceFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/ChoiceFilterTypeTest.php
@@ -34,7 +34,7 @@ class ChoiceFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(ChoiceFilterType::NAME, $this->type->getName());
+        $this->assertEquals(ChoiceFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/DateRangeFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/DateRangeFilterTypeTest.php
@@ -48,7 +48,7 @@ class DateRangeFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(DateRangeFilterType::NAME, $this->type->getName());
+        $this->assertEquals(DateRangeFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/DateTimeRangeFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/DateTimeRangeFilterTypeTest.php
@@ -52,7 +52,7 @@ class DateTimeRangeFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(DateTimeRangeFilterType::NAME, $this->type->getName());
+        $this->assertEquals(DateTimeRangeFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/EntityFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/EntityFilterTypeTest.php
@@ -45,7 +45,7 @@ class EntityFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(EntityFilterType::NAME, $this->type->getName());
+        $this->assertEquals(EntityFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     public function testGetParent()

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/FilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/FilterTypeTest.php
@@ -29,7 +29,7 @@ class FilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(FilterType::NAME, $this->type->getName());
+        $this->assertEquals(FilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/NumberFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/NumberFilterTypeTest.php
@@ -38,7 +38,7 @@ class NumberFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(NumberFilterType::NAME, $this->type->getName());
+        $this->assertEquals(NumberFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/TextFilterTypeTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Form/Type/Filter/TextFilterTypeTest.php
@@ -33,7 +33,7 @@ class TextFilterTypeTest extends AbstractTypeTestCase
 
     public function testGetName()
     {
-        $this->assertEquals(TextFilterType::NAME, $this->type->getName());
+        $this->assertEquals(TextFilterType::NAME, $this->type->getBlockPrefix());
     }
 
     /**

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace spec\Oro\Bundle\FilterBundle\Filter;
 
-use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\Query\Expr;
 use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
@@ -41,7 +40,7 @@ class StringFilterSpec extends ObjectBehavior
 
         $isNullExpr = 'teststring IS NULL';
         $eqExpr = 'teststring = :testrting1234';
-        $orExpr = new Orx();
+        $orExpr = new Expr\Orx();
 
         $builder->isNull(Argument::type('string'))->willReturn($isNullExpr);
         $builder->eq(Argument::type('string'), Argument::type('string'), true)->willReturn($eqExpr);

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace spec\Oro\Bundle\FilterBundle\Filter;
 
+use Doctrine\ORM\Query\Expr\Orx;
 use Doctrine\ORM\Query\Expr;
 use Oro\Bundle\FilterBundle\Datasource\ExpressionBuilderInterface;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
@@ -40,7 +41,7 @@ class StringFilterSpec extends ObjectBehavior
 
         $isNullExpr = 'teststring IS NULL';
         $eqExpr = 'teststring = :testrting1234';
-        $orExpr = new Expr\Orx();
+        $orExpr = new Orx();
 
         $builder->isNull(Argument::type('string'))->willReturn($isNullExpr);
         $builder->eq(Argument::type('string'), Argument::type('string'), true)->willReturn($eqExpr);

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/ExportController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/ExportController.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\PimDataGridBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Response;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -48,7 +49,7 @@ class ExportController
     /**
      * Data export action
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      */
     public function indexAction()
     {
@@ -62,7 +63,7 @@ class ExportController
     /**
      * Create a streamed response containing a file
      *
-     * @return \Symfony\Component\HttpFoundation\StreamedResponse
+     * @return StreamedResponse
      */
     protected function createStreamedResponse()
     {
@@ -153,7 +154,7 @@ class ExportController
     /**
      * TODO: Get from datagrid builder ?
      *
-     * @return \Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction
+     * @return ExportMassAction
      */
     protected function getExportMassAction()
     {

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/ExportController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/ExportController.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\PimDataGridBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Response;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\Actions\Export\ExportMassAction;
 use Oro\Bundle\PimDataGridBundle\Extension\MassAction\MassActionDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Serializer\SerializerInterface;

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/ProductExportController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/ProductExportController.php
@@ -106,7 +106,7 @@ class ProductExportController
         }
 
         $configuration = array_merge($rawParameters, $dynamicConfiguration);
-        $configuration['users_to_notify'][] = $this->getUser()->getUsername();
+        $configuration['users_to_notify'][] = $this->getUser()->getUserIdentifier();
 
         $jobExecution = $this->jobLauncher->launch($jobInstance, $this->getUser(), $configuration);
 

--- a/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Controller/Rest/DatagridViewController.php
@@ -156,7 +156,7 @@ class DatagridViewController
             throw new BadRequestHttpException('Parameter "view" needed in the request.');
         }
 
-        $loggedUsername = $this->tokenStorage->getToken()->getUser()->getUsername();
+        $loggedUsername = $this->tokenStorage->getToken()->getUser()->getUserIdentifier();
         if (isset($view['id'])) {
             $creation = false;
             $datagridView = $this->datagridViewRepo->findOneBy(['id' => $view['id'], 'datagridAlias' => $alias]);
@@ -165,7 +165,7 @@ class DatagridViewController
             }
 
             $owner = $datagridView->getOwner();
-            if (!$owner instanceof UserInterface || $owner->getUsername() !== $loggedUsername) {
+            if (!$owner instanceof UserInterface || $owner->getUserIdentifier() !== $loggedUsername) {
                 throw new AccessDeniedException();
             }
 

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/DatasourceInterface.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/DatasourceInterface.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\PimDataGridBundle\Datasource;
 
+use Doctrine\ORM\QueryBuilder;
 use Oro\Bundle\DataGridBundle\Datasource\DatasourceInterface as OroDatasourceInterface;
 use Oro\Bundle\PimDataGridBundle\Datasource\ResultRecord\HydratorInterface;
 use Oro\Bundle\PimDataGridBundle\Doctrine\ORM\Repository\MassActionRepositoryInterface;
@@ -18,7 +19,7 @@ interface DatasourceInterface extends OroDatasourceInterface
     /**
      * Get the query builder
      *
-     * @return \Doctrine\ORM\QueryBuilder
+     * @return QueryBuilder
      *
      * @deprecated you should avoid this method, it's a design flaw, still used by,
      *  `Oro\Bundle\PimDataGridBundle\Extension\MassAction\MassActionDispatcher`,

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Oro\Bundle\PimDataGridBundle\Datasource;
 
+use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRows;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRowsParameters;
-use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Doctrine\Persistence\ObjectManager;

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Oro\Bundle\PimDataGridBundle\Datasource;
 
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
-use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRows;
-use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRowsParameters;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -51,7 +49,7 @@ class ProductAndProductModelDatasource extends Datasource
         ProductQueryBuilderFactoryInterface $factory,
         NormalizerInterface $serializer,
         ValidatorInterface $validator,
-        FetchProductAndProductModelRows $fetchRows
+        Query\FetchProductAndProductModelRows $fetchRows
     ) {
         $this->om = $om;
         $this->factory = $factory;
@@ -70,7 +68,7 @@ class ProductAndProductModelDatasource extends Datasource
         $channelCode = $this->getConfiguration('scope_code');
         $localeCode = $this->getConfiguration('locale_code');
 
-        $getRowsQueryParameters = new FetchProductAndProductModelRowsParameters(
+        $getRowsQueryParameters = new Query\FetchProductAndProductModelRowsParameters(
             $this->pqb,
             $attributesToDisplay,
             $channelCode,

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/ProductAndProductModelDatasource.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Oro\Bundle\PimDataGridBundle\Datasource;
 
+use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRows;
+use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRowsParameters;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
@@ -49,7 +51,7 @@ class ProductAndProductModelDatasource extends Datasource
         ProductQueryBuilderFactoryInterface $factory,
         NormalizerInterface $serializer,
         ValidatorInterface $validator,
-        Query\FetchProductAndProductModelRows $fetchRows
+        FetchProductAndProductModelRows $fetchRows
     ) {
         $this->om = $om;
         $this->factory = $factory;
@@ -68,7 +70,7 @@ class ProductAndProductModelDatasource extends Datasource
         $channelCode = $this->getConfiguration('scope_code');
         $localeCode = $this->getConfiguration('locale_code');
 
-        $getRowsQueryParameters = new Query\FetchProductAndProductModelRowsParameters(
+        $getRowsQueryParameters = new FetchProductAndProductModelRowsParameters(
             $this->pqb,
             $attributesToDisplay,
             $channelCode,

--- a/src/Oro/Bundle/PimDataGridBundle/DependencyInjection/PimDataGridExtension.php
+++ b/src/Oro/Bundle/PimDataGridBundle/DependencyInjection/PimDataGridExtension.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\PimDataGridBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Oro/Bundle/PimDataGridBundle/DependencyInjection/PimDataGridExtension.php
+++ b/src/Oro/Bundle/PimDataGridBundle/DependencyInjection/PimDataGridExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\PimDataGridBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -19,7 +20,7 @@ class PimDataGridExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('actions.yml');
         $loader->load('adapters.yml');
         $loader->load('attribute_types.yml');

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/MassAction/MassActionDispatcher.php
@@ -236,7 +236,7 @@ class MassActionDispatcher
      *
      * @throws \LogicException
      *
-     * @return \Oro\Bundle\DataGridBundle\Extension\MassAction\Actions\MassActionInterface
+     * @return MassActionInterface
      */
     protected function getMassActionByName($massActionName, DatagridInterface $datagrid)
     {
@@ -284,7 +284,7 @@ class MassActionDispatcher
      * @param string $actionName
      * @param string $datagridName
      *
-     * @return \Oro\Bundle\DataGridBundle\Extension\MassAction\Actions\MassActionInterface
+     * @return MassActionInterface
      *
      * TODO: Need some clean up and optimization
      */

--- a/src/Oro/Bundle/PimDataGridBundle/Extension/Sorter/Configuration.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Extension/Sorter/Configuration.php
@@ -18,7 +18,7 @@ class Configuration extends OroConfiguration
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $builder = new TreeBuilder('sorters');
 

--- a/src/Oro/Bundle/PimDataGridBundle/Form/Type/DatagridViewType.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Form/Type/DatagridViewType.php
@@ -54,7 +54,7 @@ class DatagridViewType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'pim_datagrid_view';
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/DateTimeNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/DateTimeNormalizer.php
@@ -61,7 +61,7 @@ class DateTimeNormalizer implements NormalizerInterface, CacheableSupportsMethod
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof \DateTimeInterface && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/InternalApi/DatagridViewNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/InternalApi/DatagridViewNormalizer.php
@@ -37,7 +37,7 @@ class DatagridViewNormalizer implements NormalizerInterface, CacheableSupportsMe
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof DatagridView && in_array($format, $this->supportedFormat);
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/FileNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/FileNormalizer.php
@@ -38,7 +38,7 @@ class FileNormalizer implements NormalizerInterface, CacheableSupportsMethodInte
      *
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof MediaValueInterface;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/OptionNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/OptionNormalizer.php
@@ -56,7 +56,7 @@ class OptionNormalizer implements NormalizerInterface, CacheableSupportsMethodIn
      *
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof OptionValueInterface;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/OptionsNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/OptionsNormalizer.php
@@ -51,7 +51,7 @@ class OptionsNormalizer implements NormalizerInterface, CacheableSupportsMethodI
      *
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof OptionsValueInterface;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ProductValuesNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ProductValuesNormalizer.php
@@ -64,7 +64,7 @@ class ProductValuesNormalizer implements NormalizerInterface, SerializerAwareInt
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof WriteValueCollection;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ReferenceDataCollectionNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ReferenceDataCollectionNormalizer.php
@@ -65,7 +65,7 @@ class ReferenceDataCollectionNormalizer implements NormalizerInterface, Cacheabl
      *
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof ReferenceDataCollectionValueInterface;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ReferenceDataNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ReferenceDataNormalizer.php
@@ -59,7 +59,7 @@ class ReferenceDataNormalizer implements NormalizerInterface, CacheableSupportsM
      *
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return 'datagrid' === $format && $data instanceof ReferenceDataValueInterface;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ValueNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/Product/ValueNormalizer.php
@@ -39,7 +39,7 @@ class ValueNormalizer implements NormalizerInterface, CacheableSupportsMethodInt
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ValueInterface && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductAndProductModelRowNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductAndProductModelRowNormalizer.php
@@ -72,7 +72,7 @@ class ProductAndProductModelRowNormalizer implements NormalizerInterface, Normal
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof Row && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductAssociationNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductAssociationNormalizer.php
@@ -66,7 +66,7 @@ class ProductAssociationNormalizer implements NormalizerInterface, SerializerAwa
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ProductInterface && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductModelNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductModelNormalizer.php
@@ -97,7 +97,7 @@ class ProductModelNormalizer implements NormalizerInterface, NormalizerAwareInte
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ProductModelInterface && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductNormalizer.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Normalizer/ProductNormalizer.php
@@ -81,7 +81,7 @@ class ProductNormalizer implements NormalizerInterface, NormalizerAwareInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, $format = null): bool
     {
         return $data instanceof ProductInterface && 'datagrid' === $format;
     }

--- a/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
+++ b/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
@@ -2,6 +2,12 @@
 
 namespace Oro\Bundle\PimDataGridBundle;
 
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddFilterTypesPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddAttributeTypesPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSelectorsPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSortersPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddMassActionHandlersPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\ConfigurationPass;
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -21,11 +27,11 @@ class PimDataGridBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container
-            ->addCompilerPass(new Compiler\AddFilterTypesPass())
-            ->addCompilerPass(new Compiler\AddAttributeTypesPass())
-            ->addCompilerPass(new Compiler\AddSelectorsPass())
-            ->addCompilerPass(new Compiler\AddSortersPass())
-            ->addCompilerPass(new Compiler\AddMassActionHandlersPass())
-            ->addCompilerPass(new Compiler\ConfigurationPass());
+            ->addCompilerPass(new AddFilterTypesPass())
+            ->addCompilerPass(new AddAttributeTypesPass())
+            ->addCompilerPass(new AddSelectorsPass())
+            ->addCompilerPass(new AddSortersPass())
+            ->addCompilerPass(new AddMassActionHandlersPass())
+            ->addCompilerPass(new ConfigurationPass());
     }
 }

--- a/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
+++ b/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
@@ -2,13 +2,13 @@
 
 namespace Oro\Bundle\PimDataGridBundle;
 
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddFilterTypesPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler;
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddAttributeTypesPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddFilterTypesPass;
+use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddMassActionHandlersPass;
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSelectorsPass;
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSortersPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddMassActionHandlersPass;
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\ConfigurationPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 

--- a/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
+++ b/src/Oro/Bundle/PimDataGridBundle/PimDataGridBundle.php
@@ -3,12 +3,6 @@
 namespace Oro\Bundle\PimDataGridBundle;
 
 use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddAttributeTypesPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddFilterTypesPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddMassActionHandlersPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSelectorsPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\AddSortersPass;
-use Oro\Bundle\PimDataGridBundle\DependencyInjection\Compiler\ConfigurationPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,11 +21,11 @@ class PimDataGridBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container
-            ->addCompilerPass(new AddFilterTypesPass())
-            ->addCompilerPass(new AddAttributeTypesPass())
-            ->addCompilerPass(new AddSelectorsPass())
-            ->addCompilerPass(new AddSortersPass())
-            ->addCompilerPass(new AddMassActionHandlersPass())
-            ->addCompilerPass(new ConfigurationPass());
+            ->addCompilerPass(new Compiler\AddFilterTypesPass())
+            ->addCompilerPass(new Compiler\AddAttributeTypesPass())
+            ->addCompilerPass(new Compiler\AddSelectorsPass())
+            ->addCompilerPass(new Compiler\AddSortersPass())
+            ->addCompilerPass(new Compiler\AddMassActionHandlersPass())
+            ->addCompilerPass(new Compiler\ConfigurationPass());
     }
 }

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Oro\Bundle\PimDataGridBundle\Query\Sql;
 
+use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Connection;
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Configuration;
 use Oro\Bundle\DataGridBundle\Provider\ConfigurationProviderInterface;
@@ -113,7 +114,7 @@ class ListProductGridAvailableColumns implements ListProductGridAvailableColumns
      *
      * @return array
      *
-     * @throws \Doctrine\DBAL\DBALException
+     * @throws DBALException
      */
     private function fetchAttributesAsColumn(string $locale, int $limit, int $offset, string $groupCode, string $searchOnLabel): array
     {

--- a/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Query/Sql/ListProductGridAvailableColumns.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Oro\Bundle\PimDataGridBundle\Query\Sql;
 
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DBALException;
 use Oro\Bundle\DataGridBundle\Extension\Formatter\Configuration;
 use Oro\Bundle\DataGridBundle\Provider\ConfigurationProviderInterface;
 use Oro\Bundle\PimDataGridBundle\Query\ListProductGridAvailableColumns as ListProductGridAvailableColumnsQuery;

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductAndProductModelDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductAndProductModelDatasourceSpec.php
@@ -2,8 +2,6 @@
 
 namespace spec\Oro\Bundle\PimDataGridBundle\Datasource;
 
-use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRows;
-use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRowsParameters;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Row;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Rows;
@@ -31,7 +29,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $pqbFactory,
         NormalizerInterface $rowNormalizer,
         ValidatorInterface $validator,
-        FetchProductAndProductModelRows $query
+        Query\FetchProductAndProductModelRows $query
     ) {
         $this->beConstructedWith($objectManager, $pqbFactory, $rowNormalizer, $validator, $query);
 
@@ -59,7 +57,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
     ) {
         $violations = new ConstraintViolationList();
         $validator
-            ->validate(Argument::type(FetchProductAndProductModelRowsParameters::class))
+            ->validate(Argument::type(Query\FetchProductAndProductModelRowsParameters::class))
             ->willReturn($violations);
 
         $config = [
@@ -109,7 +107,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
             'parent_code',
             new WriteValueCollection()
         );
-        $query->__invoke(new FetchProductAndProductModelRowsParameters(
+        $query->__invoke(new Query\FetchProductAndProductModelRowsParameters(
             $pqb->getWrappedObject(),
             ['attribute_1', 'attribute_2'],
             'ecommerce',
@@ -197,7 +195,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([$constraint->getWrappedObject()]);
         $constraint->__toString()->willReturn('error');
         $validator
-            ->validate(Argument::type(FetchProductAndProductModelRowsParameters::class))
+            ->validate(Argument::type(Query\FetchProductAndProductModelRowsParameters::class))
             ->willReturn($violations);
 
 

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductAndProductModelDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/ProductAndProductModelDatasourceSpec.php
@@ -2,6 +2,8 @@
 
 namespace spec\Oro\Bundle\PimDataGridBundle\Datasource;
 
+use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRows;
+use Akeneo\Pim\Enrichment\Component\Product\Grid\Query\FetchProductAndProductModelRowsParameters;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\Query;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Row;
 use Akeneo\Pim\Enrichment\Component\Product\Grid\ReadModel\Rows;
@@ -29,7 +31,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
         ProductQueryBuilderFactoryInterface $pqbFactory,
         NormalizerInterface $rowNormalizer,
         ValidatorInterface $validator,
-        Query\FetchProductAndProductModelRows $query
+        FetchProductAndProductModelRows $query
     ) {
         $this->beConstructedWith($objectManager, $pqbFactory, $rowNormalizer, $validator, $query);
 
@@ -57,7 +59,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
     ) {
         $violations = new ConstraintViolationList();
         $validator
-            ->validate(Argument::type(Query\FetchProductAndProductModelRowsParameters::class))
+            ->validate(Argument::type(FetchProductAndProductModelRowsParameters::class))
             ->willReturn($violations);
 
         $config = [
@@ -107,7 +109,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
             'parent_code',
             new WriteValueCollection()
         );
-        $query->__invoke(new Query\FetchProductAndProductModelRowsParameters(
+        $query->__invoke(new FetchProductAndProductModelRowsParameters(
             $pqb->getWrappedObject(),
             ['attribute_1', 'attribute_2'],
             'ecommerce',
@@ -195,7 +197,7 @@ class ProductAndProductModelDatasourceSpec extends ObjectBehavior
         $violations = new ConstraintViolationList([$constraint->getWrappedObject()]);
         $constraint->__toString()->willReturn('error');
         $validator
-            ->validate(Argument::type(Query\FetchProductAndProductModelRowsParameters::class))
+            ->validate(Argument::type(FetchProductAndProductModelRowsParameters::class))
             ->willReturn($violations);
 
 

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/CategoryType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/CategoryType.php
@@ -23,7 +23,7 @@ class CategoryType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/DateRangeType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/DateRangeType.php
@@ -17,7 +17,7 @@ class DateRangeType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/DateTimeRangeType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/DateTimeRangeType.php
@@ -14,7 +14,7 @@ class DateTimeRangeType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -22,7 +22,7 @@ class DateTimeRangeType extends AbstractType
     /**
      * {@inheritDoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return DateRangeType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/AjaxChoiceFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/AjaxChoiceFilterType.php
@@ -26,7 +26,7 @@ class AjaxChoiceFilterType extends ChoiceFilterType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -34,7 +34,7 @@ class AjaxChoiceFilterType extends ChoiceFilterType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/BooleanFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/BooleanFilterType.php
@@ -27,7 +27,7 @@ class BooleanFilterType extends AbstractChoiceType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -35,7 +35,7 @@ class BooleanFilterType extends AbstractChoiceType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/CategoryFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/CategoryFilterType.php
@@ -27,7 +27,7 @@ class CategoryFilterType extends NumberFilterType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -35,7 +35,7 @@ class CategoryFilterType extends NumberFilterType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return NumberFilterType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/MetricFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/MetricFilterType.php
@@ -22,7 +22,7 @@ class MetricFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -30,7 +30,7 @@ class MetricFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return NumberFilterType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/PriceFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/PriceFilterType.php
@@ -39,7 +39,7 @@ class PriceFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -47,7 +47,7 @@ class PriceFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return NumberFilterType::class;
     }

--- a/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/ScopeFilterType.php
+++ b/src/Oro/Bundle/PimFilterBundle/Form/Type/Filter/ScopeFilterType.php
@@ -32,7 +32,7 @@ class ScopeFilterType extends ChoiceFilterType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return self::NAME;
     }
@@ -40,7 +40,7 @@ class ScopeFilterType extends ChoiceFilterType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return ChoiceFilterType::class;
     }

--- a/src/Oro/Bundle/SecurityBundle/Acl/Domain/RootBasedAclProvider.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Domain/RootBasedAclProvider.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\SecurityBundle\Acl\Domain;
 
+use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
@@ -96,7 +97,7 @@ class RootBasedAclProvider implements AclProviderInterface
      * @param ObjectIdentityInterface $oid
      * @param array $sids
      * @param ObjectIdentityInterface $rootOid
-     * @return RootBasedAclWrapper|\Symfony\Component\Security\Acl\Model\AclInterface
+     * @return RootBasedAclWrapper|AclInterface
      */
     protected function getAcl(ObjectIdentityInterface $oid, array $sids, ObjectIdentityInterface $rootOid)
     {

--- a/src/Oro/Bundle/SecurityBundle/Acl/Domain/RootBasedAclProvider.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Domain/RootBasedAclProvider.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\SecurityBundle\Acl\Domain;
 
-use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
+use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 

--- a/src/Oro/Bundle/SecurityBundle/Acl/Voter/AclVoter.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Voter/AclVoter.php
@@ -54,7 +54,7 @@ class AclVoter extends BaseAclVoter implements PermissionGrantingStrategyContext
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $object, array $attributes): int
     {
         $this->securityToken = $token;
         $this->object = $object instanceof FieldVote

--- a/src/Oro/Bundle/SecurityBundle/Cache/AclAnnotationCacheWarmer.php
+++ b/src/Oro/Bundle/SecurityBundle/Cache/AclAnnotationCacheWarmer.php
@@ -25,7 +25,7 @@ class AclAnnotationCacheWarmer implements CacheWarmerInterface
     /**
      * {inheritdoc}
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): array
     {
         $this->provider->warmUpCache();
     }
@@ -33,7 +33,7 @@ class AclAnnotationCacheWarmer implements CacheWarmerInterface
     /**
      * {inheritdoc}
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }

--- a/src/Oro/Bundle/SecurityBundle/Cache/AclAnnotationCacheWarmer.php
+++ b/src/Oro/Bundle/SecurityBundle/Cache/AclAnnotationCacheWarmer.php
@@ -28,6 +28,8 @@ class AclAnnotationCacheWarmer implements CacheWarmerInterface
     public function warmUp($cacheDir): array
     {
         $this->provider->warmUpCache();
+
+        return [];
     }
 
     /**

--- a/src/Oro/Bundle/SecurityBundle/Cache/ActionMetadataCacheWarmer.php
+++ b/src/Oro/Bundle/SecurityBundle/Cache/ActionMetadataCacheWarmer.php
@@ -25,7 +25,7 @@ class ActionMetadataCacheWarmer implements CacheWarmerInterface
     /**
      * {inheritdoc}
      */
-    public function warmUp($cacheDir)
+    public function warmUp($cacheDir): array
     {
         $this->provider->warmUpCache();
     }
@@ -33,7 +33,7 @@ class ActionMetadataCacheWarmer implements CacheWarmerInterface
     /**
      * {inheritdoc}
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return true;
     }

--- a/src/Oro/Bundle/SecurityBundle/Cache/ActionMetadataCacheWarmer.php
+++ b/src/Oro/Bundle/SecurityBundle/Cache/ActionMetadataCacheWarmer.php
@@ -28,6 +28,8 @@ class ActionMetadataCacheWarmer implements CacheWarmerInterface
     public function warmUp($cacheDir): array
     {
         $this->provider->warmUpCache();
+
+        return [];
     }
 
     /**

--- a/src/Oro/Bundle/SecurityBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/SecurityBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oro_security');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Oro/Bundle/SecurityBundle/DependencyInjection/OroSecurityExtension.php
+++ b/src/Oro/Bundle/SecurityBundle/DependencyInjection/OroSecurityExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\SecurityBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -22,7 +23,7 @@ class OroSecurityExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('ownership.yml');
         $loader->load('services.yml');
     }

--- a/src/Oro/Bundle/SecurityBundle/DependencyInjection/OroSecurityExtension.php
+++ b/src/Oro/Bundle/SecurityBundle/DependencyInjection/OroSecurityExtension.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\SecurityBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**

--- a/src/Oro/Bundle/SecurityBundle/EventSubscriber/FeatureFlagAclPrivilegesEventSubscriber.php
+++ b/src/Oro/Bundle/SecurityBundle/EventSubscriber/FeatureFlagAclPrivilegesEventSubscriber.php
@@ -21,7 +21,7 @@ class FeatureFlagAclPrivilegesEventSubscriber implements EventSubscriberInterfac
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [PrivilegesPostLoadEvent::class => 'disableAclIfFeatureIsDisabled'];
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/AclPermissionType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/AclPermissionType.php
@@ -34,7 +34,7 @@ class AclPermissionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_permission';
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/AclPrivilegeIdentityType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/AclPrivilegeIdentityType.php
@@ -34,7 +34,7 @@ class AclPrivilegeIdentityType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_privilege_identity';
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/AclPrivilegeType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/AclPrivilegeType.php
@@ -63,7 +63,7 @@ class AclPrivilegeType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_privilege';
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/ObjectLabelType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/ObjectLabelType.php
@@ -10,7 +10,7 @@ class ObjectLabelType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_label';
     }
@@ -18,7 +18,7 @@ class ObjectLabelType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return HiddenType::class;
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/PermissionCollectionType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/PermissionCollectionType.php
@@ -24,7 +24,7 @@ class PermissionCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_permission_collection';
     }
@@ -32,7 +32,7 @@ class PermissionCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CollectionType::class;
     }

--- a/src/Oro/Bundle/SecurityBundle/Form/Type/PrivilegeCollectionType.php
+++ b/src/Oro/Bundle/SecurityBundle/Form/Type/PrivilegeCollectionType.php
@@ -24,7 +24,7 @@ class PrivilegeCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'oro_acl_collection';
     }
@@ -32,7 +32,7 @@ class PrivilegeCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
+    public function getParent(): ?string
     {
         return CollectionType::class;
     }

--- a/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
+++ b/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
@@ -2,10 +2,11 @@
 
 namespace Oro\Bundle\SecurityBundle\Twig;
 
+use Twig\Extension\AbstractExtension;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
 use Twig\TwigFunction;
 
-class OroSecurityExtension extends \Twig\Extension\AbstractExtension
+class OroSecurityExtension extends AbstractExtension
 {
     /**
      * @var SecurityFacade

--- a/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
+++ b/src/Oro/Bundle/SecurityBundle/Twig/OroSecurityExtension.php
@@ -2,8 +2,8 @@
 
 namespace Oro\Bundle\SecurityBundle\Twig;
 
-use Twig\Extension\AbstractExtension;
 use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
 class OroSecurityExtension extends AbstractExtension

--- a/src/Oro/Bundle/TranslationBundle/DependencyInjection/Configuration.php
+++ b/src/Oro/Bundle/TranslationBundle/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oro_translation');
         $treeBuilder->getRootNode()

--- a/src/Oro/Bundle/TranslationBundle/DependencyInjection/OroTranslationExtension.php
+++ b/src/Oro/Bundle/TranslationBundle/DependencyInjection/OroTranslationExtension.php
@@ -2,10 +2,10 @@
 
 namespace Oro\Bundle\TranslationBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class OroTranslationExtension extends Extension

--- a/src/Oro/Bundle/TranslationBundle/DependencyInjection/OroTranslationExtension.php
+++ b/src/Oro/Bundle/TranslationBundle/DependencyInjection/OroTranslationExtension.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\TranslationBundle\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -17,7 +18,7 @@ class OroTranslationExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
 
         $container

--- a/tests/back/Platform/Specification/Bundle/NotificationBundle/NotifierSpec.php
+++ b/tests/back/Platform/Specification/Bundle/NotificationBundle/NotifierSpec.php
@@ -32,7 +32,7 @@ class NotifierSpec extends ObjectBehavior
         UserNotificationInterface $userNotification,
         UserInterface $user
     ) {
-        $userProvider->loadUserByUsername('author')->willReturn($user);
+        $userProvider->loadUserByIdentifier('author')->willReturn($user);
         $userNotifFactory->createUserNotification($notification, $user)->willReturn($userNotification);
 
         $notificationSaver->save($notification)->shouldBeCalled();
@@ -50,7 +50,7 @@ class NotifierSpec extends ObjectBehavior
         UserNotificationInterface $userNotification,
         UserInterface $user
     ) {
-        $userProvider->loadUserByUsername()->shouldNotBeCalled();
+        $userProvider->loadUserByIdentifier()->shouldNotBeCalled();
         $userNotifFactory->createUserNotification($notification, $user)->willReturn($userNotification);
 
         $notificationSaver->save($notification)->shouldBeCalled();
@@ -70,10 +70,10 @@ class NotifierSpec extends ObjectBehavior
         UserInterface $user,
         UserInterface $userAuthor
     ) {
-        $userProvider->loadUserByUsername('author')->willReturn($userAuthor);
+        $userProvider->loadUserByIdentifier('author')->willReturn($userAuthor);
         $userNotifFactory->createUserNotification($notification, $userAuthor)->willReturn($userNotificationAuthor);
 
-        $userProvider->loadUserByUsername($user)->shouldNotBeCalled();
+        $userProvider->loadUserByIdentifier($user)->shouldNotBeCalled();
         $userNotifFactory->createUserNotification($notification, $user)->willReturn($userNotification);
 
         $notificationSaver->save($notification)->shouldBeCalled();
@@ -89,7 +89,7 @@ class NotifierSpec extends ObjectBehavior
         NotificationInterface $notification,
         UserInterface $userSystem
     ) {
-        $userSystem->getUsername()->willReturn('system');
+        $userSystem->getUserIdentifier()->willReturn('system');
 
         $userNotifFactory->createUserNotification(Argument::cetera())->shouldNotBeCalled();
 

--- a/tests/back/Platform/Specification/Component/EventQueue/AuthorSpec.php
+++ b/tests/back/Platform/Specification/Component/EventQueue/AuthorSpec.php
@@ -22,7 +22,7 @@ class AuthorSpec extends ObjectBehavior
 
     public function it_does_create_an_author_from_user(UserInterface $user): void
     {
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $user->getFirstName()->willReturn('Julia');
         $user->getLastName()->willReturn('Doe');
         $user->isApiUser()->willReturn(false);
@@ -35,7 +35,7 @@ class AuthorSpec extends ObjectBehavior
 
     public function it_does_create_an_api_author_from_user(UserInterface $user): void
     {
-        $user->getUsername()->willReturn('julia');
+        $user->getUserIdentifier()->willReturn('julia');
         $user->getFirstName()->willReturn('Julia');
         $user->getLastName()->willReturn('Doe');
         $user->isApiUser()->willReturn(true);

--- a/tests/back/UserManagement/Specification/Bundle/Security/JobUserProviderSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/Security/JobUserProviderSpec.php
@@ -8,6 +8,7 @@ use PhpSpec\ObjectBehavior;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\InMemoryUser;
 
 class JobUserProviderSpec extends ObjectBehavior
@@ -28,8 +29,8 @@ class JobUserProviderSpec extends ObjectBehavior
     public function it_throws_an_exception_if_username_does_not_exist(UserRepositoryInterface $userRepository)
     {
         $userRepository->findOneByIdentifier('jean-pacôme')->willReturn(null);
-        $this->shouldThrow(UsernameNotFoundException::class)
-            ->during('loadUserByUsername', ['jean-pacôme']);
+        $this->shouldThrow(UserNotFoundException::class)
+            ->during('loadUserByIdentifier', ['jean-pacôme']);
     }
 
     public function it_throws_an_exception_if_user_is_disabled(UserRepositoryInterface $userRepository, UserInterface $disabledGuy)
@@ -38,15 +39,15 @@ class JobUserProviderSpec extends ObjectBehavior
         $disabledGuy->isEnabled()->willReturn(false);
         $userRepository->findOneByIdentifier('disabled-guy')->willReturn($disabledGuy);
         $this->shouldThrow(DisabledException::class)
-            ->during('loadUserByUsername', ['disabled-guy']);
+            ->during('loadUserByIdentifier', ['disabled-guy']);
     }
 
     public function it_throws_an_exception_if_user_is_api_user(UserRepositoryInterface $userRepository, UserInterface $apiUser)
     {
         $apiUser->isApiUser()->willReturn(true);
         $userRepository->findOneByIdentifier('job-user')->willReturn($apiUser);
-        $this->shouldThrow(UsernameNotFoundException::class)
-            ->during('loadUserByUsername', ['job-user']);
+        $this->shouldThrow(UserNotFoundException::class)
+            ->during('loadUserByIdentifier', ['job-user']);
     }
 
     public function it_refreshes_a_user($userRepository, UserInterface $julia)
@@ -70,7 +71,7 @@ class JobUserProviderSpec extends ObjectBehavior
         $julia->getId()->willReturn(42);
         $userRepository->find(42)->willReturn(null);
 
-        $this->shouldThrow(UsernameNotFoundException::class)
+        $this->shouldThrow(UserNotFoundException::class)
             ->during('refreshUser', [$julia]);
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

 In this PR, we upgraded the raccoon and common maintenance domain to Symfony 6. For V7 release we should make your code compliant with Symfony6. In order to keep ownership to user we migrate code by maintenance domain. All change have been made by rector (committed for now).

TLDR:
- Symfony make her code more strict (return type)
- getUsername have been replaced by getUserIdentifier => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L353-L354
- loadByUsername have been replaced by loadUserByIdentifier => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L12
- Request::MASTER_REQUEST have been replaced by Request::MAIN_REQUEST => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L141
- Kernel.php now use RoutingConfigurator on configureRoute function => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L99
- Make `WarmableInterface::warmUp()` return an array of classes to preload => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L138 => for now return an empty array because we didn't really care about those files => annotation should be trashed

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
