### PR TITLE
RAB-1235: Add storage type badge & better error message

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/DownloadFileFromStorage.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/DownloadFileFromStorage.php
@@ -68,13 +68,13 @@ final class DownloadFileFromStorage implements DownloadFileFromStorageInterface
         }
 
         if (!$fileExists) {
-            throw new \RuntimeException(sprintf('The file "%s" is not present in the storage.', $filePath));
+            throw new \RuntimeException(sprintf('The file "%s" does not exist in the selected storage.', $filePath));
         }
 
         $fileSize = $storageClient->getFileSize($filePath);
 
         if (self::MAX_FILE_SIZE < $fileSize) {
-            throw new \RuntimeException('The file is too large to be downloaded');
+            throw new \RuntimeException('The file is too large to be downloaded.');
         }
     }
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFile.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFile.php
@@ -22,7 +22,7 @@ final class TransferFile
         string $destinationFilePath
     ): void {
         if (!$sourceFilesystem->fileExists($sourceFilePath)) {
-            throw new \RuntimeException(sprintf('The file "%s" is not present in the storage.', $sourceFilePath));
+            throw new \RuntimeException(sprintf('The file "%s" does not exist in the selected storage.', $sourceFilePath));
         }
 
         try {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFilesToStorage.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFilesToStorage.php
@@ -46,8 +46,7 @@ final class TransferFilesToStorage implements TransferFilesToStorageInterface
                     $fileToTransfer->getOutputFileName()
                 );
             } catch (\Exception $exception) {
-                $message = $exception->getPrevious() ? $exception->getPrevious()->getMessage() : $exception->getMessage();
-                $this->eventDispatcher->dispatch(new FileCannotBeExported($message));
+                $this->eventDispatcher->dispatch(new FileCannotBeExported('An error occured during file upload, please check your storage configuration.'));
             }
         }
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
@@ -72,6 +72,7 @@ const AmazonS3StorageConfigurator = ({
         value={storage.secret}
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.secret.label')}
+        placeholder={translate('pim_import_export.form.job_instance.storage_form.secret.placeholder')}
         onChange={(secret: string) => onStorageChange({...storage, secret})}
         errors={filterErrors(validationErrors, '[secret]')}
       />

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
@@ -172,6 +172,7 @@ const SftpStorageConfigurator = ({
           required={true}
           type="password"
           label={translate('pim_import_export.form.job_instance.storage_form.password.label')}
+          placeholder={translate('pim_import_export.form.job_instance.storage_form.password.placeholder')}
           onChange={(password: string) => onStorageChange({...storage, password})}
           errors={filterErrors(validationErrors, '[password]')}
         />

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/import/file-path.html
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/templates/import/file-path.html
@@ -1,4 +1,4 @@
 <div>
-    <%- label %>: <span class="AknCenteredBox-highlight"><%- path %></span>
+    <span class="storage_type"></span> <%- label %>: <span class="AknCenteredBox-highlight"><%- path %></span>
 </div>
 <div data-drop-zone="buttons"></div>

--- a/tests/back/Platform/EndToEnd/ImportExport/InternalApi/GetJobExecutionEndToEnd.php
+++ b/tests/back/Platform/EndToEnd/ImportExport/InternalApi/GetJobExecutionEndToEnd.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AkeneoTest\Platform\EndToEnd\ImportExport\InternalApi;
 
 use Akeneo\Test\Integration\Configuration;
@@ -130,29 +132,29 @@ SQL;
                 'connector' => 'Akeneo CSV Connector',
                 'type' => 'import',
                 'configuration' =>
-                    [
-                        'storage' => [
-                            'type' => 'local',
-                            'file_path' => '/tmp/footwear_products.csv',
-                        ],
-                        'delimiter' => ';',
-                        'enclosure' => '"',
-                        'escape' => '\\',
-                        'withHeader' => true,
-                        'uploadAllowed' => true,
-                        'invalid_items_file_format' => 'csv',
-                        'users_to_notify' => [],
-                        'is_user_authenticated' => false,
-                        'decimalSeparator' => '.',
-                        'dateFormat' => 'yyyy-MM-dd',
-                        'enabled' => true,
-                        'categoriesColumn' => 'categories',
-                        'familyColumn' => 'family',
-                        'groupsColumn' => 'groups',
-                        'enabledComparison' => true,
-                        'realTimeVersioning' => true,
-                        'convertVariantToSimple' => false,
+                [
+                    'storage' => [
+                        'type' => 'local',
+                        'file_path' => '/tmp/footwear_products.csv',
                     ],
+                    'delimiter' => ';',
+                    'enclosure' => '"',
+                    'escape' => '\\',
+                    'withHeader' => true,
+                    'uploadAllowed' => true,
+                    'invalid_items_file_format' => 'csv',
+                    'users_to_notify' => [],
+                    'is_user_authenticated' => false,
+                    'decimalSeparator' => '.',
+                    'dateFormat' => 'yyyy-MM-dd',
+                    'enabled' => true,
+                    'categoriesColumn' => 'categories',
+                    'familyColumn' => 'family',
+                    'groupsColumn' => 'groups',
+                    'enabledComparison' => true,
+                    'realTimeVersioning' => true,
+                    'convertVariantToSimple' => false,
+                ],
                 'automation' => null,
                 'scheduled' => false,
             ],
@@ -163,6 +165,17 @@ SQL;
                 'currentStep' => 3,
                 'totalSteps' => 4,
                 'steps' => [
+                    [
+                        'jobName' => 'csv_product_import',
+                        'stepName' => 'download_files',
+                        'status' => 'STARTING',
+                        'isTrackable' => false,
+                        'hasWarning' => false,
+                        'hasError' => false,
+                        'duration' => 0,
+                        'processedItems' => 0,
+                        'totalItems' => 0,
+                    ],
                     [
                         'jobName' => 'csv_product_import',
                         'stepName' => 'validation',

--- a/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
+++ b/tests/back/Platform/Integration/ImportExport/Repository/InternalApi/GetJobExecutionTrackingIntegration.php
@@ -9,20 +9,14 @@ use Akeneo\Platform\Bundle\ImportExportBundle\Model\StepExecutionTracking;
 use Akeneo\Platform\Bundle\ImportExportBundle\Query\GetJobExecutionTracking;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
-use Akeneo\Tool\Component\Batch\Job\BatchStatus;
 use AkeneoTest\Platform\Integration\ImportExport\Utils\FrozenClock;
 use Doctrine\DBAL\Connection;
 
 class GetJobExecutionTrackingIntegration extends TestCase
 {
-    /** @var Connection */
-    private $sqlConnection;
-
-    /** @var GetJobExecutionTracking */
-    private $getJobExecutionTracking;
-
-    /** @var FrozenClock */
-    private $clock;
+    private Connection $sqlConnection;
+    private GetJobExecutionTracking $getJobExecutionTracking;
+    private FrozenClock $clock;
 
     public function setUp(): void
     {
@@ -230,6 +224,7 @@ SQL;
         $expectedJobExecutionTracking->totalSteps = 4;
 
         $expectedJobExecutionTracking->steps = [
+            $this->getDownloadStepExecutionTracking(),
             $this->getValidationStepExecutionTracking(),
             $this->getImportStepExecutionTracking(),
             $this->getImportAssociationsStepExecutionTracking()
@@ -259,6 +254,7 @@ SQL;
         $expectedStepExecutionTracking3 = $this->getImportAssociationsStepExecutionTracking();
 
         $expectedJobExecutionTracking->steps = [
+            $this->getDownloadStepExecutionTracking(),
             $expectedStepExecutionTracking1,
             $expectedStepExecutionTracking2,
             $expectedStepExecutionTracking3
@@ -289,6 +285,7 @@ SQL;
         $expectedStepExecutionTracking3->duration = 1;
 
         $expectedJobExecutionTracking->steps = [
+            $this->getDownloadStepExecutionTracking(),
             $expectedStepExecutionTracking1,
             $expectedStepExecutionTracking2,
             $expectedStepExecutionTracking3
@@ -320,6 +317,7 @@ SQL;
         $expectedStepExecutionTracking3->duration = 0;
 
         $expectedJobExecutionTracking->steps = [
+            $this->getDownloadStepExecutionTracking(),
             $expectedStepExecutionTracking1,
             $expectedStepExecutionTracking2,
             $expectedStepExecutionTracking3
@@ -355,6 +353,22 @@ SQL;
         ];
 
         return $expectedJobExecutionTracking;
+    }
+
+    private function getDownloadStepExecutionTracking(): StepExecutionTracking
+    {
+        $stepExecutionTracking = new StepExecutionTracking();
+        $stepExecutionTracking->isTrackable = false;
+        $stepExecutionTracking->jobName = 'csv_product_import';
+        $stepExecutionTracking->stepName = 'download_files';
+        $stepExecutionTracking->status = 'STARTING';
+        $stepExecutionTracking->duration = 0;
+        $stepExecutionTracking->hasError = false;
+        $stepExecutionTracking->hasWarning = false;
+        $stepExecutionTracking->processedItems = 0;
+        $stepExecutionTracking->totalItems = 0;
+
+        return $stepExecutionTracking;
     }
 
     private function getValidationStepExecutionTracking(): StepExecutionTracking


### PR DESCRIPTION
- User-friendly error message when we cannot upload file (we cannot use exception message as they are formatted differently for each provider)
- Remove dirty hack that skipped upload/download steps for old jobs, as the feature is now released for more than 90 days
- Add placeholders on password & secret inputs
- Add storage type badge next to file path & import button when having a remote storage configured

<img width="967" alt="Screenshot 2022-12-09 at 20 20 56" src="https://user-images.githubusercontent.com/3492179/207023874-73171f0b-43e7-45fa-b833-a2888bef2c23.png">
<img width="974" alt="Screenshot 2022-12-09 at 20 21 20" src="https://user-images.githubusercontent.com/3492179/207023880-bc9229e4-761f-4427-88f5-2c65666ac4f6.png">
<img width="963" alt="Screenshot 2022-12-09 at 20 21 32" src="https://user-images.githubusercontent.com/3492179/207023885-f1ee016c-adac-4521-9f6c-ce573e8fea86.png">
