### PR TITLE
GRF-595: Charge attributes values per channel dynamicaly

### DIFF
--- a/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
@@ -131,8 +131,8 @@ export const EditAttributesForm = ({attributeValues, template, onAttributeValueC
 
     return (
       <AttributeField
-        channel={attribute.is_scopable ? channel : ''}
-        locale={attribute.is_localizable ? locale : ''}
+        channel={channel}
+        locale={locale}
         value={dataForInput}
         onChange={handlers[attribute.code]}
         key={attribute.uuid}

--- a/src/Akeneo/Category/front/src/feature/components/attributes/buildRichTextFieldAttribute.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/attributes/buildRichTextFieldAttribute.tsx
@@ -4,6 +4,7 @@ import {AttributeFieldBuilder, AttributeFieldProps, AttributeInputValue} from '.
 import {getLabelFromAttribute} from './templateAttributesFactory';
 import styled from 'styled-components';
 import {memoize} from 'lodash/fp';
+import {buildCompositeKey} from '../../models';
 
 const Field960 = styled(Field)`
   max-width: 960px;
@@ -20,13 +21,13 @@ const unMemoizedBuildRichTextFieldAttribute: AttributeFieldBuilder<AttributeInpu
       return null;
     }
 
-    // TextAreaInput prop "key" = locale :
+    // TextAreaInput prop "key" = composite key (code|uuid|channel|locale):
     // because the RichTextEditor in the DSM is not able of considering a changed value
     // it loops internally on its state for the value and ignores external modifications of the value
-    // we have to force react to rebuild it when changing the value (when locale is changed for instance)
+    // we have to force react to rebuild it when changing the value (when channel or locale is changed for instance)
     return (
       <Field960 label={getLabelFromAttribute(attribute, locale)} channel={channel} locale={locale}>
-        <TextAreaInput key={locale} isRichText name={attribute.code} value={value} onChange={onChange} />
+        <TextAreaInput key={buildCompositeKey(attribute, channel, locale)} isRichText name={attribute.code} value={value} onChange={onChange} />
       </Field960>
     );
   };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Define a key for rich text editor which will include the composite key for better identifiate the component
Remove useless check which prevented to display the attribute image label that is no localizable for now

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
