### PR TITLE
OCT-199 Add catalog disable event on error for GetProduct endpoint

### DIFF
--- a/.circleci/config/commands.yml
+++ b/.circleci/config/commands.yml
@@ -109,7 +109,7 @@ commands:
                     command: |
                         [ ! -f ~/project/php-pim-image.tar ] || docker load -i php-pim-image.tar
                         [ -f ~/project/php-pim-image.tar ] || make php-image-dev
-                        [ -f ~/project/php-pim-image.tar ] || docker save -o php-pim-image.tar akeneo/pim-dev/php:8.0
+                        [ -f ~/project/php-pim-image.tar ] || docker save -o php-pim-image.tar akeneo/pim-dev/php:8.1
             -   save_cache:
                     name: Save PHP docker image cache
                     key: php-docker-image-{{ .Environment.CACHE_VERSION }}-{{ checksum "~/php-docker-image.hash" }}

--- a/components/catalogs/back/src/Application/Handler/GetProductHandler.php
+++ b/components/catalogs/back/src/Application/Handler/GetProductHandler.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace Akeneo\Catalogs\Application\Handler;
 
 use Akeneo\Catalogs\Application\Exception\CatalogNotFoundException;
+use Akeneo\Catalogs\Application\Persistence\Catalog\DisableCatalogQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Catalog\GetCatalogQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Catalog\Product\GetProductQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Catalog\Product\IsProductBelongingToCatalogQueryInterface;
+use Akeneo\Catalogs\Application\Service\DispatchInvalidCatalogDisabledEventInterface;
+use Akeneo\Catalogs\Application\Validation\IsCatalogValidInterface;
+use Akeneo\Catalogs\ServiceAPI\Exception\CatalogDisabledException;
 use Akeneo\Catalogs\ServiceAPI\Exception\CatalogNotFoundException as ServiceApiCatalogNotFoundException;
 use Akeneo\Catalogs\ServiceAPI\Exception\ProductNotFoundException;
 use Akeneo\Catalogs\ServiceAPI\Query\GetProductQuery;
@@ -21,15 +25,19 @@ use Akeneo\Catalogs\ServiceAPI\Query\GetProductQuery;
 final class GetProductHandler
 {
     public function __construct(
-        private GetCatalogQueryInterface $getCatalogQuery,
-        private IsProductBelongingToCatalogQueryInterface $isProductBelongingToCatalogQuery,
-        private GetProductQueryInterface $getProductQuery,
+        private readonly GetCatalogQueryInterface $getCatalogQuery,
+        private readonly IsProductBelongingToCatalogQueryInterface $isProductBelongingToCatalogQuery,
+        private readonly GetProductQueryInterface $getProductQuery,
+        private readonly DisableCatalogQueryInterface $disableCatalogQuery,
+        private readonly IsCatalogValidInterface $isCatalogValid,
+        private readonly DispatchInvalidCatalogDisabledEventInterface $dispatchInvalidCatalogDisabledEvent,
     ) {
     }
 
     /**
      * @throws ServiceApiCatalogNotFoundException
      * @throws ProductNotFoundException
+     * @throws CatalogDisabledException
      * @return array{uuid: string, enabled: bool, family: string, categories: string[], groups: string[], parent: string|null, values: array<string, array<string, mixed>>, associations: array<string, array{groups: string[], products: string[], product_models: string[]}>, quantified_associations: array<string, array{products: string[], product_models: string[]}>, created: string, updated: string}
      */
     public function __invoke(GetProductQuery $query): array
@@ -40,12 +48,26 @@ final class GetProductHandler
             throw new ServiceApiCatalogNotFoundException();
         }
 
-        $productUuid = $query->getProductUuid();
-
-        if (!$this->isProductBelongingToCatalogQuery->execute($catalog, $productUuid)) {
-            throw new ProductNotFoundException();
+        if (!$catalog->isEnabled()) {
+            throw new CatalogDisabledException();
         }
 
-        return $this->getProductQuery->execute($catalog, $productUuid);
+        $productUuid = $query->getProductUuid();
+
+        try {
+            if (!$this->isProductBelongingToCatalogQuery->execute($catalog, $productUuid)) {
+                throw new ProductNotFoundException();
+            }
+
+            return $this->getProductQuery->execute($catalog, $productUuid);
+        } catch (\Exception $exception) {
+            if (!($this->isCatalogValid)($catalog)) {
+                $this->disableCatalogQuery->execute($catalog->getId());
+                ($this->dispatchInvalidCatalogDisabledEvent)($catalog->getId());
+                throw new CatalogDisabledException(previous: $exception);
+            }
+
+            throw $exception;
+        }
     }
 }

--- a/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductAction.php
+++ b/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductAction.php
@@ -77,7 +77,6 @@ class GetProductAction
 
     /**
      * @return Product
-     * @throws CatalogDisabledException
      * @throws ViolationHttpException
      * @throws NotFoundHttpException
      */

--- a/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductAction.php
+++ b/components/catalogs/back/src/Infrastructure/Controller/Public/GetProductAction.php
@@ -6,6 +6,7 @@ namespace Akeneo\Catalogs\Infrastructure\Controller\Public;
 
 use Akeneo\Catalogs\Infrastructure\Security\DenyAccessUnlessGrantedTrait;
 use Akeneo\Catalogs\Infrastructure\Security\GetCurrentUsernameTrait;
+use Akeneo\Catalogs\ServiceAPI\Exception\CatalogDisabledException;
 use Akeneo\Catalogs\ServiceAPI\Exception\CatalogNotFoundException;
 use Akeneo\Catalogs\ServiceAPI\Exception\ProductNotFoundException;
 use Akeneo\Catalogs\ServiceAPI\Messenger\QueryBus;
@@ -48,15 +49,15 @@ class GetProductAction
 
         $this->denyAccessUnlessOwnerOfCatalog($catalog, $this->getCurrentUsername());
 
-        if (!$catalog->isEnabled()) {
+        try {
+            $product = $this->getProduct($catalog->getId(), $uuid);
+        } catch (CatalogDisabledException) {
             return new JsonResponse([
                 'error' => \sprintf('No products to synchronize. The catalog "%s" has been disabled on PIM side. Note that you can get catalogs status with the GET /api/rest/v1/catalogs endpoint.', $id),
-            ]);
+            ], Response::HTTP_OK);
         }
 
-        $product = $this->getProduct($catalog->getId(), $uuid);
-
-        return new JsonResponse($product);
+        return new JsonResponse($product, Response::HTTP_OK);
     }
 
     private function getCatalog(string $id, string $productUuid): Catalog
@@ -76,6 +77,9 @@ class GetProductAction
 
     /**
      * @return Product
+     * @throws CatalogDisabledException
+     * @throws ViolationHttpException
+     * @throws NotFoundHttpException
      */
     private function getProduct(string $catalogId, string $productUuid): array
     {

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
@@ -41,7 +41,7 @@ class GetProductActionTest extends IntegrationTestCase
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
         $this->createProduct('red', [new SetEnabled(true)]);
         $this->createProduct('green', [new SetEnabled(false)]);
-        $productUuid = (string) $product->getUuid();
+        $productUuid = $product->getUuid()->toString();
 
         $this->client->request(
             'GET',
@@ -208,7 +208,7 @@ class GetProductActionTest extends IntegrationTestCase
         );
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
-        $productUuid = (string) $product->getUuid();
+        $productUuid = $product->getUuid()->toString();
 
         $this->client->request(
             'GET',
@@ -239,7 +239,7 @@ class GetProductActionTest extends IntegrationTestCase
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
-        $productUuid = (string) $product->getUuid();
+        $productUuid = $product->getUuid()->toString();
 
         $this->createCatalog(
             id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
@@ -25,15 +25,18 @@ class GetProductActionTest extends IntegrationTestCase
     {
         parent::setUp();
 
+        $this->disableExperimentalTestDatabase();
         $this->purgeDataAndLoadMinimalCatalog();
     }
 
     public function testItGetsProductByCatalogIdAndUuid(): void
     {
-        $catalogId = 'db1079b6-f397-4a6a-bae4-8658e64ad47c';
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
-        $this->createCatalog($catalogId, 'Store US', 'shopifi');
-        $this->enableCatalog($catalogId);
+        $this->createCatalog(
+            id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
+            name: 'Store US',
+            ownerUsername: 'shopifi',
+        );
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
         $this->createProduct('red', [new SetEnabled(true)]);
@@ -42,7 +45,7 @@ class GetProductActionTest extends IntegrationTestCase
 
         $this->client->request(
             'GET',
-            "/api/rest/v1/catalogs/$catalogId/products/$productUuid",
+            "/api/rest/v1/catalogs/db1079b6-f397-4a6a-bae4-8658e64ad47c/products/$productUuid",
             [],
             [],
             [
@@ -123,13 +126,15 @@ class GetProductActionTest extends IntegrationTestCase
     public function testItReturnsNotFoundWhenProductDoesNotExistForTheCatalog(): void
     {
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
-        $catalogId = 'db1079b6-f397-4a6a-bae4-8658e64ad47c';
-        $this->createCatalog($catalogId, 'Store US', 'shopifi');
-        $this->enableCatalog($catalogId);
+        $this->createCatalog(
+            id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
+            name: 'Store US',
+            ownerUsername: 'shopifi',
+        );
 
         $this->client->request(
             'GET',
-            "/api/rest/v1/catalogs/$catalogId/products/c335c87e-ec23-4c5b-abfa-0638f141933a",
+            '/api/rest/v1/catalogs/db1079b6-f397-4a6a-bae4-8658e64ad47c/products/c335c87e-ec23-4c5b-abfa-0638f141933a',
             [],
             [],
             [
@@ -194,16 +199,20 @@ class GetProductActionTest extends IntegrationTestCase
 
     public function testItReturnsAnErrorWhenCatalogIsDisabled(): void
     {
-        $catalogId = 'db1079b6-f397-4a6a-bae4-8658e64ad47c';
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
-        $this->createCatalog($catalogId, 'Store US', 'shopifi', isEnabled: false);
+        $this->createCatalog(
+            id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
+            name: 'Store US',
+            ownerUsername: 'shopifi',
+            isEnabled: false,
+        );
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
         $productUuid = (string) $product->getUuid();
 
         $this->client->request(
             'GET',
-            "/api/rest/v1/catalogs/$catalogId/products/$productUuid",
+            "/api/rest/v1/catalogs/db1079b6-f397-4a6a-bae4-8658e64ad47c/products/$productUuid",
             [],
             [],
             [
@@ -217,5 +226,54 @@ class GetProductActionTest extends IntegrationTestCase
         Assert::assertEquals(200, $response->getStatusCode());
         Assert::assertArrayHasKey('error', $result);
         Assert::assertIsString($result['error']);
+    }
+
+    public function testItReturnsAnErrorWhenCatalogIsInvalid(): void
+    {
+        $this->createAttribute([
+            'code' => 'color',
+            'type' => 'pim_catalog_multiselect',
+            'options' => ['red', 'blue'],
+        ]);
+
+        $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
+
+        $product = $this->createProduct('blue', [new SetEnabled(true)]);
+        $productUuid = (string) $product->getUuid();
+
+        $this->createCatalog(
+            id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
+            name: 'Store US',
+            ownerUsername: 'shopifi',
+            catalogProductSelection: [
+                [
+                    'field' => 'color',
+                    'operator' => Operator::IN_LIST,
+                    'value' => ['red'],
+                    'scope' => null,
+                    'locale' => null,
+                ],
+            ],
+        );
+
+        $this->removeAttributeOption('color.red');
+
+        $this->client->request(
+            'GET',
+            "/api/rest/v1/catalogs/db1079b6-f397-4a6a-bae4-8658e64ad47c/products/$productUuid",
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+            ],
+        );
+
+        $response = $this->client->getResponse();
+        $result = \json_decode($response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        Assert::assertEquals(200, $response->getStatusCode());
+        Assert::assertArrayHasKey('error', $result);
+        Assert::assertIsString($result['error']);
+        Assert::assertFalse($this->getCatalog('db1079b6-f397-4a6a-bae4-8658e64ad47c')->isEnabled());
     }
 }

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/GetProductActionTest.php
@@ -41,7 +41,7 @@ class GetProductActionTest extends IntegrationTestCase
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
         $this->createProduct('red', [new SetEnabled(true)]);
         $this->createProduct('green', [new SetEnabled(false)]);
-        $productUuid = $product->getUuid()->toString();
+        $productUuid = (string) $product->getUuid();
 
         $this->client->request(
             'GET',
@@ -208,7 +208,7 @@ class GetProductActionTest extends IntegrationTestCase
         );
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
-        $productUuid = $product->getUuid()->toString();
+        $productUuid = (string) $product->getUuid();
 
         $this->client->request(
             'GET',
@@ -239,7 +239,7 @@ class GetProductActionTest extends IntegrationTestCase
         $this->client = $this->getAuthenticatedPublicApiClient(['read_catalogs', 'read_products']);
 
         $product = $this->createProduct('blue', [new SetEnabled(true)]);
-        $productUuid = $product->getUuid()->toString();
+        $productUuid = (string) $product->getUuid();
 
         $this->createCatalog(
             id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',


### PR DESCRIPTION
The catalog's GetProduct endpoint throws an error if the catalog product selection is invalid
This PR adds similar error handling to what was done on other endpoints to prevent the endpoint from crashing