### PR TITLE
CPM-828: Invalidate getGenerator on create to refresh datas

### DIFF
--- a/components/identifier-generator/front/src/feature/pages/CreateGeneratorPage.tsx
+++ b/components/identifier-generator/front/src/feature/pages/CreateGeneratorPage.tsx
@@ -5,6 +5,7 @@ import {NotificationLevel, useNotify, useTranslate} from '@akeneo-pim-community/
 import {useHistory} from 'react-router-dom';
 import {useCreateIdentifierGenerator} from '../hooks';
 import {useIdentifierGeneratorContext} from '../context';
+import {useQueryClient} from 'react-query';
 
 type CreateGeneratorProps = {
   initialGenerator: IdentifierGenerator;
@@ -14,6 +15,7 @@ const CreateGeneratorPage: React.FC<CreateGeneratorProps> = ({initialGenerator})
   const notify = useNotify();
   const translate = useTranslate();
   const history = useHistory();
+  const queryClient = useQueryClient();
   const {mutate, error, isLoading} = useCreateIdentifierGenerator();
   const identifierGeneratorContext = useIdentifierGeneratorContext();
 
@@ -32,6 +34,7 @@ const CreateGeneratorPage: React.FC<CreateGeneratorProps> = ({initialGenerator})
         }
       },
       onSuccess: ({code}: IdentifierGenerator) => {
+        queryClient.invalidateQueries('getIdentifierGenerator');
         notify(NotificationLevel.SUCCESS, translate('pim_identifier_generator.flash.create.success', {code}));
         history.push(`/${code}`);
       },

--- a/components/identifier-generator/front/src/feature/pages/CreateOrEditGeneratorPage.tsx
+++ b/components/identifier-generator/front/src/feature/pages/CreateOrEditGeneratorPage.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Button, Helper, TabBar, useBooleanState} from 'akeneo-design-system';
 import {PageHeader, SecondaryActions, useTranslate} from '@akeneo-pim-community/shared';
 import {GeneralPropertiesTab, SelectionTab, StructureTab} from '../tabs';
@@ -48,6 +48,10 @@ const CreateOrEditGeneratorPage: React.FC<CreateOrEditGeneratorProps> = ({
 
   const [generatorCodeToDelete, setGeneratorCodeToDelete] = useState<IdentifierGeneratorCode | undefined>();
   const [isDeleteGeneratorModalOpen, openDeleteGeneratorModal, closeDeleteGeneratorModal] = useBooleanState();
+
+  useEffect(() => {
+    setGenerator(initialGenerator);
+  }, [initialGenerator]);
 
   const closeModal = (): void => {
     closeDeleteGeneratorModal();

--- a/components/identifier-generator/front/src/feature/pages/__tests__/CreateGeneratorPage.test.tsx
+++ b/components/identifier-generator/front/src/feature/pages/__tests__/CreateGeneratorPage.test.tsx
@@ -5,6 +5,7 @@ import {Router} from 'react-router-dom';
 import {act, fireEvent, waitFor} from '@testing-library/react';
 import {createMemoryHistory} from 'history';
 import {initialGenerator} from '../../tests/fixtures/initialGenerator';
+import {QueryClient, QueryClientProvider} from 'react-query';
 
 jest.mock('../CreateOrEditGeneratorPage');
 
@@ -17,10 +18,14 @@ describe('CreateGeneratorPage', () => {
     });
 
     const history = createMemoryHistory();
+    const queryClient = new QueryClient();
+    const mockedQueryClient = jest.spyOn(queryClient, 'invalidateQueries');
     render(
-      <Router history={history}>
-        <CreateGeneratorPage initialGenerator={initialGenerator} />
-      </Router>
+      <QueryClientProvider client={queryClient}>
+        <Router history={history}>
+          <CreateGeneratorPage initialGenerator={initialGenerator} />
+        </Router>
+      </QueryClientProvider>
     );
     expect(screen.getByText('CreateOrEditGeneratorPage')).toBeInTheDocument();
 
@@ -31,6 +36,7 @@ describe('CreateGeneratorPage', () => {
     await waitFor(() => history.length > 1);
     expectCall();
     expect(history.location.pathname).toBe('/initialCode');
+    expect(mockedQueryClient).toBeCalledWith('getIdentifierGenerator');
   });
 
   it('should display validation errors', async () => {

--- a/components/identifier-generator/front/src/feature/pages/__tests__/CreateOrEditGeneratorPage.test.tsx
+++ b/components/identifier-generator/front/src/feature/pages/__tests__/CreateOrEditGeneratorPage.test.tsx
@@ -5,6 +5,7 @@ import {createMemoryHistory} from 'history';
 import {Router} from 'react-router';
 import {IdentifierGeneratorContext} from '../../context/IdentifierGeneratorContext';
 import {initialGenerator} from '../../tests/fixtures/initialGenerator';
+import {IdentifierGenerator, PROPERTY_NAMES} from '../../models';
 
 jest.mock('../DeleteGeneratorModal');
 jest.mock('../../tabs/GeneralPropertiesTab');
@@ -124,5 +125,40 @@ describe('CreateOrEditGeneratorPage', () => {
 
     fireEvent.click(screen.getByText('Revert Free Text'));
     expect(mockSetHasUnsavedChanges).toHaveBeenCalledWith(false);
+  });
+
+  it('should update generator on initialGenerator change', () => {
+    const {rerender} = render(
+      <CreateOrEditGeneratorPage
+        isMainButtonDisabled={false}
+        initialGenerator={initialGenerator}
+        mainButtonCallback={jest.fn()}
+        validationErrors={[]}
+        isNew={false}
+      />
+    );
+
+    expect(screen.getByText('pim_identifier_generator.tabs.identifier_structure')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('pim_identifier_generator.tabs.identifier_structure'));
+    expect(screen.getByText('StructureTabMock')).toBeInTheDocument();
+    expect(screen.getByText('[{"type":"free_text","string":"AKN"}]')).toBeInTheDocument();
+
+    const updatedGenerator: IdentifierGenerator = {
+      ...initialGenerator,
+      structure: [{type: PROPERTY_NAMES.FREE_TEXT, string: 'Updated string'}],
+    };
+
+    rerender(
+      <CreateOrEditGeneratorPage
+        isMainButtonDisabled={false}
+        initialGenerator={updatedGenerator}
+        mainButtonCallback={jest.fn()}
+        validationErrors={[]}
+        isNew={false}
+      />
+    );
+    expect(screen.getByText('pim_identifier_generator.tabs.identifier_structure')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('pim_identifier_generator.tabs.identifier_structure'));
+    expect(screen.getByText('[{"type":"free_text","string":"Updated string"}]')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We invalidate the getGenerator query on create in order to refetch the generator in all the app.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
