### PR TITLE
OCT-155: order catalog products by uuid

### DIFF
--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductIdentifiersQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductIdentifiersQuery.php
@@ -42,7 +42,6 @@ final class GetProductIdentifiersQuery implements GetProductIdentifiersQueryInte
 
             $pqbOptions['search_after'] = [
                 \strtolower($searchAfterProductIdentifier),
-                \sprintf('product_%s', $searchAfter),
             ];
         }
 

--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQuery.php
@@ -46,7 +46,6 @@ final class GetProductUuidsQuery implements GetProductUuidsQueryInterface
         if (null !== $searchAfter) {
             $pqbOptions['search_after'] = [
                 \sprintf('product_%s', $searchAfter),
-                \sprintf('product_%s', $searchAfter),
             ];
         }
 

--- a/components/catalogs/back/src/Infrastructure/TemporaryEnrichmentBridge/SearchAfterSizeUuidResultCursorFactory.php
+++ b/components/catalogs/back/src/Infrastructure/TemporaryEnrichmentBridge/SearchAfterSizeUuidResultCursorFactory.php
@@ -35,11 +35,13 @@ class SearchAfterSizeUuidResultCursorFactory implements CursorFactoryInterface
     {
         /** @var array{_source: array<string>, sort?: array<string>, size: int} $queryBuilder */
 
+        if (!isset($queryBuilder['sort']) || \count($queryBuilder['sort']) === 0) {
+            throw new \InvalidArgumentException('PQB requires sort to be defined');
+        }
+
         $options = $this->resolveOptions($options);
-        $sort = ['_id' => 'asc'];
 
         $queryBuilder['_source'] = \array_merge($queryBuilder['_source'], ['document_type', 'id']);
-        $queryBuilder['sort'] = isset($queryBuilder['sort']) ? \array_merge($queryBuilder['sort'], $sort) : $sort;
         $queryBuilder['size'] = $options['limit'];
         if (0 !== \count($options['search_after'])) {
             $queryBuilder['search_after'] = $options['search_after'];

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductsActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductsActionTest.php
@@ -26,15 +26,18 @@ class GetProductsActionTest extends IntegrationTestCase
         parent::setUp();
 
         $this->purgeDataAndLoadMinimalCatalog();
+        $this->createUser('admin', ['IT support'], ['ROLE_ADMINISTRATOR']);
     }
 
     public function testItGetsPaginatedProductsByCatalogId(): void
     {
+        $this->logAs('admin'); // Creating products requires an authenticated user with higher permissions
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
+
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
         $this->createCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c', 'Store US', 'shopifi');
         $this->enableCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c');
-        $this->createProduct('blue', [new SetEnabled(true)]);
-        $this->createProduct('green', [new SetEnabled(true)]);
 
         $this->client->request(
             'GET',
@@ -53,17 +56,21 @@ class GetProductsActionTest extends IntegrationTestCase
 
         Assert::assertEquals(200, $response->getStatusCode());
         Assert::assertCount(2, $payload['_embedded']['items']);
-        foreach ($payload['_embedded']['items'] as $product) {
-            Assert::assertTrue(Uuid::isValid($product['uuid']), 'Not a valid UUID');
-            Assert::assertTrue($product['enabled']);
-        }
+
+        $uuids = \array_map(static fn (array $item): string => $item['uuid'], $payload['_embedded']['items']);
+        Assert::assertEquals([
+            '00380587-3893-46e6-a8c2-8fee6404cc9e',
+            '8985de43-08bc-484d-aee0-4489a56ba02d'
+        ], $uuids);
     }
 
     public function testItReturnsAnEmptyListWhenTheCatalogIsDisabled(): void
     {
+        $this->logAs('admin'); // Creating products requires an authenticated user with higher permissions
+        $this->createProduct('blue');
+
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
         $this->createCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c', 'Store US', 'shopifi');
-        $this->createProduct('blue');
 
         $this->client->request(
             'GET',

--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQueryTest.php
@@ -11,6 +11,7 @@ use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Doctrine\DBAL\Connection;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
@@ -47,19 +48,15 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
                 'value' => true,
             ],
         ]);
-        $this->createProduct('tshirt-blue', [new SetEnabled(true)]);
-        $this->createProduct('tshirt-green', [new SetEnabled(true)]);
-        $this->createProduct('tshirt-red', [new SetEnabled(false)]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('c07ad6f1-78a1-4add-84af-3c1d7d8484a3'), [new SetEnabled(false)]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
         $result = $this->query->execute($catalog);
 
         $this->assertEquals([
-            $uuids['tshirt-blue'],
-            $uuids['tshirt-green'],
+            '00380587-3893-46e6-a8c2-8fee6404cc9e',
         ], $result);
     }
 
@@ -77,40 +74,17 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
                 'value' => true,
             ],
         ]);
-        $this->createProduct('tshirt-blue', [new SetEnabled(true)]);
-        $this->createProduct('tshirt-green', [new SetEnabled(true)]);
-        $this->createProduct('tshirt-red', [new SetEnabled(true)]);
-        $this->createProduct('tshirt-yellow', [new SetEnabled(true)]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('c07ad6f1-78a1-4add-84af-3c1d7d8484a3'), [new SetEnabled(true)]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
-        $result = $this->query->execute($catalog, $uuids['tshirt-green'], 1);
+        $result = $this->query->execute($catalog, '00380587-3893-46e6-a8c2-8fee6404cc9e', 1);
 
         $this->assertEquals([
-            $uuids['tshirt-red'],
+            '8985de43-08bc-484d-aee0-4489a56ba02d',
         ], $result);
-    }
-
-    public function testItThrowsWhenTheSearchAfterIsInvalid(): void
-    {
-        $this->createUser('owner');
-        $this->createCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c', 'Store US', 'owner');
-        $this->enableCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c');
-        $this->setCatalogProductSelection('db1079b6-f397-4a6a-bae4-8658e64ad47c', [
-            [
-                'field' => 'enabled',
-                'operator' => Operator::EQUALS,
-                'value' => true,
-            ],
-        ]);
-
-        $this->expectException(\InvalidArgumentException::class);
-
-        $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
-
-        $this->query->execute($catalog, 'invalid_search_after');
     }
 
     public function testItGetsMatchingProductsUuidsWhenUsingScopableAndLocalizableCriterion(): void
@@ -137,24 +111,22 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
                 'locale' => 'fr_FR',
             ],
         ]);
-        $this->createProduct('tshirt-blue', [
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [
             new SetTextValue('name', 'mobile', 'en_US', 'Blue'),
             new SetTextValue('name', 'print', 'en_US', 'Light blue'),
             new SetTextValue('name', 'print', 'fr_FR', 'Bleu clair'),
         ]);
-        $this->createProduct('wrong_blue', [
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [
             new SetTextValue('name', 'mobile', 'fr_FR', 'Bleu clair'), // wrong channel
             new SetTextValue('name', 'print', 'en_US', 'Bleu clair'), // wrong locale
         ]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
         $result = $this->query->execute($catalog);
 
         $this->assertEquals([
-            $uuids['tshirt-blue'],
+            '00380587-3893-46e6-a8c2-8fee6404cc9e',
         ], $result);
     }
 
@@ -174,19 +146,17 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
         ]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:30:00+00:00'));
-        $this->createProduct('tshirt-blue', [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:40:00+00:00'));
-        $this->createProduct('tshirt-green', [new SetEnabled(true)]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
         $result = $this->query->execute($catalog, null, 100, '2022-09-01T17:35:00+02:00');
 
         $this->assertEquals([
-            $uuids['tshirt-green'],
+            '8985de43-08bc-484d-aee0-4489a56ba02d',
         ], $result);
     }
 
@@ -206,19 +176,17 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
         ]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:30:00+00:00'));
-        $this->createProduct('tshirt-blue', [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:40:00+00:00'));
-        $this->createProduct('tshirt-green', [new SetEnabled(true)]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
         $result = $this->query->execute($catalog, null, 100, null, '2022-09-01T17:35:00+02:00');
 
         $this->assertEquals([
-            $uuids['tshirt-blue'],
+            '00380587-3893-46e6-a8c2-8fee6404cc9e',
         ], $result);
     }
 
@@ -238,39 +206,47 @@ class GetProductUuidsQueryTest extends IntegrationTestCase
         ]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:30:00+00:00'));
-        $this->createProduct('tshirt-blue', [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
 
         $this->clock->set(new \DateTimeImmutable('2022-09-01T15:40:00+00:00'));
-        $this->createProduct('tshirt-green', [new SetEnabled(true)]);
-
-        $uuids = $this->getProductIdentifierToUuidMapping();
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
         $result = $this->query->execute($catalog, null, 100, '2022-09-01T17:35:00+02:00', '2022-09-01T17:45:00+02:00');
 
         $this->assertEquals([
-            $uuids['tshirt-green'],
+            '8985de43-08bc-484d-aee0-4489a56ba02d',
         ], $result);
     }
 
-    /**
-     * @return array<string, string>
-     */
-    private function getProductIdentifierToUuidMapping(): array
+    public function testItSortsProductUuids(): void
     {
-        $sql = <<<SQL
-            SELECT BIN_TO_UUID(uuid) AS uuid, identifier
-            FROM pim_catalog_product
-        SQL;
+        $this->createUser('owner');
+        $this->logAs('owner');
 
-        $rows = $this->connection->fetchAllAssociative($sql);
-        $map = [];
+        $this->createCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c', 'Store US', 'owner');
+        $this->enableCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c');
+        $this->setCatalogProductSelection('db1079b6-f397-4a6a-bae4-8658e64ad47c', [
+            [
+                'field' => 'enabled',
+                'operator' => Operator::EQUALS,
+                'value' => true,
+            ],
+        ]);
 
-        foreach ($rows as $row) {
-            $map[$row['identifier']] = $row['uuid'];
-        }
+        $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [new SetEnabled(true)]);
+        $this->createProduct(Uuid::fromString('c07ad6f1-78a1-4add-84af-3c1d7d8484a3'), [new SetEnabled(true)]);
 
-        return $map;
+        $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
+
+        $result = $this->query->execute($catalog);
+
+        $this->assertEquals([
+            '00380587-3893-46e6-a8c2-8fee6404cc9e',
+            '8985de43-08bc-484d-aee0-4489a56ba02d',
+            'c07ad6f1-78a1-4add-84af-3c1d7d8484a3',
+        ], $result);
     }
 }

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -14,8 +14,10 @@ use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
 use Akeneo\Connectivity\Connection\ServiceApi\Service\ConnectedAppFactory;
 use Akeneo\Pim\Enrichment\Component\Product\Model\AbstractProduct;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
@@ -25,6 +27,7 @@ use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
@@ -222,7 +225,7 @@ abstract class IntegrationTestCase extends WebTestCase
     /**
      * @param array<UserIntent> $intents
      */
-    protected function createProduct(string $identifier, array $intents = [], ?int $userId = null): AbstractProduct
+    protected function createProduct(string | UuidInterface $identifier, array $intents = [], ?int $userId = null): AbstractProduct
     {
         $bus = self::getContainer()->get('pim_enrich.product.message_bus');
 
@@ -234,11 +237,22 @@ abstract class IntegrationTestCase extends WebTestCase
 
         Assert::notNull($userId);
 
-        $command = UpsertProductCommand::createWithIdentifier(
-            $userId,
-            ProductIdentifier::fromIdentifier($identifier),
-            $intents
-        );
+        $command = \is_string($identifier) ?
+            UpsertProductCommand::createWithIdentifier(
+                $userId,
+                ProductIdentifier::fromIdentifier($identifier),
+                $intents,
+            ) :
+            UpsertProductCommand::createWithUuid(
+                $userId,
+                ProductUuid::fromUuid($identifier),
+                \array_merge(
+                    [
+                        new SetIdentifierValue('sku', $identifier->toString())
+                    ],
+                    $intents,
+                ),
+            );
 
         $bus->dispatch($command);
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In EE, the order of product UUIDs is not preserved by the query `FetchUserRightsOnProduct`. We had a list ordered by identifier that was suddenly ordered by UUID and the search_after was broken.
see https://github.com/akeneo/pim-enterprise-dev/pull/15212 for the fix on the query.

On top of fixing the issue in EE, I've also changed our ordering from `identifier` to `UUID` since `identifier` will change in the future.

To make tests on this easier, I've added the possibility to create products with UUIDs in the integration tests.
I've updated some of our tests to be more resilient.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
