### PR TITLE
GRF-347 : Allow image attribute fields to be also locale (and channel)-specific

### DIFF
--- a/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
+++ b/src/Akeneo/Category/back/Infrastructure/Builder/TemplateBuilder.php
@@ -71,7 +71,7 @@ class TemplateBuilder
                     AttributeOrder::fromInteger(2),
                     AttributeIsRequired::fromBoolean(true),
                     AttributeIsScopable::fromBoolean(true),
-                    AttributeIsLocalizable::fromBoolean(false),
+                    AttributeIsLocalizable::fromBoolean(true),
                     LabelCollection::fromArray(['en_US' => 'Banner image']),
                     $templateUuid,
                     AttributeAdditionalProperties::fromArray([]),

--- a/src/Akeneo/Category/back/Infrastructure/Storage/InMemory/GetAttributeInMemory.php
+++ b/src/Akeneo/Category/back/Infrastructure/Storage/InMemory/GetAttributeInMemory.php
@@ -78,7 +78,7 @@ class GetAttributeInMemory implements GetAttribute
                 AttributeOrder::fromInteger(2),
                 AttributeIsRequired::fromBoolean(true),
                 AttributeIsScopable::fromBoolean(false),
-                AttributeIsLocalizable::fromBoolean(false),
+                AttributeIsLocalizable::fromBoolean(true),
                 LabelCollection::fromArray(['en_US' => 'Banner image']),
                 $templateUuid,
                 AttributeAdditionalProperties::fromArray([]),

--- a/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
+++ b/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
@@ -247,7 +247,7 @@ class CategoryTestCase extends TestCase
                 AttributeOrder::fromInteger(2),
                 AttributeIsRequired::fromBoolean(true),
                 AttributeIsScopable::fromBoolean(true),
-                AttributeIsLocalizable::fromBoolean(false),
+                AttributeIsLocalizable::fromBoolean(true),
                 LabelCollection::fromArray(['en_US' => 'Banner image']),
                 $templateUuid,
                 AttributeAdditionalProperties::fromArray([]),

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/FileSystem/PreviewGenerator/BinaryImageGeneratorIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/FileSystem/PreviewGenerator/BinaryImageGeneratorIntegration.php
@@ -44,7 +44,7 @@ class BinaryImageGeneratorIntegration extends TestCase
             AttributeOrder::fromInteger(2),
             AttributeIsRequired::fromBoolean(true),
             AttributeIsScopable::fromBoolean(true),
-            AttributeIsLocalizable::fromBoolean(false),
+            AttributeIsLocalizable::fromBoolean(true),
             LabelCollection::fromArray(['en_US' => 'Banner image']),
             TemplateUuid::fromString('02274dac-e99a-4e1d-8f9b-794d4c3ba330'),
             AttributeAdditionalProperties::fromArray([])

--- a/src/Akeneo/Category/back/tests/Specification/Domain/Model/Enrichment/TemplateSpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Domain/Model/Enrichment/TemplateSpec.php
@@ -77,7 +77,7 @@ class TemplateSpec extends ObjectBehavior
                     AttributeOrder::fromInteger(4),
                     AttributeIsRequired::fromBoolean(true),
                     AttributeIsScopable::fromBoolean(true),
-                    AttributeIsLocalizable::fromBoolean(false),
+                    AttributeIsLocalizable::fromBoolean(true),
                     LabelCollection::fromArray(['fr_FR' => 'attribute_image_libelle']),
                     $templateUuid,
                     AttributeAdditionalProperties::fromArray([])
@@ -138,7 +138,7 @@ class TemplateSpec extends ObjectBehavior
                     'order' => 4,
                     'is_required' => true,
                     'is_scopable' => true,
-                    'is_localizable' => false,
+                    'is_localizable' => true,
                     'labels' => ['fr_FR' => 'attribute_image_libelle'],
                     'template_uuid' => $expectedTemplateUuid,
                     'additional_properties' => []

--- a/src/Akeneo/Category/back/tests/Specification/Domain/UserIntent/Factory/ValueUserIntentFactorySpec.php
+++ b/src/Akeneo/Category/back/tests/Specification/Domain/UserIntent/Factory/ValueUserIntentFactorySpec.php
@@ -126,7 +126,7 @@ class ValueUserIntentFactorySpec extends ObjectBehavior
                 AttributeOrder::fromInteger(3),
                 AttributeIsRequired::fromBoolean(true),
                 AttributeIsScopable::fromBoolean(true),
-                AttributeIsLocalizable::fromBoolean(false),
+                AttributeIsLocalizable::fromBoolean(true),
                 LabelCollection::fromArray(['en_US' => '3/7/7/e/377e7c2bad87efd2e71eb725006a9067918d5791_banner.jpg']),
                 $templateUuid,
                 AttributeAdditionalProperties::fromArray([])

--- a/src/Akeneo/Category/front/src/feature/components/attributes/buildImageFieldAttribute.tsx
+++ b/src/Akeneo/Category/front/src/feature/components/attributes/buildImageFieldAttribute.tsx
@@ -41,7 +41,7 @@ const unMemoizedBuildImageFieldAttribute: AttributeFieldBuilder<AttributeInputVa
     });
 
     return (
-      <Field channel={channel} label={getLabelFromAttribute(attribute, locale)}>
+      <Field channel={channel} label={getLabelFromAttribute(attribute, locale)} locale={locale}>
         <MediaFileInput
           value={imageInfo}
           onChange={onChange}


### PR DESCRIPTION
…)-specific

<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
