### PR TITLE
GRF-599 fix blank page on categories when manipulating channels list before it is fetched

### DIFF
--- a/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
@@ -62,6 +62,7 @@ export const EditAttributesForm = ({attributeValues, template, onAttributeValueC
   const [locale, setLocale] = useState(catalogLocale);
   const catalogChannel = userContext.get('catalogScope');
   const [channel, setChannel] = useState(catalogChannel);
+  const channelList = useMemo(() => Object.values(channels), [channels]);
 
   const handleChannelChange = (value: string): void => {
     setChannel(value);
@@ -140,21 +141,16 @@ export const EditAttributesForm = ({attributeValues, template, onAttributeValueC
     );
   });
 
-  const channelList = Object.values(channels);
-
   return (
     <FormContainer>
       <SectionTitle>
         <SectionTitle.Title>{translate('akeneo.category.attributes')}</SectionTitle.Title>
         <SectionTitle.Spacer />
-        {
-          channelList.length > 0 &&
-          <ChannelSelector
-            value={channel}
-            values={channelList}
-            onChange={handleChannelChange}
-          />
-        }
+        <ChannelSelector
+          value={channel}
+          values={channelList}
+          onChange={handleChannelChange}
+        />
         <LocaleSelector
           value={locale}
           values={Object.values(locales)}

--- a/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/EditAttributesForm.tsx
@@ -140,16 +140,21 @@ export const EditAttributesForm = ({attributeValues, template, onAttributeValueC
     );
   });
 
+  const channelList = Object.values(channels);
+
   return (
     <FormContainer>
       <SectionTitle>
         <SectionTitle.Title>{translate('akeneo.category.attributes')}</SectionTitle.Title>
         <SectionTitle.Spacer />
-        <ChannelSelector
+        {
+          channelList.length > 0 &&
+          <ChannelSelector
             value={channel}
-            values={Object.values(channels)}
+            values={channelList}
             onChange={handleChannelChange}
-        />
+          />
+        }
         <LocaleSelector
           value={locale}
           values={Object.values(locales)}

--- a/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.test.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import {screen} from '@testing-library/react';
+import {renderWithProviders} from '@akeneo-pim-community/shared/lib/tests';
+import {ChannelSelector} from 'feature/components/channel/index';
+import userEvent from '@testing-library/user-event';
+import {Channel} from "@akeneo-pim-community/shared";
+
+const locales = [
+  {
+    code: 'en_US',
+    label: 'English (United States)',
+    region: 'United States',
+    language: 'English',
+  },
+  {
+    code: 'fr_FR',
+    label: 'French (France)',
+    region: 'France',
+    language: 'French',
+  },
+];
+
+const channels: Channel[] = [
+  {
+    code: 'ecommerce',
+    labels: {'en_US': 'Ecommerce'},
+    locales: locales,
+    category_tree: "1",
+    conversion_units: ['test'],
+    currencies: ['test'],
+    meta: {
+      created: null,
+      form: '',
+      id: 1,
+      updated: null
+    }
+  },
+  {
+    code: 'mobile',
+    labels: {'en_US': 'Mobile'},
+    locales: locales,
+    category_tree: "1",
+    conversion_units: ['test'],
+    currencies: ['test'],
+    meta: {
+      created: null,
+      form: '',
+      id: 1,
+      updated: null
+    }
+  },
+];
+
+test('It renders the current channel', () => {
+  renderWithProviders(<ChannelSelector values={channels} value={'mobile'} onChange={() => {}}/>);
+
+  expect(screen.getByText(/pim_common.channel/)).toBeInTheDocument();
+  expect(screen.getByText(/Mobile/)).toBeInTheDocument();
+});
+
+test('It renders with an unknown channel', async () => {
+  renderWithProviders(<ChannelSelector values={channels} value={'unknown_channel'} onChange={() => {}}/>);
+
+  expect(screen.getByText(/pim_common.channel/)).toBeInTheDocument();
+  expect(screen.getByTestId(`ChannelSelector.selection`)).toBeEmptyDOMElement();
+});
+
+test('It calls onChange handler when user click on another channel', async () => {
+  const onChange = jest.fn();
+
+  renderWithProviders(<ChannelSelector values={channels} value={'ecommerce'} onChange={onChange} />);
+
+  userEvent.click(screen.getByText(/Ecommerce/));
+  userEvent.click(screen.getByText(/Mobile/));
+
+  expect(onChange).toBeCalledWith('mobile');
+});

--- a/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
@@ -1,25 +1,10 @@
-import {Channel, ChannelCode, useTranslate, useUserContext} from '@akeneo-pim-community/shared';
+import React from 'react';
+import {Channel, ChannelCode, getLabel, useTranslate, useUserContext} from '@akeneo-pim-community/shared';
 import {
   Dropdown,
   SwitcherButton,
   useBooleanState
 } from 'akeneo-design-system';
-import React, {forwardRef, Ref} from 'react';
-
-const ChannelSpan = forwardRef<HTMLSpanElement, ChannelProps>(
-    ({code, label, ...rest}: ChannelProps, forwardedRef: Ref<HTMLSpanElement>) => {
-      return (
-          <span ref={forwardedRef} {...rest}>
-          {label || `[${code}]`}
-        </span>
-      );
-    }
-);
-
-type ChannelProps = {
-  code: string;
-  label: string;
-};
 
 type ChannelSelectorProps = {
   value: ChannelCode;
@@ -31,14 +16,13 @@ const ChannelSelector = ({value, values, onChange}: ChannelSelectorProps) => {
   const userContext = useUserContext();
   const catalogLocale = userContext.get('catalogLocale');
   const [isOpen, open, close] = useBooleanState(false);
-  const selectedChannel: Channel = values.find(channel => channel.code === value) || values[0];
-
+  const selectedChannel: Channel|undefined = values.find(channel => channel.code === value);
   const handleChange = (channelCode: ChannelCode) => onChange?.(channelCode);
 
   return (
     <Dropdown>
       <SwitcherButton inline onClick={() => {open();}} label={translate('pim_common.channel')}>
-        <ChannelSpan code={`[${selectedChannel?.code}]`} label={selectedChannel?.labels[catalogLocale]} />
+        <span>{selectedChannel && getLabel(selectedChannel.labels, catalogLocale, `${selectedChannel.code}`)}</span>
       </SwitcherButton>
       {isOpen && (
         <Dropdown.Overlay verticalPosition="down" onClose={close}>
@@ -57,11 +41,7 @@ const ChannelSelector = ({value, values, onChange}: ChannelSelectorProps) => {
                     }}
                     isActive={channel.code === selectedChannel?.code}
                   >
-                    <ChannelSpan
-                      code={channel.code}
-                      label={channel.labels[catalogLocale]}
-                      key={channel.code}
-                    />
+                    <span key={channel.code}>{getLabel(channel.labels, catalogLocale, `${channel.code}`)}</span>
                   </Dropdown.Item>
                 );
               }

--- a/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
@@ -22,7 +22,7 @@ const ChannelSelector = ({value, values, onChange}: ChannelSelectorProps) => {
   return (
     <Dropdown>
       <SwitcherButton inline onClick={() => {open();}} label={translate('pim_common.channel')}>
-        <span>{selectedChannel && getLabel(selectedChannel.labels, catalogLocale, `${selectedChannel.code}`)}</span>
+        <span data-testid={`ChannelSelector.selection`}>{selectedChannel && getLabel(selectedChannel.labels, catalogLocale, `${selectedChannel.code}`)}</span>
       </SwitcherButton>
       {isOpen && (
         <Dropdown.Overlay verticalPosition="down" onClose={close}>

--- a/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/channel/ChannelSelector.tsx
@@ -38,7 +38,7 @@ const ChannelSelector = ({value, values, onChange}: ChannelSelectorProps) => {
   return (
     <Dropdown>
       <SwitcherButton inline onClick={() => {open();}} label={translate('pim_common.channel')}>
-        <ChannelSpan code={`[${selectedChannel.code}]`} label={selectedChannel.labels[catalogLocale]} />
+        <ChannelSpan code={`[${selectedChannel?.code}]`} label={selectedChannel?.labels[catalogLocale]} />
       </SwitcherButton>
       {isOpen && (
         <Dropdown.Overlay verticalPosition="down" onClose={close}>
@@ -55,7 +55,7 @@ const ChannelSelector = ({value, values, onChange}: ChannelSelectorProps) => {
                       close();
                       handleChange(channel.code);
                     }}
-                    isActive={channel.code === selectedChannel.code}
+                    isActive={channel.code === selectedChannel?.code}
                   >
                     <ChannelSpan
                       code={channel.code}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When the PIM is build and launched for the 1st time, or when we delete the project's cache, the ChannelSelector component receives an empty list of channels. It try to access the "code" property of every channel of this empty list which resulted in an error and a blank page.

Now we do not display the component if the channels list is empty

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
