### PR TITLE
RAB-1138: Do not display the additional storage in CE

### DIFF
--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.test.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.test.ts
@@ -16,6 +16,7 @@ import {MicrosoftAzureStorageConfigurator} from './MicrosoftAzureStorageConfigur
 
 const featureFlagCollection = {
   import_export_local_storage: false,
+  import_export_additional_storage: false,
 };
 
 const enableFeatureFlag = (featureFlag: string) => (featureFlagCollection[featureFlag] = true);
@@ -96,17 +97,19 @@ test('it says if a storage is a google cloud storage', () => {
 
 test('it returns storage configurator', () => {
   expect(getStorageConfigurator('none', featureFlags)).toBe(null);
-
   expect(getStorageConfigurator('local', featureFlags)).toBe(null);
+
   enableFeatureFlag('import_export_local_storage');
   expect(getStorageConfigurator('local', featureFlags)).toBe(LocalStorageConfigurator);
+  expect(getStorageConfigurator('sftp', featureFlags)).toBe(null);
+  expect(getStorageConfigurator('amazon_s3', featureFlags)).toBe(null);
+  expect(getStorageConfigurator('microsoft_azure', featureFlags)).toBe(null);
+  expect(getStorageConfigurator('google_cloud_storage', featureFlags)).toBe(null);
 
+  enableFeatureFlag('import_export_additional_storage');
   expect(getStorageConfigurator('sftp', featureFlags)).toBe(SftpStorageConfigurator);
-
   expect(getStorageConfigurator('amazon_s3', featureFlags)).toBe(AmazonS3StorageConfigurator);
-
   expect(getStorageConfigurator('microsoft_azure', featureFlags)).toBe(MicrosoftAzureStorageConfigurator);
-
   expect(getStorageConfigurator('google_cloud_storage', featureFlags)).toBe(GoogleCloudStorageConfigurator);
 
   // @ts-expect-error - there is no storage configurator for type 'unknown'

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
@@ -6,6 +6,7 @@ import {
   AmazonS3Storage,
   Storage,
   StorageType,
+  additionalStorageIsEnabled,
   localStorageIsEnabled,
   MicrosoftAzureStorage,
   GoogleCloudStorage,
@@ -33,10 +34,6 @@ type StorageConfiguratorCollection = {
 
 const STORAGE_CONFIGURATORS: StorageConfiguratorCollection = {
   none: null,
-  sftp: SftpStorageConfigurator,
-  amazon_s3: AmazonS3StorageConfigurator,
-  microsoft_azure: MicrosoftAzureStorageConfigurator,
-  google_cloud_storage: GoogleCloudStorageConfigurator,
 };
 
 const getEnabledStorageConfigurators = (featureFlags: FeatureFlags): StorageConfiguratorCollection => {
@@ -44,6 +41,13 @@ const getEnabledStorageConfigurators = (featureFlags: FeatureFlags): StorageConf
 
   if (localStorageIsEnabled(featureFlags)) {
     enabledStorageConfigurators['local'] = LocalStorageConfigurator;
+  }
+
+  if (additionalStorageIsEnabled(featureFlags)) {
+    enabledStorageConfigurators['sftp'] = SftpStorageConfigurator;
+    enabledStorageConfigurators['amazon_s3'] = AmazonS3StorageConfigurator;
+    enabledStorageConfigurators['microsoft_azure'] = MicrosoftAzureStorageConfigurator;
+    enabledStorageConfigurators['google_cloud_storage'] = GoogleCloudStorageConfigurator;
   }
 
   return enabledStorageConfigurators;

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.test.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.test.ts
@@ -1,8 +1,16 @@
 import {FeatureFlags} from '@akeneo-pim-community/shared';
-import {isValidStorageType, getDefaultStorage, isExport, getDefaultFilePath, localStorageIsEnabled} from './model';
+import {
+  isValidStorageType,
+  getDefaultStorage,
+  isExport,
+  getDefaultFilePath,
+  localStorageIsEnabled,
+  additionalStorageIsEnabled,
+} from './model';
 
 const featureFlagCollection = {
   import_export_local_storage: false,
+  import_export_additional_storage: false,
 };
 
 const enableFeatureFlag = (featureFlag: string) => (featureFlagCollection[featureFlag] = true);
@@ -13,13 +21,23 @@ const featureFlags: FeatureFlags = {
 
 beforeEach(() => {
   featureFlagCollection.import_export_local_storage = false;
+  featureFlagCollection.import_export_additional_storage = false;
 });
 
 test('it says if a storage type is valid', () => {
   expect(isValidStorageType('local', featureFlags)).toBe(false);
+  expect(isValidStorageType('sftp', featureFlags)).toBe(false);
+  expect(isValidStorageType('amazon_s3', featureFlags)).toBe(false);
+  expect(isValidStorageType('microsoft_azure', featureFlags)).toBe(false);
 
   enableFeatureFlag('import_export_local_storage');
+  expect(isValidStorageType('local', featureFlags)).toBe(true);
+  expect(isValidStorageType('sftp', featureFlags)).toBe(false);
+  expect(isValidStorageType('amazon_s3', featureFlags)).toBe(false);
+  expect(isValidStorageType('microsoft_azure', featureFlags)).toBe(false);
+  expect(isValidStorageType('google_cloud_storage', featureFlags)).toBe(false);
 
+  enableFeatureFlag('import_export_additional_storage');
   expect(isValidStorageType('none', featureFlags)).toBe(true);
   expect(isValidStorageType('local', featureFlags)).toBe(true);
   expect(isValidStorageType('sftp', featureFlags)).toBe(true);
@@ -94,4 +112,10 @@ test('it check if local storage is enabled', () => {
   expect(localStorageIsEnabled(featureFlags)).toBe(false);
   enableFeatureFlag('import_export_local_storage');
   expect(localStorageIsEnabled(featureFlags)).toBe(true);
+});
+
+test('it check if additionnal storage is enabled', () => {
+  expect(additionalStorageIsEnabled(featureFlags)).toBe(false);
+  enableFeatureFlag('import_export_additional_storage');
+  expect(additionalStorageIsEnabled(featureFlags)).toBe(true);
 });

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.ts
@@ -52,16 +52,23 @@ type Storage = LocalStorage | SftpStorage | AmazonS3Storage | MicrosoftAzureStor
 
 type StorageType = 'none' | 'local' | 'sftp' | 'amazon_s3' | 'microsoft_azure' | 'google_cloud_storage';
 
-const STORAGE_TYPES = ['none', 'sftp', 'amazon_s3', 'microsoft_azure', 'google_cloud_storage'];
+const STORAGE_TYPES = ['none'];
 
 const localStorageIsEnabled = (featureFlags: FeatureFlags): boolean =>
   featureFlags.isEnabled('import_export_local_storage');
+
+const additionalStorageIsEnabled = (featureFlags: FeatureFlags): boolean =>
+  featureFlags.isEnabled('import_export_additional_storage');
 
 const getEnabledStorageTypes = (featureFlags: FeatureFlags): string[] => {
   const enabledStorageTypes = [...STORAGE_TYPES];
 
   if (localStorageIsEnabled(featureFlags)) {
     enabledStorageTypes.push('local');
+  }
+
+  if (additionalStorageIsEnabled(featureFlags)) {
+    enabledStorageTypes.push('sftp', 'amazon_s3', 'microsoft_azure', 'google_cloud_storage');
   }
 
   return enabledStorageTypes;
@@ -143,5 +150,6 @@ export {
   isExport,
   getDefaultFilePath,
   getEnabledStorageTypes,
+  additionalStorageIsEnabled,
   localStorageIsEnabled,
 };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR,

I added the fact that microsoft azure, google cloud storage and amazon s3 are not displayed in CE. To do it I added a check of the feature flag in CE and I only added the implementation of this flag in EE. By doing it microsoft azure, google cloud storage and amazon s3 are not displayed in CE.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
