### PR TITLE
OCT-188 : AttributeMapping: Error is shown one more time after correction.

### DIFF
--- a/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogErrors.ts
+++ b/components/catalogs/front/src/components/CatalogEdit/hooks/useCatalogErrors.ts
@@ -11,13 +11,17 @@ type Result = {
 };
 
 export const useCatalogErrors = (catalogId: string): Result => {
-    return useQuery<Data, Error, Data>('catalogErrors', async () => {
-        const response = await fetch(`/rest/catalogs/${catalogId}/errors`, {
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-            },
-        });
+    return useQuery<Data, Error, Data>(
+        'catalogErrors',
+        async () => {
+            const response = await fetch(`/rest/catalogs/${catalogId}/errors`, {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+            });
 
-        return await response.json();
-    });
+            return await response.json();
+        },
+        {cacheTime: 0}
+    );
 };


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
I corrected the possibility to have an error message while all errors were already corrected :
![image](https://user-images.githubusercontent.com/17602087/210240689-87f658b5-d0ed-488c-a6db-9099061a2cc6.png)

The only change is the deactivation of the cache (cacheTime: 0).
<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
