### PR TITLE
PIM-10711: Fix AbstractInvalidItemWriter does not pad empty values for trailing empty column

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,9 @@
 # 5.0.x
 
+## Bug fixes
+
+- PIM-10711: Fix AbstractInvalidItemWriter does not pad empty values for trailing empty column
+
 # 5.0.116 (2022-11-07)
 
 ## Bug fixes

--- a/src/Akeneo/Tool/Component/Connector/Archiver/AbstractInvalidItemWriter.php
+++ b/src/Akeneo/Tool/Component/Connector/Archiver/AbstractInvalidItemWriter.php
@@ -103,13 +103,14 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
             if ($invalidItemPositions->contains($currentItemPosition)) {
                 $headers = $fileIterator->getHeaders();
 
-                $readItem = $this->removeDataWithEmptyHeaders($headers, $readItem);
+                $readItem = $this->removeValuesWithEmptyHeaders($readItem, $headers);
+                $headers = $this->removeEmptyHeaders($headers);
 
-                $headers = array_filter($headers, function (string $columnName) {
-                    return '' !== trim($columnName);
-                });
+                $headersLength = count($headers);
+                $readItem = $this->padEmptyValuesToReadItem($readItem, $headersLength);
+                $readItem = $this->trimTrailingValuesWithoutHeaders($readItem, $headersLength);
 
-                $invalidItem = array_combine($headers, array_slice($readItem, 0, count($headers)));
+                $invalidItem = array_combine($headers, $readItem);
                 if (false !== $invalidItem) {
                     $itemsToWrite[] = $invalidItem;
                 }
@@ -211,7 +212,7 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
      */
     abstract protected function getFilename(): string;
 
-    private function removeDataWithEmptyHeaders(array $headers, array $readItem): array
+    private function removeValuesWithEmptyHeaders(array $readItem, array $headers): array
     {
         $emptyHeaderKeys = array_keys(array_filter($headers, function (string $columnName) {
             return '' === trim($columnName);
@@ -222,5 +223,22 @@ abstract class AbstractInvalidItemWriter extends AbstractFilesystemArchiver
         }
 
         return $readItem;
+    }
+
+    private function removeEmptyHeaders(array $headers): array
+    {
+        return array_filter($headers, function (string $columnName) {
+            return '' !== trim($columnName);
+        });
+    }
+
+    private function padEmptyValuesToReadItem(array $readItem, int $headersLength): array
+    {
+        return array_pad($readItem, $headersLength, '');
+    }
+
+    private function trimTrailingValuesWithoutHeaders(array $readItem, int $headersLength): array
+    {
+        return array_slice($readItem, 0, $headersLength);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Sometimes it happens that an invalid value (= a row) has at least one empty value at the end. FileIterator returns nothing for these values and then when we try to `array_combine` headers and row, both array length does not match and makes the invalid items files generation failing.
Basically, the fix is to pad the row by empty values to match the headers length.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
