### PR TITLE
CXP-1177: Update legal text in the authentication step

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/GetWizardDataAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/GetWizardDataAction.php
@@ -55,7 +55,7 @@ final class GetWizardDataAction
             throw new NotFoundHttpException("Invalid app identifier");
         }
 
-        [$oldAuthorizationScopeMessages, $newAuthorizationScopeMessages] = $this->getAuthorizationScopes($app->getId(), $appAuthorization);
+        [$oldAuthorizationScopeMessages, $newAuthorizationScopeMessages, $isFirstConnection] = $this->getAuthorizationScopes($app->getId(), $appAuthorization);
         [$oldAuthenticationScopes, $newAuthenticationScopes] = $this->getAuthenticationScopes($app->getId(), $appAuthorization);
 
         return new JsonResponse([
@@ -67,6 +67,7 @@ final class GetWizardDataAction
             'scopeMessages' => $newAuthorizationScopeMessages,
             'oldAuthenticationScopes' => $oldAuthenticationScopes,
             'authenticationScopes' => $newAuthenticationScopes,
+            'displayCheckboxConsent' => $isFirstConnection,
         ]);
     }
 
@@ -86,7 +87,10 @@ final class GetWizardDataAction
         $oldAuthorizationScopeMessages = $isFirstConnection ? null : $this->scopeMapperRegistry->getMessages($originalScopes);
         $newAuthorizationScopeMessages = $this->scopeMapperRegistry->getMessages($newScopes);
 
-        return [$oldAuthorizationScopeMessages, $newAuthorizationScopeMessages];
+//        dump($oldAuthorizationScopeMessages);
+//        dd($newAuthorizationScopeMessages);
+
+        return [$oldAuthorizationScopeMessages, $newAuthorizationScopeMessages, $isFirstConnection];
     }
 
     private function getAuthenticationScopes(string $appId, AppAuthorization $appAuthorization): array

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/GetWizardDataAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/Controller/Internal/GetWizardDataAction.php
@@ -87,9 +87,6 @@ final class GetWizardDataAction
         $oldAuthorizationScopeMessages = $isFirstConnection ? null : $this->scopeMapperRegistry->getMessages($originalScopes);
         $newAuthorizationScopeMessages = $this->scopeMapperRegistry->getMessages($newScopes);
 
-//        dump($oldAuthorizationScopeMessages);
-//        dd($newAuthorizationScopeMessages);
-
         return [$oldAuthorizationScopeMessages, $newAuthorizationScopeMessages, $isFirstConnection];
     }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/GetWizardDataActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/Apps/Internal/GetWizardDataActionEndToEnd.php
@@ -88,6 +88,7 @@ class GetWizardDataActionEndToEnd extends WebTestCase
             'oldScopeMessages' => null,
             'authenticationScopes' => ['email', 'profile'],
             'oldAuthenticationScopes' => null,
+            'displayCheckboxConsent' => true,
         ], \json_decode($response->getContent(), true));
     }
 
@@ -179,6 +180,7 @@ class GetWizardDataActionEndToEnd extends WebTestCase
             'oldScopeMessages' => null,
             'authenticationScopes' => [],
             'oldAuthenticationScopes' => null,
+            'displayCheckboxConsent' => true,
         ], \json_decode($response->getContent(), true));
     }
 
@@ -218,6 +220,7 @@ class GetWizardDataActionEndToEnd extends WebTestCase
             'oldScopeMessages' => null,
             'authenticationScopes' => [],
             'oldAuthenticationScopes' => null,
+            'displayCheckboxConsent' => true,
         ], \json_decode($response->getContent(), true));
     }
 
@@ -299,6 +302,7 @@ class GetWizardDataActionEndToEnd extends WebTestCase
             ],
             'authenticationScopes' => ['email', 'profile'],
             'oldAuthenticationScopes' => null,
+            'displayCheckboxConsent' => false,
         ], \json_decode($response->getContent(), true));
     }
 
@@ -388,6 +392,7 @@ class GetWizardDataActionEndToEnd extends WebTestCase
             ],
             'authenticationScopes' => ['profile'],
             'oldAuthenticationScopes' => ['email'],
+            'displayCheckboxConsent' => false,
         ], \json_decode($response->getContent(), true));
     }
 

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AppWizard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AppWizard.tsx
@@ -119,7 +119,11 @@ export const AppWizard: FC<Props> = ({clientId}) => {
             onClose={redirectToMarketplace}
             onConfirm={confirm}
             steps={steps}
-            maxAllowedStep={(!authenticationScopesConsentGiven && wizardData.displayCheckboxConsent) || certificationConsentRequired ? 'authorizations' : null}
+            maxAllowedStep={
+                (!authenticationScopesConsentGiven && wizardData.displayCheckboxConsent) || certificationConsentRequired
+                    ? 'authorizations'
+                    : null
+            }
         >
             {step => (
                 <>
@@ -132,6 +136,7 @@ export const AppWizard: FC<Props> = ({clientId}) => {
                             scopesConsentGiven={authenticationScopesConsentGiven}
                             setScopesConsent={setAuthenticationScopesConsent}
                             displayConsent={false}
+                            displayCheckboxConsent={wizardData.displayCheckboxConsent}
                         />
                     )}
                     {step.name === 'authorizations' && (

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AppWizard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AppWizard.tsx
@@ -119,7 +119,7 @@ export const AppWizard: FC<Props> = ({clientId}) => {
             onClose={redirectToMarketplace}
             onConfirm={confirm}
             steps={steps}
-            maxAllowedStep={!authenticationScopesConsentGiven || certificationConsentRequired ? 'authorizations' : null}
+            maxAllowedStep={(!authenticationScopesConsentGiven && wizardData.displayCheckboxConsent) || certificationConsentRequired ? 'authorizations' : null}
         >
             {step => (
                 <>
@@ -145,6 +145,7 @@ export const AppWizard: FC<Props> = ({clientId}) => {
                             certificationConsentGiven={certificationConsentGiven}
                             setCertificationConsent={setCertificationConsent}
                             displayCertificationConsent={wizardData.appIsCertified}
+                            displayCheckboxConsent={wizardData.displayCheckboxConsent}
                         />
                     )}
                     {step.name === 'permissions' && (

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AuthenticationModal.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/AuthenticationModal.tsx
@@ -53,7 +53,7 @@ export const AuthenticationModal: FC<Props> = ({clientId}) => {
             appName={wizardData.appName}
             onConfirm={handleConfirm}
             onClose={handleClose}
-            maxAllowedStep={!scopesConsentGiven ? 'authentication' : null}
+            maxAllowedStep={!scopesConsentGiven && wizardData.displayCheckboxConsent ? 'authentication' : null}
             steps={[
                 {
                     name: 'authentication',
@@ -70,6 +70,7 @@ export const AuthenticationModal: FC<Props> = ({clientId}) => {
                     scopesConsentGiven={scopesConsentGiven}
                     setScopesConsent={setScopesConsent}
                     displayConsent={true}
+                    displayCheckboxConsent={wizardData.displayCheckboxConsent}
                 />
             )}
         </WizardModal>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/Authentication.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/Authentication.tsx
@@ -52,6 +52,7 @@ type Props = {
     scopesConsentGiven: boolean;
     setScopesConsent: (newValue: boolean) => void;
     displayConsent: boolean;
+    displayCheckboxConsent: boolean
 };
 
 export const Authentication: FC<Props> = ({
@@ -62,6 +63,7 @@ export const Authentication: FC<Props> = ({
     scopesConsentGiven,
     setScopesConsent,
     displayConsent,
+    displayCheckboxConsent,
 }) => {
     const translate = useTranslate();
 
@@ -92,7 +94,7 @@ export const Authentication: FC<Props> = ({
                 </>
             )}
             {displayConsent && (
-                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} />
+                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} displayCheckbox={displayCheckboxConsent}/>
             )}
         </InfoContainer>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/Authentication.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/Authentication.tsx
@@ -52,7 +52,7 @@ type Props = {
     scopesConsentGiven: boolean;
     setScopesConsent: (newValue: boolean) => void;
     displayConsent: boolean;
-    displayCheckboxConsent: boolean
+    displayCheckboxConsent: boolean;
 };
 
 export const Authentication: FC<Props> = ({
@@ -94,7 +94,12 @@ export const Authentication: FC<Props> = ({
                 </>
             )}
             {displayConsent && (
-                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} displayCheckbox={displayCheckboxConsent}/>
+                <ConsentCheckbox
+                    isChecked={scopesConsentGiven}
+                    onChange={setScopesConsent}
+                    appUrl={appUrl}
+                    displayCheckbox={displayCheckboxConsent}
+                />
             )}
         </InfoContainer>
     );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.tsx
@@ -54,9 +54,9 @@ export const ConsentCheckbox: FC<Props> = ({isChecked, onChange, appUrl, display
 
     return (
         <Container>
-            {displayCheckbox && (<Checkbox checked={isChecked} onChange={onChange} />)}
+            {displayCheckbox && <Checkbox checked={isChecked} onChange={onChange} />}
             <LabelContainer>
-                {displayCheckbox && (<CheckboxLabel dangerouslySetInnerHTML={{__html: label}} />)}
+                {displayCheckbox && <CheckboxLabel dangerouslySetInnerHTML={{__html: label}} />}
                 <CheckboxSubText dangerouslySetInnerHTML={{__html: subtext}} />
             </LabelContainer>
         </Container>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.tsx
@@ -31,9 +31,10 @@ type Props = {
     isChecked: boolean;
     onChange: (newValue: boolean) => void;
     appUrl: string | null;
+    displayCheckbox: boolean;
 };
 
-export const ConsentCheckbox: FC<Props> = ({isChecked, onChange, appUrl}) => {
+export const ConsentCheckbox: FC<Props> = ({isChecked, onChange, appUrl, displayCheckbox}) => {
     const translate = useTranslate();
 
     const label = translate('akeneo_connectivity.connection.connect.apps.wizard.authentication.consent.label', {
@@ -53,9 +54,9 @@ export const ConsentCheckbox: FC<Props> = ({isChecked, onChange, appUrl}) => {
 
     return (
         <Container>
-            <Checkbox checked={isChecked} onChange={onChange} />
+            {displayCheckbox && (<Checkbox checked={isChecked} onChange={onChange} />)}
             <LabelContainer>
-                <CheckboxLabel dangerouslySetInnerHTML={{__html: label}} />
+                {displayCheckbox && (<CheckboxLabel dangerouslySetInnerHTML={{__html: label}} />)}
                 <CheckboxSubText dangerouslySetInnerHTML={{__html: subtext}} />
             </LabelContainer>
         </Container>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authorizations.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authorizations.tsx
@@ -63,7 +63,12 @@ export const Authorizations: FC<Props> = ({
             <Connect>{translate('akeneo_connectivity.connection.connect.apps.title')}</Connect>
             <ScopeListContainer appName={appName} scopeMessages={scopeMessages} oldScopeMessages={oldScopeMessages} />
             <WrappedConsentCheckbox>
-                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} displayCheckbox={displayCheckboxConsent}/>
+                <ConsentCheckbox
+                    isChecked={scopesConsentGiven}
+                    onChange={setScopesConsent}
+                    appUrl={appUrl}
+                    displayCheckbox={displayCheckboxConsent}
+                />
             </WrappedConsentCheckbox>
             {displayCertificationConsent && (
                 <WrappedCertificationConsentCheckbox>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authorizations.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/AppWizard/steps/Authorizations.tsx
@@ -41,6 +41,7 @@ type Props = {
     certificationConsentGiven: boolean;
     setCertificationConsent: (newValue: boolean) => void;
     displayCertificationConsent: boolean;
+    displayCheckboxConsent: boolean;
 };
 
 export const Authorizations: FC<Props> = ({
@@ -53,6 +54,7 @@ export const Authorizations: FC<Props> = ({
     certificationConsentGiven,
     setCertificationConsent,
     displayCertificationConsent,
+    displayCheckboxConsent,
 }) => {
     const translate = useTranslate();
 
@@ -61,7 +63,7 @@ export const Authorizations: FC<Props> = ({
             <Connect>{translate('akeneo_connectivity.connection.connect.apps.title')}</Connect>
             <ScopeListContainer appName={appName} scopeMessages={scopeMessages} oldScopeMessages={oldScopeMessages} />
             <WrappedConsentCheckbox>
-                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} />
+                <ConsentCheckbox isChecked={scopesConsentGiven} onChange={setScopesConsent} appUrl={appUrl} displayCheckbox={displayCheckboxConsent}/>
             </WrappedConsentCheckbox>
             {displayCertificationConsent && (
                 <WrappedCertificationConsentCheckbox>

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-app-wizard-data.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-app-wizard-data.ts
@@ -18,6 +18,7 @@ type Result = {
     }> | null;
     authenticationScopes: Array<'email' | 'profile'>;
     oldAuthenticationScopes: Array<'email' | 'profile'> | null;
+    displayCheckboxConsent: boolean;
 };
 
 export const useFetchAppWizardData = (clientId: string): (() => Promise<Result>) => {

--- a/src/Akeneo/Connectivity/Connection/front/src/model/Apps/wizard-data.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/model/Apps/wizard-data.ts
@@ -9,4 +9,5 @@ export interface AppWizardData {
     oldScopeMessages: ScopeMessage[] | null;
     authenticationScopes: Array<'email' | 'profile'>;
     oldAuthenticationScopes: Array<'email' | 'profile'> | null;
+    displayCheckboxConsent: boolean;
 }

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/AuthenticationModal.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/AuthenticationModal.test.tsx
@@ -160,6 +160,7 @@ test('it prevents redirection without user consent', async () => {
                 oldScopeMessages: null,
                 authenticationScopes: [],
                 oldAuthenticationScopes: null,
+                displayCheckboxConsent: true,
             },
         },
         'akeneo_connectivity_connection_apps_rest_confirm_authentication?clientId=0dfce574-2238-4b13-b8cc-8d257ce7645b':
@@ -189,6 +190,49 @@ test('it prevents redirection without user consent', async () => {
     act(() => {
         userEvent.click(screen.getByText('authentication-component'));
     });
+
+    act(() => {
+        userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.apps.wizard.action.confirm'));
+    });
+
+    await waitFor(() => expect(notify).toHaveBeenCalledTimes(1));
+
+    expect(notify).toBeCalledWith(
+        NotificationLevel.SUCCESS,
+        'akeneo_connectivity.connection.connect.apps.wizard.flash.success'
+    );
+});
+
+test('it allows redirection when checkbox consent is not displayed', async () => {
+    mockFetchResponses({
+        'akeneo_connectivity_connection_apps_rest_get_wizard_data?clientId=0dfce574-2238-4b13-b8cc-8d257ce7645b': {
+            json: {
+                appName: 'Extension 1',
+                appLogo: 'https://extension-1.test/logo.png',
+                scopeMessages: [],
+                oldScopeMessages: null,
+                authenticationScopes: [],
+                oldAuthenticationScopes: null,
+                displayCheckboxConsent: false,
+            },
+        },
+        'akeneo_connectivity_connection_apps_rest_confirm_authentication?clientId=0dfce574-2238-4b13-b8cc-8d257ce7645b':
+            {
+                json: {
+                    redirectUrl: 'https://extension-1.test/callback',
+                },
+            },
+    });
+
+    renderWithProviders(
+        <NotifyContext.Provider value={notify}>
+            <AuthenticationModal clientId='0dfce574-2238-4b13-b8cc-8d257ce7645b' />
+        </NotifyContext.Provider>
+    );
+
+    await waitFor(() => screen.queryByText('authentication-component'));
+
+    expect(screen.queryByText('authentication-component')).toBeInTheDocument();
 
     act(() => {
         userEvent.click(screen.getByText('akeneo_connectivity.connection.connect.apps.wizard.action.confirm'));

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authentication/Authentication.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authentication/Authentication.test.tsx
@@ -32,6 +32,7 @@ test('it renders correctly for first connection without consent checkbox', async
             scopesConsentGiven={false}
             setScopesConsent={() => null}
             displayConsent={false}
+            displayCheckboxConsent={true}
         />
     );
 
@@ -61,6 +62,7 @@ test('it renders correctly for first connection with consent checkbox', async ()
             scopesConsentGiven={false}
             setScopesConsent={() => null}
             displayConsent={true}
+            displayCheckboxConsent={true}
         />
     );
 
@@ -90,6 +92,7 @@ test('it renders correctly with new scopes required when not already had old sco
             scopesConsentGiven={false}
             setScopesConsent={() => null}
             displayConsent={false}
+            displayCheckboxConsent={true}
         />
     );
 
@@ -119,6 +122,7 @@ test('it renders correctly with new scopes required when already accepted old sc
             scopesConsentGiven={false}
             setScopesConsent={() => null}
             displayConsent={false}
+            displayCheckboxConsent={true}
         />
     );
 

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authentication/ConsentCheckbox.test.tsx
@@ -6,7 +6,9 @@ import {ConsentCheckbox} from '@src/connect/components/AppWizard/steps/Authentic
 import userEvent from '@testing-library/user-event';
 
 test('it renders correctly', async () => {
-    renderWithProviders(<ConsentCheckbox isChecked={false} onChange={() => null} appUrl={null} />);
+    renderWithProviders(
+        <ConsentCheckbox isChecked={false} onChange={() => null} appUrl={null} displayCheckbox={true} />
+    );
 
     await waitFor(() => screen.queryByRole('checkbox'));
 
@@ -18,7 +20,9 @@ test('it renders correctly', async () => {
 });
 
 test('it renders correctly when checked', async () => {
-    renderWithProviders(<ConsentCheckbox isChecked={true} onChange={() => null} appUrl={null} />);
+    renderWithProviders(
+        <ConsentCheckbox isChecked={true} onChange={() => null} appUrl={null} displayCheckbox={true} />
+    );
 
     await waitFor(() => screen.queryByRole('checkbox'));
 
@@ -27,7 +31,7 @@ test('it renders correctly when checked', async () => {
 
 test('it calls onChange when checked', async () => {
     const onChange = jest.fn();
-    renderWithProviders(<ConsentCheckbox isChecked={false} onChange={onChange} appUrl={null} />);
+    renderWithProviders(<ConsentCheckbox isChecked={false} onChange={onChange} appUrl={null} displayCheckbox={true} />);
 
     await waitFor(() => screen.queryByRole('checkbox'));
     expect(screen.queryByRole('checkbox', {checked: false})).toBeInTheDocument();
@@ -39,7 +43,7 @@ test('it calls onChange when checked', async () => {
 
 test('it calls onChange when unchecked', async () => {
     const onChange = jest.fn();
-    renderWithProviders(<ConsentCheckbox isChecked={true} onChange={onChange} appUrl={null} />);
+    renderWithProviders(<ConsentCheckbox isChecked={true} onChange={onChange} appUrl={null} displayCheckbox={true} />);
 
     await waitFor(() => screen.queryByRole('checkbox'));
     expect(screen.queryByRole('checkbox', {checked: true})).toBeInTheDocument();
@@ -50,11 +54,27 @@ test('it calls onChange when unchecked', async () => {
 });
 
 test('it renders url provided', async () => {
-    renderWithProviders(<ConsentCheckbox isChecked={true} onChange={() => null} appUrl={'testUrl'} />);
+    renderWithProviders(
+        <ConsentCheckbox isChecked={true} onChange={() => null} appUrl={'testUrl'} displayCheckbox={true} />
+    );
 
     await waitFor(() => screen.queryByRole('checkbox'));
 
     const linkLabel = 'akeneo_connectivity.connection.connect.apps.wizard.authentication.consent.contact_us';
     expect(screen.queryByText(linkLabel, {exact: false})).toBeInTheDocument();
     expect(screen.queryByText('testUrl', {exact: false})).toBeInTheDocument();
+});
+
+test('it renders correctly when the checkbox must be hidden', async () => {
+    renderWithProviders(
+        <ConsentCheckbox isChecked={false} onChange={() => null} appUrl={null} displayCheckbox={false} />
+    );
+
+    await waitFor(() => screen.queryByRole('checkbox'));
+
+    const label = 'akeneo_connectivity.connection.connect.apps.wizard.authentication.consent.label';
+    const subtext = 'akeneo_connectivity.connection.connect.apps.wizard.authentication.consent.subtext';
+    expect(screen.queryByText(label, {exact: false})).not.toBeInTheDocument();
+    expect(screen.queryByText(subtext, {exact: false})).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox', {checked: false})).not.toBeInTheDocument();
 });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authorizations.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/AppWizard/steps/Authorizations.test.tsx
@@ -27,6 +27,7 @@ test('The authorizations step without certification consent renders without erro
                 certificationConsentGiven={false}
                 setCertificationConsent={() => null}
                 displayCertificationConsent={false}
+                displayCheckboxConsent={true}
             />
         </ThemeProvider>
     );
@@ -49,6 +50,7 @@ test('The authorizations step with certification consent renders without error',
                 certificationConsentGiven={false}
                 setCertificationConsent={() => null}
                 displayCertificationConsent={true}
+                displayCheckboxConsent={true}
             />
         </ThemeProvider>
     );

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-app-wizard-data.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-app-wizard-data.test.ts
@@ -28,6 +28,7 @@ test('it fetches the wizard data', async () => {
         ],
         authenticationScopes: ['email'],
         oldAuthenticationScopes: ['profile'],
+        displayCheckboxConsent: true,
     };
 
     mockFetchResponses({


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Today users agree with the app privacy when connecting an app that requests authentication scopes. 

When these scopes are updated, we re-display the authentication step to warn our users that the app needs more information. They shouldn’t have to agree to the app privacy policy again. 

This is why, when the app updates its authentication scopes, we hide the agreement checkbox and only display the existing subtext as in the screenshot

![image](https://user-images.githubusercontent.com/112874333/209093978-ab745444-5fbd-495c-8d11-2c74fb4abd73.png)
