### PR TITLE
RAB-1115: Launch Symfony upgrade on octopus bounded context

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/WebhookEventBuilder.php
@@ -46,7 +46,7 @@ class WebhookEventBuilder
 
         $eventDataCollection = $eventDataBuilder->build(
             $pimEventBulk,
-            new Context($user->getUsername(), $user->getId(), $context['is_using_uuid'])
+            new Context($user->getUserIdentifier(), $user->getId(), $context['is_using_uuid'])
         );
 
         return $this->buildWebhookEvents(

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/AccessDeniedForRevokedAppTokenEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/AccessDeniedForRevokedAppTokenEventSubscriber.php
@@ -23,7 +23,7 @@ class AccessDeniedForRevokedAppTokenEventSubscriber implements EventSubscriberIn
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [ApiAuthenticationFailedEvent::class => 'throwIfDeniedAccessTokenIsRevoked'];
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/EventSubscriber/GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  */
 class GroupAllIsRemovedFromUsersUsedByAppsOnUpdateEventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [StorageEvents::PRE_SAVE => 'removeGroupAllFromUsersUsedByApps'];
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Install/InstallSubscriber.php
@@ -22,7 +22,7 @@ class InstallSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['updateSchema', -10],

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Normalizer/ViolationListNormalizer.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Normalizer/ViolationListNormalizer.php
@@ -39,7 +39,7 @@ class ViolationListNormalizer implements NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, string $format = null): bool
     {
         return $data instanceof ConstraintViolationListInterface;
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/Install/InstallSubscriber.php
@@ -19,7 +19,7 @@ class InstallSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['updateSchema', -10],

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetAllAppsAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetAllAppsAction.php
@@ -54,7 +54,7 @@ final class GetAllAppsAction
             return new Response(null, Response::HTTP_NO_CONTENT);
         }
 
-        $username = $this->userContext->getUser()->getUsername();
+        $username = $this->userContext->getUser()->getUserIdentifier();
         $analyticsQueryParameters = $this->marketplaceAnalyticsGenerator->getExtensionQueryParameters($username);
         $result = $result->withAnalytics($analyticsQueryParameters);
         $appQueryParameters = $this->appUrlGenerator->getAppQueryParameters();

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetAllExtensionsAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetAllExtensionsAction.php
@@ -46,7 +46,7 @@ final class GetAllExtensionsAction
             return new Response(null, Response::HTTP_NO_CONTENT);
         }
 
-        $username = $this->userContext->getUser()->getUsername();
+        $username = $this->userContext->getUser()->getUserIdentifier();
         $analyticsQueryParameters = $this->marketplaceAnalyticsGenerator->getExtensionQueryParameters($username);
         $result = $result->withAnalytics($analyticsQueryParameters);
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetWebMarketplaceUrlAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Controller/Internal/GetWebMarketplaceUrlAction.php
@@ -30,7 +30,7 @@ final class GetWebMarketplaceUrlAction
             return new RedirectResponse('/');
         }
 
-        $username = $this->userContext->getUser()->getUsername();
+        $username = $this->userContext->getUser()->getUserIdentifier();
         $url = $this->marketplaceUrlGenerator->generateUrl($username);
 
         return new JsonResponse($url);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/Install/InstallSubscriber.php
@@ -23,7 +23,7 @@ class InstallSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['updateSchema', -10],

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Job/PurgeEventsApiLogs.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Job/PurgeEventsApiLogs.php
@@ -8,7 +8,7 @@ use Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persist
 use Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persistence\PurgeEventsApiSuccessLogsQuery;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
-use Symfony\Bridge\Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 /**
  * @author    JM Leroux <jean-marie.leroux@akeneo.com>
@@ -20,7 +20,7 @@ class PurgeEventsApiLogs implements TaskletInterface
     protected StepExecution $stepExecution;
 
     public function __construct(
-        private Logger $logger,
+        private LoggerInterface $logger,
         private PurgeEventsApiSuccessLogsQuery $purgeSuccessLogsQuery,
         private PurgeEventsApiErrorLogsQuery $purgeErrorLogsQuery
     ) {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Install/InstallSubscriber.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/Install/InstallSubscriber.php
@@ -19,7 +19,7 @@ class InstallSubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['updateSchema', -10],

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateConnectedAppWithAuthorizationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/CreateConnectedAppWithAuthorizationHandlerIntegration.php
@@ -193,7 +193,7 @@ class CreateConnectedAppWithAuthorizationHandlerIntegration extends TestCase
 
         $foundUser = $this->userManager->findUserBy(['id' => $foundConnection->userId()->id()]);
         Assert::assertNotNull($foundUser, 'No persisted user found');
-        Assert::assertStringContainsString((string) $foundConnection->code(), $foundUser->getUsername(), 'User is not an app dedicated user');
+        Assert::assertStringContainsString((string) $foundConnection->code(), $foundUser->getUserIdentifier(), 'User is not an app dedicated user');
         Assert::assertEquals($appName, $foundUser->getFullname());
 
         /** @var Collection $userGroups */

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Install/AddAclToRolesIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Install/AddAclToRolesIntegration.php
@@ -32,7 +32,7 @@ class AddAclToRolesIntegration extends TestCase
     public function test_it_adds_acl_to_roles(): void
     {
         $user = $this->createAdminUser();
-        $token = new UsernamePasswordToken($user->getUsername(), null, 'main', $user->getRoles());
+        $token = new UsernamePasswordToken($user->getUserIdentifier(), null, 'main', $user->getRoles());
 
         $isAllowed = $this->accessDecisionManager->decide($token, ['EXECUTE'], new ObjectIdentity('action', 'akeneo_connectivity_connection_manage_apps'));
         $this->assertFalse($isAllowed);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/WebhookEventBuilderSpec.php
@@ -51,7 +51,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
         $user->getId()->willReturn(10);
-        $user->getUsername()->willReturn('ecommerce_0000');
+        $user->getUserIdentifier()->willReturn('ecommerce_0000');
 
         $collection = new EventDataCollection();
         $collection->setEventData($pimEvent, ['data']);
@@ -95,7 +95,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
         $user->getId()->willReturn(10);
-        $user->getUsername()->willReturn('ecommerce_0000');
+        $user->getUserIdentifier()->willReturn('ecommerce_0000');
 
         $collection = new EventDataCollection();
         $collection->setEventDataError($pimEvent, new \Exception());
@@ -130,7 +130,7 @@ class WebhookEventBuilderSpec extends ObjectBehavior
         $pimEventBulk = new BulkEvent([$pimEvent]);
 
         $user->getId()->willReturn(10);
-        $user->getUsername()->willReturn('ecommerce_0000');
+        $user->getUserIdentifier()->willReturn('ecommerce_0000');
 
         $collection = new EventDataCollection();
         $collection->setEventDataError($pimEvent, new \Exception());


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, we upgraded the octopus maintenance domain to Symfony 6. For V7 release we should make your code compliant with Symfony6. In order to keep ownership to user we migrate code by maintenance domain. All change have been made by rector (committed for now).

TLDR:

- Symfony make her code more strict (return type)
- getUsername have been replaced by getUserIdentifier => https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md?plain=1#L353-L354

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
