### PR TITLE
DSM: Update font size label collapse

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Collapse/Collapse.tsx
+++ b/front-packages/akeneo-design-system/src/components/Collapse/Collapse.tsx
@@ -39,7 +39,7 @@ const Label = styled.div`
   flex: 1;
   text-transform: uppercase;
   color: ${getColor('grey', 140)};
-  font-size: ${getFontSize('small')};
+  font-size: ${getFontSize('default')};
   display: flex;
   align-items: center;
   gap: 10px;


### PR DESCRIPTION
Seen with the designers, the font size for the collapse label is too small.

We need to move it from 11px to 13px.