### PR TITLE
CXP: export catalog product selection

### DIFF
--- a/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
+++ b/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
@@ -11,7 +11,7 @@ import {QueryClient, QueryClientProvider} from 'react-query';
 
 jest.mock('./utils/generateRandomId');
 
-test('it display an empty message if there is no criteria', () => {
+test('it displays an empty message if there is no criteria', () => {
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>

--- a/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
+++ b/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
@@ -25,12 +25,12 @@ test('it displays an empty message if there is no criteria', () => {
 
 test('it renders a list of criteria', async () => {
     const criteria = {
-        a: {
+        qxgJvh: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: true,
         } as StatusCriterionState,
-        b: {
+        w9WgXc: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: false,
@@ -49,7 +49,7 @@ test('it renders a list of criteria', async () => {
 });
 
 test('it updates the state when a criterion is added', async () => {
-    mocked(generateRandomId).mockReturnValue('a');
+    mocked(generateRandomId).mockReturnValue('qxgJvh');
 
     const onChange = jest.fn();
 
@@ -66,7 +66,7 @@ test('it updates the state when a criterion is added', async () => {
 
     expect(await screen.findByText('akeneo_catalogs.product_selection.criteria.status.label')).toBeInTheDocument();
     expect(onChange).toHaveBeenCalledWith({
-        a: {
+        qxgJvh: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: true,
@@ -76,7 +76,7 @@ test('it updates the state when a criterion is added', async () => {
 
 test('it updates the state when a criterion changes', async () => {
     const criteria = {
-        a: {
+        qxgJvh: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: true,
@@ -98,7 +98,7 @@ test('it updates the state when a criterion changes', async () => {
     fireEvent.click(screen.getByText('akeneo_catalogs.product_selection.criteria.status.disabled'));
 
     expect(onChange).toHaveBeenCalledWith({
-        a: {
+        qxgJvh: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: false,
@@ -108,7 +108,7 @@ test('it updates the state when a criterion changes', async () => {
 
 test('it updates the state when a criterion is removed', async () => {
     const criteria = {
-        a: {
+        qxgJvh: {
             field: 'enabled',
             operator: Operator.EQUALS,
             value: true,

--- a/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
+++ b/components/catalogs/front/src/components/ProductSelection/ProductSelection.integration.tsx
@@ -8,6 +8,7 @@ import {generateRandomId} from './utils/generateRandomId';
 import {mocked} from 'ts-jest/utils';
 import {StatusCriterionState} from './criteria/StatusCriterion';
 import {QueryClient, QueryClientProvider} from 'react-query';
+import {ProductSelectionErrors} from './models/ProductSelectionErrors';
 
 jest.mock('./utils/generateRandomId');
 
@@ -46,6 +47,48 @@ test('it renders a list of criteria', async () => {
     );
 
     expect(await screen.findAllByText('akeneo_catalogs.product_selection.criteria.status.label')).toHaveLength(2);
+});
+
+test('it renders a list of criteria with validation errors', async () => {
+    const criteria = {
+        qxgJvh: {
+            field: 'enabled',
+            operator: Operator.EQUALS,
+            value: true,
+        } as StatusCriterionState,
+        w9WgXc: {
+            field: 'enabled',
+            operator: Operator.EQUALS,
+            value: false,
+        } as StatusCriterionState,
+    };
+
+    const errors: ProductSelectionErrors = {
+        qxgJvh: {
+            field: undefined,
+            operator: undefined,
+            value: undefined,
+            locale: undefined,
+            scope: undefined,
+        },
+        w9WgXc: {
+            field: undefined,
+            operator: undefined,
+            value: 'Some random error message',
+            locale: undefined,
+            scope: undefined,
+        },
+    };
+
+    render(
+        <ThemeProvider theme={pimTheme}>
+            <QueryClientProvider client={new QueryClient()}>
+                <ProductSelection criteria={criteria} onChange={jest.fn()} errors={errors} />
+            </QueryClientProvider>
+        </ThemeProvider>
+    );
+
+    expect(await screen.findByText('Some random error message')).toBeInTheDocument();
 });
 
 test('it updates the state when a criterion is added', async () => {

--- a/components/catalogs/front/src/components/ProductSelection/hooks/useAttributeOptionsByCodes.unit.ts
+++ b/components/catalogs/front/src/components/ProductSelection/hooks/useAttributeOptionsByCodes.unit.ts
@@ -15,6 +15,10 @@ test('it returns attribute options', async () => {
             url: '/rest/catalogs/attributes/clothing_size/options?locale=en_US&codes=xs%2Cs%2Cl&search=&page=1&limit=20',
             json: [OPTION_XS, OPTION_S],
         },
+        {
+            url: '/rest/catalogs/attributes/clothing_size/options?locale=en_US&codes=l&search=&page=1&limit=20',
+            json: [],
+        },
     ]);
 
     const {result, waitForValueToChange} = renderHook(

--- a/components/catalogs/front/src/exports.ts
+++ b/components/catalogs/front/src/exports.ts
@@ -1,3 +1,4 @@
 export * from './components/CatalogEdit';
 export * from './components/CatalogList';
+export * from './components/ProductSelection';
 export {useCatalog} from './hooks/useCatalog';


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In order to reuse Catalog Product Selection in other context, in this PR we export the front component.
We also complete integration tests to cover all use cases. Thus, this integration test can be used as documentation.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
