### PR TITLE
CPM-760: Add uuid validation in ProductProcessor

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/FieldConverter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/FieldConverter.php
@@ -65,10 +65,8 @@ class FieldConverter implements FieldConverterInterface
             return $this->extractGroup($value);
         } elseif ('enabled' === $fieldName) {
             return new ConvertedField($fieldName, (bool) $value);
-        } elseif (in_array($fieldName, ['family', 'parent'])) {
+        } elseif (in_array($fieldName, ['family', 'parent', 'uuid'])) {
             return new ConvertedField($fieldName, $value);
-        } elseif ('uuid' === $fieldName) {
-            return new ConvertedField($fieldName, $value ? Uuid::fromString($value) : $value);
         }
 
         throw new \LogicException(sprintf('No converters found for attribute type "%s"', $fieldName));

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/Denormalizer/ProductProcessor.php
@@ -20,6 +20,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\InvalidArgumentException;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
@@ -79,6 +80,10 @@ class ProductProcessor extends AbstractProcessor implements ItemProcessorInterfa
         $convertVariantToSimple = $jobParameters->get('convertVariantToSimple');
         if (true !== $convertVariantToSimple && '' === $parentProductModelCode) {
             unset($item['parent']);
+        }
+
+        if (\key_exists('uuid', $item) && $item['uuid'] !== '' && !Uuid::isValid($item['uuid'])) {
+            $this->skipItemWithMessage($item, 'The uuid must be valid');
         }
 
         try {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Denormalizer/ProductProcessorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/Processor/Denormalizer/ProductProcessorSpec.php
@@ -865,6 +865,44 @@ class ProductProcessorSpec extends ObjectBehavior
             ->shouldReturn(null);
     }
 
+    function it_skips_a_product_when_uuid_is_not_valid($stepExecution, JobParameters $jobParameters)
+    {
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
+        $jobParameters->get('enabledComparison')->willReturn(true);
+        $jobParameters->get('familyColumn')->willReturn('family');
+        $jobParameters->get('categoriesColumn')->willReturn('categories');
+        $jobParameters->get('groupsColumn')->willReturn('groups');
+        $jobParameters->get('enabled')->willReturn(true);
+        $jobParameters->get('decimalSeparator')->willReturn('.');
+        $jobParameters->get('dateFormat')->willReturn('yyyy-MM-dd');
+        $jobParameters->get('convertVariantToSimple')->willReturn(false);
+
+        $convertedData = [
+            'identifier' => 'identifier',
+            'uuid' => 'invalid_uuid',
+            'values'     => [
+                'sku' => [
+                    [
+                        'locale' => null,
+                        'scope' =>  null,
+                        'data' => 'identifier'
+                    ],
+                ]
+            ],
+            'family' => 'Tshirt'
+        ];
+
+        $stepExecution->incrementSummaryInfo('skip')->shouldBeCalled();
+        $stepExecution->getSummaryInfo('item_position')->shouldBeCalled();
+
+        $this
+            ->shouldThrow(InvalidItemException::class)
+            ->during(
+                'process',
+                [$convertedData]
+            );
+    }
+
     function it_updates_an_existing_product_and_does_not_change_his_state(
         $productToImport,
         $productUpdater,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Instead of converting imported string to uuid, check it in the product processor and skip it when not valid
![Screenshot from 2022-10-21 10-56-29](https://user-images.githubusercontent.com/42606611/197156418-b1d4502b-4dc3-413f-be1a-938177a1c888.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
