### PR TITLE
PH-269: Extract `akeneo:connectivity-audit:update-data` logic

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/Command/UpdateAuditDataCommand.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/Command/UpdateAuditDataCommand.php
@@ -4,26 +4,22 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Infrastructure\Audit\Command;
 
-use Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountCommand;
-use Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountHandler;
-use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\PurgeAuditProductQueryInterface;
-use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
-use Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalSelectHourlyIntervalsToRefreshQuery;
 use Akeneo\Connectivity\Connection\Infrastructure\Audit\UpdateAuditData;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @author Romain Monceau <romain@akeneo.com>
+ * @author    Romain Monceau <romain@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
- * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 class UpdateAuditDataCommand extends Command
 {
     protected static $defaultName = 'akeneo:connectivity-audit:update-data';
 
-    public function __construct(private UpdateAuditData $updateAuditData) {
+    public function __construct(private UpdateAuditData $updateAuditData)
+    {
         parent::__construct();
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/UpdateAuditData.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/UpdateAuditData.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Audit;
+
+use Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountCommand;
+use Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountHandler;
+use Akeneo\Connectivity\Connection\Domain\Audit\Persistence\PurgeAuditProductQueryInterface;
+use Akeneo\Connectivity\Connection\Domain\ValueObject\HourlyInterval;
+use Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalSelectHourlyIntervalsToRefreshQuery;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @author JM Leroux <jean-marie.leroux@akneo.com>
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class UpdateAuditData
+{
+    public function __construct(
+        private UpdateDataSourceProductEventCountHandler $updateDataSourceProductEventCountHandler,
+        private DbalSelectHourlyIntervalsToRefreshQuery $selectHourlyIntervalsToRefreshQuery,
+        private PurgeAuditProductQueryInterface $purgeQuery,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function execute(): void
+    {
+        $this->logger->info('Start audit data purge');
+
+        $this->purgeOlderThanXDays(10);
+
+        // Create a Command for the previous hour.
+        $previousHourlyInterval = HourlyInterval::createFromDateTime(
+            new \DateTimeImmutable('now -1 hour', new \DateTimeZone('UTC'))
+        );
+        $this->updateProductEventCount($previousHourlyInterval);
+
+        // Create a Command for the previous hour.
+        $previousHourlyInterval = HourlyInterval::createFromDateTime(
+            new \DateTimeImmutable('now -1 hour', new \DateTimeZone('UTC'))
+        );
+        $this->updateProductEventCount($previousHourlyInterval);
+
+        // Create a Command for the current hour.
+        $currentHourlyInterval = HourlyInterval::createFromDateTime(
+            new \DateTimeImmutable('now', new \DateTimeZone('UTC'))
+        );
+        $this->updateProductEventCount($currentHourlyInterval);
+
+        /*
+         * Create a Command for each hour retrieved from events that are not yet complete.
+         * I.e., the last update happened before the end of the event and need to be updated again.
+         */
+        $hourlyIntervalsToRefresh = $this->selectHourlyIntervalsToRefreshQuery->execute();
+        foreach ($hourlyIntervalsToRefresh as $hourlyInterval) {
+            // Ignore the current and previous hour; already added.
+            if (true === $currentHourlyInterval->equals($hourlyInterval)
+                || true === $previousHourlyInterval->equals($hourlyInterval)
+            ) {
+                continue;
+            }
+
+            $this->updateProductEventCount($hourlyInterval);
+        }
+
+        $this->logger->info('End audit data purge');
+    }
+
+    private function purgeOlderThanXDays(int $days): void
+    {
+        $before = new \DateTimeImmutable("now - $days days", new \DateTimeZone('UTC'));
+        $before = $before->setTime((int) $before->format('H'), 0, 0);
+
+        $this->purgeQuery->execute($before);
+    }
+
+    private function updateProductEventCount(HourlyInterval $hourlyInterval): void
+    {
+        $this->updateDataSourceProductEventCountHandler->handle(
+            new UpdateDataSourceProductEventCountCommand($hourlyInterval)
+        );
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/UpdateAuditData.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Audit/UpdateAuditData.php
@@ -12,9 +12,9 @@ use Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalSelectHo
 use Psr\Log\LoggerInterface;
 
 /**
- * @author JM Leroux <jean-marie.leroux@akneo.com>
+ * @author    JM Leroux <jean-marie.leroux@akneo.com>
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
- * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 final class UpdateAuditData
 {

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/DependencyInjection/AkeneoConnectivityConnectionExtension.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/DependencyInjection/AkeneoConnectivityConnectionExtension.php
@@ -38,6 +38,7 @@ class AkeneoConnectivityConnectionExtension extends Extension
         $loader->load('Audit/handlers.yml');
         $loader->load('Audit/install.yml');
         $loader->load('Audit/persistence.yml');
+        $loader->load('Audit/services.yml');
 
         $loader->load('Connections/command.yml');
         $loader->load('Connections/controllers.yml');

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/commands.yml
@@ -7,8 +7,6 @@ services:
 
     Akeneo\Connectivity\Connection\Infrastructure\Audit\Command\UpdateAuditDataCommand:
         arguments:
-            - '@Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountHandler'
-            - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalSelectHourlyIntervalsToRefreshQuery'
-            - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalPurgeAuditProductQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\UpdateAuditData'
         tags:
             - { name: 'console.command' }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/services.yml
@@ -1,0 +1,7 @@
+services:
+    Akeneo\Connectivity\Connection\Infrastructure\Audit\UpdateAuditData:
+        arguments:
+            - '@Akeneo\Connectivity\Connection\Application\Audit\Command\UpdateDataSourceProductEventCountHandler'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalSelectHourlyIntervalsToRefreshQuery'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\DbalPurgeAuditProductQuery'
+            - '@logger'


### PR DESCRIPTION
Extract `akeneo:connectivity-audit:update-data` logic into a dedicated service.
This will allow to reuse this logic easilly, like in scheduled jobs for UCS.

I also add a few logs for observability.