### PR TITLE
RAB-1170: Upgrade elasticsearch version to 7.17.7 in order to prepare upgrade to 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       - 'pim'
 
   elasticsearch:
-    image: 'elastic/elasticsearch:7.16.2'
+    image: 'elastic/elasticsearch:7.17.7'
     environment:
       ES_JAVA_OPTS: '${ES_JAVA_OPTS:--Xms512m -Xmx512m}'
       discovery.type: 'single-node'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I changed the elasticsearch version to 7.17.7 in order to prepare upgrade to 8. As recommended in the official doc we should upgrade at the last version of v7 in order to have all deprecation message

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
