### PR TITLE
CPM-817: Add migration for column type

### DIFF
--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Install/InstallerSubscriber.php
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Install/InstallerSubscriber.php
@@ -45,7 +45,7 @@ class InstallerSubscriber implements EventSubscriberInterface
                 `product_uuid` binary(16) NOT NULL,
                 `attribute_id` INT NOT NULL,
                 `prefix` VARCHAR(255) NOT NULL,
-                `number` INT NOT NULL,
+                `number` BIGINT UNSIGNED NOT NULL,
                 CONSTRAINT `FK_PRODUCTUUID` FOREIGN KEY (`product_uuid`) REFERENCES `pim_catalog_product` (`uuid`) ON DELETE CASCADE,
                 CONSTRAINT `FK_ATTRIBUTEID` FOREIGN KEY (`attribute_id`) REFERENCES `pim_catalog_attribute` (`id`) ON DELETE CASCADE,
                 INDEX index_identifier_generator_prefixes (`attribute_id`, `prefix`, `number`)

--- a/upgrades/schema/Version_7_0_20221129093347_add_cascade_on_prefixes.php
+++ b/upgrades/schema/Version_7_0_20221129093347_add_cascade_on_prefixes.php
@@ -15,7 +15,7 @@ final class Version_7_0_20221129093347_add_cascade_on_prefixes extends AbstractM
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Adds DELETE CASCADE on pim_catalog_identifier_generator_prefixes foreign keys';
     }
 
     public function up(Schema $schema): void

--- a/upgrades/schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type.php
+++ b/upgrades/schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type.php
@@ -20,29 +20,14 @@ final class Version_7_0_20221130130031_update_identifier_generator_prefix_number
 
     public function up(Schema $schema): void
     {
-        $this->addSql('SELECT 1');
-        if ($this->getColumnType() !== 'bigint unsigned') {
-            $this->addSql(<<<SQL
+        $this->addSql(<<<SQL
 ALTER TABLE pim_catalog_identifier_generator_prefixes 
     MODIFY `number` BIGINT UNSIGNED NOT NULL;
 SQL);
-        }
     }
 
     public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
-    }
-
-    private function getColumnType(): string
-    {
-        $sql = <<<SQL
-SELECT COLUMN_TYPE from information_schema.COLUMNS 
-WHERE TABLE_SCHEMA='%s' 
-  AND TABLE_NAME='pim_catalog_identifier_generator_prefixes'
-  AND COLUMN_NAME='number';
-SQL;
-
-        return $this->connection->fetchOne(\sprintf($sql, $this->connection->getDatabase()));
     }
 }

--- a/upgrades/schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type.php
+++ b/upgrades/schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * This migration updates `number` column type of pim_catalog_identifier_generator_prefixes from INT to BIGINT UNSIGNED.
+ * This table is empty in production, so it will be instant.
+ */
+final class Version_7_0_20221130130031_update_identifier_generator_prefix_number_type extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Updates `number` column type of pim_catalog_identifier_generator_prefixes from INT to BIGINT UNSIGNED';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('SELECT 1');
+        if ($this->getColumnType() !== 'bigint unsigned') {
+            $this->addSql(<<<SQL
+ALTER TABLE pim_catalog_identifier_generator_prefixes 
+    MODIFY `number` BIGINT UNSIGNED NOT NULL;
+SQL);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+
+    private function getColumnType(): string
+    {
+        $sql = <<<SQL
+SELECT COLUMN_TYPE from information_schema.COLUMNS 
+WHERE TABLE_SCHEMA='%s' 
+  AND TABLE_NAME='pim_catalog_identifier_generator_prefixes'
+  AND COLUMN_NAME='number';
+SQL;
+
+        return $this->connection->fetchOne(\sprintf($sql, $this->connection->getDatabase()));
+    }
+}

--- a/upgrades/test_schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20221130130031_update_identifier_generator_prefix_number_type_Integration.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+final class Version_7_0_20221130130031_update_identifier_generator_prefix_number_type_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private Connection $connection;
+    private const MIGRATION_LABEL = '_7_0_20221130130031_update_identifier_generator_prefix_number_type';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_changes_column_type(): void
+    {
+        $this->rollback();
+        Assert::assertEquals($this->getColumnType(), 'int');
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertEquals($this->getColumnType(), 'bigint unsigned');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function rollback(): void
+    {
+        $this->connection->executeQuery(<<<SQL
+ALTER TABLE pim_catalog_identifier_generator_prefixes 
+    MODIFY `number` INT NOT NULL;
+SQL);
+    }
+
+    private function getColumnType(): string
+    {
+        $sql = <<<SQL
+SELECT COLUMN_TYPE from information_schema.COLUMNS 
+WHERE TABLE_SCHEMA='%s' 
+  AND TABLE_NAME='pim_catalog_identifier_generator_prefixes'
+  AND COLUMN_NAME='number';
+SQL;
+
+        return $this->connection->fetchOne(\sprintf($sql, $this->connection->getDatabase()));
+    }
+}


### PR DESCRIPTION
Previous max number was INT(8) -> -2147483648 to 2147483647
Now it can have INT(16) UNSIGNED -> 0 to 2^64 - 1

https://dev.mysql.com/doc/refman/8.0/en/integer-types.html#:~:text=MySQL%20supports%20the%20SQL%20standard,TINYINT%20%2C%20MEDIUMINT%20%2C%20and%20BIGINT%20.