### PR TITLE
PIM-10664 Hidden sub-categories from the sub category trees unless page is refreshed

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,8 @@
 # 6.0.x
 
+## Bug fixes
+PIM-10664 Fix expand/collapse arrow disappearing after category creation
+
 # 6.0.51 (2022-11-03)
 
 # 6.0.50 (2022-11-02)

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
@@ -4,7 +4,7 @@ import {buildNodesFromCategoryTree} from '../../helpers';
 
 type CategoryTreeState = {
   nodes: TreeNode<CategoryTreeModel>[];
-  setNodes:  React.Dispatch<React.SetStateAction<TreeNode<CategoryTreeModel>[]>>;
+  setNodes: React.Dispatch<React.SetStateAction<TreeNode<CategoryTreeModel>[]>>;
 };
 
 const CategoryTreeContext = createContext<CategoryTreeState>({

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/providers/CategoryTreeProvider.tsx
@@ -4,7 +4,7 @@ import {buildNodesFromCategoryTree} from '../../helpers';
 
 type CategoryTreeState = {
   nodes: TreeNode<CategoryTreeModel>[];
-  setNodes: (nodes: TreeNode<CategoryTreeModel>[]) => void;
+  setNodes:  React.Dispatch<React.SetStateAction<TreeNode<CategoryTreeModel>[]>>;
 };
 
 const CategoryTreeContext = createContext<CategoryTreeState>({

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
@@ -207,7 +207,7 @@ const useCategoryTreeNode = (id: number) => {
   // When a category is created inside the node, force reload children and open it.
   const onCreateCategory = useCallback(() => {
     if (node) {
-      setNodes((nodes) => {
+      setNodes(nodes => {
         const updatedNodes = update(nodes, {
           ...node,
           childrenStatus: 'to-reload',
@@ -235,8 +235,8 @@ const useCategoryTreeNode = (id: number) => {
       });
 
       return arrayUnique<TreeNode<CategoryTreeModel>>(
-          [...updatedNodes, ...newChildren],
-          (node, currentNode) => node.identifier === currentNode.identifier
+        [...updatedNodes, ...newChildren],
+        (node, currentNode) => node.identifier === currentNode.identifier
       );
     });
   }, [childrenData]);

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/categories/useCategoryTreeNode.ts
@@ -207,12 +207,13 @@ const useCategoryTreeNode = (id: number) => {
   // When a category is created inside the node, force reload children and open it.
   const onCreateCategory = useCallback(() => {
     if (node) {
-      const updatedNodes = update(nodes, {
-        ...node,
-        childrenStatus: 'to-reload',
+      setNodes((nodes) => {
+        const updatedNodes = update(nodes, {
+          ...node,
+          childrenStatus: 'to-reload',
+        });
+        return [...updatedNodes];
       });
-
-      setNodes([...updatedNodes]);
       open();
     }
   }, [node]);
@@ -225,19 +226,19 @@ const useCategoryTreeNode = (id: number) => {
       return buildTreeNodeFromCategoryTree(convertToCategoryTree(child), node.identifier);
     });
 
-    const updatedNodes = update(nodes, {
-      ...node,
-      childrenIds: newChildren.map(child => child.identifier),
-      childrenStatus: 'loaded',
-      type: node.type !== 'root' ? (newChildren.length > 0 ? 'node' : 'leaf') : 'root',
-    });
+    setNodes((nodes: TreeNode<CategoryTreeModel>[]) => {
+      const updatedNodes = update(nodes, {
+        ...node,
+        childrenIds: newChildren.map(child => child.identifier),
+        childrenStatus: 'loaded',
+        type: node.type !== 'root' ? (newChildren.length > 0 ? 'node' : 'leaf') : 'root',
+      });
 
-    setNodes(
-      arrayUnique<TreeNode<CategoryTreeModel>>(
-        [...updatedNodes, ...newChildren],
-        (node, currentNode) => node.identifier === currentNode.identifier
-      )
-    );
+      return arrayUnique<TreeNode<CategoryTreeModel>>(
+          [...updatedNodes, ...newChildren],
+          (node, currentNode) => node.identifier === currentNode.identifier
+      );
+    });
   }, [childrenData]);
 
   useEffect(() => {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

State managing nodes list was not well synchronized with user actions (adding new categories in the tree for instance).
When updating the state, some of the newly created nodes lost the information of having children, resulting in not visible "child categories".

Fix give the setNodes function the previous state to make sure the synchronisation is well done.

**Definition Of Done (for Core Developer only)**

- [x] Changelog (maintenance bug fixes)
