### PR TITLE
CPM-842 : Erase the default number of digits for the auto number

### DIFF
--- a/components/identifier-generator/front/src/feature/models/properties/autoNumber.ts
+++ b/components/identifier-generator/front/src/feature/models/properties/autoNumber.ts
@@ -2,8 +2,8 @@ import {PROPERTY_NAMES} from '../structure';
 
 type AutoNumber = {
   type: PROPERTY_NAMES.AUTO_NUMBER;
-  digitsMin: number;
-  numberMin: number;
+  digitsMin: number | null;
+  numberMin: number | null;
 };
 
 export type {AutoNumber};

--- a/components/identifier-generator/front/src/feature/tabs/structure/edit/AutoNumberEdit.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/structure/edit/AutoNumberEdit.tsx
@@ -8,14 +8,14 @@ const AutoNumberEdit: PropertyEditFieldsProps<AutoNumber> = ({selectedProperty, 
   const translate = useTranslate();
   const onDigitsMinChange = useCallback(
     (value: string) => {
-      onChange({...selectedProperty, digitsMin: Math.max(1, Number(value))});
+      onChange({...selectedProperty, digitsMin: '' !== value ? Math.max(1, Number(value)) : null});
     },
     [onChange, selectedProperty]
   );
 
   const onNumberMinChange = useCallback(
     (value: string) => {
-      onChange({...selectedProperty, numberMin: Number(value)});
+      onChange({...selectedProperty, numberMin: '' !== value ? Number(value) : null});
     },
     [onChange, selectedProperty]
   );

--- a/components/identifier-generator/front/src/feature/tabs/structure/edit/__tests__/AutoNumberEdit.test.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/structure/edit/__tests__/AutoNumberEdit.test.tsx
@@ -26,5 +26,19 @@ describe('AutoNumberEdit', () => {
       numberMin: 42,
       digitsMin: 5,
     });
+
+    fireEvent.change(screen.getByTitle('42'), {target: {value: ''}});
+    expect(onChange).toBeCalledWith({
+      type: PROPERTY_NAMES.AUTO_NUMBER,
+      numberMin: null,
+      digitsMin: 10,
+    });
+
+    fireEvent.change(screen.getByTitle('10'), {target: {value: ''}});
+    expect(onChange).toBeCalledWith({
+      type: PROPERTY_NAMES.AUTO_NUMBER,
+      numberMin: 42,
+      digitsMin: null,
+    });
   });
 });

--- a/components/identifier-generator/front/src/feature/tabs/structure/preview/AutoNumberPreview.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/structure/preview/AutoNumberPreview.tsx
@@ -9,7 +9,7 @@ type AutoNumberPreviewProps = {
 const AutoNumberPreview: React.FC<AutoNumberPreviewProps> = ({property}) => {
   const {digitsMin, numberMin} = property;
 
-  const formattedNumber = useMemo(() => String(numberMin).padStart(digitsMin, '0'), [digitsMin, numberMin]);
+  const formattedNumber = useMemo(() => String(numberMin).padStart(digitsMin || 0, '0'), [digitsMin, numberMin]);
 
   return <Preview.Highlight>{formattedNumber}</Preview.Highlight>;
 };

--- a/components/identifier-generator/front/src/feature/validators/__tests__/validateAutoNumber.test.ts
+++ b/components/identifier-generator/front/src/feature/validators/__tests__/validateAutoNumber.test.ts
@@ -1,0 +1,20 @@
+import {validateAutoNumber} from '../validateAutoNumber';
+import {PROPERTY_NAMES} from '../../models';
+
+describe('validateAutoNumber', () => {
+  it('should not add violation for valid digitsMin and numberMin', () => {
+    expect(validateAutoNumber({type: PROPERTY_NAMES.AUTO_NUMBER, digitsMin: 3, numberMin: 2}, 'path')).toHaveLength(0);
+  });
+
+  it('should add violation for empty digitsMin', () => {
+    expect(validateAutoNumber({type: PROPERTY_NAMES.AUTO_NUMBER, digitsMin: null, numberMin: 2}, 'path')).toHaveLength(
+      1
+    );
+  });
+
+  it('should add violation for empty numberMin', () => {
+    expect(validateAutoNumber({type: PROPERTY_NAMES.AUTO_NUMBER, digitsMin: 3, numberMin: null}, 'path')).toHaveLength(
+      1
+    );
+  });
+});

--- a/components/identifier-generator/front/src/feature/validators/__tests__/validateStructure.test.ts
+++ b/components/identifier-generator/front/src/feature/validators/__tests__/validateStructure.test.ts
@@ -16,13 +16,39 @@ describe('validateStructure', () => {
     ).toHaveLength(0);
   });
 
-  it('should not add violations for structure properties', () => {
+  it('should add violation for wrong structure property', () => {
     expect(
       validateStructure(
         [
           {
             type: PROPERTY_NAMES.FREE_TEXT,
             string: '',
+          },
+        ],
+        'structure'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      validateStructure(
+        [
+          {
+            type: PROPERTY_NAMES.AUTO_NUMBER,
+            digitsMin: null,
+            numberMin: 1,
+          },
+        ],
+        'structure'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      validateStructure(
+        [
+          {
+            type: PROPERTY_NAMES.AUTO_NUMBER,
+            digitsMin: 2,
+            numberMin: null,
           },
         ],
         'structure'

--- a/components/identifier-generator/front/src/feature/validators/validateAutoNumber.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateAutoNumber.ts
@@ -8,14 +8,14 @@ const validateAutoNumber: Validator<AutoNumber> = (autoNumber, path) => {
   if (null === autoNumber.digitsMin) {
     violations.push({
       path: `${path}.digitsMin`,
-      message: 'DigitsMin should not be empty',
+      message: 'You must add a minimum number of digits',
     });
   }
 
   if (null === autoNumber.numberMin) {
     violations.push({
       path: `${path}.numberMin`,
-      message: 'NumberMin should not be empty',
+      message: 'You must add a minimum value',
     });
   }
 

--- a/components/identifier-generator/front/src/feature/validators/validateAutoNumber.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateAutoNumber.ts
@@ -1,0 +1,25 @@
+import {Validator} from './Validator';
+import {AutoNumber} from '../models';
+import {Violation} from './Violation';
+
+const validateAutoNumber: Validator<AutoNumber> = (autoNumber, path) => {
+  const violations: Violation[] = [];
+
+  if (null === autoNumber.digitsMin) {
+    violations.push({
+      path: `${path}.digitsMin`,
+      message: 'DigitsMin should not be empty',
+    });
+  }
+
+  if (null === autoNumber.numberMin) {
+    violations.push({
+      path: `${path}.numberMin`,
+      message: 'NumberMin should not be empty',
+    });
+  }
+
+  return violations;
+};
+
+export {validateAutoNumber};

--- a/components/identifier-generator/front/src/feature/validators/validateStructure.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateStructure.ts
@@ -2,6 +2,7 @@ import {Validator} from './Validator';
 import {ALLOWED_PROPERTY_NAMES, PROPERTY_NAMES, Structure} from '../models';
 import {Violation} from './Violation';
 import {validateFreeText} from './validateFreeText';
+import {validateAutoNumber} from './validateAutoNumber';
 
 const validateStructure: Validator<Structure | undefined> = (structure, path) => {
   const violations: Violation[] = [];
@@ -26,6 +27,9 @@ const validateStructure: Validator<Structure | undefined> = (structure, path) =>
 
     if (property.type === PROPERTY_NAMES.FREE_TEXT) {
       violations.push(...validateFreeText(property, subPath));
+    }
+    if (property.type === PROPERTY_NAMES.AUTO_NUMBER) {
+      violations.push(...validateAutoNumber(property, subPath));
     }
   });
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Set the AutoNumber nullable in order to erase data. 
Validation will add violation on null digitsMin or numberMin

**Definition Of Done (for Core Developer only)**

- [X] Tests
