### PR TITLE
PIM-10724: Fix textarea template so that first break line is not cons…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PIM-10718: Fix categories with empty labels throw 500 error
 - PIM-10725: Fix get family variant case sensitive
 - PIM-10720: Fix price versioning normalizer to round numbers
+- PIM-10724: Fix textarea template so that first break line is not considered as break in html
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/textarea.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/product/field/textarea.html
@@ -8,4 +8,5 @@
     data-locale="<%- locale %>"
     data-scope="<%- scope %>"
     <%- editMode === 'view' ? 'disabled' : '' %>
-><%- value ? value.data: null %></textarea>
+>
+<%- value ? value.data: null %></textarea>


### PR DESCRIPTION
…idered as break in html
**Description (for Contributor and Core Developer)**

When the value given is: `\ncoucou`

Before:
What is rendered:
```
<textarea>
coucou</textarea>
``` 
What is seen: No line break, the browser computes it as code style

After:
What is rendered: 
```
<textarea>

coucou
</textarea>
```
What is seen: 
The new line is considered as the value of the textarea

... voilà

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
