### PR TITLE
CXP-1338: Product mapping schema - 404 not found error instead of 500

### DIFF
--- a/components/catalogs/back/src/Application/Handler/DeleteProductMappingSchemaHandler.php
+++ b/components/catalogs/back/src/Application/Handler/DeleteProductMappingSchemaHandler.php
@@ -33,7 +33,7 @@ final class DeleteProductMappingSchemaHandler
             throw new ServiceApiCatalogNotFoundException();
         }
 
-        $this->catalogsMappingStorage->delete(\sprintf('%d_product.json', $catalog->getId()));
+        $this->catalogsMappingStorage->delete(\sprintf('%s_product.json', $catalog->getId()));
 
         $this->upsertCatalogQuery->execute(new Catalog(
             $catalog->getId(),

--- a/components/catalogs/back/src/Application/Handler/GetProductMappingSchemaHandler.php
+++ b/components/catalogs/back/src/Application/Handler/GetProductMappingSchemaHandler.php
@@ -35,7 +35,7 @@ final class GetProductMappingSchemaHandler
             throw new ServiceApiCatalogNotFoundException();
         }
 
-        $productMappingSchemaFile = \sprintf('%d_product.json', $catalog->getId());
+        $productMappingSchemaFile = \sprintf('%s_product.json', $catalog->getId());
 
         if (!$this->catalogsMappingStorage->exists($productMappingSchemaFile)) {
             throw new ServiceApiProductSchemaMappingNotFoundException();

--- a/components/catalogs/back/src/Application/Handler/UpdateProductMappingSchemaHandler.php
+++ b/components/catalogs/back/src/Application/Handler/UpdateProductMappingSchemaHandler.php
@@ -31,7 +31,7 @@ final class UpdateProductMappingSchemaHandler
         }
 
         $this->catalogsMappingStorage->write(
-            \sprintf('%d_product.json', $catalog->getId()),
+            \sprintf('%s_product.json', $catalog->getId()),
             \json_encode($command->getProductMappingSchema(), JSON_THROW_ON_ERROR),
         );
     }

--- a/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductMappingSchemaAction.php
+++ b/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductMappingSchemaAction.php
@@ -6,6 +6,7 @@ namespace Akeneo\Catalogs\Infrastructure\Controller\Public;
 
 use Akeneo\Catalogs\Infrastructure\Security\DenyAccessUnlessGrantedTrait;
 use Akeneo\Catalogs\Infrastructure\Security\GetCurrentUsernameTrait;
+use Akeneo\Catalogs\ServiceAPI\Exception\ProductSchemaMappingNotFoundException as ServiceApiProductSchemaMappingNotFoundException;
 use Akeneo\Catalogs\ServiceAPI\Messenger\QueryBus;
 use Akeneo\Catalogs\ServiceAPI\Model\Catalog;
 use Akeneo\Catalogs\ServiceAPI\Query\GetCatalogQuery;
@@ -47,6 +48,8 @@ final class GetProductMappingSchemaAction
             $productMappingSchema = $this->queryBus->execute(new GetProductMappingSchemaQuery($catalogId));
         } catch (ValidationFailedException $e) {
             throw new ViolationHttpException($e->getViolations());
+        } catch (ServiceApiProductSchemaMappingNotFoundException $e) {
+            throw new NotFoundHttpException(\sprintf('Catalog "%s" does not have a product mapping schema.', $catalogId), $e);
         }
 
         return new JsonResponse($productMappingSchema, Response::HTTP_OK);

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductMappingSchemaActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductMappingSchemaActionTest.php
@@ -141,6 +141,32 @@ class GetProductMappingSchemaActionTest extends IntegrationTestCase
         Assert::assertEquals(404, $response->getStatusCode());
     }
 
+    public function testItReturnsNotFoundWhenCatalogHasNoProductMappingSchema(): void
+    {
+        $this->client = $this->getAuthenticatedPublicApiClient([
+            'read_catalogs',
+        ]);
+        $this->commandBus->execute(new CreateCatalogCommand(
+            'db1079b6-f397-4a6a-bae4-8658e64ad47c',
+            'Store US',
+            'shopifi',
+        ));
+
+        $this->client->request(
+            'GET',
+            '/api/rest/v1/catalogs/db1079b6-f397-4a6a-bae4-8658e64ad47c/mapping-schemas/product',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(404, $response->getStatusCode());
+    }
+
     private function getValidSchemaData(): string
     {
         return <<<'JSON_WRAP'

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -26,6 +26,9 @@ use Akeneo\Test\IntegrationTestsBundle\Helper\ExperimentalTransactionHelper;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
+use League\Flysystem\FileAttributes;
+use League\Flysystem\Filesystem;
+use League\Flysystem\StorageAttributes;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -86,14 +89,32 @@ abstract class IntegrationTestCase extends WebTestCase
 
     protected static function purgeData(): void
     {
+        self::resetCatalogMappingFilesystem();
         $fixturesLoader = self::getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
         $fixturesLoader->purge();
+    }
+
+    protected static function resetCatalogMappingFilesystem(): void
+    {
+        /** @var Filesystem $catalogMappingFilesystem */
+        $catalogMappingFilesystem = self::getContainer()->get('oneup_flysystem.catalogs_mapping_filesystem');
+
+        $paths = $catalogMappingFilesystem->listContents('/')->filter(
+            fn (StorageAttributes $attributes): bool => $attributes instanceof FileAttributes
+        )->map(
+            fn (FileAttributes $attributes): string => $attributes->path()
+        );
+
+        foreach ($paths as $path) {
+            $catalogMappingFilesystem->delete($path);
+        }
     }
 
     protected function purgeDataAndLoadMinimalCatalog(): void
     {
         $catalog = self::getContainer()->get('akeneo_integration_tests.catalogs');
         $configuration = $catalog->useMinimalCatalog();
+        self::resetCatalogMappingFilesystem();
         $fixturesLoader = self::getContainer()->get('akeneo_integration_tests.loader.fixtures_loader');
         $fixturesLoader->load($configuration);
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Fixes:
- GET product mapping schema returns a 404 instead of 500 when there is no product schema
- product schema file name on filesystem (every files had the same name because we casted `uuid string` into `int` in `sprintf`)
- reset catalog mapping file storage between each tests

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
