### PR TITLE
OCT-165: Add 'id' to events_api_debug index

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
+++ b/src/Akeneo/Connectivity/Connection/back/Application/Webhook/Service/EventsApiDebugLogger.php
@@ -11,6 +11,7 @@ use Akeneo\Connectivity\Connection\Domain\Webhook\Model\EventsApiDebugLogLevels;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Model\WebhookEvent;
 use Akeneo\Connectivity\Connection\Domain\Webhook\Persistence\Repository\EventsApiDebugRepositoryInterface;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -48,6 +49,7 @@ class EventsApiDebugLogger implements
         EventInterface $event
     ): void {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::NOTICE,
             'message' => 'The event was not sent because it was raised by the same connection.',
@@ -66,6 +68,7 @@ class EventsApiDebugLogger implements
         array $headers
     ): void {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::INFO,
             'message' => 'The API event request was sent.',
@@ -84,6 +87,7 @@ class EventsApiDebugLogger implements
     public function logLimitOfEventsApiRequestsReached(): void
     {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::WARNING,
             'message' => 'The maximum number of events sent per hour has been reached.',
@@ -97,6 +101,7 @@ class EventsApiDebugLogger implements
         EventInterface $event
     ): void {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::NOTICE,
             'message' => 'The event was not sent because the product does not exists or the connection does not have the required permissions.',
@@ -117,6 +122,7 @@ class EventsApiDebugLogger implements
     public function logEventsApiRequestFailed(string $connectionCode, array $webhookEvents, string $url, int $statusCode, array $headers): void
     {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::ERROR,
             'message' => 'The endpoint returned an error.',
@@ -139,6 +145,7 @@ class EventsApiDebugLogger implements
         float $timeout
     ): void {
         $this->repository->persist([
+            'id' => Uuid::uuid4()->toString(),
             'timestamp' => $this->clock->now()->getTimestamp(),
             'level' => EventsApiDebugLogLevels::ERROR,
             'message' => \sprintf('The endpoint failed to answer under %d ms.', \round($timeout * 1000, 0)),

--- a/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Persistence/Repository/EventsApiDebugRepositoryInterface.php
+++ b/src/Akeneo/Connectivity/Connection/back/Domain/Webhook/Persistence/Repository/EventsApiDebugRepositoryInterface.php
@@ -17,6 +17,7 @@ interface EventsApiDebugRepositoryInterface
      * you need to call the flush method to effectively do it.
      *
      * @param array{
+     *  id: string,
      *  timestamp: int,
      *  level: string,
      *  message: string,

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml
@@ -1,5 +1,7 @@
 mappings:
     properties:
+        id:
+            type: 'keyword'
         connection_code:
             type: 'keyword'
         timestamp:

--- a/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/.php_cd.php
@@ -160,6 +160,8 @@ $rules = [
             'FOS\RestBundle\Context\Context',
             'FOS\RestBundle\Serializer\Serializer',
 
+            'Ramsey\Uuid\Uuid',
+
             'Akeneo\Catalogs\ServiceAPI\Model\Catalog',
         ]
     )->in('Akeneo\Connectivity\Connection\Application'),
@@ -304,6 +306,8 @@ $rules = [
 
             'Psr\Log\LoggerInterface',
             'Psr\Http\Message\ResponseInterface',
+
+            'Ramsey\Uuid\Uuid',
         ]
     )->in('Akeneo\Connectivity\Connection\Application\Webhook'),
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/ElasticsearchEventsApiDebugRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/ElasticsearchEventsApiDebugRepositoryIntegration.php
@@ -30,6 +30,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
     public function test_it_saves_logs(): void
     {
         $this->elasticsearchEventsApiDebugRepository->persist([
+            'id' => 'test_id_1',
             'timestamp' => 631152000,
             'level' => 'info',
             'message' => 'An information message.',
@@ -43,6 +44,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
             ],
         ]);
         $this->elasticsearchEventsApiDebugRepository->persist([
+            'id' => 'test_id_2',
             'timestamp' => 946684800,
             'level' => 'warning',
             'message' => 'A warning message!',
@@ -58,6 +60,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
 
         Assert::assertEquals(
             [
+                'id' => 'test_id_1',
                 'timestamp' => 631152000,
                 'level' => 'info',
                 'message' => 'An information message.',
@@ -76,6 +79,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
 
         Assert::assertEquals(
             [
+                'id' => 'test_id_2',
                 'timestamp' => 946684800,
                 'level' => 'warning',
                 'message' => 'A warning message!',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/ElasticsearchEventsApiDebugRepositoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/ElasticsearchEventsApiDebugRepositoryIntegration.php
@@ -30,7 +30,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
     public function test_it_saves_logs(): void
     {
         $this->elasticsearchEventsApiDebugRepository->persist([
-            'id' => 'test_id_1',
+            'id' => 'bb1ff8f4-bad8-4c5e-8d42-6116c23a3629',
             'timestamp' => 631152000,
             'level' => 'info',
             'message' => 'An information message.',
@@ -44,7 +44,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
             ],
         ]);
         $this->elasticsearchEventsApiDebugRepository->persist([
-            'id' => 'test_id_2',
+            'id' => '02cac8dc-5b75-11ed-9b6a-0242ac120002',
             'timestamp' => 946684800,
             'level' => 'warning',
             'message' => 'A warning message!',
@@ -60,7 +60,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
 
         Assert::assertEquals(
             [
-                'id' => 'test_id_1',
+                'id' => 'bb1ff8f4-bad8-4c5e-8d42-6116c23a3629',
                 'timestamp' => 631152000,
                 'level' => 'info',
                 'message' => 'An information message.',
@@ -79,7 +79,7 @@ class ElasticsearchEventsApiDebugRepositoryIntegration extends TestCase
 
         Assert::assertEquals(
             [
-                'id' => 'test_id_2',
+                'id' => '02cac8dc-5b75-11ed-9b6a-0242ac120002',
                 'timestamp' => 946684800,
                 'level' => 'warning',
                 'message' => 'A warning message!',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
@@ -51,7 +51,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
 
         $eventsApiDebugRepository->persist(
             Argument::that(function ($actual) {
-                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                if (!isset($actual['id']) || !\is_string($actual['id'])) {
                     return false;
                 }
                 unset($actual['id']);
@@ -100,7 +100,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
 
         $eventsApiDebugRepository->persist(
             Argument::that(function ($actual) {
-                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                if (!isset($actual['id']) || !\is_string($actual['id'])) {
                     return false;
                 }
                 unset($actual['id']);
@@ -138,7 +138,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
 
         $eventsApiDebugRepository->persist(
             Argument::that(function ($actual) {
-                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                if (!isset($actual['id']) || !\is_string($actual['id'])) {
                     return false;
                 }
                 unset($actual['id']);
@@ -167,7 +167,7 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
         $this->shouldImplement(ApiEventBuildErrorLoggerInterface::class);
         $eventsApiDebugRepository->persist(
             Argument::that(function ($actual) {
-                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                if (!isset($actual['id']) || !\is_string($actual['id'])) {
                     return false;
                 }
                 unset($actual['id']);

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Application/Webhook/Service/EventsApiDebugLoggerSpec.php
@@ -15,6 +15,7 @@ use Akeneo\Platform\Component\EventQueue\Author;
 use Akeneo\Platform\Component\EventQueue\Event;
 use Akeneo\Platform\Component\EventQueue\EventInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -49,28 +50,33 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
         $this->shouldImplement(EventSubscriptionSkippedOwnEventLoggerInterface::class);
 
         $eventsApiDebugRepository->persist(
-            [
-                'timestamp' => 1609459200,
-                'level' => 'info',
-                'message' => 'The API event request was sent.',
-                'connection_code' => 'erp_000',
-                'context' => [
-                    'event_subscription_url' => 'http://my-url.com',
-                    'status_code' => 200,
-                    'headers' => [],
-                    'events' => [
-                        [
-                            "action" => "my_event",
-                            "event_id" => "9979c367-595d-42ad-9070-05f62f31f49b",
-                            "event_datetime" => "1970-01-01T00:00:00+00:00",
-                            "author" => "julia",
-                            "author_type" => "ui",
+            Argument::that(function ($actual) {
+                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                    return false;
+                }
+                unset($actual['id']);
+                return $actual === [
+                        'timestamp' => 1609459200,
+                        'level' => 'info',
+                        'message' => 'The API event request was sent.',
+                        'connection_code' => 'erp_000',
+                        'context' => [
+                            'event_subscription_url' => 'http://my-url.com',
+                            'status_code' => 200,
+                            'headers' => [],
+                            'events' => [
+                                [
+                                    "action" => "my_event",
+                                    "event_id" => "9979c367-595d-42ad-9070-05f62f31f49b",
+                                    "event_datetime" => "1970-01-01T00:00:00+00:00",
+                                    "author" => "julia",
+                                    "author_type" => "ui",
+                                ],
+                            ],
                         ],
-                    ],
-                ],
-            ]
-        )
-            ->shouldBeCalled();
+                    ];
+            })
+        )->shouldBeCalled();
 
         $this->logEventsApiRequestSucceed(
             'erp_000',
@@ -93,23 +99,28 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
         $this->shouldImplement(EventSubscriptionSkippedOwnEventLoggerInterface::class);
 
         $eventsApiDebugRepository->persist(
-            [
-                'timestamp' => 1609459200,
-                'level' => 'notice',
-                'message' => 'The event was not sent because it was raised by the same connection.',
-                'connection_code' => 'erp_000',
-                'context' => [
-                    'event' => [
-                        'action' => 'my_event',
-                        'event_id' => '9979c367-595d-42ad-9070-05f62f31f49b',
-                        'event_datetime' => '1970-01-01T00:00:00+00:00',
-                        'author' => 'julia',
-                        'author_type' => 'ui',
-                    ],
-                ],
-            ]
-        )
-            ->shouldBeCalled();
+            Argument::that(function ($actual) {
+                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                    return false;
+                }
+                unset($actual['id']);
+                return $actual === [
+                        'timestamp' => 1609459200,
+                        'level' => 'notice',
+                        'message' => 'The event was not sent because it was raised by the same connection.',
+                        'connection_code' => 'erp_000',
+                        'context' => [
+                            'event' => [
+                                'action' => 'my_event',
+                                'event_id' => '9979c367-595d-42ad-9070-05f62f31f49b',
+                                'event_datetime' => '1970-01-01T00:00:00+00:00',
+                                'author' => 'julia',
+                                'author_type' => 'ui',
+                            ],
+                        ],
+                    ];
+            })
+        )->shouldBeCalled();
 
         $this->logEventSubscriptionSkippedOwnEvent('erp_000', $this->createEvent());
     }
@@ -126,15 +137,20 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
         $this->shouldImplement(LimitOfEventsApiRequestsReachedLoggerInterface::class);
 
         $eventsApiDebugRepository->persist(
-            [
-                'timestamp' => 1609459200,
-                'level' => 'warning',
-                'message' => 'The maximum number of events sent per hour has been reached.',
-                'connection_code' => null,
-                'context' => [],
-            ]
-        )
-            ->shouldBeCalled();
+            Argument::that(function ($actual) {
+                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                    return false;
+                }
+                unset($actual['id']);
+                return $actual === [
+                        'timestamp' => 1609459200,
+                        'level' => 'warning',
+                        'message' => 'The maximum number of events sent per hour has been reached.',
+                        'connection_code' => null,
+                        'context' => [],
+                    ];
+            })
+        )->shouldBeCalled();
 
         $this->logLimitOfEventsApiRequestsReached();
     }
@@ -149,23 +165,28 @@ class EventsApiDebugLoggerSpec extends ObjectBehavior
             1
         );
         $this->shouldImplement(ApiEventBuildErrorLoggerInterface::class);
-
         $eventsApiDebugRepository->persist(
-            [
-                'timestamp' => 1609459200,
-                'level' => 'notice',
-                'message' => 'The event was not sent because the product does not exists or the connection does not have the required permissions.',
-                'connection_code' => 'erp_000',
-                'context' => [
-                    'event' => [
-                        'action' => 'my_event',
-                        'event_id' => '9979c367-595d-42ad-9070-05f62f31f49b',
-                        'event_datetime' => '1970-01-01T00:00:00+00:00',
-                        'author' => 'julia',
-                        'author_type' => 'ui',
-                    ],
-                ],
-            ]
+            Argument::that(function ($actual) {
+                if (!isset($actual['id']) || !is_string($actual['id'])) {
+                    return false;
+                }
+                unset($actual['id']);
+                return $actual === [
+                        'timestamp' => 1609459200,
+                        'level' => 'notice',
+                        'message' => 'The event was not sent because the product does not exists or the connection does not have the required permissions.',
+                        'connection_code' => 'erp_000',
+                        'context' => [
+                            'event' => [
+                                'action' => 'my_event',
+                                'event_id' => '9979c367-595d-42ad-9070-05f62f31f49b',
+                                'event_datetime' => '1970-01-01T00:00:00+00:00',
+                                'author' => 'julia',
+                                'author_type' => 'ui',
+                            ],
+                        ],
+                    ];
+            })
         )->shouldBeCalled();
 
         $this->logResourceNotFoundOrAccessDenied('erp_000', $this->createEvent());

--- a/upgrades/schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping.php
+++ b/upgrades/schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Elasticsearch\ClientBuilder;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * This migration aims to add a new field (id) to the events_api_debug ES index mapping
+ */
+final class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping extends AbstractMigration implements ContainerAwareInterface
+{
+    private ContainerInterface $container;
+
+    public function up(Schema $schema): void
+    {
+        $this->disableMigrationWarning();
+        $indexHosts = $this->container->getParameter('index_hosts');
+        $eventsApiDebugIndexName = $this->container->getParameter('events_api_debug_index_name');
+
+        $builder = new ClientBuilder();
+
+        $client = $builder->setHosts([$indexHosts])->build()->indices();
+
+        $existingMapping = $client->getMapping(['index' => $eventsApiDebugIndexName]);
+        if (!\is_array($existingMapping) || !isset(current($existingMapping)['mappings']['properties'])) {
+            throw new \RuntimeException('Unable to retrieve existing mapping.');
+        }
+
+        $client->putMapping([
+            'index' => $eventsApiDebugIndexName,
+            'body' => [
+                'properties' => [
+                    'id' => ['type' => 'keyword'],
+                ],
+            ],
+        ]);
+
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        Assert::notNull($container);
+        $this->container = $container;
+    }
+
+    private function disableMigrationWarning(): void
+    {
+        $this->addSql('SELECT 1');
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integration.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
+use Elasticsearch\Client as NativeClient;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    const MIGRATION_LABEL = '_7_0_20221026154157_add_id_to_events_api_debug_index_mapping';
+
+    private NativeClient $nativeClient;
+    private Client $eventsApiDebugClient;
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->nativeClient = $this->get('akeneo_elasticsearch.client_builder')->build();
+        $this->eventsApiDebugClient = $this->get('akeneo_connectivity.client.events_api_debug');
+    }
+
+    public function test_it_adds_the_entity_updated_property_to_the_mapping(): void
+    {
+        $this->recreateIndexWithoutIdFieldInTheMapping();
+        $properties = $this->getIndexMappingProperties();
+        self::assertArrayNotHasKey('id', $properties);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $properties = $this->getIndexMappingProperties();
+        self::assertArrayHasKey('id', $properties);
+        self::assertSame(['type' => 'keyword'], $properties['id']);
+    }
+
+    private function recreateIndexWithoutIdFieldInTheMapping(): void
+    {
+        $configFiles = $this->getParameter('elasticsearch_index_configuration_files');
+        $config = [];
+        foreach ($configFiles as $configFile) {
+            $config = array_merge_recursive($config, Yaml::parseFile($configFile));
+        }
+
+        self::assertArrayHasKey('mappings', $config);
+        self::assertIsArray($config['mappings']);
+        self::assertArrayHasKey('properties', $config['mappings']);
+        self::assertIsArray($config['mappings']['properties']);
+        self::assertArrayHasKey('id', $config['mappings']['properties'], 'Test cannot be relevant: "id" is missing');
+        unset($config['mappings']['properties']['id']);
+
+        $newConfigFile = tempnam(sys_get_temp_dir(), 'migration_events_api_debug_id');
+        file_put_contents($newConfigFile, Yaml::dump($config));
+
+        $loader = new Loader([$newConfigFile], $this->get(ParameterBagInterface::class));
+        $client = new Client(
+            $this->get('akeneo_elasticsearch.client_builder'),
+            $loader,
+            [$this->getParameter('index_hosts')],
+            $this->eventsApiDebugClient->getIndexName()
+        );
+        $client->resetIndex();
+    }
+
+    private function getIndexMappingProperties(): array
+    {
+        $mapping = current($this->nativeClient->indices()->getMapping(
+            ['index' => $this->eventsApiDebugClient->getIndexName()]
+        ));
+
+        return $mapping['mappings']['properties'] ?? [];
+    }
+}


### PR DESCRIPTION
Currently, our logs are polluted with deprecation messages such as:
```
Loading the fielddata on the _id field is deprecated and will be removed in future versions. If you require sorting or aggregating on this field you should also include the id in the body of your documents, and map this field as a keyword field that has [doc_values] enabled
```
In order to mitigate it, another mapped field is required to be used instead of _id
This PR only adds the new field to the list of mapped fields
[Another PR](https://github.com/akeneo/pim-community-dev/pull/18268) will update queries that use _id on the events_api_debug index