### PR TITLE
PIM-10753: Fix 500 error in the API when patching a product metric with a mathematical notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@
 - PIM:10739: Fix find families controller access.
 - PIM:10741: Fix diff indexation of product models
 - PIM:10743: Fix HTTP 500 on measurement PATCH without unit
+- PIM-10753: Fix HTTP 500 in the API when patching product metric with a mathematical notation
 - PIM:10744: Fix product import with a quantified association column is missing
 
 ## Improvements

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/MetricValueFactory.php
@@ -12,17 +12,16 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
- * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @copyright 2019 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 final class MetricValueFactory implements ValueFactory
 {
-    /** @var MetricFactory */
-    private $metricFactory;
+    private const AMOUNT_DECIMAL_FORMAT_REGEX = '#^-?\d+(\.\d+)?$#';
 
-    public function __construct(MetricFactory $metricFactory)
-    {
-        $this->metricFactory = $metricFactory;
+    public function __construct(
+        private readonly MetricFactory $metricFactory,
+    ) {
     }
 
     public function createWithoutCheckingData(Attribute $attribute, ?string $channelCode, ?string $localeCode, $data): ValueInterface
@@ -50,7 +49,7 @@ final class MetricValueFactory implements ValueFactory
         if (!\is_array($data)) {
             throw InvalidPropertyTypeException::arrayExpected(
                 $attribute->code(),
-                static::class,
+                MetricValueFactory::class,
                 $data
             );
         }
@@ -59,7 +58,7 @@ final class MetricValueFactory implements ValueFactory
             throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->code(),
                 'amount',
-                static::class,
+                MetricValueFactory::class,
                 $data
             );
         }
@@ -68,7 +67,7 @@ final class MetricValueFactory implements ValueFactory
             throw InvalidPropertyTypeException::arrayKeyExpected(
                 $attribute->code(),
                 'unit',
-                static::class,
+                MetricValueFactory::class,
                 $data
             );
         }
@@ -77,8 +76,16 @@ final class MetricValueFactory implements ValueFactory
             throw InvalidPropertyTypeException::validArrayStructureExpected(
                 $attribute->code(),
                 sprintf('key "unit" has to be a string, "%s" given', gettype($data['unit'])),
-                static::class,
+                MetricValueFactory::class,
                 $data
+            );
+        }
+
+        if (is_string($data['amount']) && is_numeric($data['amount']) && !preg_match(self::AMOUNT_DECIMAL_FORMAT_REGEX, $data['amount'])) {
+            throw InvalidPropertyTypeException::decimalExpected(
+                $attribute->code(),
+                MetricValueFactory::class,
+                $data['amount'],
             );
         }
 

--- a/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
+++ b/src/Akeneo/Tool/Component/StorageUtils/Exception/InvalidPropertyTypeException.php
@@ -20,6 +20,7 @@ class InvalidPropertyTypeException extends PropertyException
     const INTEGER_EXPECTED_CODE = 104;
     const NUMERIC_EXPECTED_CODE = 105;
     const STRING_EXPECTED_CODE = 106;
+    const DECIMAL_EXPECTED_CODE = 107;
 
     const ARRAY_EXPECTED_CODE = 200;
     const VALID_ARRAY_STRUCTURE_EXPECTED_CODE = 201;
@@ -162,6 +163,28 @@ class InvalidPropertyTypeException extends PropertyException
             $className,
             sprintf($message, $propertyName, gettype($propertyValue)),
             self::NUMERIC_EXPECTED_CODE
+        );
+    }
+
+    /**
+     * Build an exception when the data is not a decimal value.
+     *
+     * @param string $propertyName
+     * @param string $className
+     * @param mixed  $propertyValue a value that is not a numeric
+     *
+     * @return InvalidPropertyTypeException
+     */
+    public static function decimalExpected($propertyName, $className, $propertyValue)
+    {
+        $message = 'Property "%s" expects a decimal as data, "%s" given.';
+
+        return new static(
+            $propertyName,
+            $propertyValue,
+            $className,
+            sprintf($message, $propertyName, $propertyValue),
+            self::DECIMAL_EXPECTED_CODE
         );
     }
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/MetricValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/MetricValueFactorySpec.php
@@ -20,22 +20,22 @@ use PhpSpec\ObjectBehavior;
  */
 final class MetricValueFactorySpec extends ObjectBehavior
 {
-    public function let(MetricFactory $metricFactory)
+    public function let(MetricFactory $metricFactory): void
     {
         $this->beConstructedWith($metricFactory);
     }
 
-    public function it_is_a_read_value_factory()
+    public function it_is_a_read_value_factory(): void
     {
         $this->shouldBeAnInstanceOf(ValueFactory::class);
     }
 
-    public function it_supports_metric_attribute_type()
+    public function it_supports_metric_attribute_type(): void
     {
         $this->supportedAttributeType()->shouldReturn(AttributeTypes::METRIC);
     }
 
-    public function it_does_not_support_null()
+    public function it_does_not_support_null(): void
     {
         $this->shouldThrow(InvalidPropertyTypeException::class)->during('createByCheckingData', [
             $this->getAttribute(true, true),
@@ -45,7 +45,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         ]);
     }
 
-    public function it_creates_a_localizable_and_scopable_value(MetricFactory $metricFactory)
+    public function it_creates_a_localizable_and_scopable_value(MetricFactory $metricFactory): void
     {
         $metric = new Metric('distance', 'centimeters', 5, 'meters', 0.05);
         $metricFactory->createMetric('distance', 'centimeters', 5)->willReturn($metric);
@@ -54,7 +54,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MetricValue::scopableLocalizableValue('an_attribute', $metric, 'ecommerce', 'fr_FR'));
     }
 
-    public function it_creates_a_localizable_value(MetricFactory $metricFactory)
+    public function it_creates_a_localizable_value(MetricFactory $metricFactory): void
     {
         $metric = new Metric('distance', 'centimeters', 5, 'meters', 0.05);
         $metricFactory->createMetric('distance', 'centimeters', 5)->willReturn($metric);
@@ -63,7 +63,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MetricValue::localizableValue('an_attribute', $metric, 'fr_FR'));
     }
 
-    public function it_creates_a_scopable_value(MetricFactory $metricFactory)
+    public function it_creates_a_scopable_value(MetricFactory $metricFactory): void
     {
         $metric = new Metric('distance', 'centimeters', 5, 'meters', 0.05);
         $metricFactory->createMetric('distance', 'centimeters', 5)->willReturn($metric);
@@ -72,7 +72,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MetricValue::scopableValue('an_attribute', $metric, 'ecommerce'));
     }
 
-    public function it_creates_a_non_localizable_and_non_scopable_value(MetricFactory $metricFactory)
+    public function it_creates_a_non_localizable_and_non_scopable_value(MetricFactory $metricFactory): void
     {
         $metric = new Metric('distance', 'centimeters', 5, 'meters', 0.05);
         $metricFactory->createMetric('distance', 'centimeters', 5)->willReturn($metric);
@@ -81,7 +81,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MetricValue::value('an_attribute', $metric));
     }
 
-    public function it_creates_a_value_without_checking_data(MetricFactory $metricFactory)
+    public function it_creates_a_value_without_checking_data(MetricFactory $metricFactory): void
     {
         $metric = new Metric('distance', 'centimeters', 5, 'meters', 0.05);
         $metricFactory->createMetric('distance', 'centimeters', 5)->willReturn($metric);
@@ -90,7 +90,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(MetricValue::value('an_attribute', $metric));
     }
 
-    function it_throws_an_exception_if_provided_data_is_not_an_array(MetricFactory $metricFactory)
+    public function it_throws_an_exception_if_provided_data_is_not_an_array(): void
     {
         $attribute = $this->getAttribute(false, false);
         $exception = InvalidPropertyTypeException::arrayExpected(
@@ -104,7 +104,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
             ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', 'foobar']);
     }
 
-    function it_throws_an_exception_if_provided_data_has_no_amount(MetricFactory $metricFactory)
+    public function it_throws_an_exception_if_provided_data_has_no_amount(): void
     {
         $attribute = $this->getAttribute(false, false);
 
@@ -120,7 +120,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
             ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', ['foo' => 42, 'unit' => 'GRAM']]);
     }
 
-    function it_should_not_throws_an_exception_if_provided_data_has_non_numeric_amount(MetricFactory $metricFactory)
+    public function it_should_not_throws_an_exception_if_provided_data_has_non_numeric_amount(): void
     {
         $attribute = $this->getAttribute(false, false);
 
@@ -129,7 +129,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
             ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', ['amount' => 'aa', 'foo' => 42, 'unit' => 'GRAM']]);
     }
 
-    function it_throws_an_exception_if_provided_data_has_no_unit(MetricFactory $metricFactory)
+    public function it_throws_an_exception_if_provided_data_has_no_unit(): void
     {
         $attribute = $this->getAttribute(false, false);
 
@@ -145,7 +145,7 @@ final class MetricValueFactorySpec extends ObjectBehavior
             ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', ['amount' => 42, 'bar' => 'GRAM']]);
     }
 
-    function it_throws_an_exception_if_provided_data_has_bad_format_unit(MetricFactory $metricFactory)
+    public function it_throws_an_exception_if_provided_data_has_bad_format_unit(): void
     {
         $attribute = $this->getAttribute(false, false);
 
@@ -159,6 +159,21 @@ final class MetricValueFactorySpec extends ObjectBehavior
         $this
             ->shouldThrow($exception)
             ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', ['amount' => 42, 'bar' => 'GRAM', 'unit' => []]]);
+    }
+
+    public function it_throws_an_exception_if_provided_data_has_bad_format_amount(): void
+    {
+        $attribute = $this->getAttribute(false, false);
+
+        $exception = InvalidPropertyTypeException::decimalExpected(
+            'an_attribute',
+            MetricValueFactory::class,
+            '35999999999999997E-2'
+        );
+
+        $this
+            ->shouldThrow($exception)
+            ->during('createByCheckingData', [$attribute, 'ecommerce', 'en_US', ['amount' => '35999999999999997E-2', 'bar' => 'GRAM', 'unit' => 'GRAM']]);
     }
 
     private function getAttribute(bool $isLocalizable, bool $isScopable): Attribute


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We have to invalidate value in hexadecimal or power exponent format. Actually, there is no function to do that in php (`ctype_digit` only works with integer and we can receive float here), so we have have to invalidate it with a regex.

see https://akeneo.atlassian.net/browse/PIM-10753

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
