### PR TITLE
OCT-158: add test on open id public key

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Public/GetOpenIdPublicKeyEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Public/GetOpenIdPublicKeyEndToEnd.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Connectivity\Connection\Tests\EndToEnd\Apps\Public;
 
+use Akeneo\Connectivity\Connection\Application\Apps\Command\GenerateAsymmetricKeysCommand;
+use Akeneo\Connectivity\Connection\Application\Apps\Command\GenerateAsymmetricKeysHandler;
 use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
 use Akeneo\Connectivity\Connection\Domain\Apps\DTO\AsymmetricKeys;
 use Akeneo\Connectivity\Connection\Domain\Apps\Exception\OpenIdKeysNotFoundException;
@@ -19,6 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class GetOpenIdPublicKeyEndToEnd extends WebTestCase
 {
+    private GenerateAsymmetricKeysHandler $generateAsymmetricKeysHandler;
     private PimConfigurationLoader $pimConfigurationLoader;
     private Connection $connection;
 
@@ -26,6 +29,7 @@ class GetOpenIdPublicKeyEndToEnd extends WebTestCase
     {
         parent::setUp();
         $this->pimConfigurationLoader = $this->get(PimConfigurationLoader::class);
+        $this->generateAsymmetricKeysHandler = $this->get(GenerateAsymmetricKeysHandler::class);
         $this->connection = $this->get('database_connection');
     }
 
@@ -49,6 +53,25 @@ class GetOpenIdPublicKeyEndToEnd extends WebTestCase
 
         Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
         Assert::assertEquals('{"public_key":"the_public_key"}', $result);
+    }
+
+    public function test_the_openid_public_key_can_be_read_by_openssl(): void
+    {
+        $this->generateAsymmetricKeysHandler->handle(new GenerateAsymmetricKeysCommand());
+        $this->client->request(
+            'GET',
+            '/connect/apps/v1/openid/public-key',
+        );
+        $result = $this->client->getResponse()->getContent();
+
+        Assert::assertEquals(Response::HTTP_OK, $this->client->getResponse()->getStatusCode());
+        $result = \json_decode($result, true);
+
+        $publicKey = \openssl_pkey_get_public($result['public_key']);
+        Assert::assertNotFalse($publicKey);
+        $details = \openssl_pkey_get_details($publicKey);
+        Assert::assertNotFalse($details);
+        Assert::assertEquals(OPENSSL_KEYTYPE_RSA, $details['type']);
     }
 
     public function test_it_gets_an_error_if_there_is_no_openid_public_key_into_database(): void


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Following the phpseclib migration from v2 to v3 here https://github.com/akeneo/pim-community-dev/pull/17101 we found a bug by testing manually the PR. The new public key was not readable by the openssl standard function of PHP.
This PR aims to add an automatic test to ensure the public key delivered by our open id endpoint is still readable by openssl. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
