### PR TITLE
PIM-10674: Add possibility to send a loading method on Card component

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Card/Card.unit.tsx
+++ b/front-packages/akeneo-design-system/src/components/Card/Card.unit.tsx
@@ -135,6 +135,18 @@ test('it displays a stack style when the card is marked as stacked', () => {
   expect(screen.getByTestId('stack')).toBeInTheDocument();
 });
 
+test('Card supports forwardRef', () => {
+  const ref = {current: null};
+
+  render(
+    <Card src="some.jpg" ref={ref}>
+      Card text
+    </Card>
+  );
+
+  expect(ref.current).not.toBe(null);
+});
+
 test('Card supports ...rest props', () => {
   render(
     <Card src="some.jpg" data-testid="my_value">


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR I modified the Card component in order to :
- Have the possibility to give a ref, for example to detect if the component is in the user screen
- Add a props called `loading` that indicates how the browser should load the card image

In order to ease the review you can `Hide whitespace`
![Screenshot from 2022-10-26 16-35-07](https://user-images.githubusercontent.com/7239572/198055490-0a8c80b1-ec7b-43f2-8808-1be3b3a45e7f.png)

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
