### PR TITLE
PIM-10735: Assets export fails because of a failed warning messages

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+PIM-10734: Assets export fails because of a failed warning messages
+
 # 6.0.55 (2022-11-21)
 
 # 6.0.54 (2022-11-18)

--- a/src/Akeneo/Tool/Component/Connector/Archiver/FileWriterArchiver.php
+++ b/src/Akeneo/Tool/Component/Connector/Archiver/FileWriterArchiver.php
@@ -125,8 +125,8 @@ class FileWriterArchiver extends AbstractFilesystemArchiver
                 $this->logger->warning(
                     'The remote file could not be read from the remote filesystem',
                     [
-                        'key' => $filesToArchive->sourceKey(),
-                        'storage' => $filesToArchive->sourceStorage(),
+                        'key' => $fileToArchive->sourceKey(),
+                        'storage' => $fileToArchive->sourceStorage(),
                         'exception' => [
                             'type' => \get_class($e),
                             'message' => $e->getMessage(),


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I fixed a fatal error due to the fact that we call a function on an array instead of calling the function on the object

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
