### PR TITLE
CPM-735: Fix react-query cache config

### DIFF
--- a/components/identifier-generator/front/src/feature/IdentifierGeneratorApp.tsx
+++ b/components/identifier-generator/front/src/feature/IdentifierGeneratorApp.tsx
@@ -3,7 +3,15 @@ import {HashRouter as Router, Route, Switch} from 'react-router-dom';
 import {Edit, List} from './controllers';
 import {QueryClient, QueryClientProvider} from 'react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: false,
+      staleTime: Infinity,
+    },
+  },
+});
 
 const IdentifierGeneratorApp: React.FC = () => {
   return (

--- a/components/identifier-generator/front/src/feature/hooks/useIdentifierAttributes.ts
+++ b/components/identifier-generator/front/src/feature/hooks/useIdentifierAttributes.ts
@@ -21,12 +21,7 @@ const useIdentifierAttributes: () => {
 
   const {error, data, isSuccess} = useQuery<FlattenAttribute[], Error, FlattenAttribute[]>(
     'getIdentifierAttributes',
-    getIdentifierAttributes,
-    {
-      keepPreviousData: true,
-      refetchOnWindowFocus: false,
-      retry: false,
-    }
+    getIdentifierAttributes
   );
 
   return {data, error, isSuccess};

--- a/components/identifier-generator/front/src/feature/hooks/useUiLocales.ts
+++ b/components/identifier-generator/front/src/feature/hooks/useUiLocales.ts
@@ -19,11 +19,7 @@ const useUiLocales: () => {
     });
   };
 
-  const {error, data, isSuccess} = useQuery<UiLocale[], Error, UiLocale[]>('getUiLocales', getUiLocales, {
-    keepPreviousData: true,
-    refetchOnWindowFocus: false,
-    retry: false,
-  });
+  const {error, data, isSuccess} = useQuery<UiLocale[], Error, UiLocale[]>('getUiLocales', getUiLocales);
 
   return {data, error, isSuccess};
 };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Using react-query, the queries should not be retrieved multiple times with the same props.
Before: the queryClient was not well configured to have that behavior because staleTime is set to 0 minutes as default value.
Now: staleTime is infinite, so that the queryClient keeps infinitly the cached queries

+ adding global settings inside QueryClient initialization

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
