### PR TITLE
OCT-167: Updated queries to use mapped field id instead of ES _id

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/GetAllEventSubscriptionDebugLogsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/GetAllEventSubscriptionDebugLogsQuery.php
@@ -39,14 +39,14 @@ class GetAllEventSubscriptionDebugLogsQuery implements GetAllEventSubscriptionDe
             'size' => 1000,
             'sort' => [
                 'timestamp' => 'ASC',
-                '_id' => 'ASC'
+                'id' => 'ASC'
             ],
             'query' => [
                 'bool' => [
                     'should' => [
                         ['bool' => ['must' => [
                             ['terms' => ['level' => [EventsApiDebugLogLevels::NOTICE, EventsApiDebugLogLevels::INFO]]],
-                            ['terms' => ['_id' => $lastNoticeAndInfoIdentifiers]],
+                            ['terms' => ['id' => $lastNoticeAndInfoIdentifiers]],
                             ['bool' => ['should' => [
                                 ['term' => ['connection_code' => $connectionCode]],
                                 ['bool' => ['must_not' => ['exists' => ['field' => 'connection_code']]]], // connection_code IS NULL
@@ -103,7 +103,7 @@ class GetAllEventSubscriptionDebugLogsQuery implements GetAllEventSubscriptionDe
         );
 
         foreach ($result['hits']['hits'] as $hit) {
-            yield $hit['_id'];
+            yield $hit['_source']['id'];
         }
     }
 }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/PurgeEventsApiSuccessLogsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/PurgeEventsApiSuccessLogsQuery.php
@@ -28,7 +28,7 @@ class PurgeEventsApiSuccessLogsQuery
         $result = $this->esClient->search($search);
         $esIdsToKeep = [];
         foreach ($result['hits']['hits'] as $hit) {
-            $esIdsToKeep[] = $hit['_id'];
+            $esIdsToKeep[] = $hit['_source']['id'];
         }
         $this->esClient->deleteByQuery($this->getDeleteAllDocumentsButGivenIdsQuery($esIdsToKeep));
     }
@@ -38,12 +38,12 @@ class PurgeEventsApiSuccessLogsQuery
         return [
             'query' => [
                 'bool' => [
-                    'must_not' => ['terms' => ['_id' => $idsToKeep]],
+                    'must_not' => ['terms' => ['id' => $idsToKeep]],
                     'must' => [
                         'terms' => [
                             'level' => [
                                 EventsApiDebugLogLevels::INFO,
-                                EventsApiDebugLogLevels::NOTICE
+                                EventsApiDebugLogLevels::NOTICE,
                             ],
                         ],
                     ],
@@ -63,10 +63,13 @@ class PurgeEventsApiSuccessLogsQuery
                     'filter' => [
                         'bool' => [
                             'filter' => [
-                                'terms' => [
-                                    'level' => [
-                                        EventsApiDebugLogLevels::INFO,
-                                        EventsApiDebugLogLevels::NOTICE
+                                ['exists' => ['field' => 'id']],
+                                [
+                                    'terms' => [
+                                        'level' => [
+                                            EventsApiDebugLogLevels::INFO,
+                                            EventsApiDebugLogLevels::NOTICE,
+                                        ],
                                     ],
                                 ],
                             ],

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/SearchEventSubscriptionDebugLogsQuery.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Webhook/EventsApiDebug/Persistence/SearchEventSubscriptionDebugLogsQuery.php
@@ -126,13 +126,14 @@ class SearchEventSubscriptionDebugLogsQuery implements SearchEventSubscriptionDe
     ): array {
         $nowTimestamp = $this->clock->now()->getTimestamp();
         $constraints = [
+            ['exists' => ['field' => 'id']],
             [
                 'bool' => [
                     'should' => [
                         [
                             'bool' => [
                                 'must' => [
-                                    ['terms' => ['_id' => $lastNoticeAndInfoIds['ids']]],
+                                    ['terms' => ['id' => $lastNoticeAndInfoIds['ids']]],
                                 ],
                             ],
                         ],
@@ -206,7 +207,7 @@ class SearchEventSubscriptionDebugLogsQuery implements SearchEventSubscriptionDe
             'size' => 25,
             'sort' => [
                 'timestamp' => 'DESC',
-                '_id' => 'ASC',
+                'id' => 'ASC',
             ],
             'track_total_hits' => true,
             'query' => [
@@ -268,12 +269,13 @@ class SearchEventSubscriptionDebugLogsQuery implements SearchEventSubscriptionDe
             '_source' => ['id'],
             'sort' => [
                 'timestamp' => 'DESC',
-                '_id' => 'ASC',
+                'id' => 'ASC',
             ],
             'size' => self::MAX_NUMBER_OF_NOTICE_AND_INFO_LOGS,
             'query' => [
                 'bool' => [
                     'must' => [
+                        ['exists' => ['field' => 'id']],
                         ['terms' => ['level' => [EventsApiDebugLogLevels::INFO, EventsApiDebugLogLevels::NOTICE]]],
                         [
                             'bool' => [
@@ -303,10 +305,10 @@ class SearchEventSubscriptionDebugLogsQuery implements SearchEventSubscriptionDe
         $result = $this->elasticsearchClient->search($query);
 
         return [
-            'first_id' => $result['hits']['hits'][0]['_id'] ?? null,
+            'first_id' => $result['hits']['hits'][0]['_source']['id'] ?? null,
             'first_search_after' => $result['hits']['hits'][0]['sort'] ?? null,
             'ids' => \array_map(
-                fn ($hit) => $hit['_id'],
+                fn ($hit) => $hit['_source']['id'],
                 $result['hits']['hits']
             ),
         ];
@@ -344,7 +346,7 @@ class SearchEventSubscriptionDebugLogsQuery implements SearchEventSubscriptionDe
             'ids' => \array_merge(
                 [$firstId],
                 \array_map(
-                    fn ($hit) => $hit['_id'],
+                    fn ($hit) => $hit['_source']['id'],
                     $result['hits']['hits']
                 )
             ),

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/EventsApiDebug/Controller/Internal/DownloadEventSubscriptionLogsEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/EventsApiDebug/Controller/Internal/DownloadEventSubscriptionLogsEndToEnd.php
@@ -13,6 +13,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -35,6 +36,7 @@ class DownloadEventSubscriptionLogsEndToEnd extends WebTestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $now - 2,
                     'level' => 'warning',
                     'message' => 'Foo bar',
@@ -42,6 +44,7 @@ class DownloadEventSubscriptionLogsEndToEnd extends WebTestCase
                     'context' => ['foo' => 'bar'],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $now - 1,
                     'level' => 'warning',
                     'message' => 'Foo bar 2',

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/EventsApiDebug/Controller/Internal/SearchEventSubscriptionLogsEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/EventsApiDebug/Controller/Internal/SearchEventSubscriptionLogsEndToEnd.php
@@ -12,6 +12,7 @@ use Akeneo\Connectivity\Connection\Infrastructure\Service\Clock\SystemClock;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\EventSubscriptionLogLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\WebhookLoader;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -46,6 +47,7 @@ class SearchEventSubscriptionLogsEndToEnd extends WebTestCase
         $this->generateLogs(
             function () use ($timestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -92,6 +94,7 @@ class SearchEventSubscriptionLogsEndToEnd extends WebTestCase
 
         $this->insertLogs([
             [
+                'id' => Uuid::uuid4()->toString(),
                 'timestamp' => $timestamp,
                 'level' => EventsApiDebugLogLevels::NOTICE,
                 'message' => 'Foo bar',
@@ -99,6 +102,7 @@ class SearchEventSubscriptionLogsEndToEnd extends WebTestCase
                 'context' => [],
             ],
             [
+                'id' => Uuid::uuid4()->toString(),
                 'timestamp' => $timestamp,
                 'level' => EventsApiDebugLogLevels::ERROR,
                 'message' => 'Foo bar',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/GetAllEventSubscriptionDebugLogsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/GetAllEventSubscriptionDebugLogsQueryIntegration.php
@@ -11,6 +11,7 @@ use Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persist
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -40,6 +41,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function ($index) use ($timestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => $index % 2 ? EventsApiDebugLogLevels::NOTICE : EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -67,6 +69,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                 $timestampNow -= $timestampStep;
 
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow,
                     'level' => $index % 2 ? EventsApiDebugLogLevels::NOTICE : EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -99,6 +102,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampOlderThanLimit,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -106,6 +110,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNewerThanLimit,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -113,6 +118,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampOlderThanLimit,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -120,6 +126,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNewerThanLimit,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -141,6 +148,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 5,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -148,6 +156,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 1,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -155,6 +164,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 3,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -162,6 +172,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 4,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -169,6 +180,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 2,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -194,6 +206,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -201,6 +214,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -208,6 +222,7 @@ class GetAllEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/PurgeEventsApiSuccessLogsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/PurgeEventsApiSuccessLogsQueryIntegration.php
@@ -9,6 +9,7 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 class PurgeEventsApiSuccessLogsQueryIntegration extends TestCase
 {
@@ -89,6 +90,7 @@ class PurgeEventsApiSuccessLogsQueryIntegration extends TestCase
         $datetime = new \DateTime('now');
         for ($i = 0 ; $i < $number ; $i++) {
             $documents[] = [
+                'id' => Uuid::uuid4()->toString(),
                 'content' => $content,
                 'level' => $level,
                 'timestamp' => $datetime->getTimestamp(),

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/SearchEventSubscriptionDebugLogsQueryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Webhook/EventsApiDebug/Persistence/SearchEventSubscriptionDebugLogsQueryIntegration.php
@@ -11,6 +11,7 @@ use Akeneo\Connectivity\Connection\Infrastructure\Webhook\EventsApiDebug\Persist
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\EventSubscriptionLogLoader;
 use Akeneo\Test\Integration\TestCase;
 use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
 
 /**
  * @copyright 2021 Akeneo SAS (http://www.akeneo.com)
@@ -42,6 +43,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function () use ($timestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -65,6 +67,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function ($index) use ($timestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => $index % 2 ? EventsApiDebugLogLevels::NOTICE : EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -95,6 +98,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function ($index) use ($timestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -130,6 +134,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampOlderThanLimit,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -137,6 +142,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNewerThanLimit,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -144,6 +150,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampOlderThanLimit,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -151,6 +158,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNewerThanLimit,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -172,6 +180,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 5,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -179,6 +188,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 1,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -186,6 +196,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 3,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -193,6 +204,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 4,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -200,6 +212,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampNow - 2,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -225,6 +238,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -232,6 +246,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -239,6 +254,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -263,6 +279,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function () use ($firstTimestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $firstTimestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -281,6 +298,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->generateLogs(
             function () use ($secondTimestamp) {
                 return [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $secondTimestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -309,6 +327,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -316,6 +335,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -323,6 +343,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -330,6 +351,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -337,6 +359,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -372,6 +395,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -379,6 +403,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -386,6 +411,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -393,6 +419,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -400,6 +427,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -433,6 +461,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampFrom + 20,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -440,6 +469,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampFrom,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -447,6 +477,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampFrom,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -454,6 +485,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampFrom - 20,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -494,6 +526,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampTo + 20,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Foo bar',
@@ -501,6 +534,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampTo,
                     'level' => EventsApiDebugLogLevels::INFO,
                     'message' => 'Foo bar',
@@ -508,6 +542,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampTo,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -515,6 +550,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestampTo - 20,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -558,6 +594,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $firstTimestampToFind,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'Message a word to find',
@@ -565,6 +602,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $secondTimestampToFind,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'the messagE to finD',
@@ -572,6 +610,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'a message not found because the second word is missing',
@@ -579,6 +618,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $anotherTimestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => 'no word here',
@@ -586,6 +626,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     'context' => [],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $anotherTimestamp,
                     'level' => EventsApiDebugLogLevels::WARNING,
                     'message' => '',
@@ -623,6 +664,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
         $this->insertLogs(
             [
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $firstTimestampToFind,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',
@@ -638,6 +680,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     ],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $secondTimestampToFind,
                     'level' => EventsApiDebugLogLevels::ERROR,
                     'message' => 'Foo bar',
@@ -661,6 +704,7 @@ class SearchEventSubscriptionDebugLogsQueryIntegration extends TestCase
                     ],
                 ],
                 [
+                    'id' => Uuid::uuid4()->toString(),
                     'timestamp' => $timestamp,
                     'level' => EventsApiDebugLogLevels::NOTICE,
                     'message' => 'Foo bar',


### PR DESCRIPTION
This PR updates queries that use `_id` field to use the mapped field `id` created by [OCT-165](https://github.com/akeneo/pim-community-dev/pull/18267)