### PR TITLE
CXP-1363: Add route to reach connected app edit page by id with redirection

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Public/RedirectToEditConnectedAppAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Public/RedirectToEditConnectedAppAction.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Model\ConnectedApp;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\FindOneConnectedAppByIdQueryInterface;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RedirectToEditConnectedAppAction
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly SecurityFacade $security,
+        private readonly FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+    ) {
+    }
+
+    public function __invoke(string $id): Response
+    {
+        $connectedApp = $this->findOneConnectedAppByIdQuery->execute($id);
+        if (null === $connectedApp) {
+            throw new NotFoundHttpException();
+        }
+
+        $this->denyAccessUnlessGrantedToManage($connectedApp);
+
+        return new RedirectResponse(
+            '/#' . $this->router->generate('akeneo_connectivity_connection_connect_connected_apps_edit', [
+                'connectionCode' => $connectedApp->getConnectionCode(),
+            ])
+        );
+    }
+
+    private function denyAccessUnlessGrantedToManage(ConnectedApp $app): void
+    {
+        if (!$this->isGrantedToManage($app)) {
+            throw new AccessDeniedHttpException();
+        }
+    }
+
+    private function isGrantedToManage(ConnectedApp $app): bool
+    {
+        return
+            (
+                $app->isTestApp() &&
+                $this->security->isGranted('akeneo_connectivity_connection_manage_test_apps')
+            ) || (
+                !$app->isTestApp() &&
+                $this->security->isGranted('akeneo_connectivity_connection_manage_apps')
+            );
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/controllers.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/controllers.yml
@@ -166,3 +166,10 @@ services:
             - '@oro_security.security_facade'
             - '@Akeneo\Catalogs\ServiceAPI\Messenger\QueryBus'
             - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByUserIdentifierQuery'
+
+    Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public\RedirectToEditConnectedAppAction:
+        public: true
+        arguments:
+            - '@router'
+            - '@oro_security.security_facade'
+            - '@Akeneo\Connectivity\Connection\Infrastructure\Apps\Persistence\FindOneConnectedAppByIdQuery'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/routing.yml
@@ -90,6 +90,11 @@ akeneo_connectivity_connection_connect_apps_v1_redirect_to_catalog:
     controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public\RedirectToEditCatalogAction
     methods: [ GET ]
 
+akeneo_connectivity_connection_connect_apps_v1_redirect_to_connected_app:
+    path: '/connect/apps/v1/connected_app/{id}'
+    controller: Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public\RedirectToEditConnectedAppAction
+    methods: [ GET ]
+
 # Front API
 ## Apps
 akeneo_connectivity_connection_connect_apps_activate:

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Public/RedirectToEditConnectedAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Public/RedirectToEditConnectedAppActionEndToEnd.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Connectivity\Connection\Tests\EndToEnd\Apps\Public;
+
+use Akeneo\Connectivity\Connection\back\tests\EndToEnd\WebTestCase;
+use Akeneo\Connectivity\Connection\Tests\CatalogBuilder\ConnectedAppLoader;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\Internal\Test\FilePersistedFeatureFlags;
+use Akeneo\Test\Integration\Configuration;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RedirectToEditConnectedAppActionEndToEnd extends WebTestCase
+{
+    private FilePersistedFeatureFlags $featureFlags;
+    private ConnectedAppLoader $connectedAppLoader;
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->featureFlags = $this->get('feature_flags');
+        $this->connectedAppLoader = $this->get('akeneo_connectivity.connection.fixtures.connected_app_loader');
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_is_redirected_to_the_connected_app_edit_page():void
+    {
+        $this->featureFlags->enable('marketplace_activate');
+        $this->addAclToRole('ROLE_ADMINISTRATOR', 'akeneo_connectivity_connection_manage_apps');
+        $this->authenticateAsAdmin();
+
+        $appId = '238b1eef-3acd-408e-9133-d90f695bee3d';
+        $this->connectedAppLoader->createConnectedAppWithUserAndTokens(
+            $appId,
+            'random_connection_code',
+            ['read_products'],
+        );
+
+        $this->client->request(
+            'GET',
+            '/connect/apps/v1/connected_app/'. $appId,
+        );
+        $response = $this->client->getResponse();
+
+        Assert::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+        \assert($response instanceof RedirectResponse);
+        Assert::assertEquals('/#/connect/connected-apps/random_connection_code', $response->getTargetUrl());
+    }
+}

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Controller/Public/RedirectToEditConnectedAppActionSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/Controller/Public/RedirectToEditConnectedAppActionSpec.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public;
+
+use Akeneo\Connectivity\Connection\Domain\Apps\Model\ConnectedApp;
+use Akeneo\Connectivity\Connection\Domain\Apps\Persistence\FindOneConnectedAppByIdQueryInterface;
+use Akeneo\Connectivity\Connection\Infrastructure\Apps\Controller\Public\RedirectToEditConnectedAppAction;
+use Oro\Bundle\SecurityBundle\SecurityFacade;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class RedirectToEditConnectedAppActionSpec extends ObjectBehavior
+{
+    public function let(
+        RouterInterface $router,
+        SecurityFacade $security,
+        FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+    ) {
+        $this->beConstructedWith(
+            $router,
+            $security,
+            $findOneConnectedAppByIdQuery,
+        );
+    }
+
+    public function it_is_a_redirect_to_connected_app_editing_action(): void
+    {
+        $this->beAnInstanceOf(RedirectToEditConnectedAppAction::class);
+    }
+
+    public function it_throws_not_found_exception_when_connected_app_is_not_found(
+        FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+    ): void {
+        $badId = '00000000-0000-0000-0000-000000000000';
+
+        $findOneConnectedAppByIdQuery
+            ->execute($badId)
+            ->willReturn(null);
+
+        $this->shouldThrow(new NotFoundHttpException())->during('__invoke', [$badId]);
+    }
+
+    public function it_denies_user_that_cannot_manage_a_test_app(
+        FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+        SecurityFacade $security,
+    ): void {
+        $appId = '06416ae6-56e6-4a63-82af-522373fbf901';
+        $findOneConnectedAppByIdQuery
+            ->execute($appId)
+            ->willReturn(new ConnectedApp(
+                $appId,
+                'a_connected_app_name',
+                ['read_scope_d', 'read_scope_b'],
+                'random_connection_code',
+                'a/path/to/a/logo',
+                'an_author',
+                'a_group',
+                'an_username',
+                [],
+                false,
+                null,
+                true,
+            ));
+
+        $security->isGranted('akeneo_connectivity_connection_manage_test_apps')->willReturn(false);
+        $security->isGranted('akeneo_connectivity_connection_manage_apps')->willReturn(true);
+        $security->isGranted('akeneo_connectivity_connection_open_apps')->willReturn(true);
+
+        $this->shouldThrow(new AccessDeniedHttpException())->during('__invoke', [$appId]);
+    }
+
+    public function it_denies_user_that_cannot_manage_an_app(
+        FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+        SecurityFacade $security,
+    ): void {
+        $appId = '06416ae6-56e6-4a63-82af-522373fbf901';
+        $findOneConnectedAppByIdQuery
+            ->execute($appId)
+            ->willReturn(new ConnectedApp(
+                'a_connected_app_id',
+                'a_connected_app_name',
+                ['read_scope_d', 'read_scope_b'],
+                'random_connection_code',
+                'a/path/to/a/logo',
+                'an_author',
+                'a_group',
+                'an_username',
+                [],
+                false,
+                null,
+                false,
+            ));
+
+        $security->isGranted('akeneo_connectivity_connection_manage_test_apps')->willReturn(false);
+        $security->isGranted('akeneo_connectivity_connection_manage_apps')->willReturn(false);
+        $security->isGranted('akeneo_connectivity_connection_open_apps')->willReturn(true);
+
+        $this->shouldThrow(new AccessDeniedHttpException())->during('__invoke', [$appId]);
+    }
+
+    public function it_redirects_user_to_the_edit_connected_app_page(
+        FindOneConnectedAppByIdQueryInterface $findOneConnectedAppByIdQuery,
+        SecurityFacade $security,
+        RouterInterface $router,
+    ): void {
+        $appId = '06416ae6-56e6-4a63-82af-522373fbf901';
+        $findOneConnectedAppByIdQuery
+            ->execute($appId)
+            ->willReturn(new ConnectedApp(
+                'a_connected_app_id',
+                'a_connected_app_name',
+                ['read_scope_d', 'read_scope_b'],
+                'random_connection_code',
+                'a/path/to/a/logo',
+                'an_author',
+                'a_group',
+                'an_username',
+                [],
+                false,
+                null,
+                false,
+            ));
+
+        $security->isGranted('akeneo_connectivity_connection_manage_test_apps')->willReturn(false);
+        $security->isGranted('akeneo_connectivity_connection_manage_apps')->willReturn(true);
+        $security->isGranted('akeneo_connectivity_connection_open_apps')->willReturn(true);
+
+        $router
+            ->generate('akeneo_connectivity_connection_connect_connected_apps_edit', [
+                'connectionCode' => 'random_connection_code',
+            ])
+            ->willReturn('/connect/connected-apps/random_connection_code');
+
+        $this
+            ->__invoke($appId)
+            ->shouldBeLike(new RedirectResponse('/#' . '/connect/connected-apps/random_connection_code'));
+    }
+}


### PR DESCRIPTION

**Description (for Contributor and Core Developer)**

To be able to modify the Go to PIM link in demo app to directly reach the connected app edit page, we need the connection code.
So, this new public route allows to do this.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->


