### PR TITLE
Grf 562 : Order attributes in Template structure page same as in the static template itself

### DIFF
--- a/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
+++ b/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
@@ -56,7 +56,7 @@ class TemplateBuilder
             $this->generateTemplateLabelCollection($categoryTree->getLabels()),
             $categoryTree->getId(),
             AttributeCollection::fromArray([
-                AttributeRichText::create(
+                AttributeTextArea::create(
                     AttributeUuid::fromUuid(Uuid::uuid4()),
                     new AttributeCode('description'),
                     AttributeOrder::fromInteger(1),
@@ -89,7 +89,7 @@ class TemplateBuilder
                     $templateUuid,
                     AttributeAdditionalProperties::fromArray([])
                 ),
-                AttributeTextArea::create(
+                AttributeText::create(
                     AttributeUuid::fromUuid(Uuid::uuid4()),
                     new AttributeCode('seo_meta_description'),
                     AttributeOrder::fromInteger(4),
@@ -100,7 +100,7 @@ class TemplateBuilder
                     $templateUuid,
                     AttributeAdditionalProperties::fromArray([])
                 ),
-                AttributeTextArea::create(
+                AttributeText::create(
                     AttributeUuid::fromUuid(Uuid::uuid4()),
                     new AttributeCode('seo_keywords'),
                     AttributeOrder::fromInteger(5),

--- a/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
+++ b/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
@@ -69,12 +69,12 @@ class TemplateBuilder
                 ),
                 AttributeImage::create(
                     AttributeUuid::fromUuid(Uuid::uuid4()),
-                    new AttributeCode('banner_image'),
+                    new AttributeCode('hero_banner'),
                     AttributeOrder::fromInteger(2),
                     AttributeIsRequired::fromBoolean(true),
                     AttributeIsScopable::fromBoolean(false),
                     AttributeIsLocalizable::fromBoolean(false),
-                    LabelCollection::fromArray(['en_US' => 'Banner image']),
+                    LabelCollection::fromArray(['en_US' => 'Hero Banner']),
                     $templateUuid,
                     AttributeAdditionalProperties::fromArray([])
                 ),

--- a/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Category/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -20,6 +20,12 @@ akeneo.category:
         notification_error: Template could not be activated
         attribute:
             description_title: Description Settings
+            type:
+                text: Text
+                textarea: Text Area
+                richtext: Rich Text
+                image: Image
+
     template_list:
         columns:
             header: Header

--- a/src/Akeneo/Category/back/tests/Specification/Infrastructure/Builder/TemplateBuilderSpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Infrastructure/Builder/TemplateBuilderSpec.php
@@ -73,10 +73,10 @@ class TemplateBuilderSpec extends ObjectBehavior
         $descriptionAttribute->getOrder()->intValue()->shouldReturn(1);
         $descriptionAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('Description');
 
-        $imageAttribute = $template->getAttributeCollection()->getAttributeByCode('banner_image');
+        $imageAttribute = $template->getAttributeCollection()->getAttributeByCode('hero_banner');
         $imageAttribute->getType()->__toString()->shouldReturn(AttributeType::IMAGE);
         $imageAttribute->getOrder()->intValue()->shouldReturn(2);
-        $imageAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('Banner image');
+        $imageAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('Hero Banner');
 
         $metaTitleAttribute = $template->getAttributeCollection()->getAttributeByCode('seo_meta_title');
         $metaTitleAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXT);

--- a/src/Akeneo/Category/back/tests/Specification/Infrastructure/Builder/TemplateBuilderSpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Infrastructure/Builder/TemplateBuilderSpec.php
@@ -69,7 +69,7 @@ class TemplateBuilderSpec extends ObjectBehavior
         $template->getLabelCollection()->getTranslation('en_US')->shouldReturn('Category code template');
 
         $descriptionAttribute = $template->getAttributeCollection()->getAttributeByCode('description');
-        $descriptionAttribute->getType()->__toString()->shouldReturn(AttributeType::RICH_TEXT);
+        $descriptionAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXTAREA);
         $descriptionAttribute->getOrder()->intValue()->shouldReturn(1);
         $descriptionAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('Description');
 
@@ -84,12 +84,12 @@ class TemplateBuilderSpec extends ObjectBehavior
         $metaTitleAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('SEO Meta Title');
 
         $metaDescriptionAttribute = $template->getAttributeCollection()->getAttributeByCode('seo_meta_description');
-        $metaDescriptionAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXTAREA);
+        $metaDescriptionAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXT);
         $metaDescriptionAttribute->getOrder()->intValue()->shouldReturn(4);
         $metaDescriptionAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('SEO Meta Description');
 
         $keywordsAttribute = $template->getAttributeCollection()->getAttributeByCode('seo_keywords');
-        $keywordsAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXTAREA);
+        $keywordsAttribute->getType()->__toString()->shouldReturn(AttributeType::TEXT);
         $keywordsAttribute->getOrder()->intValue()->shouldReturn(5);
         $keywordsAttribute->getLabelCollection()->getTranslation('en_US')->shouldReturn('SEO Keywords');
     }

--- a/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
@@ -129,10 +129,14 @@ export const EditAttributesForm = ({attributeValues, template, onAttributeValueC
       <SectionTitle>
         <SectionTitle.Title>{translate('Attributes')}</SectionTitle.Title>
         <SectionTitle.Spacer />
-        <LocaleSelector value={locale} values={Object.values(locales)} onChange={(value) => {
-          setLocale(value);
-          userContext.set('catalogLocale', value, {});
-        }} />
+        <LocaleSelector
+          value={locale}
+          values={Object.values(locales)}
+          onChange={value => {
+            setLocale(value);
+            userContext.set('catalogLocale', value, {});
+          }}
+        />
       </SectionTitle>
       {attributeFields}
     </FormContainer>

--- a/src/Akeneo/Category/front/src/feature/components/datagrids/CategoryTreeDataGrid.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/datagrids/CategoryTreeDataGrid.tsx
@@ -8,6 +8,7 @@ import {
   useRouter,
   useSecurity,
   useTranslate,
+  useUserContext,
 } from '@akeneo-pim-community/shared';
 import {CategoryTreeModel, Template} from '../../models';
 import styled from 'styled-components';
@@ -33,6 +34,8 @@ const CategoryTreesDataGrid: FC<Props> = ({trees, refreshCategoryTrees}) => {
   const [isConfirmationModalOpen, openConfirmationModal, closeConfirmationModal] = useBooleanState();
   const [categoryTreeToDelete, setCategoryTreeToDelete] = useState<CategoryTreeModel | null>(null);
   const [displayCategoryTemplatesColumn, setDisplayCategoryTemplatesColumn] = useState<boolean>(false);
+  const userContext = useUserContext();
+  const catalogLocale = userContext.get('catalogLocale');
 
   const followCategoryTree = useCallback(
     (tree: CategoryTreeModel): void => {
@@ -75,7 +78,7 @@ const CategoryTreesDataGrid: FC<Props> = ({trees, refreshCategoryTrees}) => {
   };
 
   const onCreateTemplate = (categoryTree: CategoryTreeModel) => {
-    createTemplate(categoryTree, router)
+    createTemplate(categoryTree, catalogLocale, router)
       .then(response => {
         response.json().then((template: Template) => {
           if (template) {

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
@@ -22,17 +22,14 @@ export const EditTemplateAttributesForm = ({attributes}: Props) => {
   const catalogLocale = userContext.get('catalogLocale');
   const translate = useTranslate();
 
-  const sortByOrder = useCallback(
-    (attribute1: Attribute, attribute2: Attribute): number => {
-      if (attribute1.order >= attribute2.order) {
-        return 1;
-      } else if (attribute1.order < attribute2.order) {
-        return -1;
-      }
-      return 0;
-    },
-    []
-  );
+  const sortByOrder = useCallback((attribute1: Attribute, attribute2: Attribute): number => {
+    if (attribute1.order >= attribute2.order) {
+      return 1;
+    } else if (attribute1.order < attribute2.order) {
+      return -1;
+    }
+    return 0;
+  }, []);
 
   return (
     <FormContainer>

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useCallback} from 'react';
 import styled from 'styled-components';
 import {SectionTitle, Table} from 'akeneo-design-system';
 import {useTranslate, useUserContext} from '@akeneo-pim-community/shared';
@@ -22,6 +22,18 @@ export const EditTemplateAttributesForm = ({attributes}: Props) => {
   const catalogLocale = userContext.get('catalogLocale');
   const translate = useTranslate();
 
+  const sortByOrder = useCallback(
+    (attribute1: Attribute, attribute2: Attribute): number => {
+      if (attribute1.order >= attribute2.order) {
+        return 1;
+      } else if (attribute1.order < attribute2.order) {
+        return -1;
+      }
+      return 0;
+    },
+    []
+  );
+
   return (
     <FormContainer>
       <SectionTitle>
@@ -34,10 +46,8 @@ export const EditTemplateAttributesForm = ({attributes}: Props) => {
           <Table.HeaderCell>{translate('akeneo.category.template_list.columns.type')}</Table.HeaderCell>
         </Table.Header>
         <Table.Body>
-          {attributes?.map((attribute: Attribute) => (
-            <Table.Row
-              key={attribute.uuid}
-            >
+          {attributes?.sort(sortByOrder).map((attribute: Attribute) => (
+            <Table.Row key={attribute.uuid}>
               <Table.Cell rowTitle>{getLabelFromAttribute(attribute, catalogLocale)}</Table.Cell>
               <Table.Cell>{attribute.code}</Table.Cell>
               <Table.Cell>{attribute.type}</Table.Cell>

--- a/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/EditTemplateAttributesForm.tsx
@@ -50,7 +50,7 @@ export const EditTemplateAttributesForm = ({attributes}: Props) => {
             <Table.Row key={attribute.uuid}>
               <Table.Cell rowTitle>{getLabelFromAttribute(attribute, catalogLocale)}</Table.Cell>
               <Table.Cell>{attribute.code}</Table.Cell>
-              <Table.Cell>{attribute.type}</Table.Cell>
+              <Table.Cell>{translate(`akeneo.category.template.attribute.type.${attribute.type}`)}</Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>

--- a/src/Akeneo/Category/front/src/feature/components/templates/createTemplate.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/templates/createTemplate.tsx
@@ -1,10 +1,10 @@
 import {Router} from '@akeneo-pim-community/shared';
 import {CategoryTreeModel} from '../../models';
 
-const createTemplate = async (categoryTree: CategoryTreeModel, router: Router) => {
+const createTemplate = async (categoryTree: CategoryTreeModel, catalogLocale: string, router: Router) => {
   const data = {
     code: categoryTree.code + '_template',
-    labels: [categoryTree.label + ' template'],
+    labels: {[catalogLocale]: categoryTree.label + ' template'},
   };
 
   const url = router.generate('pim_category_template_rest_create', {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

Type 1, 4 and 5 weren't the good ones, and I created labels for corresping attribute types and the Image code.

![image](https://user-images.githubusercontent.com/114410848/201049332-cde94db7-49ee-4a91-93d2-524e34ec5316.png)

Beyond the fix, I used this subject to discover the pim and experiment dynamic variables to handle attributes sorting.

My idea was based on usual dynamic database.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
