### PR TITLE
CPM-824: Add empty/not empty operator on identifier filter in product grid

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Extension/RegisterIdentifierFilters.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Extension/RegisterIdentifierFilters.php
@@ -58,6 +58,7 @@ class RegisterIdentifierFilters
                 'field_options' => [
                     'attr' => [
                         'choice_list' => true,
+                        'empty_choice' => true,
                     ],
                 ],
             ],

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/datagrid/product.yml
@@ -321,6 +321,7 @@ datagrid:
                         field_options:
                             attr:
                                 choice_list: true
+                                empty_choice: true
                 entity_type:
                     label: 'pim_datagrid.filters.entity_type.label'
                     data_name: entity_type

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -531,7 +531,7 @@ services:
         class: '%pim_catalog.query.elasticsearch.filter.identifier_attribute.class%'
         arguments:
             - ['pim_catalog_identifier']
-            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN']
+            - ['STARTS WITH', 'CONTAINS', 'DOES NOT CONTAIN', '=', '!=', 'IN', 'NOT IN', 'EMPTY', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/attribute_types.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/attribute_types.yml
@@ -9,6 +9,7 @@ parameters:
                 field_options:
                     attr:
                         choice_list: true
+                        empty_choice: true
         sorter:          product_value
     pim_datagrid.product.attribute_type.pim_catalog_text:
         column:

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/identifier-filter.js
@@ -15,6 +15,8 @@ define(['underscore', 'oro/translator', 'oro/datafilter/choice-filter'], functio
         {label: __('pim_datagrid.filters.common.equal'), value: '3'},
         {label: __('pim_datagrid.filters.common.start_with'), value: '4'},
         {label: __('pim_datagrid.filters.common.in_list'), value: 'in'},
+        {label: __('pim_datagrid.filters.common.empty'), value: 'empty'},
+        {label: __('pim_datagrid.filters.common.not_empty'), value: 'not empty'},
       ];
       this.emptyValue = {type: 'in', value: ''};
 
@@ -31,6 +33,8 @@ define(['underscore', 'oro/translator', 'oro/datafilter/choice-filter'], functio
         '3': __('pim_datagrid.filters.common.equal'),
         '4': __('pim_datagrid.filters.common.start_with'),
         in: __('pim_datagrid.filters.common.in_list'),
+        empty: __('pim_datagrid.filters.common.empty'),
+        'not empty': __('pim_datagrid.filters.common.not_empty'),
       };
     },
   });

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Extension/RegisterIdentifierFiltersSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Extension/RegisterIdentifierFiltersSpec.php
@@ -38,7 +38,7 @@ class RegisterIdentifierFiltersSpec extends ObjectBehavior
         $this->beConstructedWith($getAttributes, $getAttributeTranslations, $userContext, $requestParams, $requestStack);
     }
 
-    public function it_add_attribute_identifier_as_filters(
+    public function it_adds_attribute_identifier_as_filters(
         BuildBefore $buildBefore,
         DatagridConfiguration $datagridConfiguration,
         GetAttributes $getAttributes,
@@ -90,6 +90,7 @@ class RegisterIdentifierFiltersSpec extends ObjectBehavior
                         'field_options' => [
                             'attr' => [
                                 'choice_list' => true,
+                                'empty_choice' => true,
                             ],
                         ],
                     ],
@@ -100,7 +101,7 @@ class RegisterIdentifierFiltersSpec extends ObjectBehavior
         $this->buildBefore($buildBefore);
     }
 
-    public function it_callback_to_attribute_code_if_label_is_not_found(
+    public function it_falls_back_to_attribute_code_if_label_is_not_found(
         BuildBefore $buildBefore,
         DatagridConfiguration $datagridConfiguration,
         UserInterface $user,
@@ -152,6 +153,7 @@ class RegisterIdentifierFiltersSpec extends ObjectBehavior
                         'field_options' => [
                             'attr' => [
                                 'choice_list' => true,
+                                'empty_choice' => true,
                             ],
                         ],
                     ],


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
