### PR TITLE
SDS-27322: Optimize get completeness SQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - BH-1159: Refactor BatchCommand to use execution ID without batch code
 - BH-1159: Add tenant ID for batch processing
 - BH-1159: Use available JobMessage class for denormalization
+- PIM-10782: Optimize get completeness SQL query
 
 ## New features
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Mysql statistics are very simple. It is possible to calculate a cardinality of 8000 channels in the table `pim_catalog_completeness`, even if there are maximum 20 channels in the PIM.
This is due to its way it calculate it with sampling. It fetches completeness by filtering on completeness instead of product uuids. We forced to filter on product uuids thanks to CTE + DISTINCT as barrier optimization.

It's exactly the same issue as here: https://github.com/akeneo/pim-community-dev/pull/13648/files


<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
