### PR TITLE
CPM-766: Fix duplicate to allow empty identifier

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/form/creation/identifier.js
@@ -33,6 +33,8 @@ define([
           return this;
         }
 
+        this.updateModel({target: {value: this.getFormData()[this.identifier] || ''}});
+
         return FetcherRegistry.getFetcher('attribute')
           .getIdentifierAttribute()
           .then(


### PR DESCRIPTION
If we didn't send anything to the backend, it fails because it needs a value (null or "").
I have no idea how to add a test for this part @cemorin 