### PR TITLE
RAB-1149: Fix minors depreciations

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/WebTestCase.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/WebTestCase.php
@@ -56,7 +56,7 @@ abstract class WebTestCase extends TestCase
         $firewallName = 'main';
         $firewallContext = 'main';
 
-        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        $token = new UsernamePasswordToken($user, $firewallName, $user->getRoles());
         $session = $this->getSession();
         $session->set('_security_' . $firewallContext, \serialize($token));
         $session->save();

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/AppRoleWithScopesFactoryIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/AppRoleWithScopesFactoryIntegration.php
@@ -80,7 +80,7 @@ SQL;
 
     private function assertRoleAcls(string $role, array $acls): void
     {
-        $token = new UsernamePasswordToken('username', null, 'main', [$role]);
+        $token = new UsernamePasswordToken('username', 'main', [$role]);
 
         foreach ($acls as $acl => $expectedValue) {
             \assert(\is_bool($expectedValue));

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandlerIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Command/UpdateConnectedAppScopesWithAuthorizationHandlerIntegration.php
@@ -188,7 +188,7 @@ class UpdateConnectedAppScopesWithAuthorizationHandlerIntegration extends TestCa
 
     private function assertRoleIsUpdatedWithAcls(string $role, array $acls): void
     {
-        $token = new UsernamePasswordToken('username', null, 'main', [$role]);
+        $token = new UsernamePasswordToken('username', 'main', [$role]);
 
         foreach ($acls as $acl => $expectedValue) {
             \assert(\is_bool($expectedValue));

--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Install/AddAclToRolesIntegration.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Apps/Install/AddAclToRolesIntegration.php
@@ -32,7 +32,7 @@ class AddAclToRolesIntegration extends TestCase
     public function test_it_adds_acl_to_roles(): void
     {
         $user = $this->createAdminUser();
-        $token = new UsernamePasswordToken($user->getUserIdentifier(), null, 'main', $user->getRoles());
+        $token = new UsernamePasswordToken($user->getUserIdentifier(), 'main', $user->getRoles());
 
         $isAllowed = $this->accessDecisionManager->decide($token, ['EXECUTE'], new ObjectIdentity('action', 'akeneo_connectivity_connection_manage_apps'));
         $this->assertFalse($isAllowed);

--- a/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
+++ b/src/Akeneo/Connectivity/Connection/tests/Context/AppActivateContext.php
@@ -301,7 +301,7 @@ SQL;
 
         /** @var AccessDecisionManagerInterface $decisionManager */
         $decisionManager = $this->getMainContext()->getContainer()->get('security.access.decision_manager');
-        $token = new UsernamePasswordToken('username', null, 'main', $roles);
+        $token = new UsernamePasswordToken('username', 'main', $roles);
 
         foreach ($acls as $acl => $expectedValue) {
             assert(is_bool($expectedValue));

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Context/UserContext.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Context/UserContext.php
@@ -43,7 +43,7 @@ final class UserContext implements Context
         $user = $this->userFactory->create();
         $user->setUsername('admin');
 
-        $token = new UsernamePasswordToken($user, null, 'main', ['ROLE_USER']);
+        $token = new UsernamePasswordToken($user, 'main', ['ROLE_USER']);
         $this->tokenStorage->setToken($token);
     }
 

--- a/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/WebTestCase.php
+++ b/src/Akeneo/Platform/Bundle/CommunicationChannelBundle/back/tests/Integration/WebTestCase.php
@@ -41,7 +41,7 @@ abstract class WebTestCase extends TestCase
         $firewallName = 'main';
         $firewallContext = 'main';
 
-        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        $token = new UsernamePasswordToken($user, $firewallName, $user->getRoles());
         $session = $this->getSession();
         $session->set('_security_' . $firewallContext, serialize($token));
         $session->save();

--- a/tests/back/Acceptance/User/UserContext.php
+++ b/tests/back/Acceptance/User/UserContext.php
@@ -35,7 +35,7 @@ class UserContext implements Context
         $user = $this->userFactory->create();
         $user->setUsername('admin');
 
-        $token = new UsernamePasswordToken($user, null, 'main', ['ROLE_ADMINISTRATOR']);
+        $token = new UsernamePasswordToken($user, 'main', ['ROLE_ADMINISTRATOR']);
         $this->tokenStorage->setToken($token);
     }
 
@@ -48,7 +48,7 @@ class UserContext implements Context
         $user = $this->userFactory->create();
         $user->setUsername('julia');
 
-        $token = new UsernamePasswordToken($user, null, 'main', ['ROLE_USER']);
+        $token = new UsernamePasswordToken($user, 'main', ['ROLE_USER']);
         $this->tokenStorage->setToken($token);
     }
 }

--- a/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/InternalApiTestCase.php
@@ -33,7 +33,7 @@ abstract class InternalApiTestCase extends TestCase
         $firewallName = 'main';
         $firewallContext = 'main';
 
-        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        $token = new UsernamePasswordToken($user, $firewallName, $user->getRoles());
         $session = $this->getSession();
         $session->set('_security_' . $firewallContext, serialize($token));
         $session->save();

--- a/tests/back/Platform/EndToEnd/InternalApiTestCase.php
+++ b/tests/back/Platform/EndToEnd/InternalApiTestCase.php
@@ -28,7 +28,7 @@ abstract class InternalApiTestCase extends TestCase
         $firewallName = 'main';
         $firewallContext = 'main';
 
-        $token = new UsernamePasswordToken($user, null, $firewallName, $user->getRoles());
+        $token = new UsernamePasswordToken($user, $firewallName, $user->getRoles());
         $session = $this->getSession();
         $session->set('_security_' . $firewallContext, serialize($token));
         $session->save();

--- a/upgrades/test_schema/Version_6_0_20210908142400_add_product_web_api_acl_Integration.php
+++ b/upgrades/test_schema/Version_6_0_20210908142400_add_product_web_api_acl_Integration.php
@@ -148,7 +148,7 @@ class Version_6_0_20210908142400_add_product_web_api_acl_Integration extends Tes
     {
         /** @var AccessDecisionManagerInterface $decisionManager */
         $decisionManager = $this->get('security.access.decision_manager');
-        $token = new UsernamePasswordToken('username', null, 'main', [$role]);
+        $token = new UsernamePasswordToken('username', 'main', [$role]);
 
         foreach ($acls as $acl => $expectedValue) {
             assert(is_bool($expectedValue));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Following the merge of this [PR](https://github.com/akeneo/pim-community-dev/pull/18434), I fixed minors depreciations :
- UsernamePasswordToken does not accept anymore $credentials in his constructor so I removed from every new clauses

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
