### PR TITLE
OCT-182: [Free trial] Displayed apps are not the right ones

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/WebMarketplaceAliases.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Marketplace/WebMarketplaceAliases.php
@@ -17,6 +17,7 @@ class WebMarketplaceAliases implements WebMarketplaceAliasesInterface
     public function __construct(
         private VersionProviderInterface $versionProvider,
         private PimVersion $growthVersion,
+        private PimVersion $freeTrialVersion,
     ) {
     }
 
@@ -32,6 +33,7 @@ class WebMarketplaceAliases implements WebMarketplaceAliasesInterface
     {
         return match ($this->versionProvider->getEdition()) {
             $this->growthVersion->editionName() => 'growth-edition',
+            $this->freeTrialVersion->editionName() => 'growth-edition',
             default => 'community-edition',
         };
     }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/services.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Marketplace/services.yml
@@ -41,6 +41,7 @@ services:
         arguments:
             - '@pim_catalog.version_provider'
             - '@Akeneo\Platform\Bundle\PimVersionBundle\Version\GrowthVersion'
+            - '@Akeneo\Platform\Bundle\PimVersionBundle\Version\FreeTrialVersion'
 
     Akeneo\Connectivity\Connection\Infrastructure\Marketplace\ContentSecurityPolicy\MarketplaceContentSecurityPolicy:
         tags:

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/WebMarketplaceAliasesSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Marketplace/WebMarketplaceAliasesSpec.php
@@ -6,6 +6,7 @@ namespace spec\Akeneo\Connectivity\Connection\Infrastructure\Marketplace;
 
 use Akeneo\Connectivity\Connection\Application\Marketplace\WebMarketplaceAliasesInterface;
 use Akeneo\Connectivity\Connection\Infrastructure\Marketplace\WebMarketplaceAliases;
+use Akeneo\Platform\Bundle\PimVersionBundle\Version\FreeTrialVersion;
 use Akeneo\Platform\Bundle\PimVersionBundle\Version\GrowthVersion;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use PhpSpec\ObjectBehavior;
@@ -19,7 +20,7 @@ class WebMarketplaceAliasesSpec extends ObjectBehavior
     public function let(
         VersionProviderInterface $versionProvider
     ) {
-        $this->beConstructedWith($versionProvider, new GrowthVersion());
+        $this->beConstructedWith($versionProvider, new GrowthVersion(), new FreeTrialVersion());
     }
 
     public function it_is_initializable(): void
@@ -48,6 +49,14 @@ class WebMarketplaceAliasesSpec extends ObjectBehavior
         VersionProviderInterface $versionProvider
     ) {
         $versionProvider->getEdition()->willReturn('Growth Edition');
+
+        $this->getEdition()->shouldReturn('growth-edition');
+    }
+
+    public function it_returns_the_edition_when_free_trial(
+        VersionProviderInterface $versionProvider
+    ) {
+        $versionProvider->getEdition()->willReturn('Free Trial Edition');
 
         $this->getEdition()->shouldReturn('growth-edition');
     }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Localization/Presenter/MetricPresenter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Localization/Presenter/MetricPresenter.php
@@ -65,10 +65,19 @@ class MetricPresenter extends NumberPresenter
                     LocaleIdentifier::fromCode($options['locale'])
                 );
             } catch (\Exception $e) {
-                $this->logger->warning('An error occured while trying to fetch the measurement family of a metric value to present it.');
+                $this->logger->warning('An error occurred while trying to fetch the measurement family of a metric value to present it.', [
+                    'error_message' => $e->getMessage(),
+                    'error_trace' => $e->getTrace(),
+                ]);
             }
         } else {
-            $this->logger->warning('Expected to have an attribute code given in the options of the presenter, none given.');
+            $this->logger->warning('Expected to have an attribute code given in the options of the presenter, none given.', [
+                'options' => [
+                    'attribute' => $options['attribute'] ?? 'undefined',
+                    'unit' => $options['unit'] ?? 'undefined',
+                    'locale' => $options['locale'] ?? 'undefined',
+                ],
+            ]);
         }
 
         $amount = isset($value['amount']) ? parent::present($value['amount'], $options) : null;

--- a/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
+++ b/tests/legacy/features/pim/enrichment/product/mass-action/quick-export/quick_export_with_localized_data.feature
@@ -35,7 +35,7 @@ Feature: Quick export many products with localized attributes from datagrid
     And I press the "Tous les attributs" button
     And I press the "Avec codes" button
     And I press the "Avec images" button
-    And I press the "With UUID" button
+    And I press the "Avec UUID" button
     And I press the "Export" button
     And I wait for the "xlsx_product_quick_export" quick export to finish
     And I am on the dashboard page


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Apps displayed in the app store of a free trial edition should be the same as for the Growth edition. As there is no "free-trial-edition" option in app store API (see https://github.com/akeneo/marketplace-store-api/blob/master/docs/openapi.yaml#L69), we use "growth-edition"

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
