### PR TITLE
OCT-169: fix migration of ES index

### DIFF
--- a/upgrades/.php_cd.php
+++ b/upgrades/.php_cd.php
@@ -41,6 +41,7 @@ $rules = [
             'Symfony\Component\Console\Input\ArrayInput',
             'Symfony\Component\Console\Output\BufferedOutput',
             'Symfony\Component\DependencyInjection\ParameterBag\ParameterBag',
+            'Symfony\Component\Yaml\Yaml',
             'Webmozart\Assert\Assert',
         ]
     )->in('Pim\Upgrade\Schema'),

--- a/upgrades/schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping.php
+++ b/upgrades/schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping.php
@@ -9,6 +9,7 @@ use Doctrine\Migrations\AbstractMigration;
 use Elasticsearch\ClientBuilder;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Yaml\Yaml;
 use Webmozart\Assert\Assert;
 
 /**
@@ -33,6 +34,11 @@ final class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping 
             throw new \RuntimeException('Unable to retrieve existing mapping.');
         }
 
+        if ('text' === (current($existingMapping)['mappings']['properties']['id']['type'] ?? '')) {
+            $this->reindexWhenThereIsAlreadyAnId();
+            return;
+        }
+
         $client->putMapping([
             'index' => $eventsApiDebugIndexName,
             'body' => [
@@ -41,7 +47,79 @@ final class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping 
                 ],
             ],
         ]);
+    }
 
+    private function reindexWhenThereIsAlreadyAnId(): void
+    {
+        $builder = $this->container->get('akeneo_elasticsearch.client_builder');
+        $builder->setHosts([$this->container->getParameter('index_hosts')]);
+        /** @var \Elasticsearch\Client $client */
+        $client = $builder->build();
+        $alias = $this->container->getParameter('events_api_debug_index_name');
+        $copy = sprintf('%s_copy', $alias);
+        $indice = array_keys($client->indices()->getAlias(['name' => $alias]))[0];
+
+        $mapping = $this->getMappingConfiguration();
+
+        $client->indices()->create([
+            'index' => $copy,
+            'body' => $mapping,
+        ]);
+
+        $client->reindex([
+            'refresh' => true,
+            'body' => [
+                'source' => [
+                    'index' => $indice,
+                ],
+                'dest' => [
+                    'index' => $copy,
+                ],
+            ],
+        ]);
+
+        $client->indices()->putAlias([
+            'name' => $alias,
+            'index' => $copy,
+        ]);
+
+        $client->indices()->delete([
+            'index' => $indice,
+        ]);
+
+        $client->indices()->create([
+            'index' => $indice,
+            'body' => $mapping,
+        ]);
+
+        $client->reindex([
+            'refresh' => true,
+            'body' => [
+                'source' => [
+                    'index' => $copy,
+                ],
+                'dest' => [
+                    'index' => $indice,
+                ],
+            ],
+        ]);
+
+        $client->indices()->putAlias([
+            'name' => $alias,
+            'index' => $indice,
+        ]);
+
+        $client->indices()->delete([
+            'index' => $copy,
+        ]);
+    }
+
+    private function getMappingConfiguration(): array
+    {
+        $ceDir = $this->container->getParameter('pim_ce_dev_src_folder_location');
+        $path = "{$ceDir}/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/elasticsearch/events_api_debug_mapping.yml";
+
+        return Yaml::parseFile($path);
     }
 
     public function down(Schema $schema): void

--- a/upgrades/test_schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integration.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema\Tests;
 
+use Akeneo\Connectivity\Connection\Domain\Webhook\Model\EventsApiDebugLogLevels;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\Loader;
 use Elasticsearch\Client as NativeClient;
+use Ramsey\Uuid\Uuid;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Yaml\Yaml;
 
@@ -37,7 +39,7 @@ class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integr
         $this->eventsApiDebugClient = $this->get('akeneo_connectivity.client.events_api_debug');
     }
 
-    public function test_it_adds_the_entity_updated_property_to_the_mapping(): void
+    public function test_it_adds_the_id_property_to_the_mapping(): void
     {
         $this->recreateIndexWithoutIdFieldInTheMapping();
         $properties = $this->getIndexMappingProperties();
@@ -48,6 +50,43 @@ class Version_7_0_20221026154157_add_id_to_events_api_debug_index_mapping_Integr
         $properties = $this->getIndexMappingProperties();
         self::assertArrayHasKey('id', $properties);
         self::assertSame(['type' => 'keyword'], $properties['id']);
+    }
+
+    public function test_it_changes_the_id_property_from_text_to_keyword(): void
+    {
+        $this->recreateIndexWithoutIdFieldInTheMapping();
+        self::assertArrayNotHasKey('id', $this->getIndexMappingProperties());
+
+        $this->nativeClient->index([
+            'index' => self::getContainer()->getParameter('events_api_debug_index_name'),
+            'body' => [
+                'id' => 'aa63292c-a06c-4c50-afb9-c98c97dc8a13',
+                'timestamp' => '1667946703',
+                'level' => 'notice',
+                'message' => 'foobar',
+                'connection_code' => 'foo',
+                'context' => [],
+            ],
+        ]);
+        $this->nativeClient->indices()->refresh();
+        self::assertSame('text', $this->getIndexMappingProperties()['id']['type']);
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+
+        $properties = $this->getIndexMappingProperties();
+        self::assertSame('keyword', $properties['id']['type']);
+
+        $documents = $this->nativeClient->search([
+            'index' => self::getContainer()->getParameter('events_api_debug_index_name'),
+        ]);
+        self::assertSame([
+            'id' => 'aa63292c-a06c-4c50-afb9-c98c97dc8a13',
+            'timestamp' => '1667946703',
+            'level' => 'notice',
+            'message' => 'foobar',
+            'connection_code' => 'foo',
+            'context' => [],
+        ], $documents['hits']['hits'][0][('_source')]);
     }
 
     private function recreateIndexWithoutIdFieldInTheMapping(): void


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Context**

The migration is executed asynchronously. 
Before the doctrine migration was executed, the webhook consumer started indexing new documents in the index `akeneo_connectivity_connection_events_api_debug`, with a new property `id`.
Because you can index documents without configuring a mapping beforehand, the new property has been automatically created by ES with the type `text` instead of `keyword`.

In ES, you cannot directly change the type of a property. (see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html#updating-field-mappings)

The migration is failing for customers having sent webhooks between the deployment and the doctrine migration execution.

**The dirty solution**

Since we cannot rename a property, cannot change the type of a property, cannot remove a property of an existing index without re-indexing everything, and we cannot re-index this particular index.

Here what's happening in the new migration:
- if the `id` property already exists
- then, creates a temporary indice
- copy documents from the corrupted indice to the temporary one (using re-index with `source` + `dest`)
- redirects the alias from the corrupted indice to the temporary one (so what we are still writing/reading somewhere)
- delete the corrupted indice
- create a new indice with the correct mapping and the original name
- copy documents from the temporary indice to the new one
- redirects the alias from the temporary indice to the new one
- removes the temporary indice

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
