### PR TITLE
RAC-1283: Fix email subject of a job notification

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
@@ -19,6 +19,9 @@ use Twig\Environment;
  */
 class MailNotifier implements Notifier
 {
+    private const SUCCESS_SUBJECT_TEMPLATE = 'Akeneo successfully completed your "%s" job';
+    private const FAILURE_SUBJECT_TEMPLATE = 'Akeneo completed your "%s" job with errors';
+
     private array $recipientEmails = [];
 
     public function __construct(
@@ -77,9 +80,9 @@ class MailNotifier implements Notifier
 
     private function getSubject(JobExecution $jobExecution): string
     {
-        $jobType = $jobExecution->getJobInstance()->getType();
-        $status = $jobExecution->getStatus()->isUnsuccessful() ? 'fail' : 'success';
+        $subjectTemplate = $jobExecution->getStatus()->isUnsuccessful() ? self::FAILURE_SUBJECT_TEMPLATE : self::SUCCESS_SUBJECT_TEMPLATE;
+        $jobLabel = $jobExecution->getJobInstance()->getLabel();
 
-        return sprintf('Akeneo completed your %s: %s', $jobType, $status);
+        return sprintf($subjectTemplate, $jobLabel);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Notification/MailNotifier.php
@@ -61,7 +61,7 @@ class MailNotifier implements Notifier
             'jobExecution' => $jobExecution,
         ];
 
-        $subject = $jobExecution->getStatus()->isUnsuccessful() ? 'Akeneo completed your export: fail' : 'Akeneo completed your export: success';
+        $subject = $this->getSubject($jobExecution);
 
         try {
             $txtBody = $this->twig->render('@AkeneoBatch/Email/notification.txt.twig', $parameters);
@@ -73,5 +73,13 @@ class MailNotifier implements Notifier
                 ['Exception' => $exception]
             );
         }
+    }
+
+    private function getSubject(JobExecution $jobExecution): string
+    {
+        $jobType = $jobExecution->getJobInstance()->getType();
+        $status = $jobExecution->getStatus()->isUnsuccessful() ? 'fail' : 'success';
+
+        return sprintf('Akeneo completed your %s: %s', $jobType, $status);
     }
 }

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.html.twig
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.html.twig
@@ -31,9 +31,9 @@
 {% block emailMessage %}
     <p style="margin: 0 0 30px 0; font-size: 20px; font-family: 'Lato', sans-serif">
         {% if jobExecution.status.unsuccessful %}
-            Akeneo completed your {{ jobExecution.jobInstance.type }} with errors.
+            Akeneo completed your "{{ jobExecution.jobInstance.label }}" job with errors.
         {% else %}
-            Akeneo successfully completed your {{ jobExecution.jobInstance.type }}.
+            Akeneo successfully completed your "{{ jobExecution.jobInstance.label }}" job.
         {% endif %}
     </p>
     <p style="margin: 0 0 20px 0; font-size: 12px;font-family: 'Lato', sans-serif">

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/views/Email/notification.txt.twig
@@ -3,9 +3,9 @@
 {% block emailMessage %}
     Dear {{ email }},
     {% if jobExecution.status.unsuccessful %}
-        Akeneo completed your {{ jobExecution.jobInstance.type }} with errors.
+        Akeneo completed your "{{ jobExecution.jobInstance.label }}" job with errors.
     {% else %}
-        Akeneo successfully completed your {{ jobExecution.jobInstance.type }}.
+        Akeneo successfully completed your "{{ jobExecution.jobInstance.label }}" job.
     {% endif %}
 
     Started on {{ jobExecution.startTime|date("Y-m-d") }} at {{ jobExecution.startTime|date("H:i:s")  }}.

--- a/src/Akeneo/Tool/Bundle/BatchBundle/spec/Notification/MailNotifierSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/spec/Notification/MailNotifierSpec.php
@@ -32,12 +32,12 @@ class MailNotifierSpec extends ObjectBehavior
     ): void {
         $batchStatus = new BatchStatus(BatchStatus::COMPLETED);
         $jobExecution->getStatus()->willReturn($batchStatus);
-        $jobInstance->getType()->willReturn('export');
+        $jobInstance->getLabel()->willReturn('An export');
         $jobExecution->getJobInstance()->willReturn($jobInstance);
 
         $mailer->notify(
             ['test@akeneo.com'],
-            'Akeneo completed your export: success',
+            'Akeneo successfully completed your "An export" job',
             Argument::any(),
             Argument::any()
         )->shouldBeCalled();
@@ -52,12 +52,12 @@ class MailNotifierSpec extends ObjectBehavior
     ): void {
         $batchStatus = new BatchStatus(BatchStatus::UNKNOWN);
         $jobExecution->getStatus()->willReturn($batchStatus);
-        $jobInstance->getType()->willReturn('mass_edit');
+        $jobInstance->getLabel()->willReturn('Mass Edith');
         $jobExecution->getJobInstance()->willReturn($jobInstance);
 
         $mailer->notify(
             ['test@akeneo.com'],
-            'Akeneo completed your mass_edit: fail',
+            'Akeneo completed your "Mass Edith" job with errors',
             Argument::any(),
             Argument::any()
         )->shouldBeCalled();
@@ -73,7 +73,7 @@ class MailNotifierSpec extends ObjectBehavior
     ): void {
         $batchStatus = new BatchStatus(BatchStatus::COMPLETED);
         $jobExecution->getStatus()->willReturn($batchStatus);
-        $jobInstance->getType()->willReturn('export');
+        $jobInstance->getLabel()->willReturn('An export');
         $jobExecution->getJobInstance()->willReturn($jobInstance);
 
         $mailer->notify(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Export type was hardcoded in the mail subject, it is now using the job instance label in the received event.
I also updated the subject and message inside mail template.

![Screenshot from 2022-11-10 11-23-09](https://user-images.githubusercontent.com/35272857/201066163-21c41c55-0a04-469f-9486-c513e4b6b934.png)
![Screenshot from 2022-11-10 11-23-37](https://user-images.githubusercontent.com/35272857/201066162-312d79a1-d020-4339-b27f-de4592e57ca9.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
