### PR TITLE
CPM-771: Fix product creation without sku

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -142,7 +142,7 @@ class ProductController
         $violations = $this->validator->validate($product);
 
         if (0 === $violations->count()) {
-            $this->productSaver->save($product, ['force_save' => true]);
+            $this->productSaver->save($product);
 
             return new JsonResponse($this->normalizer->normalize(
                 $product,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/ProductController.php
@@ -142,7 +142,7 @@ class ProductController
         $violations = $this->validator->validate($product);
 
         if (0 === $violations->count()) {
-            $this->productSaver->save($product);
+            $this->productSaver->save($product, ['force_save' => true]);
 
             return new JsonResponse($this->normalizer->normalize(
                 $product,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Model/AbstractProduct.php
@@ -81,6 +81,7 @@ abstract class AbstractProduct implements ProductInterface
         $this->associations = new ArrayCollection();
         $this->uniqueData = new ArrayCollection();
         $this->quantifiedAssociationCollection = QuantifiedAssociationCollection::createFromNormalized([]);
+        $this->dirty = true;
     }
 
     /**

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/ProductCreationEndToEnd.php
@@ -42,6 +42,14 @@ class ProductCreationEndToEnd extends InternalApiTestCase
         $this->assertEquals($identifier, $createdProduct[0]->identifier());
     }
 
+    public function testThatWeCanCreateAProductWithoutIdentifier(): void
+    {
+        $previousCount = $this->getProductsCount();
+        $this->createProductWithInternalApi('');
+
+        $this->assertEquals($previousCount + 1, $this->getProductsCount());
+    }
+
     private function createProductWithInternalApi(string $identifier): void
     {
         $this->client->request(
@@ -88,5 +96,14 @@ SQL;
                 ['identifiers' => Connection::PARAM_STR_ARRAY]
             )
         );
+    }
+
+    private function getProductsCount(): int
+    {
+        $sql = <<<SQL
+SELECT COUNT(1) FROM pim_catalog_product
+SQL;
+
+        return \intval(self::getContainer()->get('database_connection')->executeQuery($sql)->fetchOne());
     }
 }


### PR DESCRIPTION
When saving a product without data, it is still marked as "not dirty", so it's not saved.
By forcing the save, the product is saved.