### PR TITLE
OCT-164: Add 'id' to connection_error ES index

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Domain/ErrorManagement/Model/Write/ApiError.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/ErrorManagement/Model/Write/ApiError.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\Write;
 
 use Akeneo\Connectivity\Connection\Domain\ErrorManagement\Model\ValueObject\ErrorType;
-use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionCode;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @author    Willy Mesnage <willy.mesnage@akeneo.com>
@@ -13,8 +13,8 @@ use Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionC
  */
 abstract class ApiError implements ApiErrorInterface
 {
+    private string $id;
     private string $content;
-
     private \DateTimeImmutable $dateTime;
 
     public function __construct(string $content, \DateTimeImmutable $dateTime = null)
@@ -38,8 +38,14 @@ abstract class ApiError implements ApiErrorInterface
             $dateTime = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         }
 
+        $this->id = Uuid::uuid4()->toString();
         $this->content = $content;
         $this->dateTime = $dateTime;
+    }
+
+    public function id(): string
+    {
+        return  $this->id;
     }
 
     public function content(): string
@@ -55,6 +61,7 @@ abstract class ApiError implements ApiErrorInterface
     public function normalize(): array
     {
         return [
+            'id' => $this->id(),
             'content' => \json_decode($this->content(), true, 512, JSON_THROW_ON_ERROR),
             'error_datetime' => $this->dateTime->format(\DateTimeInterface::ATOM),
         ];

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/connection_error_mapping.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/connection_error_mapping.yml
@@ -1,5 +1,7 @@
 mappings:
     properties:
+        id:
+            type: 'keyword'
         connection_code:
             type: 'keyword'
         content:

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -33,6 +33,7 @@ $rules = [
             'Akeneo\Pim\Enrichment\Component\Product\Message\ProductUpdated',
 
             'Webmozart\Assert\Assert',
+            'Ramsey\Uuid\Uuid',
         ]
     )->in('Akeneo\Connectivity\Connection\Domain'),
 
@@ -64,6 +65,7 @@ $rules = [
             // Exceptions
             'Akeneo\Connectivity\Connection\Domain\ValueObject',
             'Akeneo\Connectivity\Connection\Domain\Settings\Model\ValueObject\ConnectionCode',
+            'Ramsey\Uuid\Uuid'
         ]
     )->in('Akeneo\Connectivity\Connection\Domain\ErrorManagement'),
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectDomainErrorFromProductEndpointEndToEnd.php
@@ -10,7 +10,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\Stream\StreamResourceResponse;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
-use Elasticsearch\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -22,14 +22,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CollectDomainErrorFromProductEndpointEndToEnd extends ApiTestCase
 {
-    /** @var FamilyLoader */
-    private $familyLoader;
-
-    /** @var ProductLoader */
-    private $productLoader;
-
-    /** @var Client */
-    private $elasticsearch;
+    private ?FamilyLoader $familyLoader;
+    private ?ProductLoader $productLoader;
+    private ?Client $elasticsearch;
 
     protected function setUp(): void
     {
@@ -37,7 +32,6 @@ class CollectDomainErrorFromProductEndpointEndToEnd extends ApiTestCase
 
         $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
         $this->productLoader = $this->get('akeneo_connectivity.connection.fixtures.enrichment.product');
-
         $this->elasticsearch = $this->get('akeneo_connectivity.client.connection_error');
     }
 
@@ -85,6 +79,7 @@ class CollectDomainErrorFromProductEndpointEndToEnd extends ApiTestCase
         $result = $this->elasticsearch->search([]);
 
         Assert::assertCount(1, $result['hits']['hits']);
+        Assert::assertNotEmpty($result['hits']['hits'][0]['_source']['id']);
     }
 
     /**
@@ -127,6 +122,7 @@ class CollectDomainErrorFromProductEndpointEndToEnd extends ApiTestCase
         $result = $this->elasticsearch->search([]);
 
         Assert::assertCount(1, $result['hits']['hits']);
+        Assert::assertNotEmpty($result['hits']['hits'][0]['_source']['id']);
     }
 
     /**
@@ -182,5 +178,6 @@ class CollectDomainErrorFromProductEndpointEndToEnd extends ApiTestCase
         $result = $this->elasticsearch->search([]);
 
         Assert::assertCount(1, $result['hits']['hits']);
+        Assert::assertNotEmpty($result['hits']['hits'][0]['_source']['id']);
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductDomainErrorEndToEnd.php
@@ -10,7 +10,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoade
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
-use Elasticsearch\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,17 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CollectProductDomainErrorEndToEnd extends ApiTestCase
 {
-    /** @var AttributeLoader */
-    private $attributeLoader;
-
-    /** @var FamilyLoader */
-    private $familyLoader;
-
-    /** @var ProductLoader */
-    private $productLoader;
-
-    /** @var Client */
-    private $elasticsearch;
+    private ?AttributeLoader $attributeLoader;
+    private ?FamilyLoader $familyLoader;
+    private ?ProductLoader $productLoader;
+    private ?Client $elasticsearch;
 
     protected function setUp(): void
     {
@@ -98,6 +91,7 @@ class CollectProductDomainErrorEndToEnd extends ApiTestCase
 
         $doc = $result['hits']['hits'][0]['_source'];
         Assert::assertEquals('erp', $doc['connection_code']);
+        Assert::assertNotEmpty($doc['id']);
 
         $expectedContent = [
             'type' => 'domain_error',
@@ -228,6 +222,7 @@ class CollectProductDomainErrorEndToEnd extends ApiTestCase
 
         $doc = $result['hits']['hits'][0]['_source'];
         Assert::assertEquals('erp', $doc['connection_code']);
+        Assert::assertNotEmpty($doc['id']);
 
         $this->assertReponsesEquals($expectedContent, $doc['content']);
     }
@@ -263,6 +258,7 @@ class CollectProductDomainErrorEndToEnd extends ApiTestCase
 
         $doc = $result['hits']['hits'][0]['_source'];
         Assert::assertEquals('erp', $doc['connection_code']);
+        Assert::assertNotEmpty($doc['id']);
 
         $expectedContent = [
             'type' => 'domain_error',
@@ -333,6 +329,7 @@ class CollectProductDomainErrorEndToEnd extends ApiTestCase
 
         $doc = $result['hits']['hits'][0]['_source'];
         Assert::assertEquals('erp', $doc['connection_code']);
+        Assert::assertNotEmpty($doc['id']);
 
         $expectedContent = [
             'type' => 'domain_error',

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/ErrorManagement/CollectApiError/CollectProductValidationErrorEndToEnd.php
@@ -9,7 +9,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoade
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ApiBundle\tests\integration\ApiTestCase;
-use Elasticsearch\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,14 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class CollectProductValidationErrorEndToEnd extends ApiTestCase
 {
-    /** @var AttributeLoader */
-    private $attributeLoader;
-
-    /** @var FamilyLoader */
-    private $familyLoader;
-
-    /** @var Client */
-    private $elasticsearch;
+    private ?AttributeLoader $attributeLoader;
+    private ?FamilyLoader $familyLoader;
+    private ?Client $elasticsearch;
 
     protected function setUp(): void
     {
@@ -35,7 +30,6 @@ class CollectProductValidationErrorEndToEnd extends ApiTestCase
 
         $this->attributeLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.attribute');
         $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
-
         $this->elasticsearch = $this->get('akeneo_connectivity.client.connection_error');
     }
 
@@ -89,6 +83,7 @@ class CollectProductValidationErrorEndToEnd extends ApiTestCase
 
         $doc = $result['hits']['hits'][0]['_source'];
         Assert::assertEquals('erp', $doc['connection_code']);
+        Assert::assertNotEmpty($doc['id']);
 
         $uuid = $doc['content']['product']['uuid'];
         Assert::assertTrue(Uuid::isValid($uuid));

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/ElasticsearchBusinessErrorRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/ElasticsearchBusinessErrorRepositoryIntegration.php
@@ -43,18 +43,15 @@ class ElasticsearchBusinessErrorRepositoryIntegration extends TestCase
         $doc2 = $result['hits']['hits'][1]['_source'];
 
         Assert::assertCount(2, $result['hits']['hits']);
+        Assert::assertArrayHasKey('id', $doc1);
+        Assert::assertEquals('erp', $doc1['connection_code']);
+        Assert::assertEquals(['message' => 'First error!'], $doc1['content']);
+        Assert::assertEquals('2019-12-31T00:00:00+00:00', $doc1['error_datetime']);
 
-        Assert::assertEquals([
-            'connection_code' => 'erp',
-            'content' => ['message' => 'First error!'],
-            'error_datetime' => '2019-12-31T00:00:00+00:00',
-        ], $doc1);
-
-        Assert::assertEquals([
-            'connection_code' => 'erp',
-            'content' => ['message' => 'Second error!', 'property' => 'name'],
-            'error_datetime' => '2020-01-01T00:00:00+00:00'
-        ], $doc2);
+        Assert::assertArrayHasKey('id', $doc2);
+        Assert::assertEquals('erp', $doc2['connection_code']);
+        Assert::assertEquals(['message' => 'Second error!', 'property' => 'name'], $doc2['content']);
+        Assert::assertEquals('2020-01-01T00:00:00+00:00', $doc2['error_datetime']);
     }
 
     protected function getConfiguration(): Configuration

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/ElasticsearchSelectLastConnectionBusinessErrorsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/ElasticsearchSelectLastConnectionBusinessErrorsQueryIntegration.php
@@ -11,6 +11,7 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 class ElasticsearchSelectLastConnectionBusinessErrorsQueryIntegration extends TestCase
 {
@@ -28,34 +29,40 @@ class ElasticsearchSelectLastConnectionBusinessErrorsQueryIntegration extends Te
         $this->esClient->bulkIndexes([
             // Ignored: error is too old (more than 7 days)
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'erp',
                 'error_datetime' => '2019-12-31T00:00:00+00:00',
                 'content' => ['message' => 'Error 1'],
             ],
             // Ignored: 3rd result (oldest) on a $limit of 2
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'erp',
                 'error_datetime' => '2020-01-01T00:00:00+00:00',
                 'content' => ['message' => 'Error 2'],
             ],
             // Ignored: wrong connection code
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'ecommerce',
                 'error_datetime' => '2020-01-05T00:00:00+00:00',
                 'content' => ['message' => 'Error 3'],
             ],
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'erp',
                 'error_datetime' => '2020-01-06T00:00:00+00:00',
                 'content' => ['message' => 'Error 4'],
             ],
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'erp',
                 'error_datetime' => '2020-01-07T00:00:00+00:00',
                 'content' => ['message' => 'Error 5'],
             ],
             // Ignored: error is newer than the $endDate param
             [
+                'id' => Uuid::uuid4()->toString(),
                 'connection_code' => 'erp',
                 'error_datetime' => '2020-01-09T00:00:00+00:00',
                 'content' => ['message' => 'Error 6'],

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/PurgeConnectionErrorsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/ErrorManagement/Persistence/PurgeConnectionErrorsQueryIntegration.php
@@ -9,7 +9,11 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
+/**
+ * @covers \Akeneo\Connectivity\Connection\Infrastructure\ErrorManagement\Persistence\PurgeConnectionErrorsQuery
+ */
 class PurgeConnectionErrorsQueryIntegration extends TestCase
 {
     private Client $esClient;
@@ -96,6 +100,7 @@ class PurgeConnectionErrorsQueryIntegration extends TestCase
             $datetime = new \DateTime('now');
             for ($i = 0 ; $i < $number ; $i++) {
                 $documents[] = [
+                    'id' => Uuid::uuid4()->toString(),
                     'connection_code' => $connectionCode,
                     'content' => $content,
                     'error_datetime' => $datetime->format(\DateTimeInterface::ATOM),

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/ErrorManagement/Model/Write/BusinessErrorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/ErrorManagement/Model/Write/BusinessErrorSpec.php
@@ -58,6 +58,7 @@ class BusinessErrorSpec extends ObjectBehavior
         $this->beConstructedWith($content, $dateTime);
 
         $expected = [
+            'id' => $this->id(),
             'content' => \json_decode($content, true),
             'error_datetime' => '2020-01-01T00:00:00+00:00',
         ];

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/ErrorManagement/Model/Write/TechnicalErrorSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Domain/ErrorManagement/Model/Write/TechnicalErrorSpec.php
@@ -58,6 +58,7 @@ class TechnicalErrorSpec extends ObjectBehavior
         $this->beConstructedWith($content, $dateTime);
 
         $expected = [
+            'id' => $this->id(),
             'content' => \json_decode($content, true),
             'error_datetime' => '2020-01-01T00:00:00+00:00',
         ];

--- a/upgrades/schema/Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping.php
+++ b/upgrades/schema/Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Elasticsearch\ClientBuilder;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This migration adds a mapped field (id) to connection_error index mapping
+ */
+final class Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping extends AbstractMigration implements ContainerAwareInterface
+{
+    private ContainerInterface $container;
+
+    public function up(Schema $schema) : void
+    {
+        $this->disableMigrationWarning();
+        $indexHosts = $this->container->getParameter('index_hosts');
+        $connectionErrorIndexName = $this->container->getParameter('connection_error_index_name');
+
+        $builder = new ClientBuilder();
+
+        $client = $builder->setHosts([$indexHosts])->build()->indices();
+
+        $existingMapping = $client->getMapping(['index' => $connectionErrorIndexName]);
+        if (!\is_array($existingMapping) || !isset(current($existingMapping)['mappings']['properties'])) {
+            throw new \RuntimeException('Unable to retrieve existing mapping.');
+        }
+
+        $client->putMapping([
+            'index' => $connectionErrorIndexName,
+            'body' => [
+                'properties' => [
+                    'id' => ['type' => 'keyword'],
+                ],
+            ],
+        ]);
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        Assert::notNull($container);
+        $this->container = $container;
+    }
+
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+
+}

--- a/upgrades/test_schema/Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping_Integration.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
+use Elasticsearch\Client as NativeClient;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_7_0_20221027152057_add_id_field_to_connection_error_index_mapping_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    const MIGRATION_LABEL = '_7_0_20221027152057_add_id_field_to_connection_error_index_mapping';
+
+    private NativeClient $nativeClient;
+    private Client $connectionErrorClient;
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nativeClient = $this->get('akeneo_elasticsearch.client_builder')->build();
+        $this->connectionErrorClient = $this->get('akeneo_connectivity.client.connection_error');
+    }
+
+    /** @test */
+    public function it_adds_the_entity_updated_property_to_the_mapping(): void
+    {
+
+        $this->recreateConnectionErrorIndexWithoutIdInTheMapping();
+        $properties = $this->getMappingProperties();
+        self::assertArrayNotHasKey('id', $properties);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $properties = $this->getMappingProperties();
+        self::assertArrayHasKey('id', $properties);
+        self::assertSame(['type' => 'keyword'], $properties['id']);
+    }
+
+    private function recreateConnectionErrorIndexWithoutIdInTheMapping(): void
+    {
+        $configFiles = $this->getParameter('elasticsearch_index_configuration_files');
+        $config = [];
+        foreach ($configFiles as $configFile) {
+            $config = array_merge_recursive($config, Yaml::parseFile($configFile));
+        }
+
+        self::assertArrayHasKey('mappings', $config);
+        self::assertIsArray($config['mappings']);
+        self::assertArrayHasKey('properties', $config['mappings']);
+        self::assertIsArray($config['mappings']['properties']);
+        self::assertArrayHasKey('id', $config['mappings']['properties'], 'Test cannot be relevant: "id" is missing');
+        unset($config['mappings']['properties']['id']);
+
+        $newConfigFile = tempnam(sys_get_temp_dir(), 'migration_connection_error_id');
+        file_put_contents($newConfigFile, Yaml::dump($config));
+
+        $loader = new Loader([$newConfigFile], $this->get(ParameterBagInterface::class));
+        $client = new Client(
+            $this->get('akeneo_elasticsearch.client_builder'),
+            $loader,
+            [$this->getParameter('index_hosts')],
+            $this->connectionErrorClient->getIndexName()
+        );
+        $client->resetIndex();
+    }
+
+    private function getMappingProperties(): array
+    {
+        $mapping = current($this->nativeClient->indices()->getMapping(
+            ['index' => $this->connectionErrorClient->getIndexName()]
+        ));
+
+        return $mapping['mappings']['properties'] ?? [];
+    }
+}


### PR DESCRIPTION
Currently, our logs are polluted with deprecation messages such as:
```
Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled
```
In order to mitigate it, another mapped field is required to be used instead of `_id`
This PR only adds the new field to the list of mapped fields
[Another PR](https://github.com/akeneo/pim-community-dev/pull/18266) will update queries that use `_id` on the `connection_error` index