### PR TITLE
PIM-10671: Fix slowness on product association page with a lot of categories

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10671: Fix slowness on product association page with a lot of categories
+
 # 5.0.115 (2022-10-18)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/associations/product.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/associations/product.yml
@@ -3,7 +3,7 @@ extensions:
         module: pim/product-edit-form/product-and-product-model-picker
         config:
             datagridName: association-product-picker-grid
-            categoryTreeRoute: pim_enrich_categorytree
+            categoryTreeRoute: pim_enrich_product_grid_category_tree
             columnName: identifier
             fetcher: product
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Use the product grid category tree route in the association picker, which is way faster than the former route (and is for enrichment anyway). This allows rendering the category picker much faster if there are a lot of categories

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
