### PR TITLE
CPM-779: Allow uppercase in uuid inputs

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/external_api/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/external_api/product.yml
@@ -41,7 +41,7 @@ pim_api_product_uuid_delete:
         _format: json
     methods: [DELETE]
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 pim_api_product_uuid_list:
     path: /products-uuid
@@ -57,7 +57,7 @@ pim_api_product_uuid_get:
         _format: json
     methods: [GET]
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 pim_api_product_uuid_create:
     path: /products-uuid
@@ -73,7 +73,7 @@ pim_api_product_uuid_partial_update:
         _format: json
     methods: [PATCH]
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 
 pim_api_product_uuid_partial_update_list:
     path: /products-uuid

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/internal_api/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/internal_api/product.yml
@@ -2,7 +2,7 @@ pim_enrich_product_category_rest_list:
     path: /rest/{uuid}/categories
     defaults: { _controller: pim_enrich.controller.rest.product_category:listAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET]
 
 pim_enrich_product_rest_index:
@@ -14,7 +14,7 @@ pim_enrich_product_rest_get:
     path: /rest/{uuid}
     defaults: { _controller: pim_enrich.controller.rest.product:getAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET]
 
 pim_enrich_product_rest_create:
@@ -26,21 +26,21 @@ pim_enrich_product_rest_post:
     path: /rest/{uuid}
     defaults: { _controller: Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi\Product\UpdateProductController }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [POST]
 
 pim_enrich_product_rest_remove:
     path: /rest/{uuid}
     defaults: { _controller: pim_enrich.controller.rest.product:removeAction, _format: json }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [DELETE]
 
 pim_enrich_product_remove_attribute_rest:
     path: /rest/{uuid}/{attributeId}
     defaults: { _controller: pim_enrich.controller.rest.product:removeAttributeAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
         attributeId: '\d+'
     methods: [DELETE]
 
@@ -48,28 +48,28 @@ pim_enrich_product_rest_convert_to_simple:
     path: /rest/{uuid}/convert-to-simple
     defaults: { _controller: pim_enrich.controller.rest.product:convertToSimpleProductAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [POST]
 
 pim_enrich_product_comments_rest_get:
     path: /{uuid}/comments
     defaults: { _controller: pim_enrich.controller.rest.product_comment:getAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET]
 
 pim_enrich_product_comments_rest_post:
     path: /{uuid}/comments
     defaults: { _controller: pim_enrich.controller.rest.product_comment:postAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [POST]
 
 pim_enrich_product_comment_reply_rest_post:
     path: /{uuid}/comments/{commentId}
     defaults: { _controller: pim_enrich.controller.rest.product_comment:postReplyAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
         commentId: '[0-9a-f]+'
     methods: [POST]
 
@@ -77,12 +77,12 @@ pim_enrich_product_history_rest_get:
     path: /rest/product/{entityId}/history
     defaults: { _controller: pim_enrich.controller.rest.versioning:getAction, entityType: product }
     requirements:
-        entityId: '[0-9a-f]+|([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})'
+        entityId: '[0-9a-f]+|([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})'
     methods: [GET]
 
 pim_pdf_generator_download_product_pdf:
     path: /{uuid}/download-pdf
     defaults: { _controller: pim_pdf_generator.controller.product:downloadPdfAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET]

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/ui/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/routing/ui/product.yml
@@ -4,26 +4,26 @@ pim_enrich_product_index:
 pim_enrich_product_edit:
     path: /{uuid}
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET, POST]
 
 pim_enrich_product_edit_categories:
     path: /categories/{uuid}
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [GET]
 
 pim_enrich_product_toggle_status:
     path: /{uuid}/toggle-status
     defaults: { _controller: pim_enrich.controller.product:toggleStatusAction }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
     methods: [POST]
 
 pim_enrich_product_listcategories:
     path: /list-categories/product/{uuid}/parent/{categoryId}
     defaults: { _controller: pim_enrich.controller.product:listCategoriesAction, _format: json }
     requirements:
-        uuid: '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+        uuid: '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
         categoryId: \d+
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductsByUuidQueryHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/ListProductsByUuidQueryHandler.php
@@ -17,6 +17,7 @@ use Akeneo\Tool\Component\Api\Exception\InvalidQueryException;
 use Akeneo\Tool\Component\Api\Pagination\PaginationTypes;
 use Akeneo\Tool\Component\StorageUtils\Exception\PropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -109,7 +110,8 @@ final class ListProductsByUuidQueryHandler
         if (null !== $query->searchAfter) {
             // @see ListProductsQueryHandler comment
             $pqbOptions['search_after_unique_key'] = 'product_z';
-            $pqbOptions['search_after'] = [sprintf('product_%s', $query->searchAfter)];
+            $searchAfter = Uuid::isValid($query->searchAfter) ? Uuid::fromString($query->searchAfter)->toString() : $query->searchAfter;
+            $pqbOptions['search_after'] = [sprintf('product_%s', $searchAfter)];
         }
 
         return $this->searchAfterPqbFactory->create($pqbOptions);

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Tool\Bundle\ApiBundle\Stream;
 
 use Akeneo\Pim\Enrichment\Component\Product\Validator\UniqueValuesSet;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -80,12 +81,17 @@ final class StreamResourceResponse
                         throw new UnprocessableEntityHttpException(sprintf('%s is missing.', ucfirst($this->identifierKey)));
                     }
 
+                    $identifierToReturn = $data[$this->identifierKey];
+                    if (Uuid::isValid($identifierToReturn)) {
+                        $identifierToReturn = Uuid::fromString($identifierToReturn)->toString();
+                    }
+
                     $response = [
                         'line'               => $lineNumber,
-                        $this->identifierKey => $data[$this->identifierKey],
+                        $this->identifierKey => $identifierToReturn,
                     ];
 
-                    $uriParameters[$this->uriParamName]  = $data[$this->identifierKey];
+                    $uriParameters[$this->uriParamName] = $data[$this->identifierKey];
                     $subResponse = $this->forward($uriParameters, $line);
 
                     if ('' !== $subResponse->getContent()) {

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/CreateProductWithUuidEndToEnd.php
@@ -816,6 +816,36 @@ JSON;
         $this->assertSame($this->getProductUuidFromIdentifier('foo')->toString(), 'a48ca2b8-656d-4b2c-b9cc-b2243e876ebf');
     }
 
+    public function testItCreatesWithUppercaseUuid()
+    {
+        $client = $this->createAuthenticatedClient();
+
+        $data =
+            <<<JSON
+    {
+        "uuid": "A48CA2B8-656D-4b2c-b9cc-b2243e876ebf",
+        "values": {
+            "sku": [
+                {"locale": null, "scope": null, "data": "foo"}
+            ]
+        }
+    }
+JSON;
+
+        $client->request('POST', 'api/rest/v1/products-uuid', [], [], [], $data);
+        $response = $client->getResponse();
+
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+        $this->assertArrayHasKey('location', $response->headers->all());
+        $this->assertSame(
+            'http://localhost/api/rest/v1/products-uuid/a48ca2b8-656d-4b2c-b9cc-b2243e876ebf',
+            $response->headers->get('location')
+        );
+
+        $this->assertSame($this->getProductUuidFromIdentifier('foo')->toString(), 'a48ca2b8-656d-4b2c-b9cc-b2243e876ebf');
+    }
+
     public function testResponseWhenIdentifierIsFilled()
     {
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/DeleteProductWithUuidEndToEnd.php
@@ -42,6 +42,21 @@ class DeleteProductWithUuidEndToEnd extends AbstractProductTestCase
         $this->assertEventCount(1, ProductRemoved::class);
     }
 
+    public function testDeleteAProductByUppercaseUuid()
+    {
+        $this->createAdminUser();
+        $client = $this->createAuthenticatedClient();
+
+        $testProduct = $this->createProduct('test_uuid', []);
+        $this->assertCount(8, $this->get('pim_catalog.repository.product')->findAll());
+
+        $this->get('pim_catalog.elasticsearch.indexer.product')->indexFromProductUuids([$testProduct->getUuid()]);
+        $client->request('DELETE', 'api/rest/v1/products-uuid/' . \strtoupper($testProduct->getUuid()->toString()));
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+    }
+
     public function testProductUuidNotFound()
     {
         $this->createAdminUser();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductWithUuidEndToEnd.php
@@ -202,6 +202,20 @@ class GetProductWithUuidEndToEnd extends AbstractProductTestCase
         $this->assertResponse($response, $standardProduct);
     }
 
+    public function test_it_gets_a_product_with_uppercase_uuid()
+    {
+        $product = $this->createProduct('product', [new SetFamily('familyA1')]);
+
+        $client = $this->createAuthenticatedClient();
+        $client->request(
+            'GET',
+            sprintf('api/rest/v1/products-uuid/%s', \strtoupper($product->getUuid()->toString()))
+        );
+
+        $response = $client->getResponse();
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+    }
+
     public function test_it_throws_a_404_response_when_the_product_is_not_found()
     {
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductsWithUuidEndToEnd.php
@@ -794,12 +794,22 @@ JSON;
 }
 JSON;
 
-        $expected = \strtr($expected, [
+        $this->assertListResponse($client->getResponse(), \strtr($expected, [
             '{searchAfterProductUuid}' => $sortedProducts[$searchAfterIndex]->getUuid()->toString(),
             '{lastProductUuid}' => $sortedProducts[$searchAfterIndex + 3]->getUuid()->toString(),
-        ]);
+        ]), false);
 
-        $this->assertListResponse($client->getResponse(), $expected, false);
+        // check that the search_after param is case-insensitive
+        $client->restart();
+        $client->request('GET', sprintf(
+            'api/rest/v1/products-uuid?pagination_type=search_after&limit=3&search_after=%s',
+            \mb_strtoupper($sortedProducts[$searchAfterIndex]->getUuid()->toString())
+        ));
+
+        $this->assertListResponse($client->getResponse(), \strtr($expected, [
+            '{searchAfterProductUuid}' => \mb_strtoupper($sortedProducts[$searchAfterIndex]->getUuid()->toString()),
+            '{lastProductUuid}' => $sortedProducts[$searchAfterIndex + 3]->getUuid()->toString(),
+        ]), false);
     }
 
     public function testSearchAfterPaginationLastPageOfTheListOfProducts()

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
@@ -35,10 +35,12 @@ class PartialUpdateListProductWithUuidEndToEnd extends AbstractProductTestCase
     public function testCreateAndUpdateAListOfProducts()
     {
         $uuid = Uuid::uuid4();
+        $uppercaseUuid = \strtoupper($uuid->toString());
+        $productFamilyUppercaseUuid = \strtoupper($this->productFamilyUuid->toString());
         $data =
 <<<JSON
-    {"uuid": "{$this->productFamilyUuid->toString()}", "family": "familyA1", "values": {"sku": [{"locale": null, "scope": null, "data": "product_family" }]}}
-    {"uuid": "{$uuid->toString()}", "family": "familyA2", "values": {"sku": [{"locale": null, "scope": null, "data": "my_identifier" }]}}
+    {"uuid": "$productFamilyUppercaseUuid", "family": "familyA1", "values": {"sku": [{"locale": null, "scope": null, "data": "product_family" }]}}
+    {"uuid": "$uppercaseUuid", "family": "familyA2", "values": {"sku": [{"locale": null, "scope": null, "data": "my_identifier" }]}}
 JSON;
 
         $expectedContent =

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateProductWithUuidEndToEnd.php
@@ -109,6 +109,29 @@ JSON;
         $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
     }
 
+    public function testCreateProductWithSameUppercaseUuid()
+    {
+        $client = $this->createAuthenticatedClient();
+        $uuid = Uuid::uuid4();
+        $uuidString = \strtoupper($uuid->toString());
+
+        $data =
+            <<<JSON
+    {
+        "uuid": "$uuidString",
+        "values": {
+            "sku": [{ "locale": null, "scope": null, "data": "new_identifier" }]
+        }
+    }
+JSON;
+
+        $client->request('PATCH', sprintf('api/rest/v1/products-uuid/%s', $uuidString), [], [], [], $data);
+
+        $response = $client->getResponse();
+        $this->assertSame('', $response->getContent());
+        $this->assertSame(Response::HTTP_CREATED, $response->getStatusCode());
+    }
+
     public function testCreateProductWithDifferentUuid()
     {
         $client = $this->createAuthenticatedClient();

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/InternalApi/DownloadProductPdfEndToEnd.php
@@ -51,6 +51,31 @@ class DownloadProductPdfEndToEnd extends InternalApiTestCase
         Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
     }
 
+    public function test_it_downloads_a_pdf_for_a_product_with_an_image_with_uppercase_uuid(): void
+    {
+        $product = $this->createProduct(
+            'simple',
+            'familyA',
+            [
+                new SetImageValue(
+                    'an_image',
+                    null,
+                    null,
+                    $this->getFileInfoKey($this->getFixturePath('akeneo.jpg')))
+            ]
+        );
+
+        $url = $this->getRouter()->generate('pim_pdf_generator_download_product_pdf', [
+            'uuid' => \strtoupper($product->getUuid()->toString()),
+            'dataLocale' => 'en_US',
+            'dataScope' => 'ecommerce',
+        ]);
+
+        $this->client->request('GET', $url);
+
+        Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+    }
+
     public function test_it_downloads_a_pdf_for_a_product_without_family(): void
     {
         $product = $this->createProduct('simple', null, []);


### PR DESCRIPTION
The RFC [RFC 4122: A Universally Unique IDentifier (UUID) URN Namespace](https://www.rfc-editor.org/rfc/rfc4122#section-3)
says that a uuid should be displayed with lowercase only.

But each input should accept uuid with 1 or more letter with uppercase, like “B9146fca-5456-433a-9360-27273258fcbC”