### PR TITLE
PIM-10718: Categories with empty labels throw 500 error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - PIM-10673: Fix media URL port display for Events API
 - PIM-10686: Fix percentage of inaccurate completeness in the activity dashboard
 - PIM-10659: Fix associated products in grid are now sorted using their uuids
+- PIM-10718: Fix categories with empty labels throw 500 error
 
 ## Improvements
 

--- a/src/Akeneo/Category/back/Domain/ValueObject/LabelCollection.php
+++ b/src/Akeneo/Category/back/Domain/ValueObject/LabelCollection.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\Category\Domain\ValueObject;
 
-use Webmozart\Assert\Assert;
-
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -18,8 +16,6 @@ final class LabelCollection implements \IteratorAggregate
      */
     private function __construct(private ?array $translatedLabels)
     {
-        Assert::allString($translatedLabels);
-        Assert::allStringNotEmpty($translatedLabels);
     }
 
     /**

--- a/src/Akeneo/Category/back/Domain/ValueObject/LabelCollection.php
+++ b/src/Akeneo/Category/back/Domain/ValueObject/LabelCollection.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Category\Domain\ValueObject;
 
+use Webmozart\Assert\Assert;
+
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -16,6 +18,8 @@ final class LabelCollection implements \IteratorAggregate
      */
     private function __construct(private ?array $translatedLabels)
     {
+        Assert::nullOrIsArray($translatedLabels);
+        Assert::allStringNotEmpty(array_keys($translatedLabels));
     }
 
     /**


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Labels are not mandatory in the PIM, we can have a LabelCollection like this : 
```
[
   'en_US' => null,
   'de_DE' => null,
   'fr_FR' => null,
]
```

We can remove assert validation in the constructor of LabelCollection.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
