### PR TITLE
RAB-1124: Update guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
         "friendsofsymfony/rest-bundle": "^3.0.5",
         "gedmo/doctrine-extensions": "^3.2.0",
         "google/cloud-pubsub": "^1.35.0",
-        "guzzlehttp/guzzle": "^6.5.8",
+        "guzzlehttp/guzzle": "^7.5.0",
         "imagine/imagine": "1.2.4",
         "justinrainbow/json-schema": "^5.2",
         "khaled.alshamaa/ar-php": "^6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "369c2bf8744138d014dae520d93d8060",
+    "content-hash": "0ba6cc39390161787d8204a66c7a1309",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -3150,37 +3150,49 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.8",
+            "version": "7.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981"
+                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a52f0440530b54fa079ce76e8c5d196a42cad981",
-                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b50a2a1251152e43f6a37f0fa053e730a67d25ba",
+                "reference": "b50a2a1251152e43f6a37f0fa053e730a67d25ba",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.9",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17"
+                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/psr7": "^1.9 || ^2.4",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.1"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                },
                 "branch-alias": {
-                    "dev-master": "6.5-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -3233,19 +3245,20 @@
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
                 "curl",
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5.8"
+                "source": "https://github.com/guzzle/guzzle/tree/7.5.0"
             },
             "funding": [
                 {
@@ -3261,7 +3274,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T22:16:07+00:00"
+            "time": "2022-08-28T15:39:27+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -5319,6 +5332,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-message",
@@ -15764,58 +15829,6 @@
                 }
             ],
             "time": "2022-10-28T06:00:21+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
-            },
-            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-factory",

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/services_test.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/services_test.yml
@@ -1,10 +1,10 @@
 services:
-    Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistory:
+    Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistoryContainer:
         arguments:
             - '%kernel.project_dir%/var/cache/test/guzzle_history.json'
 
     akeneo_connectivity.connection.webhook.guzzle_handler:
-        class: 'Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack'
-        factory: ['Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack', 'createWithHistoryContainer']
+        class: 'GuzzleHttp\HandlerStack'
+        factory: ['Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStackFactory', 'createWithHistoryContainer']
         arguments:
-            - '@Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistory'
+            - '@Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistoryContainer'

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleJsonHistoryContainer.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleJsonHistoryContainer.php
@@ -15,7 +15,7 @@ use Webmozart\Assert\Assert;
  * A filesystem container to store Guzzle history in a json file.
  * We need this filesytem json file to share it between process and keep track of the history in the tests
  */
-class GuzzleJsonHistory implements \ArrayAccess, \Countable
+class GuzzleJsonHistoryContainer implements \ArrayAccess, \Countable
 {
     public function __construct(private string $filepath)
     {

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleMockHandlerStackFactory.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/GuzzleMockHandlerStackFactory.php
@@ -14,21 +14,14 @@ use GuzzleHttp\Psr7\Response;
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
  * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  *
- * A sub class of the Guzzle handler stack providing a JSON filesystem history.
- * The purpose of this handler is to share its history between a parent process and subprocess. It is useful to  keep track of the history of the webhook call in the tests. Indeed, the webhook call is performed in a subprocess.
+ * A factory providing a Guzzle handler stack with a JSON filesystem history.
+ * The purpose of this handler is to share its history between a parent process and subprocess. It is useful to keep track of the history of the webhook call in the tests. Indeed, the webhook call is performed in a subprocess.
  */
-class GuzzleMockHandlerStack extends HandlerStack
+class GuzzleMockHandlerStackFactory
 {
-    private ?GuzzleJsonHistory $container;
-
-    public function historyContainer(): GuzzleJsonHistory
+    public static function createWithHistoryContainer(GuzzleJsonHistoryContainer $historyContainer): HandlerStack
     {
-        return $this->container;
-    }
-
-    public static function createWithHistoryContainer(GuzzleJsonHistory $historyContainer)
-    {
-        $stack = new self(new MockHandler([new Response(200)]));
+        $stack = new HandlerStack(new MockHandler([new Response(200)]));
         $stack->push(Middleware::httpErrors(), 'http_errors');
         $stack->push(Middleware::redirect(), 'allow_redirects');
         $stack->push(Middleware::cookies(), 'cookies');
@@ -37,8 +30,6 @@ class GuzzleMockHandlerStack extends HandlerStack
         $historyContainer->resetHistory();
         $history = Middleware::history($historyContainer);
         $stack->push($history);
-
-        $stack->container = $historyContainer;
 
         return $stack;
     }

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Webhook/IncrementEventsApiRequestCountEndToEnd.php
@@ -10,7 +10,7 @@ use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\CategoryLoade
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Enrichment\ProductLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\AttributeLoader;
 use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\Structure\FamilyLoader;
-use Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleMockHandlerStack;
+use Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistoryContainer;
 use Akeneo\Pim\Enrichment\Component\Product\Message\ProductCreated;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Platform\Component\EventQueue\Author;
@@ -34,6 +34,7 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
     private ProductInterface $referenceProduct;
     private Author $referenceAuthor;
     private DbalConnection $dbalConnection;
+    private GuzzleJsonHistoryContainer $historyContainer;
 
     protected function setUp(): void
     {
@@ -44,6 +45,7 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
         $this->familyLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.family');
         $this->attributeLoader = $this->get('akeneo_connectivity.connection.fixtures.structure.attribute');
         $this->dbalConnection = $this->get('database_connection');
+        $this->historyContainer = $this->get('Akeneo\Connectivity\Connection\Tests\EndToEnd\GuzzleJsonHistoryContainer');
 
         $this->referenceProduct = $this->loadReferenceProduct();
         $this->referenceAuthor = Author::fromNameAndType('julia', Author::TYPE_UI);
@@ -60,9 +62,6 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
 
     public function test_it_increments_events_api_request_count()
     {
-        /** @var GuzzleMockHandlerStack $handlerStack */
-        $handlerStack = $this->get('akeneo_connectivity.connection.webhook.guzzle_handler');
-
         $message = new BulkEvent(
             [
                 new ProductCreated(
@@ -81,7 +80,7 @@ class IncrementEventsApiRequestCountEndToEnd extends ApiTestCase
         $businessEventHandler = $this->get(BusinessEventHandler::class);
         $businessEventHandler->__invoke($message);
 
-        Assert::assertCount(1, $handlerStack->historyContainer());
+        Assert::assertCount(1, $this->historyContainer);
 
         $eventsApiRequestCount = $this->getEventsApiRequestCount();
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I upgraded `guzzlehttp/guzzle` to v7.
I had to refactor a bit a mock used in Connectivity 2e2. Basically, `HandlerStack` is now final, so we can't extends it. I removed the extension and injected the history container in tests to query it.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
