### PR TITLE
RAB-1127: [php 8.0 => 8.1] update image

### DIFF
--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -175,7 +175,7 @@ jobs:
                             command: |
                                 ls php-pim-image.tar && docker load -i php-pim-image.tar
                                 ls php-pim-image.tar || make php-image-dev
-                                ls php-pim-image.tar || docker save -o php-pim-image.tar akeneo/pim-dev/php:8.0
+                                ls php-pim-image.tar || docker save -o php-pim-image.tar akeneo/pim-dev/php:8.1
                       - save_cache:
                             name: Save PHP docker image cache
                             key: php-docker-image-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/php-docker-image.hash" }}

--- a/.circleci/jobs/build_and_deploy.yml
+++ b/.circleci/jobs/build_and_deploy.yml
@@ -550,11 +550,11 @@ jobs:
                   at: ~/
             - run:
                   name: Build Akeneo PHP image
-                  command: docker build -t akeneo/pim-php-dev:master .
+                  command: docker build -t akeneo/pim-php-dev:8.1 .
             - run:
                   name: Display PHP version
                   command: |
-                      docker run --rm akeneo/pim-php-dev:master php -v
+                      docker run --rm akeneo/pim-php-dev:8.1 php -v
             - run:
                   name: Build Akeneo Node image
                   command: docker build -t akeneo/node:16 -f docker/Dockerfile_node .
@@ -567,5 +567,5 @@ jobs:
                   name: Push images to Dockerhub
                   command: |
                       docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PWD"
-                      docker push akeneo/pim-php-dev:master
+                      docker push akeneo/pim-php-dev:8.1
                       docker push akeneo/node:16

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update && \
         default-mysql-client \
         git \
         perceptualdiff \
-        php8.0-xdebug \
+        php8.1-xdebug \
         procps \
         unzip &&\
     apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,35 +19,35 @@ RUN echo 'APT::Install-Recommends "0" ; APT::Install-Suggests "0" ;' > /etc/apt/
     apt-get --yes install imagemagick \
         libmagickcore-6.q16-6-extra \
         ghostscript \
-        php8.0-fpm \
-        php8.0-cli \
-        php8.0-intl \
-        php8.0-opcache \
-        php8.0-mysql \
-        php8.0-zip \
-        php8.0-xml \
-        php8.0-gd \
-        php8.0-grpc \
-        php8.0-curl \
-        php8.0-mbstring \
-        php8.0-bcmath \
-        php8.0-imagick \
-        php8.0-apcu \
-        php8.0-exif \
+        php8.1-fpm \
+        php8.1-cli \
+        php8.1-intl \
+        php8.1-opcache \
+        php8.1-mysql \
+        php8.1-zip \
+        php8.1-xml \
+        php8.1-gd \
+        php8.1-grpc \
+        php8.1-curl \
+        php8.1-mbstring \
+        php8.1-bcmath \
+        php8.1-imagick \
+        php8.1-apcu \
+        php8.1-exif \
+        php8.1-memcached \
         openssh-client \
-        php8.0-memcached \
         aspell \
         aspell-en aspell-es aspell-de aspell-fr && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/sbin/php-fpm8.0 /usr/local/sbin/php-fpm && \
+    ln -s /usr/sbin/php-fpm8.1 /usr/local/sbin/php-fpm && \
     usermod --uid 1000 www-data && groupmod --gid 1000 www-data && \
     mkdir /srv/pim && \
-    sed -i "s#listen = /run/php/php8.0-fpm.sock#listen = 9000#g" /etc/php/8.0/fpm/pool.d/www.conf && \
+    sed -i "s#listen = /run/php/php8.1-fpm.sock#listen = 9000#g" /etc/php/8.1/fpm/pool.d/www.conf && \
     mkdir -p /run/php
 
-COPY docker/build/akeneo.ini /etc/php/8.0/cli/conf.d/99-akeneo.ini
-COPY docker/build/akeneo.ini /etc/php/8.0/fpm/conf.d/99-akeneo.ini
+COPY docker/build/akeneo.ini /etc/php/8.1/cli/conf.d/99-akeneo.ini
+COPY docker/build/akeneo.ini /etc/php/8.1/fpm/conf.d/99-akeneo.ini
 
 FROM base as dev
 
@@ -72,10 +72,10 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY docker/build/xdebug.ini /etc/php/8.0/cli/conf.d/99-akeneo-xdebug.ini
-COPY docker/build/xdebug.ini /etc/php/8.0/fpm/conf.d/99-akeneo-xdebug.ini
-COPY docker/build/blackfire.ini /etc/php/8.0/cli/conf.d/99-akeneo-blackfire.ini
-COPY docker/build/blackfire.ini /etc/php/8.0/fpm/conf.d/99-akeneo-blackfire.ini
+COPY docker/build/xdebug.ini /etc/php/8.1/cli/conf.d/99-akeneo-xdebug.ini
+COPY docker/build/xdebug.ini /etc/php/8.1/fpm/conf.d/99-akeneo-xdebug.ini
+COPY docker/build/blackfire.ini /etc/php/8.1/cli/conf.d/99-akeneo-blackfire.ini
+COPY docker/build/blackfire.ini /etc/php/8.1/fpm/conf.d/99-akeneo-blackfire.ini
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
 RUN chmod +x /usr/local/bin/composer

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
         }
     },
     "require": {
-        "php": "8.0.*",
+        "php": "8.1.*",
         "ext-apcu": "*",
         "ext-bcmath": "*",
         "ext-curl": ">=7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -18925,7 +18925,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.0.*",
+        "php": "8.1.*",
         "ext-apcu": "*",
         "ext-bcmath": "*",
         "ext-curl": ">=7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3879c068aaba9df2be0382f5cb76a97",
+    "content-hash": "fc360ddaa6751fdf70251dd7de19d4b3",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   php:
-    image: 'akeneo/pim-php-dev:master'
+    image: 'akeneo/pim-php-dev:8.1'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
       COMPOSER_HOME: '/var/www/.composer'
@@ -23,7 +23,7 @@ services:
       - 'pim'
 
   fpm:
-    image: 'akeneo/pim-php-dev:master'
+    image: 'akeneo/pim-php-dev:8.1'
     environment:
       APP_ENV: '${APP_ENV:-prod}'
       BEHAT_TMPDIR: '/srv/pim/var/cache/tmp'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I upgraded the PHP version used by the PIM to 8.1. 

akeneo/pim-php-dev have been tagged to 8.1 (https://hub.docker.com/layers/akeneo/pim-php-dev/8.1/images/sha256-ce7ec077b50a358347f8fdcf6e7ba0aff4e193a974697d2f1ddfc1a93eef35e7?context=explore), there is no more master tag but just tag version related to the PHP version, let's use it now !

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
