### PR TITLE
CPM-899: Add validation for delimiter

### DIFF
--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/validation/create_generator_command.yml
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/validation/create_generator_command.yml
@@ -81,6 +81,9 @@ Akeneo\Pim\Automation\IdentifierGenerator\Application\Create\CreateGeneratorComm
                 allowNull: true
             - Length:
                 max: 100
+            - Regex:
+                  pattern: /^[^ ,;]*$/
+                  message: delimiter must not contain a comma, a semicolon or any space
         textTransformation:
             - Choice:
                   choices: ['no', 'uppercase', 'lowercase']

--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/validation/update_generator_command.yml
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/config/validation/update_generator_command.yml
@@ -80,6 +80,9 @@ Akeneo\Pim\Automation\IdentifierGenerator\Application\Update\UpdateGeneratorComm
                 allowNull: true
             - Length:
                 max: 100
+            - Regex:
+                  pattern: /^[^ ,;]*$/
+                  message: delimiter must not contain a comma, a semicolon or any space
         textTransformation:
             - Choice:
                   choices: ['no', 'uppercase', 'lowercase']

--- a/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/translations/validators.en_US.yml
+++ b/components/identifier-generator/back/src/Infrastructure/Symfony/Resources/translations/validators.en_US.yml
@@ -7,6 +7,7 @@ validation:
         attribute_does_not_exist: 'The "{{code}}" attribute does not exist.'
         attribute_should_have_type: 'The "{{ code }}" attribute code is "{{ type }}" type and should be of type "{{ expected }}".'
         free_text_string_field_required: 'Free text should contain "string" key'
+        free_text_string_field_invalid: 'Free text must not contain a comma, a semicolon or any space'
         enabled_value_field_required: 'Enabled should contain "value" key'
         enabled_boolean_value: 'This value should be a boolean.'
         auto_number_fields_required: '"{{field}}" fields are required for "auto_number" type'

--- a/components/identifier-generator/back/src/Infrastructure/Validation/FreeTextShouldBeValid.php
+++ b/components/identifier-generator/back/src/Infrastructure/Validation/FreeTextShouldBeValid.php
@@ -13,6 +13,7 @@ use Symfony\Component\Validator\Constraint;
 final class FreeTextShouldBeValid extends Constraint
 {
     public string $stringKeyRequired = 'validation.identifier_generator.free_text_string_field_required';
+    public string $stringIsInvalid = 'validation.identifier_generator.free_text_string_field_invalid';
 
     /**
      * @inerhitDoc

--- a/components/identifier-generator/back/src/Infrastructure/Validation/FreeTextShouldBeValidValidator.php
+++ b/components/identifier-generator/back/src/Infrastructure/Validation/FreeTextShouldBeValidValidator.php
@@ -33,5 +33,11 @@ final class FreeTextShouldBeValidValidator extends ConstraintValidator
                 ->buildViolation($constraint->stringKeyRequired)
                 ->addViolation();
         }
+
+        if (array_key_exists('string', $property) && !preg_match('/^[^ ,;]*$/', $property['string'])) {
+            $this->context
+                ->buildViolation($constraint->stringIsInvalid)
+                ->addViolation();
+        }
     }
 }

--- a/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Subscriber/SetIdentifiersSubscriberEndToEnd.php
+++ b/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Subscriber/SetIdentifiersSubscriberEndToEnd.php
@@ -104,7 +104,13 @@ class SetIdentifiersSubscriberEndToEnd extends EndToEndTestCase
     /** @test */
     public function it_should_not_generate_the_identifier_if_generated_product_contains_invalid_character(): void
     {
-        $this->createIdentifierGeneratorWithFreeTextValue(',');
+        $exceptionMsg = '';
+        try {
+            $this->createIdentifierGeneratorWithFreeTextValue(',');
+        } catch (ViolationsException $exception) {
+            $exceptionMsg = $exception->getMessage();
+        }
+        Assert::assertSame('structure[0]: Free text must not contain a comma, a semicolon or any space', $exceptionMsg);
 
         $productFromDatabase = $this->createProduct();
         Assert::assertSame(null, $productFromDatabase->getIdentifier());

--- a/components/identifier-generator/back/tests/features/createIdentifierGenerator.feature
+++ b/components/identifier-generator/back/tests/features/createIdentifierGenerator.feature
@@ -72,6 +72,11 @@ Feature: Create Identifier Generator
     Then I should get an error with message 'structure[0][unknown]: This field was not expected.'
     And the identifier should not be created
 
+  Scenario: Cannot create an identifier generator if structure contains free text with invalid text
+    When I try to create an identifier generator with free text ' AKN'
+    Then I should get an error with message 'Free text must not contain a comma, a semicolon or any space'
+    And the identifier should not be created
+
   # Structure : Auto number
   Scenario: Cannot create an identifier generator with autoNumber missing required field
     When I try to create an identifier generator with autoNumber without required field

--- a/components/identifier-generator/back/tests/features/createIdentifierGenerator.feature
+++ b/components/identifier-generator/back/tests/features/createIdentifierGenerator.feature
@@ -359,6 +359,11 @@ Feature: Create Identifier Generator
     Then I should get an error with message 'delimiter: This value is too long. It should have 100 characters or less.'
     And the identifier should not be created
 
+  Scenario: Cannot create an identifier generator with delimiter with invalid characters
+    When I try to create an identifier generator with delimiter ' , '
+    Then I should get an error with message 'delimiter: delimiter must not contain a comma, a semicolon or any space'
+    And the identifier should not be created
+
   # Text transformation
   Scenario: Cannot create an identifier generator with unknown text transformation
     When I try to create an identifier generator with text transformation unknown

--- a/components/identifier-generator/back/tests/features/updateIdentifierGenerator.feature
+++ b/components/identifier-generator/back/tests/features/updateIdentifierGenerator.feature
@@ -65,6 +65,18 @@ Feature: Update Identifier Generator
     When I try to update an identifier generator with free text with unknown field
     Then I should get an error on update with message 'structure[0][unknown]: This field was not expected.'
 
+  Scenario: Cannot update and identifier generator if structure contains free text with invalid text
+    When I try to update an identifier generator with free text ' AKN'
+    Then I should get an error on update with message 'Free text must not contain a comma, a semicolon or any space'
+
+  Scenario: Cannot update and identifier generator if structure contains free text with invalid text
+    When I try to update an identifier generator with free text 'AKN,COL'
+    Then I should get an error on update with message 'Free text must not contain a comma, a semicolon or any space'
+
+  Scenario: Cannot update and identifier generator if structure contains free text with invalid text
+    When I try to update an identifier generator with free text 'AKN;COL'
+    Then I should get an error on update with message 'Free text must not contain a comma, a semicolon or any space'
+
   # Structure : Auto number
   Scenario: Cannot update an identifier generator with autoNumber missing required field
     When I try to update an identifier generator with autoNumber without required field

--- a/components/identifier-generator/back/tests/features/updateIdentifierGenerator.feature
+++ b/components/identifier-generator/back/tests/features/updateIdentifierGenerator.feature
@@ -298,6 +298,18 @@ Feature: Update Identifier Generator
     When I try to update an identifier generator with delimiter 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec suscipit nisi erat, sed tincidunt urna finibus non. Nullam id lacus et augue ullamcorper euismod sed id nibh. Praesent luctus cursus finibus. Maecenas et euismod tellus. Nunc sed est nec mi consequat consequat sit amet ac ex. '
     Then I should get an error on update with message 'delimiter: This value is too long. It should have 100 characters or less.'
 
+  Scenario: Cannot update an identifier generator with delimiter containing spaces
+    When I try to update an identifier generator with delimiter ' / '
+    Then I should get an error on update with message 'delimiter: delimiter must not contain a comma, a semicolon or any space'
+
+  Scenario: Cannot update an identifier generator with delimiter containing comma
+    When I try to update an identifier generator with delimiter ','
+    Then I should get an error on update with message 'delimiter: delimiter must not contain a comma, a semicolon or any space'
+
+  Scenario: Cannot update an identifier generator with delimiter containing semicolon
+    When I try to update an identifier generator with delimiter ';'
+    Then I should get an error on update with message 'delimiter: delimiter must not contain a comma, a semicolon or any space'
+
   # Text transformation
   Scenario: Cannot update an identifier generator with unknown text transformation
     When I try to update an identifier generator with text transformation unknown


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Delimiter can now be anything but spaces, comma or semicolon

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
