### PR TITLE
PIM-10673: Added default port to router request context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - PIM-10669: Fix the attribute list does not update if we don't scroll
 - PIM-10655: Fix format of empty completeness in API
 - PIM-10644: Fix identifier format check on multiple product update
+- PIM-10673: Fix media URL port display for Events API
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/FrameworkBundle/PimFrameworkBundle.php
+++ b/src/Akeneo/Platform/Bundle/FrameworkBundle/PimFrameworkBundle.php
@@ -40,10 +40,10 @@ class PimFrameworkBundle extends Bundle
 
             switch (strtolower($scheme)) {
                 case 'https':
-                    $requestContext->setHttpsPort($port);
+                    $requestContext->setHttpsPort($port ?: 443);
                     break;
                 case 'http':
-                    $requestContext->setHttpPort($port);
+                    $requestContext->setHttpPort($port ?: 80);
                     break;
             }
         }


### PR DESCRIPTION
Events API generates a normalized product for the event subscription to send
Naturally, if a product contains media it is normalized, and a [HAL link is generated](https://github.com/akeneo/pim-community-dev/blob/4c20b1011c3cd091f4d00ed8fe36689ff7519dab/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/ExternalApi/ValuesNormalizer.php#L60)
Issue here is that  events API is taking place as part of a CLI command thus Request Context is using `AKENEO_PIM_URL` environment variable to populate itself (instead of $_REQUEST). If `AKENEO_PIM_URL` have no explicit port, the port extracted from it becomes `0` (because of the cast to integer). When [the router generate an absolute URL it appends  the port `0`](https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Routing/Generator/UrlGenerator.php#L251-L263)

This fix adds a failsafe by adding default ports for `HTTP` and `HTTPS` cases