### PR TITLE
PIM-10765: Fix Out of sort memory on Process Tracker

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,12 +1,16 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10765: Fix Out of sort memory on Process Tracker
+
 # 6.0.57 (2022-12-07)
 
 # 6.0.56 (2022-11-28)
 
 ## Bug fixes
 
-PIM-10734: Assets export fails because of a failed warning messages
+- PIM-10734: Assets export fails because of a failed warning messages
 
 # 6.0.55 (2022-11-21)
 
@@ -43,8 +47,9 @@ PIM-10734: Assets export fails because of a failed warning messages
 # 6.0.46 (2022-10-20)
 
 ## Bug fixes
-PIM-10670: Fix memory leak on creating combinations for currencies
-PIM-10679: Fix out of sort memory on ProductModelImagesFromCodes
+
+- PIM-10670: Fix memory leak on creating combinations for currencies
+- PIM-10679: Fix out of sort memory on ProductModelImagesFromCodes
 
 # 6.0.45 (2022-10-06)
 

--- a/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
+++ b/src/Akeneo/Platform/Job/back/Infrastructure/Query/SearchJobExecution.php
@@ -77,6 +77,7 @@ SQL;
         LIMIT :offset, :limit
     )
     SELECT
+        /*+ SET_VAR(sort_buffer_size = 1000000) */
         job_execution.*,
         COUNT(step_execution.job_execution_id) AS current_step_number,
         JSON_ARRAYAGG(JSON_OBJECT(


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Sometimes, it happens that the buffer size limit is triggered due to a huge value in `failures_exceptions` column.
see https://akeneo.atlassian.net/browse/PIM-10765

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
