### PR TITLE
RAB-1243: Add prepare_60_to_70.sh into std-build directories

### DIFF
--- a/std-build/migration/prepare_60_to_70.sh
+++ b/std-build/migration/prepare_60_to_70.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+DEV_DISTRIB_DIR=$(dirname $0)/../..
+STANDARD_DISTRIB_DIR=./
+
+# We use the same bootstrap.php to load .env file on standard as on CE-dev
+cp $DEV_DISTRIB_DIR/config/bootstrap.php $STANDARD_DISTRIB_DIR/config/
+
+# Security configuration cannot be read on CE-dev and overriden in standard. We need to fully copy it
+cp $DEV_DISTRIB_DIR/config/packages/security.yml $STANDARD_DISTRIB_DIR/config/packages/security.yml
+
+# Partners are most likely to develop and deploy using local filesystem, not MinIO
+cp -r $DEV_DISTRIB_DIR/config/packages/dev $STANDARD_DISTRIB_DIR/config/packages/
+
+# We need a console and FPM entrypoint
+cp $DEV_DISTRIB_DIR/bin/console $STANDARD_DISTRIB_DIR/bin/
+chmod +x $STANDARD_DISTRIB_DIR/bin/console
+cp $DEV_DISTRIB_DIR/public/* $STANDARD_DISTRIB_DIR/public/
+
+# We provide a kernel that loads configuration from the CE dev and override it with the one in standard
+cp $DEV_DISTRIB_DIR/std-build/Kernel.php $STANDARD_DISTRIB_DIR/src
+
+# Copy STD configuration
+# Uses same docker compose than the CE
+cp $DEV_DISTRIB_DIR/docker-compose.yml $STANDARD_DISTRIB_DIR/docker-compose.yml
+# Usable example Makefile
+cp $DEV_DISTRIB_DIR/std-build/Makefile $STANDARD_DISTRIB_DIR/Makefile
+
+# Front dependencies using workspace to depends on CE-dev and inherits its deps
+cp $DEV_DISTRIB_DIR/std-build/package.json $STANDARD_DISTRIB_DIR/package.json
+cp $DEV_DISTRIB_DIR/yarn.lock $STANDARD_DISTRIB_DIR/yarn.lock
+
+# Needed to define the loader path to target the CE-dev
+cp $DEV_DISTRIB_DIR/std-build/tsconfig.json $STANDARD_DISTRIB_DIR/tsconfig.json
+
+# Needed to define Elasticsearch mapping file location inside CE-dev
+cp $DEV_DISTRIB_DIR/std-build/services.yml $STANDARD_DISTRIB_DIR/config/services/
+
+# We use the same bootstrap.php to load .env file on standard as on CE-dev
+cp $DEV_DISTRIB_DIR/.env $STANDARD_DISTRIB_DIR/
+
+# Prepare database upgrades to run
+# First of all, removing potential deprecated migration scripts
+mkdir -p $STANDARD_DISTRIB_DIR/upgrades/schema
+rm -f $STANDARD_DISTRIB_DIR/upgrades/schema/*
+cp -r $DEV_DISTRIB_DIR/upgrades/* $STANDARD_DISTRIB_DIR/upgrades/
+
+printf "Done. \n"


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, I added the missing prepare script used when a PIM is migrated from v6 to v7. This file is the same than the v6 for now, let's see if we need to change it after merging it and test a migration

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
