### PR TITLE
PIM-10686: Fix percentage of inaccurate completeness in the activity dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - PIM-10655: Fix format of empty completeness in API
 - PIM-10644: Fix identifier format check on multiple product update
 - PIM-10673: Fix media URL port display for Events API
+- PIM-10686: Fix percentage of inaccurate completeness in the activity dashboard
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/helpers/convertBackendDashboardCompletenessData.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/helpers/convertBackendDashboardCompletenessData.ts
@@ -8,13 +8,13 @@ const convertBackendDashboardCompletenessData = (
   let result: ChannelsLocalesCompletenessRatios = {};
   Object.entries(data).map(([channelCode, channelData]: [string, BackendChannelData]) => {
     const divider: number = channelData.total * Object.keys(channelData.locales).length;
-    const channelRatio: number = divider === 0 ? 0 : Math.round((channelData.complete / divider) * 100);
+    const channelRatio: number = divider === 0 ? 0 : Math.floor((channelData.complete / divider) * 100);
     const channelLabel = channelData.labels[catalogLocale] || `[${channelCode}]`;
 
     let localesRatios: {[localeTranslation: string]: number} = {};
     Object.entries(channelData.locales).map(([localeLabel, localeCompleteCount]: [string, number]) => {
       const divider: number = channelData.total;
-      localesRatios[localeLabel] = divider === 0 ? 0 : Math.round((localeCompleteCount / divider) * 100);
+      localesRatios[localeLabel] = divider === 0 ? 0 : Math.floor((localeCompleteCount / divider) * 100);
     });
 
     result[channelLabel] = {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/tests/front/unit/helpers/convertBackendDashboardCompletenessData.unit.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/tests/front/unit/helpers/convertBackendDashboardCompletenessData.unit.ts
@@ -31,25 +31,43 @@ const data: BackendCompletenessData = {
       'French (France)': 88,
     },
   },
+  ecommerce: {
+    labels: {
+      de_DE: 'Ecommerce',
+      en_US: 'Ecommerce',
+      fr_FR: 'Ecommerce FR',
+    },
+    total: 2000,
+    complete: 1999,
+    locales: {
+      'French (France)': 1999,
+    },
+  },
 };
 
-test('', () => {
+test('It calculate the completeness by channels and by locales', () => {
   const result: ChannelsLocalesCompletenessRatios = convertBackendDashboardCompletenessData(data, 'en_US');
   expect(result).toEqual({
     Print: {
       channelRatio: 15,
       localesRatios: {
-        'English (United States)': 28,
-        'German (Germany)': 9,
+        'English (United States)': 27,
+        'German (Germany)': 8,
         'French (France)': 12,
       },
     },
     Mobile: {
       channelRatio: 11,
       localesRatios: {
-        'English (United States)': 21,
-        'German (Germany)': 6,
+        'English (United States)': 20,
+        'German (Germany)': 5,
         'French (France)': 7,
+      },
+    },
+    Ecommerce: {
+      channelRatio: 99,
+      localesRatios: {
+        'French (France)': 99,
       },
     },
   });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, i have a round to the inferior in order to not display 100% when completeness is 99,99%. By doing it we continue to do not display decimal on the dashboard.
<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
