### PR TITLE
CPM-898: Add validation on delimiter value

### DIFF
--- a/components/identifier-generator/front/src/feature/pages/__tests__/CreateGeneratorPage.test.tsx
+++ b/components/identifier-generator/front/src/feature/pages/__tests__/CreateGeneratorPage.test.tsx
@@ -82,6 +82,6 @@ describe('CreateGeneratorPage', () => {
       fireEvent.click(screen.getByText('Main button'));
     });
 
-    expect(screen.getByText('structure The structure must contain at least one property')).toBeInTheDocument();
+    expect(screen.getByText('structure The structure must contain at least 1 property')).toBeInTheDocument();
   });
 });

--- a/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
@@ -56,6 +56,11 @@ const StructureTab: React.FC<StructureTabProps> = ({
       });
     };
 
+  const displayedErrors = useMemo(
+    () => validationErrors?.map(({message}) => message).filter((value, index, self) => self.indexOf(value) === index),
+    [validationErrors]
+  );
+
   const onPropertyChange = (property: Property) => {
     if (selectedProperty) {
       const updatedPropertyIndex = structure.findIndex(p => selectedProperty.id === p.id);

--- a/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
@@ -56,11 +56,6 @@ const StructureTab: React.FC<StructureTabProps> = ({
       });
     };
 
-  const displayedErrors = useMemo(
-    () => validationErrors?.map(({message}) => message).filter((value, index, self) => self.indexOf(value) === index),
-    [validationErrors]
-  );
-
   const onPropertyChange = (property: Property) => {
     if (selectedProperty) {
       const updatedPropertyIndex = structure.findIndex(p => selectedProperty.id === p.id);

--- a/components/identifier-generator/front/src/feature/validators/__tests__/validateDelimiter.test.ts
+++ b/components/identifier-generator/front/src/feature/validators/__tests__/validateDelimiter.test.ts
@@ -17,4 +17,34 @@ describe('validateDelimiter', () => {
       },
     ]);
   });
+
+  it('should add violation if delimiter contains comma, semicolon or leading/trailing space', () => {
+    expect(validateDelimiter(' /', 'delimiter')).toEqual([
+      {
+        path: 'delimiter',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+
+    expect(validateDelimiter('/ ', 'delimiter')).toEqual([
+      {
+        path: 'delimiter',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+
+    expect(validateDelimiter(',', 'delimiter')).toEqual([
+      {
+        path: 'delimiter',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+
+    expect(validateDelimiter(';', 'delimiter')).toEqual([
+      {
+        path: 'delimiter',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+  });
 });

--- a/components/identifier-generator/front/src/feature/validators/__tests__/validateFreeText.test.ts
+++ b/components/identifier-generator/front/src/feature/validators/__tests__/validateFreeText.test.ts
@@ -9,4 +9,27 @@ describe('validateFreeText', () => {
   it('should add violation for empty text', () => {
     expect(validateFreeText({type: PROPERTY_NAMES.FREE_TEXT, string: ''}, 'path')).toHaveLength(1);
   });
+
+  it('should add violation if free text contains comma, semicolon or any space', () => {
+    expect(validateFreeText({type: PROPERTY_NAMES.FREE_TEXT, string: ' AKN'}, 'freetext')).toEqual([
+      {
+        path: 'freetext',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+
+    expect(validateFreeText({type: PROPERTY_NAMES.FREE_TEXT, string: ','}, 'freetext')).toEqual([
+      {
+        path: 'freetext',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+
+    expect(validateFreeText({type: PROPERTY_NAMES.FREE_TEXT, string: ';'}, 'freetext')).toEqual([
+      {
+        path: 'freetext',
+        message: 'The property must not contain a comma, a semicolon or any space',
+      },
+    ]);
+  });
 });

--- a/components/identifier-generator/front/src/feature/validators/validateDelimiter.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateDelimiter.ts
@@ -12,6 +12,12 @@ const validateDelimiter: Validator<Delimiter | null> = (delimiter, path) => {
     });
   }
 
+  if (delimiter !== null && /(^[ ].*)|(.*[ ]$)|(^.*[,;].*$)/.exec(delimiter)) {
+    violations.push({
+      path,
+      message: 'The property must not contain a comma, a semicolon or any space',
+    });
+  }
   return violations;
 };
 

--- a/components/identifier-generator/front/src/feature/validators/validateDelimiter.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateDelimiter.ts
@@ -12,7 +12,7 @@ const validateDelimiter: Validator<Delimiter | null> = (delimiter, path) => {
     });
   }
 
-  if (delimiter !== null && /(^[ ].*)|(.*[ ]$)|(^.*[,;].*$)/.exec(delimiter)) {
+  if (delimiter !== null && /[ ,;]/.exec(delimiter)) {
     violations.push({
       path,
       message: 'The property must not contain a comma, a semicolon or any space',

--- a/components/identifier-generator/front/src/feature/validators/validateFreeText.ts
+++ b/components/identifier-generator/front/src/feature/validators/validateFreeText.ts
@@ -12,6 +12,13 @@ const validateFreeText: Validator<FreeText> = (freeText, path) => {
     });
   }
 
+  if (/[ ,;]/.exec(freeText.string)) {
+    violations.push({
+      path,
+      message: 'The property must not contain a comma, a semicolon or any space',
+    });
+  }
+
   return violations;
 };
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
![Screenshot from 2023-01-02 14-08-10](https://user-images.githubusercontent.com/42606611/210236990-4813d72a-81d8-43c7-9833-f96e5cc029e5.png)

User cannot create/save a generator which has a delimiter with the following values: ` spaceBefore`, `spaceAfter `, `,`, `;`
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
