### PR TITLE
OCT-108: Upgrade lcobucci/jwt to ^4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "imagine/imagine": "1.2.4",
         "justinrainbow/json-schema": "^5.2",
         "khaled.alshamaa/ar-php": "^6.2",
-        "lcobucci/jwt": "~4.1.5",
+        "lcobucci/jwt": "^4.2",
         "league/flysystem": "^3.11.0",
         "liip/imagine-bundle": "2.6.1",
         "maennchen/zipstream-php": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "375d0e17ca5c2122a57205c1ddd9ad5b",
+    "content-hash": "f41bb7e3f844a0606e7073dec26468f9",
     "packages": [
         {
             "name": "akeneo/oauth-server-bundle",
@@ -3786,16 +3786,16 @@
         },
         {
             "name": "lcobucci/jwt",
-            "version": "4.1.5",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "fe2d89f2eaa7087af4aa166c6f480ef04e000582"
+                "reference": "72ac6d807ee51a70ad376ee03a2387e8646e10f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/fe2d89f2eaa7087af4aa166c6f480ef04e000582",
-                "reference": "fe2d89f2eaa7087af4aa166c6f480ef04e000582",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/72ac6d807ee51a70ad376ee03a2387e8646e10f3",
+                "reference": "72ac6d807ee51a70ad376ee03a2387e8646e10f3",
                 "shasum": ""
             },
             "require": {
@@ -3811,12 +3811,12 @@
                 "infection/infection": "^0.21",
                 "lcobucci/coding-standard": "^6.0",
                 "mikey179/vfsstream": "^1.6.7",
-                "phpbench/phpbench": "^1.0",
+                "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-deprecation-rules": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/php-invoker": "^3.1",
                 "phpunit/phpunit": "^9.5"
             },
@@ -3844,7 +3844,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/4.1.5"
+                "source": "https://github.com/lcobucci/jwt/tree/4.2.1"
             },
             "funding": [
                 {
@@ -3856,7 +3856,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-09-28T19:34:56+00:00"
+            "time": "2022-08-19T23:14:07+00:00"
         },
         {
             "name": "league/flysystem",

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
@@ -35,6 +35,10 @@ class CreateJsonWebToken
         string $lastName,
         string $email
     ): string {
+        /**
+         * @var non-empty-string $publicKey
+         * @var non-empty-string $privateKey
+         */
         ['public_key' => $publicKey, 'private_key' => $privateKey] = $this->getAsymmetricKeysQuery->execute(
         )->normalize();
         $privateKey = InMemory::plainText($privateKey);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
@@ -10,7 +10,6 @@ use Akeneo\Connectivity\Connection\Domain\Apps\ValueObject\ScopeList;
 use Akeneo\Connectivity\Connection\Domain\ClockInterface;
 use Akeneo\Platform\Bundle\FrameworkBundle\Service\PimUrl;
 use Lcobucci\JWT\Configuration;
-use Lcobucci\JWT\Signer\Key;
 use Lcobucci\JWT\Signer\Key\InMemory;
 use Lcobucci\JWT\Signer\Rsa\Sha256;
 use Ramsey\Uuid\Uuid;
@@ -21,18 +20,11 @@ use Ramsey\Uuid\Uuid;
  */
 class CreateJsonWebToken
 {
-    private ClockInterface $clock;
-    private PimUrl $pimUrl;
-    private GetAsymmetricKeysQueryInterface $getAsymmetricKeysQuery;
-
     public function __construct(
-        ClockInterface $clock,
-        PimUrl $pimUrl,
-        GetAsymmetricKeysQueryInterface $getAsymmetricKeysQuery
+        private ClockInterface $clock,
+        private PimUrl $pimUrl,
+        private GetAsymmetricKeysQueryInterface $getAsymmetricKeysQuery
     ) {
-        $this->clock = $clock;
-        $this->pimUrl = $pimUrl;
-        $this->getAsymmetricKeysQuery = $getAsymmetricKeysQuery;
     }
 
     public function create(

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/OAuth/CreateJsonWebTokenSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/OAuth/CreateJsonWebTokenSpec.php
@@ -50,7 +50,7 @@ class CreateJsonWebTokenSpec extends ObjectBehavior
         $this->beConstructedWith($clock, $pimUrl, $getAsymmetricKeysQuery);
     }
 
-    public function it_is_a_crate_json_web_token(): void
+    public function it_is_a_create_json_web_token(): void
     {
         $this->shouldBeAnInstanceOf(CreateJsonWebToken::class);
     }
@@ -164,29 +164,53 @@ class CreateJsonWebTokenSpec extends ObjectBehavior
 
         $this->privateKey = <<<EOD
         -----BEGIN RSA PRIVATE KEY-----
-        MIICXAIBAAKBgQC8kGa1pSjbSYZVebtTRBLxBz5H4i2p/llLCrEeQhta5kaQu/Rn
-        vuER4W8oDH3+3iuIYW4VQAzyqFpwuzjkDI+17t5t0tyazyZ8JXw+KgXTxldMPEL9
-        5+qVhgXvwtihXC1c5oGbRlEDvDF6Sa53rcFVsYJ4ehde/zUxo6UvS7UrBQIDAQAB
-        AoGAb/MXV46XxCFRxNuB8LyAtmLDgi/xRnTAlMHjSACddwkyKem8//8eZtw9fzxz
-        bWZ/1/doQOuHBGYZU8aDzzj59FZ78dyzNFoF91hbvZKkg+6wGyd/LrGVEB+Xre0J
-        Nil0GReM2AHDNZUYRv+HYJPIOrB0CRczLQsgFJ8K6aAD6F0CQQDzbpjYdx10qgK1
-        cP59UHiHjPZYC0loEsk7s+hUmT3QHerAQJMZWC11Qrn2N+ybwwNblDKv+s5qgMQ5
-        5tNoQ9IfAkEAxkyffU6ythpg/H0Ixe1I2rd0GbF05biIzO/i77Det3n4YsJVlDck
-        ZkcvY3SK2iRIL4c9yY6hlIhs+K9wXTtGWwJBAO9Dskl48mO7woPR9uD22jDpNSwe
-        k90OMepTjzSvlhjbfuPN1IdhqvSJTDychRwn1kIJ7LQZgQ8fVz9OCFZ/6qMCQGOb
-        qaGwHmUK6xzpUbbacnYrIM6nLSkXgOAwv7XXCojvY614ILTK3iXiLBOxPu5Eu13k
-        eUz9sHyD6vkgZzjtxXECQAkp4Xerf5TGfQXGXhxIX52yH+N2LtujCdkQZjXAsGdm
-        B2zNzvrlgRmgBrklMTrMYgm1NPcW+bRLGcwgW2PTvNM=
+        MIIEowIBAAKCAQEAxMV/ALXjkbQp50M26P9op95v1LIHs3vLvjROGxEBBnR/dEYN
+        HVbmOxKRGL8yne8xow7W4NiMVvm2VdgoDyTKF48cU679W7rsfkJqK0u1vGitlH0z
+        wG2e3AoMw+/7yLjCotG/PgRNSzXa6W2dTqduPO/2UeRBrScEpR6xnGQDrY5hXckS
+        Y1JU36laadlSYHIE3sf/VLoKItHeXHjeaXRGb0xGJ5pn1t33HfyI0ASSjURzANzB
+        jok/5kHq4g2xlkH1xSRSlgRyVhx8+5Pkuhe2mxDs1tJhaibZOxEb8kP4fizfxipg
+        lLEHclMdqDxoznxrI1XKTAfiAjhHlRxUa4B4dQIDAQABAoIBAEf70/1HjQvVc+rl
+        XOYZ4YhfyFtwEX8oj51ydwxRySU6YxH/Onb8Pldn8Gq0L2k1gtwa5qL0tUpwKbL3
+        05fOppu9v+ghQRBYroF1/G8AUGivhqimsNL5hz8J8ieP2HVSmemEf8jJPBmChyYT
+        8pM+jwZ95oeI0Dnu5zUcqG8E64+GvFYtT7Q99+U2yk/M/fA+tJP7fTWQgWSNm4MB
+        +oP4sFZMKV/qE3OWVHTWQ881TjmMpkdiyCwgUL3BZK4z/DmHoKW7KZr5DIFH+7MF
+        gGXHv59TJIGM2fyc6/CYaJ0znvEHZhjyYLgHWIVQPqeqXiVk21E8QfpukPtwnkcu
+        rSWaQyECgYEA/PM+4Ka9itSX7LWj2tDEGg5hGyJTA00AjXcZLYMpKRbAkDwT/5Aw
+        bwlV00//X3az0bfS1YuUziTXQ7qgWL4YFSFrxwTNceyDYiDMNPfa7ffjvO6SpPJ5
+        HWTXtpuseNrZHBkz2JkOSPkx/BQUYsz/RwMQdOzQpbPdCSo76HO+Gq0CgYEAxyTZ
+        gpq0Ppmb95ypPQikI2Ylgl3Mzs7ou1Cgf+ZVfXppDdRWt2bwEzid8kBsE1AGA0Zm
+        k+u2/ALDZDKp6uZ+qEHJRhBm1T/U/zA7c19x6YC7g2D33nMvLLeFlx9MuHKUV5+W
+        31gi//E8VqizPhPSk8LopeLCo+8X7GHVQouyFekCgYBatKtuibxcZWHZa0VHuScp
+        JNDjlwpnm5xAHl4z+N2ws0z4K+ML+Nu1ZYaWURCFXh6bbKy5EOWaipF64xiO2hPu
+        t95bLrixSpvOe25e7CZgwUy0OmTxq1WNGdVU0Twm1muWbN8vo6sAtgObnmO1DkfY
+        YhvroeQsF3SCzddPwvl/vQKBgFiKR7LLuavDfBbBLnWWa/PZLIAj2DVyxQLTPCjh
+        bc0WKbMeX1e3irHhEEhu4B5OC/5UxLKrsHWnfNwFsopf5JxGc4iVLkNN2BOFjEkl
+        fG4G8FffOxVKPQUyq1Cfd+rh9pZmvBudAiKtTNhytQ66nXtYwztN8KAWY5qTfM/T
+        cGBRAoGBAMrb6qicrZjjlsyx1Ci5AUE9jIE913R3G0Ner2EUVxrbDoNhD/AoCIuG
+        uJkuKNYJY20BSf4l7gwfZFA9uGBHpkhJZACq7vRoCKm0jOyhmmuoRZ/ClQZi8dq1
+        f8h9KC7ZDrEnth5za44DZYPXKcAxxsi7Zv6nmQO7qys0a1F2v4Pn
         -----END RSA PRIVATE KEY-----
         EOD;
 
         $this->publicKey = <<<EOD
-        -----BEGIN PUBLIC KEY-----
-        MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC8kGa1pSjbSYZVebtTRBLxBz5H
-        4i2p/llLCrEeQhta5kaQu/RnvuER4W8oDH3+3iuIYW4VQAzyqFpwuzjkDI+17t5t
-        0tyazyZ8JXw+KgXTxldMPEL95+qVhgXvwtihXC1c5oGbRlEDvDF6Sa53rcFVsYJ4
-        ehde/zUxo6UvS7UrBQIDAQAB
-        -----END PUBLIC KEY-----
+        -----BEGIN CERTIFICATE-----
+        MIIC7zCCAdegAwIBAgIUf9G4IrNSbjiOJW17UepkNlkh64owDQYJKoZIhvcNAQEL
+        BQAwETEPMA0GA1UECgwGQWtlbmVvMB4XDTIyMTIxMzE0NTgxN1oXDTIzMTIxMzE0
+        NTgxN1owETEPMA0GA1UECgwGQWtlbmVvMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+        MIIBCgKCAQEAxMV/ALXjkbQp50M26P9op95v1LIHs3vLvjROGxEBBnR/dEYNHVbm
+        OxKRGL8yne8xow7W4NiMVvm2VdgoDyTKF48cU679W7rsfkJqK0u1vGitlH0zwG2e
+        3AoMw+/7yLjCotG/PgRNSzXa6W2dTqduPO/2UeRBrScEpR6xnGQDrY5hXckSY1JU
+        36laadlSYHIE3sf/VLoKItHeXHjeaXRGb0xGJ5pn1t33HfyI0ASSjURzANzBjok/
+        5kHq4g2xlkH1xSRSlgRyVhx8+5Pkuhe2mxDs1tJhaibZOxEb8kP4fizfxipglLEH
+        clMdqDxoznxrI1XKTAfiAjhHlRxUa4B4dQIDAQABoz8wPTALBgNVHQ8EBAMCAQYw
+        DwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUuajENl2pPtXRJg2trCIV4u/qj1ow
+        DQYJKoZIhvcNAQELBQADggEBAGggphqPc72aqeaYOhu+oCqDmWymiiZvPAf8y+AY
+        cP1P4E4xcxc+xtqZOFfb9wtv2shjMf1Bz4XezxngssnNZr1PrmBuO+/am/4Q9KLl
+        WJV7qKEn3MZCx8Ajpw1XPkAu/ptqylm4dM8qiGBZbj94k4MpIGFhRIaPE1ii+Mz9
+        lmH84Y9kMHpg2tGW0hD9covc20BSii2TzkHlohfk6u0vXjkubXyq4VkwkRn2Rvh4
+        QqpHwbLe9lru+mlcn5HMmc4rVxE2q3BUhY8caZ73B/Vyejsfvuslu0j22xTSEjcR
+        1L/iY6KJdPVRR+6GZd4DMP+TChLM1U+jwxvfZNTSHNawBVo=
+        -----END CERTIFICATE-----
         EOD;
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Around 22 August, `lcobucci/jwt` released a new minor 4.2.0 that introduces a BC break due to security reason: https://github.com/lcobucci/jwt/issues/877

This new version did not allow SHA256 with private key of 1024 bits, which is the default length used by phpseclib : https://lcobucci-jwt.readthedocs.io/en/4.2.1/supported-algorithms/#deprecated-items_1

As there is no `composer.lock` on EE and in our `composer.json` we set `"lcobucci/jwt": "^4.1"`, we have automatically upgraded and it broke some tests in the CI.

![image](https://user-images.githubusercontent.com/4290650/207544961-ce96ad6a-6146-424b-bfce-ca81289a71ba.png)

To quickly fix this behavior, we locked the vendor to the last working version and planned an update: https://github.com/akeneo/pim-community-dev/pull/17696

Since this day we made an update of phpseclib from version 2 to 3 : https://github.com/akeneo/pim-community-dev/pull/17101 In this new version the private key default length is 2048 bits and our generated keys have rotated.

In this PR we upgrade `lcobucci/jwt` to `^4.2` to be more secure.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
