### PR TITLE
PIM-10751: Avoid 500 error and print a violation when user try to save measurement value with space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@
 - PIM-10718: Fix categories with empty labels throw 500 error
 - PIM-10725: Fix get family variant case sensitive
 - PIM-10720: Fix price versioning normalizer to round numbers
+- PIM-10751: Avoid error 500 and print a violation when user try to save measurement value with space
 - PIM-10724: Fix textarea template so that first break line is not considered as break in html
 - PIM-10716: Fix uuids in quantified association revert version
 - PIM-10734: Fix failing product export profiles with "[object Object]" family filter since last weekly upgrade

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/translations/validators.en_US.yml
@@ -38,6 +38,7 @@ The %attribute% attribute requires a string, a %givenType% was detected.: The %a
 The {{ attribute_code }} attribute requires a date that should be {{ limit }} or after.: The {{ attribute_code }} attribute requires a date that should be {{ limit }} or after.
 The {{ attribute_code }} attribute requires a date that should be {{ limit }} or before.: The {{ attribute_code }} attribute requires a date that should be {{ limit }} or before.
 The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.: The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.
+The {{ attribute }} attribute requires a value which does not contain space, and the submitted "{{ value }}" has at least one.: The {{ attribute }} attribute requires a value which does not contain space, and the submitted "{{ value }}" has at least one.
 The %attribute% attribute must not contain more than %limit% characters. The submitted value is too long.: The %attribute% attribute must not contain more than %limit% characters. The submitted value is too long.
 The %type% file extension is not allowed for the %attribute% attribute. Allowed extensions are %extensions%.: The %type% file extension is not allowed for the %attribute% attribute. Allowed extensions are %extensions%.
 "The %attribute% attribute requires a url link.": The %attribute% attribute requires a url link.

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumeric.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumeric.php
@@ -8,16 +8,14 @@ use Symfony\Component\Validator\Constraint;
  * Constraint
  *
  * @author    Antoine Guigan <antoine@akeneo.com>
- * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @copyright 2013 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class IsNumeric extends Constraint
 {
-    const IS_NUMERIC = "3ee14592-14a8-4314-836f-b6177aaf7c05";
+    public const IS_NUMERIC = '3ee14592-14a8-4314-836f-b6177aaf7c05';
+    public const SHOULD_BE_NUMERIC_MESSAGE = 'The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.';
+    public const SHOULD_NOT_CONTAINS_SPACE_MESSAGE = 'The {{ attribute }} attribute requires a value which does not contains space, and the submitted "{{ value }}" has at least one.';
 
-    /** @var string */
-    public $message = 'The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.';
-
-    /** @var string */
-    public $attributeCode = '';
+    public string $attributeCode = '';
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumericValidator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Validator/Constraints/IsNumericValidator.php
@@ -12,42 +12,59 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  * Constraint
  *
  * @author    Antoine Guigan <antoine@akeneo.com>
- * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
- * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @copyright 2013 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class IsNumericValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
      */
-    public function validate($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint): void
     {
         if (!$constraint instanceof IsNumeric) {
             throw new UnexpectedTypeException($constraint, IsNumeric::class);
         }
 
+        $propertyPath = null;
+
         if ($value instanceof MetricInterface || $value instanceof ProductPriceInterface) {
             $propertyPath = 'data';
             $value = $value->getData();
         }
+
         if (null === $value) {
             return;
         }
+
         if (!is_numeric($value)) {
-            $violation = $this->context->buildViolation(
-                $constraint->message,
-                [
-                    '{{ attribute }}' => $constraint->attributeCode,
-                    '{{ value }}' => $value,
-                ]
-            )
-                ->setCode(IsNumeric::IS_NUMERIC);
-
-            if (isset($propertyPath)) {
-                $violation->atPath($propertyPath);
-            }
-
-            $violation->addViolation();
+            $this->buildViolation($constraint, IsNumeric::SHOULD_BE_NUMERIC_MESSAGE, $value, $propertyPath);
         }
+
+        if (0 < $this->context->getViolations()->count()) {
+            return;
+        }
+
+        if (is_string($value) && str_contains($value, ' ')) {
+            $this->buildViolation($constraint, IsNumeric::SHOULD_NOT_CONTAINS_SPACE_MESSAGE, $value, $propertyPath);
+        }
+    }
+
+    private function buildViolation(IsNumeric $constraint, string $message, mixed $value, ?string $path): void
+    {
+        $violation = $this->context->buildViolation(
+            $message,
+            [
+                '{{ attribute }}' => $constraint->attributeCode,
+                '{{ value }}' => $value,
+            ]
+        )
+            ->setCode(IsNumeric::IS_NUMERIC);
+
+        if ($path) {
+            $violation->atPath($path);
+        }
+
+        $violation->addViolation();
     }
 }

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Convert/MeasureConverter.php
@@ -105,7 +105,7 @@ class MeasureConverter
      */
     protected function applyOperation($value, $operator, $operand)
     {
-        if (!is_numeric($value)) {
+        if (!is_numeric($value) || (is_string($value) && str_contains($value, ' '))) {
             return '0';
         }
 

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/spec/Convert/MeasureConverterSpec.php
@@ -12,7 +12,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class MeasureConverterSpec extends ObjectBehavior
 {
-    function let(LegacyMeasurementProvider $provider)
+    function let(LegacyMeasurementProvider $provider): void
     {
         $yaml = <<<YAML
 measures_config:
@@ -45,13 +45,13 @@ YAML;
         $this->beConstructedWith($provider);
     }
 
-    public function it_allows_to_define_the_family()
+    public function it_allows_to_define_the_family(): void
     {
         $this->setFamily('Length')->shouldReturnAnInstanceOf(MeasureConverter::class);
         $this->setFamily('length')->shouldReturnAnInstanceOf(MeasureConverter::class);
     }
 
-    public function it_throws_an_exception_if_an_unknown_family_is_set()
+    public function it_throws_an_exception_if_an_unknown_family_is_set(): void
     {
         $this
             ->shouldThrow(
@@ -60,7 +60,7 @@ YAML;
             ->during('setFamily', ['foo']);
     }
 
-    public function it_converts_a_value_from_a_base_unit_to_a_final_unit()
+    public function it_converts_a_value_from_a_base_unit_to_a_final_unit(): void
     {
         $this->setFamily('Weight');
         $this->convert(
@@ -70,7 +70,7 @@ YAML;
         )->shouldReturn('1000000.000000000000');
     }
 
-    public function it_converts_a_value_from_a_base_unit_to_a_final_unit_case_insensitive()
+    public function it_converts_a_value_from_a_base_unit_to_a_final_unit_case_insensitive(): void
     {
         $this->setFamily('weight');
         $this->convert(
@@ -80,14 +80,14 @@ YAML;
         )->shouldReturn('1000000.000000000000');
     }
 
-    public function it_converts_a_value_to_a_standard_unit()
+    public function it_converts_a_value_to_a_standard_unit(): void
     {
         $this->setFamily('Weight');
         $this->convertBaseToStandard('MILLIGRAM', 1000)->shouldReturn('1.000000000000');
         $this->convertBaseToStandard('milligram', 1000)->shouldReturn('1.000000000000');
     }
 
-    public function it_converts_a_very_small_value_to_a_standard_unit()
+    public function it_converts_a_very_small_value_to_a_standard_unit(): void
     {
         $this->setFamily('Weight');
         $this->convertBaseToStandard(
@@ -96,7 +96,7 @@ YAML;
         )->shouldReturn('0.000100000000');
     }
 
-    public function it_returns_zero_when_value_is_not_numeric()
+    public function it_returns_zero_when_value_is_not_numeric(): void
     {
         $this->setFamily('Weight');
         $this->convertBaseToStandard(
@@ -105,14 +105,23 @@ YAML;
         )->shouldReturn('0');
     }
 
-    public function it_converts_a_standard_value_to_a_final_unit()
+    public function it_returns_zero_when_value_is_numeric_and_contains_space(): void
+    {
+        $this->setFamily('Weight');
+        $this->convertBaseToStandard(
+            'KILOGRAM',
+            ' 1.900'
+        )->shouldReturn('0');
+    }
+
+    public function it_converts_a_standard_value_to_a_final_unit(): void
     {
         $this->setFamily('Weight');
         $this->convertStandardToResult('KILOGRAM', 10)->shouldReturn('0.010000000000');
         $this->convertStandardToResult('KiloGram', 10)->shouldReturn('0.010000000000');
     }
 
-    public function it_throws_an_exception_if_the_unit_measure_does_not_exist()
+    public function it_throws_an_exception_if_the_unit_measure_does_not_exist(): void
     {
         $this->setFamily('Weight');
         $this

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/MetricGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/MetricGuesserSpec.php
@@ -10,12 +10,12 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 
 class MetricGuesserSpec extends ObjectBehavior
 {
-    function it_is_an_attribute_constraint_guesser()
+    public function it_is_an_attribute_constraint_guesser(): void
     {
         $this->shouldImplement(ConstraintGuesserInterface::class);
     }
 
-    function it_enforces_attribute_type(AttributeInterface $attribute)
+    public function it_enforces_attribute_type(AttributeInterface $attribute): void
     {
         $attribute->getType()
             ->willReturn('pim_catalog_metric');
@@ -33,8 +33,9 @@ class MetricGuesserSpec extends ObjectBehavior
             ->shouldReturn(false);
     }
 
-    function it_always_guess(AttributeInterface $attribute)
+    public function it_always_guess(AttributeInterface $attribute): void
     {
+        $attribute->getCode()->willReturn('');
         $constraints = $this->guessConstraints($attribute);
 
         $constraints->shouldHaveCount(2);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/NumericGuesserSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/ConstraintGuesser/NumericGuesserSpec.php
@@ -9,12 +9,12 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 
 class NumericGuesserSpec extends ObjectBehavior
 {
-    function it_is_an_attribute_constraint_guesser()
+    public function it_is_an_attribute_constraint_guesser(): void
     {
         $this->shouldImplement(ConstraintGuesserInterface::class);
     }
 
-    function it_enforces_attribute_type(AttributeInterface $attribute)
+    public function it_enforces_attribute_type(AttributeInterface $attribute): void
     {
         $attribute->getType()
             ->willReturn('pim_catalog_metric');
@@ -37,8 +37,9 @@ class NumericGuesserSpec extends ObjectBehavior
             ->shouldReturn(false);
     }
 
-    function it_always_guess(AttributeInterface $attribute)
+    public function it_always_guess(AttributeInterface $attribute): void
     {
+        $attribute->getCode()->willReturn('');
         $constraints = $this->guessConstraints($attribute);
 
         $constraints->shouldHaveCount(1);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericSpec.php
@@ -8,28 +8,23 @@ use Symfony\Component\Validator\Constraint;
 
 class IsNumericSpec extends ObjectBehavior
 {
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(IsNumeric::class);
     }
 
-    function it_has_message()
-    {
-        $this->message->shouldBe('The {{ attribute }} attribute requires a number, and the submitted {{ value }} value is not.');
-    }
-
-    function it_is_a_validator_constraint()
+    public function it_is_a_validator_constraint(): void
     {
         $this->shouldBeAnInstanceOf(Constraint::class);
     }
 
-    function it_provides_attribute_code(): void
+    public function it_provides_attribute_code(): void
     {
         $this->beConstructedWith(['attributeCode' => 'weight']);
         $this->attributeCode->shouldBe('weight');
     }
 
-    function it_provides_empty_string_if_no_attribute_code_has_been_provided(): void
+    public function it_provides_empty_string_if_no_attribute_code_has_been_provided(): void
     {
         $this->attributeCode->shouldBe('');
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericValidatorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Validator/Constraints/IsNumericValidatorSpec.php
@@ -8,27 +8,37 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\MetricInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductPriceInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Validator\Constraints\IsNumeric;
 use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 
 class IsNumericValidatorSpec extends ObjectBehavior
 {
-    function let(ExecutionContextInterface $context)
+    public function let(
+        ExecutionContextInterface $context,
+        ConstraintViolationListInterface $constraintViolationList,
+    ): void
     {
         $this->initialize($context);
+        $context
+            ->getViolations()
+            ->willReturn($constraintViolationList);
+        $constraintViolationList
+            ->count()
+            ->willReturn(0);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(IsNumericValidator::class);
     }
 
-    function it_is_a_validator_constraint()
+    public function it_is_a_validator_constraint(): void
     {
         $this->shouldBeAnInstanceOf('Symfony\Component\Validator\ConstraintValidator');
     }
 
-    function it_does_not_add_violation_null_value($context, IsNumeric $numericConstraint)
+    public function it_does_not_add_violation_null_value(ExecutionContextInterface $context, IsNumeric $numericConstraint): void
     {
         $context
             ->buildViolation(Argument::cetera())
@@ -40,7 +50,11 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate(null, $numericConstraint);
     }
 
-    function it_does_not_add_violation_metric_with_no_data($context, MetricInterface $metric, IsNumeric $numericConstraint)
+    public function it_does_not_add_violation_metric_with_no_data(
+        ExecutionContextInterface $context,
+        MetricInterface $metric,
+        IsNumeric $numericConstraint,
+    ): void
     {
         $metric->getData()->willReturn(null);
         $context
@@ -53,10 +67,10 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate($metric, $numericConstraint);
     }
 
-    function it_does_not_add_violation_product_price_with_no_data(
-        $context,
+    public function it_does_not_add_violation_product_price_with_no_data(
+        ExecutionContextInterface $context,
         ProductPriceInterface $productPrice,
-        IsNumeric $numericConstraint
+        IsNumeric $numericConstraint,
     ) {
         $productPrice->getData()->willReturn(null);
         $context
@@ -69,7 +83,7 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate($productPrice, $numericConstraint);
     }
 
-    function it_does_not_add_violation_when_validates_numeric_value($context, IsNumeric $numericConstraint)
+    public function it_does_not_add_violation_when_validates_numeric_value(ExecutionContextInterface $context, IsNumeric $numericConstraint): void
     {
         $propertyPath = null;
         $context
@@ -79,11 +93,11 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate(5, $numericConstraint);
     }
 
-    function it_does_not_add_violation_when_validates_numeric_metric_value(
+    public function it_does_not_add_violation_when_validates_numeric_metric_value(
         $context,
         MetricInterface $metric,
-        IsNumeric $numericConstraint
-    ) {
+        IsNumeric $numericConstraint,
+    ): void {
         $metric->getData()->willReturn(5);
         $context
             ->buildViolation(Argument::cetera())
@@ -92,11 +106,11 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate($metric, $numericConstraint);
     }
 
-    function it_does_not_add_violation_when_validates_numeric_product_price_value(
+    public function it_does_not_add_violation_when_validates_numeric_product_price_value(
         $context,
         ProductPriceInterface $productPrice,
         IsNumeric $numericConstraint
-    ) {
+    ): void {
         $productPrice->getData()->willReturn(5);
         $context
             ->buildViolation(Argument::cetera())
@@ -105,16 +119,16 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate($productPrice, $numericConstraint);
     }
 
-    function it_adds_violation_when_validating_non_numeric_value(
+    public function it_adds_violation_when_validating_non_numeric_value(
         $context,
         ConstraintViolationBuilderInterface $violationBuilder
-    ) {
+    ): void {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
 
         $context
             ->buildViolation(
-                $numericConstraint->message,
+                IsNumeric::SHOULD_BE_NUMERIC_MESSAGE,
                 [
                     '{{ attribute }}' => $numericConstraint->attributeCode,
                     '{{ value }}' => 'a',
@@ -128,18 +142,18 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate('a', $numericConstraint);
     }
 
-    function it_adds_violation_when_validating_non_numeric_metric_value(
+    public function it_adds_violation_when_validating_non_numeric_metric_value(
         $context,
         MetricInterface $metric,
         ConstraintViolationBuilderInterface $violationBuilder
-    ) {
+    ): void {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
         $metric->getData()->willReturn('a');
 
         $context
             ->buildViolation(
-                $numericConstraint->message,
+                IsNumeric::SHOULD_BE_NUMERIC_MESSAGE,
                 [
                     '{{ attribute }}' => $numericConstraint->attributeCode,
                     '{{ value }}' => 'a',
@@ -155,17 +169,17 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $this->validate($metric, $numericConstraint);
     }
 
-    function it_adds_violation_when_validating_non_numeric_product_price_value(
+    public function it_adds_violation_when_validating_non_numeric_product_price_value(
         $context,
         ProductPriceInterface $productPrice,
         ConstraintViolationBuilderInterface $violationBuilder
-    ) {
+    ): void {
         $numericConstraint = new IsNumeric();
         $numericConstraint->attributeCode = 'number';
         $productPrice->getData()->willReturn('a');
         $context
             ->buildViolation(
-                $numericConstraint->message,
+                IsNumeric::SHOULD_BE_NUMERIC_MESSAGE,
                 [
                     '{{ attribute }}' => $numericConstraint->attributeCode,
                     '{{ value }}' => 'a',
@@ -179,5 +193,32 @@ class IsNumericValidatorSpec extends ObjectBehavior
         $violationBuilder->addViolation()->shouldBeCalled();
 
         $this->validate($productPrice, $numericConstraint);
+    }
+
+    public function it_adds_violation_when_validating_numeric_value_with_space(
+        $context,
+        MetricInterface $metric,
+        ConstraintViolationBuilderInterface $violationBuilder,
+    ): void {
+        $numericConstraint = new IsNumeric();
+        $numericConstraint->attributeCode = 'number';
+        $metric->getData()->willReturn(' 3.14');
+
+        $context
+            ->buildViolation(
+                IsNumeric::SHOULD_NOT_CONTAINS_SPACE_MESSAGE,
+                [
+                    '{{ attribute }}' => $numericConstraint->attributeCode,
+                    '{{ value }}' => ' 3.14',
+                ]
+            )
+            ->shouldBeCalled()
+            ->willReturn($violationBuilder);
+
+        $violationBuilder->setCode(IsNumeric::IS_NUMERIC)->willReturn($violationBuilder);
+        $violationBuilder->atPath('data')->willReturn($violationBuilder);
+        $violationBuilder->addViolation()->shouldBeCalled();
+
+        $this->validate($metric, $numericConstraint);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When a user try to save a measurement value with a space, it encounters a 500 error.
I fixed the MeasureConverter to ignore the value and added a check in IsNumeric constraint to be able to unvalidate the product and print a message to the user.

![Screenshot from 2022-12-12 18-26-18](https://user-images.githubusercontent.com/35272857/207112558-87771c65-cda0-4350-a598-4c5651fd3470.png)

see https://akeneo.atlassian.net/browse/PIM-10751

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
