### PR TITLE
RAB-1124: Remove outdated dependency sensio/framework-extra-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,6 @@
         "psr/event-dispatcher": "^1.0.0",
         "ramsey/uuid": "^4.5.1",
         "ramsey/uuid-doctrine": "^1.8",
-        "sensio/framework-extra-bundle": "^5.4",
         "symfony/acl-bundle": "^2.1.0",
         "symfony/asset": "^5.4.0",
         "symfony/cache": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8bfeebea98bc3a960ead74204ca510fc",
+    "content-hash": "1b91c8e70041543c8e604d6da23c6197",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -5895,86 +5895,6 @@
                 "source": "https://github.com/sabberworm/PHP-CSS-Parser/tree/8.4.0"
             },
             "time": "2021-12-11T13:40:54+00:00"
-        },
-        {
-            "name": "sensio/framework-extra-bundle",
-            "version": "v5.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "430d14c01836b77c28092883d195a43ce413ee32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/430d14c01836b77c28092883d195a43ce413ee32",
-                "reference": "430d14c01836b77c28092883d195a43ce413ee32",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/annotations": "^1.0",
-                "php": ">=7.2.5",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/framework-bundle": "^4.4|^5.0",
-                "symfony/http-kernel": "^4.4|^5.0"
-            },
-            "conflict": {
-                "doctrine/doctrine-cache-bundle": "<1.3.1",
-                "doctrine/persistence": "<1.3"
-            },
-            "require-dev": {
-                "doctrine/dbal": "^2.10|^3.0",
-                "doctrine/doctrine-bundle": "^1.11|^2.0",
-                "doctrine/orm": "^2.5",
-                "nyholm/psr7": "^1.1",
-                "symfony/browser-kit": "^4.4|^5.0",
-                "symfony/doctrine-bridge": "^4.4|^5.0",
-                "symfony/dom-crawler": "^4.4|^5.0",
-                "symfony/expression-language": "^4.4|^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/monolog-bridge": "^4.0|^5.0",
-                "symfony/monolog-bundle": "^3.2",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9",
-                "symfony/psr-http-message-bridge": "^1.1",
-                "symfony/security-bundle": "^4.4|^5.0",
-                "symfony/twig-bundle": "^4.4|^5.0",
-                "symfony/yaml": "^4.4|^5.0",
-                "twig/twig": "^1.34|^2.4|^3.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
-                },
-                "exclude-from-classmap": [
-                    "/tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "This bundle provides a way to configure your controllers with annotations",
-            "keywords": [
-                "annotations",
-                "controllers"
-            ],
-            "support": {
-                "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
-                "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v5.6.1"
-            },
-            "time": "2020-08-25T19:10:18+00:00"
         },
         {
             "name": "stella-maris/clock",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -2,7 +2,6 @@
 
 return [
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
-    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],

--- a/config/packages/security.yml
+++ b/config/packages/security.yml
@@ -19,7 +19,7 @@ security:
             security:                       false
 
         login:
-            pattern:                        ^/user/(login|reset-request|send-email|check-email)$
+            pattern:                        ^/user/(login|reset-request|send-email)$
             provider:                       chain_provider
 
         reset_password:
@@ -73,7 +73,7 @@ security:
                 samesite:                   'lax'
 
     access_control:
-        - { path: ^/user/(login|reset-request|send-email|check-email)$, roles: PUBLIC_ACCESS }
+        - { path: ^/user/(login|reset-request|send-email)$, roles: PUBLIC_ACCESS }
         - { path: ^/user/reset/*, roles: PUBLIC_ACCESS }
         - { path: ^/api/rest/v1$, roles: PUBLIC_ACCESS }
         - { path: ^/api/, roles: pim_api_overall_access }

--- a/config/packages/sensio_framework_extra.yml
+++ b/config/packages/sensio_framework_extra.yml
@@ -1,4 +1,0 @@
-# To remove when upgrading to Symfony 4 as it will be the default
-sensio_framework_extra:
-    router:
-        annotations: false

--- a/src/Akeneo/Channel/back/Infrastructure/Controller/UI/CurrencyController.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Controller/UI/CurrencyController.php
@@ -3,7 +3,7 @@
 namespace Akeneo\Channel\Infrastructure\Controller\UI;
 
 use Akeneo\Channel\Infrastructure\Component\Exception\LinkedChannelException;
-use Akeneo\Channel\Infrastructure\Component\Model\Currency;
+use Akeneo\Channel\Infrastructure\Component\Repository\CurrencyRepositoryInterface;
 use Akeneo\Platform\Bundle\FrameworkBundle\Security\SecurityFacadeInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
 use Oro\Bundle\SecurityBundle\Exception\AccessDeniedException;
@@ -19,15 +19,16 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class CurrencyController
 {
     public function __construct(
-        private SaverInterface $currencySaver,
-        private SecurityFacadeInterface $securityFacade,
+        private readonly SaverInterface $currencySaver,
+        private readonly SecurityFacadeInterface $securityFacade,
+        private readonly CurrencyRepositoryInterface $currencyRepository,
     ) {
     }
 
     /**
      * Activate/Deactivate a currency
      */
-    public function toggleAction(Currency $currency): JsonResponse
+    public function toggleAction(int $id): JsonResponse
     {
         if (!$this->securityFacade->isGranted('pim_enrich_currency_toggle')) {
             throw AccessDeniedException::create(
@@ -35,6 +36,8 @@ class CurrencyController
                 __METHOD__,
             );
         }
+
+        $currency = $this->currencyRepository->find($id);
 
         try {
             $currency->toggleActivation();

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/controllers.yml
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/controllers.yml
@@ -75,3 +75,4 @@ services:
         arguments:
             - '@pim_catalog.saver.currency'
             - '@oro_security.security_facade'
+            - '@pim_catalog.repository.currency'

--- a/src/Akeneo/UserManagement/.php_cd.php
+++ b/src/Akeneo/UserManagement/.php_cd.php
@@ -51,7 +51,6 @@ $rules = [
         'Akeneo\UserManagement',
         'Webmozart\Assert\Assert',
         'Oro\Bundle\SecurityBundle',
-        'Sensio\Bundle\FrameworkExtraBundle',
         'Symfony\Bundle\FrameworkBundle',
         'Symfony\Bundle\SecurityBundle',
         'Twig\TwigFunction',

--- a/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
@@ -8,7 +8,6 @@ use Akeneo\UserManagement\Component\Model\Group;
 use Akeneo\UserManagement\Component\UserEvents;
 use Doctrine\ORM\EntityManagerInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -16,6 +15,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GroupController extends AbstractController
@@ -46,7 +46,6 @@ class GroupController extends AbstractController
     /**
      * Create group form
      *
-     * @Template("@PimUser/Group/update.html.twig")
      * @AclAncestor("pim_user_group_create")
      */
     public function create()
@@ -59,7 +58,6 @@ class GroupController extends AbstractController
     /**
      * Edit group form
      *
-     * @Template("@PimUser/Group/update.html.twig")
      * @AclAncestor("pim_user_group_edit")
      */
     public function update(Group $entity)
@@ -99,7 +97,7 @@ class GroupController extends AbstractController
     /**
      * @param Group $entity
      *
-     * @return array|JsonResponse
+     * @return Response|JsonResponse
      */
     private function updateGroup(Group $entity)
     {
@@ -117,9 +115,9 @@ class GroupController extends AbstractController
             );
         }
 
-        return [
+        return $this->render('@PimUser/Group/update.html.twig', [
             'form' => $this->form->createView(),
-        ];
+        ]);
     }
 
     /**

--- a/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/GroupController.php
@@ -5,8 +5,8 @@ namespace Akeneo\UserManagement\Bundle\Controller;
 use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
 use Akeneo\UserManagement\Bundle\Form\Handler\GroupHandler;
 use Akeneo\UserManagement\Component\Model\Group;
+use Akeneo\UserManagement\Component\Repository\GroupRepositoryInterface;
 use Akeneo\UserManagement\Component\UserEvents;
-use Doctrine\ORM\EntityManagerInterface;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -20,27 +20,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class GroupController extends AbstractController
 {
-    private EntityManagerInterface $entityManager;
-    private RemoverInterface $remover;
-    private GroupHandler $groupHandler;
-    private TranslatorInterface $translator;
-    private FormInterface $form;
-    private EventDispatcherInterface $eventDispatcher;
-
     public function __construct(
-        EntityManagerInterface $entityManager,
-        RemoverInterface $remover,
-        GroupHandler $groupHandler,
-        TranslatorInterface $translator,
-        FormInterface $form,
-        EventDispatcherInterface $eventDispatcher
+        private readonly GroupRepositoryInterface $groupRepository,
+        private readonly RemoverInterface $remover,
+        private readonly GroupHandler $groupHandler,
+        private readonly TranslatorInterface $translator,
+        private readonly FormInterface $form,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->entityManager = $entityManager;
-        $this->remover = $remover;
-        $this->groupHandler = $groupHandler;
-        $this->translator = $translator;
-        $this->form = $form;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -48,11 +35,12 @@ class GroupController extends AbstractController
      *
      * @AclAncestor("pim_user_group_create")
      */
-    public function create()
+    public function create(): Response
     {
         $this->dispatchGroupEvent(UserEvents::PRE_CREATE_GROUP);
 
-        return $this->update(new Group());
+        $newGroup = new Group();
+        return $this->updateGroup($newGroup);
     }
 
     /**
@@ -60,11 +48,13 @@ class GroupController extends AbstractController
      *
      * @AclAncestor("pim_user_group_edit")
      */
-    public function update(Group $entity)
+    public function update(int $id): Response
     {
-        $this->dispatchGroupEvent(UserEvents::PRE_UPDATE_GROUP, $entity);
+        $group = $this->groupRepository->find($id);
 
-        return $this->updateGroup($entity);
+        $this->dispatchGroupEvent(UserEvents::PRE_UPDATE_GROUP, $group);
+
+        return $this->updateGroup($group);
     }
 
     /**
@@ -72,36 +62,30 @@ class GroupController extends AbstractController
      *
      * @AclAncestor("pim_user_group_remove")
      */
-    public function delete(Request $request, $id)
+    public function delete(Request $request, int $id): Response
     {
         if (!$request->isXmlHttpRequest()) {
             return new RedirectResponse('/');
         }
 
-        $groupClass = $this->container->getParameter('pim_user.entity.group.class');
-        $group = $this->entityManager->getRepository($groupClass)->find($id);
+        $group = $this->groupRepository->find($id);
 
-        if (!$group) {
+        if (null === $group) {
             throw $this->createNotFoundException(sprintf('Group with id %d could not be found.', $id));
         }
 
         try {
             $this->remover->remove($group);
         } catch (\Exception $exception) {
-            return new JsonResponse(['message' => $exception->getMessage()], 500);
+            return new JsonResponse(['message' => $exception->getMessage()], Response::HTTP_UNPROCESSABLE_ENTITY);
         };
 
         return new JsonResponse('', 204);
     }
 
-    /**
-     * @param Group $entity
-     *
-     * @return Response|JsonResponse
-     */
-    private function updateGroup(Group $entity)
+    private function updateGroup(Group $group): Response
     {
-        if ($this->groupHandler->process($entity)) {
+        if ($this->groupHandler->process($group)) {
             $this->addFlash(
                 'success',
                 $this->translator->trans('pim_user.controller.group.message.saved')
@@ -110,7 +94,7 @@ class GroupController extends AbstractController
             return new JsonResponse(
                 [
                     'route' => 'pim_user_group_update',
-                    'params' => ['id' => $entity->getId()]
+                    'params' => ['id' => $group->getId()]
                 ]
             );
         }
@@ -120,11 +104,7 @@ class GroupController extends AbstractController
         ]);
     }
 
-    /**
-     * @param string $event
-     * @param Group  $group
-     */
-    private function dispatchGroupEvent($event, Group $group = null)
+    private function dispatchGroupEvent(string $event, Group $group = null): void
     {
         $this->eventDispatcher->dispatch(new GenericEvent($group), $event);
     }

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -5,7 +5,6 @@ namespace Akeneo\UserManagement\Bundle\Controller;
 use Akeneo\UserManagement\Bundle\Form\Handler\ResetHandler;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\UserManagement\Bundle\Notification\MailResetNotifier;
-use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,8 +14,6 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class ResetController extends AbstractController
 {
-    const SESSION_EMAIL = 'pim_user_reset_email';
-
     public function __construct(
         private readonly UserManager $userManager,
         private readonly SessionInterface $session,
@@ -56,8 +53,6 @@ class ResetController extends AbstractController
         if (null === $user->getConfirmationToken()) {
             $user->setConfirmationToken($user->generateToken());
         }
-
-        $this->session->set(static::SESSION_EMAIL, $this->getObfuscatedEmail($user));
 
         $user->setPasswordRequestedAt(new \DateTime('now', new \DateTimeZone('UTC')));
         $this->userManager->updateUser($user);
@@ -103,20 +98,5 @@ class ResetController extends AbstractController
             'token' => $token,
             'form' => $this->form->createView(),
         ]);
-    }
-
-    /**
-     * Get the truncated email displayed when requesting the resetting.
-     * The default implementation only keeps the part following @ in the address.
-     */
-    protected function getObfuscatedEmail(UserInterface $user): string
-    {
-        $email = $user->getEmail();
-
-        if (false !== $pos = strpos($email, '@')) {
-            $email = '...' . substr($email, $pos);
-        }
-
-        return $email;
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/ResetController.php
@@ -8,7 +8,6 @@ use Akeneo\UserManagement\Bundle\Notification\MailResetNotifier;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -19,12 +18,12 @@ class ResetController extends AbstractController
     const SESSION_EMAIL = 'pim_user_reset_email';
 
     public function __construct(
-        private UserManager           $userManager,
-        private SessionInterface      $session,
-        private ResetHandler          $resetHandler,
-        private TokenStorageInterface $tokenStorage,
-        private FormInterface         $form,
-        private MailResetNotifier     $mailer
+        private readonly UserManager $userManager,
+        private readonly SessionInterface $session,
+        private readonly ResetHandler $resetHandler,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly FormInterface $form,
+        private readonly MailResetNotifier $mailer,
     ) {
     }
 
@@ -36,7 +35,7 @@ class ResetController extends AbstractController
     /**
      * Request reset user password
      */
-    public function sendEmail(Request $request): Response|RedirectResponse
+    public function sendEmail(Request $request): Response
     {
         $username = $request->request->get('username');
         $user = $this->userManager->findUserByUsernameOrEmail($username);
@@ -71,7 +70,7 @@ class ResetController extends AbstractController
     /**
      * Reset user password
      */
-    public function reset($token)
+    public function reset(string $token): Response
     {
         $user = $this->userManager->findUserByConfirmationToken($token);
 
@@ -109,12 +108,8 @@ class ResetController extends AbstractController
     /**
      * Get the truncated email displayed when requesting the resetting.
      * The default implementation only keeps the part following @ in the address.
-     *
-     * @param UserInterface $user
-     *
-     * @return string
      */
-    protected function getObfuscatedEmail(UserInterface $user)
+    protected function getObfuscatedEmail(UserInterface $user): string
     {
         $email = $user->getEmail();
 

--- a/src/Akeneo/UserManagement/Bundle/Controller/RoleController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/RoleController.php
@@ -8,7 +8,6 @@ use Akeneo\UserManagement\Component\Model\Role;
 use Akeneo\UserManagement\Component\Repository\RoleRepositoryInterface;
 use Oro\Bundle\SecurityBundle\Acl\Persistence\AclSidManager;
 use Oro\Bundle\SecurityBundle\Annotation\AclAncestor;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -40,7 +39,6 @@ class RoleController extends AbstractController
 
     /**
      * @AclAncestor("pim_user_role_create")
-     * @Template("@PimUser/Role/update.html.twig")
      */
     public function create()
     {
@@ -49,7 +47,6 @@ class RoleController extends AbstractController
 
     /**
      * @AclAncestor("pim_user_role_edit")
-     * @Template("@PimUser/Role/update.html.twig")
      */
     public function update(Role $entity)
     {
@@ -89,7 +86,7 @@ class RoleController extends AbstractController
     /**
      * @param Role $entity
      *
-     * @return array|JsonResponse
+     * @return Response|JsonResponse
      */
     private function updateUser(Role $entity)
     {
@@ -106,9 +103,9 @@ class RoleController extends AbstractController
             );
         }
 
-        return [
+        return $this->render('@PimUser/Role/update.html.twig', [
             'form' => $this->aclRoleHandler->createView(),
             'privilegesConfig' => $this->container->getParameter('pim_user.privileges'),
-        ];
+        ]);
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
@@ -2,13 +2,14 @@
 
 namespace Akeneo\UserManagement\Bundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
-class SecurityController
+class SecurityController extends AbstractController
 {
     private AuthenticationUtils $authenticationUtils;
     private CsrfTokenManagerInterface $csrfTokenManager;
@@ -30,10 +31,7 @@ class SecurityController
         $this->additionalHiddenFields = $additionalHiddenFields;
     }
 
-    /**
-     * @Template("@PimUser/Security/login.html.twig")
-     */
-    public function login(): array
+    public function login(): Response
     {
         // get the login error if there is one
         $error = $this->authenticationUtils->getLastAuthenticationError();
@@ -42,14 +40,14 @@ class SecurityController
         $lastUsername = $this->authenticationUtils->getLastUsername();
         $csrfToken = $this->csrfTokenManager->getToken('authenticate')->getValue();
 
-        return [
+        return $this->render('@PimUser/Security/login.html.twig', [
             // last username entered by the user
             'last_username'            => $lastUsername,
             'csrf_token'               => $csrfToken,
             'error'                    => $error,
             'action_route'             => $this->actionRoute,
             'additional_hidden_fields' => $this->additionalHiddenFields,
-        ];
+        ]);
     }
 
     public function check()

--- a/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
@@ -2,19 +2,20 @@
 
 namespace Akeneo\UserManagement\Bundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
+use Twig\Environment;
 
-class SecurityController extends AbstractController
+class SecurityController
 {
     public function __construct(
         private readonly AuthenticationUtils $authenticationUtils,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly LogoutUrlGenerator $logoutUrlGenerator,
+        private readonly Environment $twig,
         private readonly string $actionRoute,
         private readonly array $additionalHiddenFields
     ) {
@@ -29,7 +30,7 @@ class SecurityController extends AbstractController
         $lastUsername = $this->authenticationUtils->getLastUsername();
         $csrfToken = $this->csrfTokenManager->getToken('authenticate')->getValue();
 
-        return $this->render('@PimUser/Security/login.html.twig', [
+        $content = $this->twig->render('@PimUser/Security/login.html.twig', [
             // last username entered by the user
             'last_username'            => $lastUsername,
             'csrf_token'               => $csrfToken,
@@ -37,6 +38,8 @@ class SecurityController extends AbstractController
             'action_route'             => $this->actionRoute,
             'additional_hidden_fields' => $this->additionalHiddenFields,
         ]);
+
+        return new Response($content);
     }
 
     public function check()

--- a/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
+++ b/src/Akeneo/UserManagement/Bundle/Controller/SecurityController.php
@@ -11,24 +11,13 @@ use Symfony\Component\Security\Http\Logout\LogoutUrlGenerator;
 
 class SecurityController extends AbstractController
 {
-    private AuthenticationUtils $authenticationUtils;
-    private CsrfTokenManagerInterface $csrfTokenManager;
-    private string $actionRoute;
-    private array $additionalHiddenFields;
-    private LogoutUrlGenerator $logoutUrlGenerator;
-
     public function __construct(
-        AuthenticationUtils $authenticationUtils,
-        CsrfTokenManagerInterface $csrfTokenManager,
-        LogoutUrlGenerator $logoutUrlGenerator,
-        string $actionRoute,
-        array $additionalHiddenFields
+        private readonly AuthenticationUtils $authenticationUtils,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly LogoutUrlGenerator $logoutUrlGenerator,
+        private readonly string $actionRoute,
+        private readonly array $additionalHiddenFields
     ) {
-        $this->authenticationUtils = $authenticationUtils;
-        $this->csrfTokenManager = $csrfTokenManager;
-        $this->logoutUrlGenerator = $logoutUrlGenerator;
-        $this->actionRoute = $actionRoute;
-        $this->additionalHiddenFields = $additionalHiddenFields;
     }
 
     public function login(): Response

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -94,6 +94,9 @@ services:
             - '@security.logout_url_generator'
             - '%pim_user.login_form.action_route%'
             - '%pim_user.login_form.additional_hidden_fields%'
+        calls:
+            - [ 'setContainer', [ '@service_container' ] ]
+
 
     Akeneo\UserManagement\Bundle\Controller\Rest\FindAllProfilesController:
         public: true

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -50,13 +50,12 @@ services:
         public: true
         class: 'Akeneo\UserManagement\Bundle\Controller\GroupController'
         arguments:
-            - '@doctrine.orm.entity_manager'
+            - '@pim_user.repository.group'
             - '@pim_user.remover.user_group'
             - '@pim_user.form.handler.group'
             - '@translator'
             - '@pim_user.form.group'
             - '@event_dispatcher'
-            - '@session'
         calls:
             - [ 'setContainer', [ '@service_container' ] ]
 

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/controllers.yml
@@ -91,10 +91,9 @@ services:
             - '@security.authentication_utils'
             - '@security.csrf.token_manager'
             - '@security.logout_url_generator'
+            - '@twig'
             - '%pim_user.login_form.action_route%'
             - '%pim_user.login_form.additional_hidden_fields%'
-        calls:
-            - [ 'setContainer', [ '@service_container' ] ]
 
 
     Akeneo\UserManagement\Bundle\Controller\Rest\FindAllProfilesController:

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/routing/old_oro_routes.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/routing/old_oro_routes.yml
@@ -28,11 +28,6 @@ pim_user_reset_send_email:
     defaults: { _controller: pim_user.controller.reset:sendEmail }
     methods: [POST]
 
-pim_user_reset_check_email:
-    path: /user/check-email
-    defaults: { _controller: pim_user.controller.reset:checkEmail }
-    methods: [GET]
-
 pim_user_reset_reset:
     path: /user/reset/{token}
     defaults: { _controller: pim_user.controller.reset:reset }

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ca_ES.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ca_ES.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Iniciar Sessió
   pim_user_reset_reset: Reiniciar contrasenya
   pim_user_reset_request: He oblidat la contrasenya
-  pim_user_reset_check_email: Reiniciar contrasenya | Revisar el correu electrònic
   pim_user_group_create: 'Grups | Crear'
   pim_user_group_update: 'Grup {{ group }} | Editar'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.da_DK.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.da_DK.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Login
   pim_user_reset_reset: Nulstil adgangskode
   pim_user_reset_request: Glemt adgangskode
-  pim_user_reset_check_email: Nulstil adgangskode | Tjek email
   pim_user_group_create: 'Grupper | Opret'
   pim_user_group_update: 'Gruppe {{ group }} | Ret'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.de_DE.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.de_DE.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Anmelden
   pim_user_reset_reset: Passwort zurücksetzen
   pim_user_reset_request: Passwort vergessen
-  pim_user_reset_check_email: Passwort zurücksetzen | E-Mail überprüfen
   pim_user_group_create: 'Gruppen | Anlegen'
   pim_user_group_update: 'Gruppe {{ group }} | Bearbeiten'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_AU.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_AU.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Login
   pim_user_reset_reset: Password Reset
   pim_user_reset_request: Forgot Password
-  pim_user_reset_check_email: Password Reset | Check Email
   pim_user_group_create: 'Groups | Create'
   pim_user_group_update: 'Group {{ group }} | Edit'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_GB.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_GB.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Login
   pim_user_reset_reset: Password Reset
   pim_user_reset_request: Forgot Password
-  pim_user_reset_check_email: Password Reset | Check Email
   pim_user_group_create: 'Groups | Create'
   pim_user_group_update: 'Group {{ group }} | Edit'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_NZ.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_NZ.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Login
   pim_user_reset_reset: Password Reset
   pim_user_reset_request: Forgot Password
-  pim_user_reset_check_email: Password Reset | Check Email
   pim_user_group_create: 'Groups | Create'
   pim_user_group_update: 'Group {{ group }} | Edit'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -14,7 +14,6 @@ pim_title:
 
     pim_user_reset_reset: Password Reset
     pim_user_reset_request: Forgot Password
-    pim_user_reset_check_email: Password Reset | Check Email
 
     pim_user_group_create: 'Groups | Create'
     pim_user_group_update: 'Group {{ group }} | Edit'

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.es_ES.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.es_ES.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Ingresar
   pim_user_reset_reset: Reiniciar contraseña
   pim_user_reset_request: Contraseña olvidada
-  pim_user_reset_check_email: Reiniciar contraseña | Verificar correo electrónico
   pim_user_group_create: 'Grupos | Crear'
   pim_user_group_update: 'Grupo {{ group }} | Editar'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.es_VE.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.es_VE.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Iniciar sesión
   pim_user_reset_reset: Reiniciar contraseña
   pim_user_reset_request: Contraseña olvidada
-  pim_user_reset_check_email: Reiniciar contraseña | Verificar correo electrónico
   pim_user_group_create: 'Grupos | Crear'
   pim_user_group_update: 'Grupo {{ group }} | Editar'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.fi_FI.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.fi_FI.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Kirjaudu sisään
   pim_user_reset_reset: Salasanan asettaminen
   pim_user_reset_request: Unohdin salasanani
-  pim_user_reset_check_email: Salasanan asettaminen | tarkista sähköposti
   pim_user_group_create: 'Käyttäjäryhmät | luo'
   pim_user_group_update: 'Ryhmä {{ group }} | Muokkaa'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.fr_FR.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.fr_FR.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Connexion
   pim_user_reset_reset: Réinitialisation de mot de passe
   pim_user_reset_request: Mot de passe oublié
-  pim_user_reset_check_email: Réinitialisation de mot de passe | Email de vérification
   pim_user_group_create: 'Groupes | Création'
   pim_user_group_update: 'Groupes {{ group }} | Édition'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.it_IT.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.it_IT.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Login
   pim_user_reset_reset: Reimposta password
   pim_user_reset_request: Password Dimenticata
-  pim_user_reset_check_email: Reimpostazione password | Controllo Email
   pim_user_group_create: 'Gruppi | Crea'
   pim_user_group_update: 'Gruppo {{ group }} | Modifica'
 confirmation:
@@ -32,7 +31,7 @@ pim_user.profile:
   why_is_it_needed: Perché abbiamo bisogno di queste informazioni?
   save_button: Salva e accedi all'App Store
   selector:
-    placeholder: Scegli un'opzione 
+    placeholder: Scegli un'opzione
     not_found: Nessun risultato trovato
   product_manager: Gestisco i cataloghi dei prodotti.
   redactor: Arricchisco i dati di prodotto.

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ja_JP.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ja_JP.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: ログイン
   pim_user_reset_reset: パスワードリセット
   pim_user_reset_request: パスワードのリセット
-  pim_user_reset_check_email: パスワードリセット | Email確認
   pim_user_group_create: 'グループ | 作成'
   pim_user_group_update: 'グループ {{ group }} | 編集'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ko_KR.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.ko_KR.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: 로그인
   pim_user_reset_reset: 암호 재설정
   pim_user_reset_request: 암호 분실
-  pim_user_reset_check_email: 암호 재설정 | 이메일 확인
   pim_user_group_create: '그룹 | 만들기'
   pim_user_group_update: '그룹 {{ group }} | 편집'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.nl_NL.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.nl_NL.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Aanmelden
   pim_user_reset_reset: Wachtwoord resetten
   pim_user_reset_request: Wachtwoord vergeten
-  pim_user_reset_check_email: Wachtwoord opnieuw instellen - Bekijk E-mail
   pim_user_group_create: 'Groepen | Aanmaken'
   pim_user_group_update: 'Groep {{ group }} | Bewerken'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.no_NO.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.no_NO.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Logg inn
   pim_user_reset_reset: Tilbakestilling av passord
   pim_user_reset_request: Glemt passord
-  pim_user_reset_check_email: Nullstill passord | Sjekk e-post
   pim_user_group_create: 'Grupper | Opprett'
   pim_user_group_update: 'Gruppe {{ group }} | Rediger'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.pl_PL.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.pl_PL.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Zaloguj się
   pim_user_reset_reset: Resetowanie hasła
   pim_user_reset_request: Zapomniałem hasła
-  pim_user_reset_check_email: Resetowanie hasła | Sprawdź e-mail
   pim_user_group_create: 'Grupy | Utwórz'
   pim_user_group_update: 'Grupa {{ group }} | Edytuj'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.pt_BR.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.pt_BR.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Entrar
   pim_user_reset_reset: Redefinição de Senha
   pim_user_reset_request: Esqueci a senha
-  pim_user_reset_check_email: Redefinição de senha | Verificar e-mail
   pim_user_group_create: 'Grupos | Criar'
   pim_user_group_update: 'Grupo {{ group }} | Editar'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.sv_SE.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.sv_SE.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: Logga in
   pim_user_reset_reset: Återställ lösenord
   pim_user_reset_request: Glömt Lösenord
-  pim_user_reset_check_email: Återställ lösenord | Kontrollera e-post
   pim_user_group_create: 'Grupper | Skapa'
   pim_user_group_update: 'Grupp {{ group }} | Redigera'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.zh_CN.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.zh_CN.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: 登录
   pim_user_reset_reset: 密码重置
   pim_user_reset_request: 忘记密码
-  pim_user_reset_check_email: 密码重置 | 检查电子邮件
   pim_user_group_create: '分组 | 创建'
   pim_user_group_update: '分组 {{ group }} | 编辑'
 confirmation:

--- a/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.zh_TW.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/translations/jsmessages.zh_TW.yml
@@ -10,7 +10,6 @@ pim_title:
   pim_user_security_login: 登入
   pim_user_reset_reset: 重設密碼
   pim_user_reset_request: 忘記密碼
-  pim_user_reset_check_email: 重設密碼 | 查看郵件
   pim_user_group_create: '分組 | 創建'
   pim_user_group_update: '分組 {{ group }} | 編輯'
 confirmation:

--- a/src/Akeneo/UserManagement/Component/Repository/RoleRepositoryInterface.php
+++ b/src/Akeneo/UserManagement/Component/Repository/RoleRepositoryInterface.php
@@ -12,4 +12,6 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 interface RoleRepositoryInterface extends IdentifiableObjectRepositoryInterface
 {
     public function findAll();
+
+    public function find($id);
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -576,18 +576,6 @@
     "sebastian/version": {
         "version": "2.0.1"
     },
-    "sensio/framework-extra-bundle": {
-        "version": "5.2",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "5.2",
-            "ref": "fb7e19da7f013d0d422fa9bce16f5c510e27609b"
-        },
-        "files": [
-            "config/packages/sensio_framework_extra.yaml"
-        ]
-    },
     "sensiolabs/behat-page-object-extension": {
         "version": "v2.1.0"
     },


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, I removed one of our dependency `sensio/framework-extra-bundle`. This one is no longer maintained by Symfony team because they finished to re-implement features offered by this bundle in Symfony core.
In the PIM, this bundle is used for rendering some templates in former Oro controllers using `@Template` annotation, I replaced them by calling `$this->render()` (exposed by `AbstractController`).
Also this bundle do some magic during request handling by the HttpKernel : when you require a Doctrine entity as param of your controller method, a listener is called and inject the entity corresponding to the id passed in the route in the request (cf https://github.com/sensiolabs/SensioFrameworkExtraBundle/blob/master/src/Request/ParamConverter/DoctrineParamConverter.php). This is why I refactored a bit controllers to use the id as param of methods and call the repository to fetch the doctrine entity inside them.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
