### PR TITLE
PIM-10684 : fix an issue when Elasticsearch index is empty

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/IndexProductModelCommand.php
@@ -157,6 +157,7 @@ class IndexProductModelCommand extends Command
         $indexedCount = 0;
 
         $progressBar->start();
+
         foreach ($chunkedCodes as $codes) {
             $treatedBachSize = $this->batchEsStateHandler->bulkExecute($codes, $codesEsHandler);
             $indexedCount+=$treatedBachSize;
@@ -268,6 +269,11 @@ SQL;
                 '_source' => false,
                 'size' => $batchSize
             ]);
+
+            if (count($results['hits']['hits']) === 0) {
+                yield array_column($rows, 'code');
+                break;
+            }
 
             $esIdentifiers = array_map(function ($doc) {
                 return $doc['_id'];


### PR DESCRIPTION
 fix an issue when Elasticsearch index is empty

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
