### PR TITLE
OCT-194: Remove slack notifications when `test_catalogs` fails on a PR but keep it for the nightly

### DIFF
--- a/.circleci/workflows/pull_request.yml
+++ b/.circleci/workflows/pull_request.yml
@@ -75,9 +75,6 @@ workflows:
             - test_back_catalogs_ee:
                   requires:
                       - build_dev
-                  notify: true
-                  context:
-                      - octopus-slack
             - ready_to_build_only_ce?:
                   type: approval
                   filters:


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

EE: https://github.com/akeneo/pim-enterprise-dev/pull/15913

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
