### PR TITLE
CPM-762: Fix memory leak on pricemask

### DIFF
--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -150,6 +150,7 @@ $rules = [
         'Psr\Log\LoggerInterface',
         'Ramsey\Uuid',
         'Akeneo\Pim\Enrichment\Product\API',
+        'Akeneo\Channel\API',
 
         // Event API
         'Akeneo\Platform\Component\EventQueue',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness_mask_generators.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/completeness_mask_generators.yml
@@ -10,6 +10,8 @@ services:
 
     akeneo.pim.enrichment.completeness.mask_item_generator.price_collection:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Completeness\MaskItemGenerator\PriceCollectionMaskItemGenerator'
+        arguments:
+            - '@Akeneo\Channel\Infrastructure\Query\Cache\CachedFindChannels'
         tags: [{ name: akeneo.pim.enrichment.completeness.mask_item_generator }]
 
     akeneo.pim.enrichment.completeness.mask_item_generator.metric:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/PriceCollectionMaskItemGenerator.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Completeness/MaskItemGenerator/PriceCollectionMaskItemGenerator.php
@@ -59,7 +59,9 @@ class PriceCollectionMaskItemGenerator implements MaskItemGeneratorForAttributeT
     public function forRawValue(string $attributeCode, string $channelCode, string $localeCode, $value): array
     {
         $filledCurrencies = [];
-        $activeCurrencies = $this->getActiveCurrencies($channelCode);
+        $activeCurrencies = $channelCode === '<all_channels>' ?
+            $this->getAllActiveCurrencies() :
+            $this->getActiveCurrencies($channelCode);
         foreach ($value as $price) {
             if (
                 \in_array($price['currency'], $activeCurrencies) &&
@@ -123,5 +125,19 @@ class PriceCollectionMaskItemGenerator implements MaskItemGeneratorForAttributeT
         }
 
         return [];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAllActiveCurrencies()
+    {
+        $result = [];
+        $channels = $this->findChannels->findAll();
+        foreach ($channels as $channel) {
+            $result[] = $channel->getActiveCurrencies();
+        }
+
+        return \array_unique(\array_merge(...$result));
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/MaskItemGenerator/PriceCollectionMaskItemGeneratorSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Completeness/MaskItemGenerator/PriceCollectionMaskItemGeneratorSpec.php
@@ -98,4 +98,30 @@ class PriceCollectionMaskItemGeneratorSpec extends ObjectBehavior
         $this->forRawValue('attributeCode', 'channelCode', 'localeCode', $value)
             ->shouldReturn([]);
     }
+
+    public function it_filters_every_channel_active_currencies(
+        FindChannels $findChannels
+    ) {
+        $findChannels->findAll()->shouldBeCalled()->willReturn([
+            new Channel('channel1', ['localeCode'], LabelCollection::fromArray([]), ['USD', 'GPB']),
+            new Channel('channel2', ['localeCode'], LabelCollection::fromArray([]), ['EUR', 'GPB']),
+        ]);
+
+        $value = [
+            ['amount' => 200, 'currency' => 'USD'],
+            ['amount' => 100, 'currency' => 'EUR'],
+            ['amount' => 100, 'currency' => 'CNY'], // Inactive
+            ['amount' => 50, 'currency' => 'GPB'],
+        ];
+        $this->forRawValue('attributeCode', '<all_channels>', 'localeCode', $value)
+            ->shouldReturn([
+                'attributeCode-EUR-<all_channels>-localeCode',
+                'attributeCode-GPB-<all_channels>-localeCode',
+                'attributeCode-USD-<all_channels>-localeCode',
+                'attributeCode-EUR-GPB-<all_channels>-localeCode',
+                'attributeCode-EUR-USD-<all_channels>-localeCode',
+                'attributeCode-EUR-GPB-USD-<all_channels>-localeCode',
+                'attributeCode-GPB-USD-<all_channels>-localeCode',
+            ]);
+    }
 }


### PR DESCRIPTION
When computing the masks of a price value, if the number of currencies is big (> 20), the mask generation creates a memory error because the number of masks is 2^19, and it takes a lot of memory.

A first solution was done to improve the computation of the mask and avoid creation of big arrays (see https://github.com/akeneo/pim-community-dev/commit/3166742a438db5da1ab5db32c5fe93fbc53f7553 ).

This solution will remove from the currencies list the currencies which are not active anymore. When you had in the past 20 active currencies, you can save a product with these currencies. But if you deactive a currency, the value remains in the product.
This PR removes the non-active currencies.