### PR TITLE
PIM-10768: Fix update list status_code response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@
 - PIM-10789: Fix password is displayed in SFTP and Amazon S3 form and encrypted password is displayed on history
 - PIM-10779: Fix lowercase on get attribute group code for dqi activation
 - PIM-10791: Fix product and product model completeness compute on attribute removal
+- PIM-10768: Fix update list status_code response
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Stream/StreamResourceResponse.php
@@ -96,9 +96,9 @@ final class StreamResourceResponse
 
                     if ('' !== $subResponse->getContent()) {
                         $subResponse = json_decode($subResponse->getContent(), true);
-                        if (isset($subResponse[$this->uriParamName])) {
-                            $response['status_code'] = $subResponse[$this->uriParamName];
-                            unset($subResponse[$this->uriParamName]);
+                        if (isset($subResponse['code'])) {
+                            $response['status_code'] = $subResponse['code'];
+                            unset($subResponse['code']);
                         }
 
                         $response = array_merge($response, $subResponse);

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/PartialUpdateListProductWithUuidEndToEnd.php
@@ -224,7 +224,7 @@ JSON;
 {"line":8,"status_code":413,"message":"Line is too long."}
 {"line":9,"status_code":413,"message":"Line is too long."}
 {"line":10,"status_code":400,"message":"Invalid json message received"}
-{"line":11,"uuid":"122345","code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
+{"line":11,"uuid":"122345","status_code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products-uuid', [], [], [], $data);
@@ -273,7 +273,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"uuid":"{$uuid->toString()}","code":422,"message":"Property \"group\" does not exist. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
+{"line":1,"uuid":"{$uuid->toString()}","status_code":422,"message":"Property \"group\" does not exist. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
 JSON;
 
         $response = $this->executeStreamRequest('PATCH', 'api/rest/v1/products-uuid', [], [], [], $data);
@@ -293,7 +293,7 @@ JSON;
 
         $expectedContent =
 <<<JSON
-{"line":1,"uuid":"{$uuid->toString()},","code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
+{"line":1,"uuid":"{$uuid->toString()},","status_code":422,"message":"This is not a valid UUID. Check the expected format on the API documentation.","_links":{"documentation":{"href":"http:\/\/api.akeneo.com\/api-reference.html#patch_products_uuid__uuid_"}}}
 JSON;
 
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

param $this->uriParamName has been created in order to work with both 'uuid' and 'code' but meaning the code or uuid as set in the url calling.

Here it's the 'code' of the response, so it will always be 'code'

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
