### PR TITLE
PIM-10689: Add sorting on ES id for product associations grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@
 - PIM-10644: Fix identifier format check on multiple product update
 - PIM-10673: Fix media URL port display for Events API
 - PIM-10686: Fix percentage of inaccurate completeness in the activity dashboard
+- PIM-10659: Fix associated products in grid are now sorted using their uuids
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/QuickExport/ProductAndProductModelProcessor.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/Processor/QuickExport/ProductAndProductModelProcessor.php
@@ -82,7 +82,7 @@ class ProductAndProductModelProcessor extends AbstractProcessor
 
         $parameters = $this->stepExecution->getJobParameters();
         $normalizerContext = $this->getNormalizerContext($parameters);
-        $productStandard = $this->normalizer->normalize($entityWithValues, 'standard', $normalizerContext);
+        $productStandard = $this->normalizer->normalize($entityWithValues, 'standard', array_merge($normalizerContext, ['with_association_uuids' => false]));
 
         if ($entityWithValues instanceof ProductInterface) {
             $productStandard = $this->fillMissingProductValues->fromStandardFormat($productStandard);

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
+use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Exception\InvalidObjectException;
 use Doctrine\Persistence\ObjectManager;
@@ -225,6 +226,7 @@ class AssociatedProductDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('id', Operators::IN_LIST, $associatedProductsIds);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductInterface::class);
+        $pqb->addSorter('id', Directions::ASCENDING);
 
         return $pqb->execute();
     }
@@ -248,6 +250,7 @@ class AssociatedProductDatasource extends ProductDatasource
         $pqb = $this->createQueryBuilder($limit, $from, $locale, $scope);
         $pqb->addFilter('id', Operators::IN_LIST, $associatedProductModelsIds);
         $pqb->addFilter('entity_type', Operators::EQUALS, ProductModelInterface::class);
+        $pqb->addSorter('id', Directions::ASCENDING);
 
         return $pqb->execute();
     }

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -186,6 +186,11 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
                 Operators::EQUALS,
                 ProductInterface::class
             )->shouldBeCalled();
+        $pqbAsso
+            ->addSorter(
+                'id',
+                Directions::ASCENDING
+            )->shouldBeCalled();
         $pqbAsso->execute()->willReturn($associatedProductCursor);
 
         $associatedProductCursor->rewind()->shouldBeCalled();
@@ -215,6 +220,11 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
                 'entity_type',
                 Operators::EQUALS,
                 ProductModelInterface::class
+            )->shouldBeCalled();
+        $pqbAssoProductModel
+            ->addSorter(
+                'id',
+                Directions::ASCENDING
             )->shouldBeCalled();
         $pqbAssoProductModel->execute()->willReturn($associatedProductModelCursor);
 
@@ -417,6 +427,11 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
                 'entity_type',
                 Operators::EQUALS,
                 ProductInterface::class
+            )->shouldBeCalled();
+        $pqbAsso
+            ->addSorter(
+                'id',
+                Directions::ASCENDING
             )->shouldBeCalled();
         $pqbAsso->execute()->willReturn($associatedProductCursor);
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Currently, associations in the grid are not properly sorted, this PR adds a sort on the ElasticSearch field ID to make sure products are sorted using their uuids.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
