### PR TITLE
Fix Akeneo\Tool\Bundle\BatchBundle\Notification\MailNotifier - Unable to send email : Variable "email" does not exist

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
@@ -1,7 +1,6 @@
 {% extends "@PimNotification/Email/notification.txt.twig" %}
 
 {% block emailMessage %}
-    Dear {{ email }},
     {% if jobExecution.status.unsuccessful %}
         Akeneo completed your {{ jobExecution.jobInstance.type }} with errors.
     {% else %}


### PR DESCRIPTION
… .

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
