### PR TITLE
Fix version name

### DIFF
--- a/src/Akeneo/Platform/CommunityVersion.php
+++ b/src/Akeneo/Platform/CommunityVersion.php
@@ -15,7 +15,7 @@ class CommunityVersion
     public const VERSION = '6.0.53';
 
     /** @staticvar string */
-    const VERSION_CODENAME = 'Bully for Bugs';
+    const VERSION_CODENAME = 'Buccaneer Bunny';
 
     /** @staticvar string */
     const EDITION = 'CE';


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The version name for 6.0 is wrong, maybe overrided by a previous pull-up from 5.0.

![Screenshot from 2022-11-18 13-33-29](https://user-images.githubusercontent.com/35272857/202705984-21871e76-a7a1-4de6-8b31-57f3f396c36a.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
