### PR TITLE
OCT-185: Add javascript-dev-strict command to CXP CI

### DIFF
--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -24,6 +24,23 @@ jobs:
                     name: Lint front
                     command: make connectivity-connection-lint-front
 
+    test_front_build_connectivity:
+        machine:
+            image: *executor-machine
+            docker_layer_caching: true
+        steps:
+            -   attach_workspace:
+                    at: ~/
+            -   run:
+                    name: Create yarn cache folder
+                    command: mkdir -p  ~/.cache/yarn
+            -   run:
+                    name: Change owner on project dir (docker needs uid 1000, circleci can be another uid)
+                    command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
+            -   run:
+                    name: Build front in strict mode
+                    command: make javascript-dev-strict
+
     test_front_unit_connectivity:
         machine:
             image: *executor-machine

--- a/.circleci/workflows/squads/octopus/octopus_connectivity_pull_request.yml
+++ b/.circleci/workflows/squads/octopus/octopus_connectivity_pull_request.yml
@@ -36,6 +36,10 @@ workflows:
                     name: test_cxp_front_lint
                     requires:
                         - install_front_dependencies
+            -   test_front_build_connectivity:
+                    name: text_cxp_front_build
+                    requires:
+                        - build
             -   test_back_unit_connectivity:
                     name: test_cxp_back_unit
                     requires:
@@ -56,6 +60,7 @@ workflows:
                     requires:
                         - test_cxp_front_lint
                         - test_cxp_front_unit
+                        - text_cxp_front_build
                         - test_cxp_back_unit
                         - test_cxp_back_integration
                         - test_cxp_back_e2e


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

This is a slow step but it guarantee that we didn't break the build (it happened a few days ago because imports paths were valid only in tests, so the CI was green)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
