### PR TITLE
PH-430: Use Application::find() to run the command in CommandExecutor

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -250,7 +250,10 @@ class DatabaseCommand extends Command
     {
         $latestMigration = $this->getLatestMigration($input);
 
-        $this->commandExecutor->runCommand('doctrine:migrations:sync-metadata-storage', ['-q' => true]);
+        $this->commandExecutor->runCommand(
+            'doctrine:migrations:sync-metadata-storage',
+            ['-q' => true]
+        );
 
         $this->commandExecutor->runCommand(
             'doctrine:migrations:version',

--- a/src/Akeneo/Tool/Component/Console/CommandExecutor.php
+++ b/src/Akeneo/Tool/Component/Console/CommandExecutor.php
@@ -34,8 +34,13 @@ class CommandExecutor
 
         $command = $this->application->find($commandName);
 
+        $commandInput = new ArrayInput($params);
+        if ($this->input->hasOption('no-interaction')) {
+            $commandInput->setInteractive(false);
+        }
+
         $command->run(
-            new ArrayInput($params),
+            $commandInput,
             $this->input->hasOption('quiet') ? new NullOutput() : $this->output
         );
 

--- a/src/Akeneo/Tool/Component/Console/CommandExecutor.php
+++ b/src/Akeneo/Tool/Component/Console/CommandExecutor.php
@@ -5,45 +5,39 @@ namespace Akeneo\Tool\Component\Console;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command executor
  *
  * @author    Romain Monceau <romain@akeneo.com>
+ * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class CommandExecutor
 {
     public function __construct(
-        protected InputInterface $input,
-        protected OutputInterface $output,
-        protected Application $application
+        protected readonly InputInterface $input,
+        protected readonly OutputInterface $output,
+        protected readonly Application $application
     ) {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function runCommand($command, $params = []): static
+    public function runCommand(string $commandName, array $params = []): static
     {
         $params = array_merge(
-            ['command' => $command],
             $params,
             $this->getDefaultParams()
         );
 
-        $this->application->setAutoExit(false);
-        $exitCode = $this->application->run(new ArrayInput($params), $this->output);
+        $command = $this->application->find($commandName);
 
-        if (0 !== $exitCode) {
-            $this->application->setAutoExit(true);
-            $errorMessage = sprintf('The command terminated with an error code: %u.', $exitCode);
-            $this->output->writeln("<error>$errorMessage</error>");
-            $e = new \Exception($errorMessage, $exitCode);
-            throw $e;
-        }
+        $command->run(
+            new ArrayInput($params),
+            $this->input->hasOption('quiet') ? new NullOutput() : $this->output
+        );
 
         return $this;
     }

--- a/src/Akeneo/Tool/Component/Console/CommandExecutor.php
+++ b/src/Akeneo/Tool/Component/Console/CommandExecutor.php
@@ -35,13 +35,13 @@ class CommandExecutor
         $command = $this->application->find($commandName);
 
         $commandInput = new ArrayInput($params);
-        if ($this->input->hasOption('no-interaction')) {
-            $commandInput->setInteractive(false);
-        }
+        $commandInput->setInteractive(false);
+
+        $quiet = isset($params['--quiet']) || isset($params['-q']);
 
         $command->run(
             $commandInput,
-            $this->input->hasOption('quiet') ? new NullOutput() : $this->output
+            $quiet ? new NullOutput() : $this->output
         );
 
         return $this;


### PR DESCRIPTION
The CommandExecutor should only run a _Command_ and not a full _Application_.
With this PR, we find the command into the application and run it without having to trick exception handler or autoexit.

Also, I come to this PR while working on upper stack and having issues with logger, because the logger is kind of _reset_ when using Application::run. I didn't manage to find the exact inner reason, but just running the command canceled this side effect.

Last but not least, using the find method is the recommended way in the docs: https://symfony.com/doc/current/console/calling_commands.html