### PR TITLE
PIM-10789: Do not return and show encrypted password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - PIM-10753: Fix HTTP 500 in the API when patching product metric with a mathematical notation
 - PIM:10744: Fix product import with a quantified association column is missing
 - PIM-10750: Fix category code validation to allow '0'
+- PIM-10789: Fix password is displayed in SFTP and Amazon S3 form and encrypted password is displayed on history
 
 ## Improvements
 

--- a/front-packages/shared/src/components/TextField.tsx
+++ b/front-packages/shared/src/components/TextField.tsx
@@ -12,7 +12,17 @@ type TextFieldProps = FieldProps &
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   (
-    {actions, required = false, errors = [], label, incomplete, locale, channel, children, ...inputProps}: TextFieldProps,
+    {
+      actions,
+      required = false,
+      errors = [],
+      label,
+      incomplete,
+      locale,
+      channel,
+      children,
+      ...inputProps
+    }: TextFieldProps,
     forwardedRef: Ref<HTMLInputElement>
   ) => {
     const translate = useTranslate();

--- a/front-packages/shared/src/components/TextField.tsx
+++ b/front-packages/shared/src/components/TextField.tsx
@@ -1,23 +1,25 @@
-import React, {Ref} from 'react';
+import React, {ReactNode, Ref} from 'react';
 import {FieldProps, TextInputProps, Field, TextInput, Helper} from 'akeneo-design-system';
 import {useTranslate} from '../hooks';
 import {ValidationError, formatParameters} from '../models';
 
 type TextFieldProps = FieldProps &
   TextInputProps & {
+    actions?: ReactNode;
     required?: boolean;
     errors?: ValidationError[];
   };
 
 const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
   (
-    {required = false, errors = [], label, incomplete, locale, channel, children, ...inputProps}: TextFieldProps,
+    {actions, required = false, errors = [], label, incomplete, locale, channel, children, ...inputProps}: TextFieldProps,
     forwardedRef: Ref<HTMLInputElement>
   ) => {
     const translate = useTranslate();
 
     return (
       <Field
+        actions={actions}
         label={required ? `${label} ${translate('pim_common.required_label')}` : label}
         incomplete={incomplete}
         locale={locale}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -233,8 +233,8 @@ class JobInstanceController
         }
 
         if (isset($data['configuration']['storage'])) {
-            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->mergeCredentials($jobInstance, $data['configuration']['storage']);
-            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->encryptCredentials($data['configuration']['storage']);
+            $previousStorageData = $jobInstance->getRawParameters()['configuration']['storage'];
+            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->encryptCredentials($previousStorageData ?? [], $data['configuration']['storage']);
         }
         $this->updater->update($jobInstance, $data);
 
@@ -564,10 +564,6 @@ class JobInstanceController
         );
 
         $normalizedJobInstance = $this->normalizeJobInstance($jobInstance);
-
-        if (isset($normalizedJobInstance['configuration']['storage'])) {
-            $normalizedJobInstance['configuration']['storage'] = $this->credentialsEncrypterRegistry->decryptCredentials($normalizedJobInstance['configuration']['storage']);
-        }
 
         return new JsonResponse($normalizedJobInstance);
     }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -193,7 +193,7 @@ class JobInstanceController
         $normalizedJobInstance = $this->normalizeJobInstance($jobInstance);
 
         if (isset($normalizedJobInstance['configuration']['storage'])) {
-            $normalizedJobInstance['configuration']['storage'] = $this->credentialsEncrypterRegistry->decryptCredentials($normalizedJobInstance['configuration']['storage']);
+            $normalizedJobInstance['configuration']['storage'] = $this->credentialsEncrypterRegistry->obfuscateCredentials($normalizedJobInstance['configuration']['storage']);
         }
 
         return new JsonResponse($normalizedJobInstance);
@@ -233,6 +233,7 @@ class JobInstanceController
         }
 
         if (isset($data['configuration']['storage'])) {
+            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->mergeCredentials($jobInstance, $data['configuration']['storage']);
             $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->encryptCredentials($data['configuration']['storage']);
         }
         $this->updater->update($jobInstance, $data);
@@ -256,7 +257,7 @@ class JobInstanceController
         $normalizedJobInstance = $this->normalizeJobInstance($jobInstance);
 
         if (isset($normalizedJobInstance['configuration']['storage'])) {
-            $normalizedJobInstance['configuration']['storage'] = $this->credentialsEncrypterRegistry->decryptCredentials($normalizedJobInstance['configuration']['storage']);
+            $normalizedJobInstance['configuration']['storage'] = $this->credentialsEncrypterRegistry->obfuscateCredentials($normalizedJobInstance['configuration']['storage']);
         }
 
         return new JsonResponse($normalizedJobInstance);

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Controller/InternalApi/JobInstanceController.php
@@ -213,6 +213,7 @@ class JobInstanceController
         }
 
         $jobInstance = $this->getJobInstance($identifier);
+        $previousJobInstanceParameters = $jobInstance->getRawParameters();
         if ($this->objectFilter->filterObject($jobInstance, 'pim.internal_api.job_instance.edit')) {
             throw new AccessDeniedHttpException();
         }
@@ -233,8 +234,8 @@ class JobInstanceController
         }
 
         if (isset($data['configuration']['storage'])) {
-            $previousStorageData = $jobInstance->getRawParameters()['configuration']['storage'];
-            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->encryptCredentials($previousStorageData ?? [], $data['configuration']['storage']);
+            $previousStorageData = $previousJobInstanceParameters['storage'];
+            $data['configuration']['storage'] = $this->credentialsEncrypterRegistry->encryptCredentials($previousStorageData, $data['configuration']['storage']);
         }
         $this->updater->update($jobInstance, $data);
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypter.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypter.php
@@ -2,11 +2,17 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security;
 
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+
 interface CredentialsEncrypter
 {
     public function encryptCredentials(array $data): array;
 
     public function decryptCredentials(array $data): array;
+
+    public function obfuscateCredentials(array $data): array;
+
+    public function mergeCredentials(JobInstance $initialJobInstance, array $data): array;
 
     public function support(array $data): bool;
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypter.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypter.php
@@ -2,17 +2,13 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security;
 
-use Akeneo\Tool\Component\Batch\Model\JobInstance;
-
 interface CredentialsEncrypter
 {
-    public function encryptCredentials(array $data): array;
+    public function encryptCredentials(array $previousData, array $data): array;
 
     public function decryptCredentials(array $data): array;
 
     public function obfuscateCredentials(array $data): array;
-
-    public function mergeCredentials(JobInstance $initialJobInstance, array $data): array;
 
     public function support(array $data): bool;
 }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
@@ -2,8 +2,6 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security;
 
-use Akeneo\Tool\Component\Batch\Model\JobInstance;
-
 final class CredentialsEncrypterRegistry
 {
     public function __construct(

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
@@ -12,11 +12,11 @@ final class CredentialsEncrypterRegistry
     ) {
     }
 
-    public function encryptCredentials(array $data): array
+    public function encryptCredentials(array $previousData, array $data): array
     {
         foreach ($this->credentialsEncrypters as $credentialsEncrypter) {
             if ($credentialsEncrypter->support($data)) {
-                return $credentialsEncrypter->encryptCredentials($data);
+                return $credentialsEncrypter->encryptCredentials($previousData, $data);
             }
         }
 
@@ -28,17 +28,6 @@ final class CredentialsEncrypterRegistry
         foreach ($this->credentialsEncrypters as $credentialsEncrypter) {
             if ($credentialsEncrypter->support($data)) {
                 return $credentialsEncrypter->obfuscateCredentials($data);
-            }
-        }
-
-        return $data;
-    }
-
-    public function mergeCredentials(JobInstance $initialJobInstance, array $data)
-    {
-        foreach ($this->credentialsEncrypters as $credentialsEncrypter) {
-            if ($credentialsEncrypter->support($data)) {
-                return $credentialsEncrypter->mergeCredentials($initialJobInstance, $data);
             }
         }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistry.php
@@ -2,6 +2,8 @@
 
 namespace Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security;
 
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
+
 final class CredentialsEncrypterRegistry
 {
     public function __construct(
@@ -21,11 +23,22 @@ final class CredentialsEncrypterRegistry
         return $data;
     }
 
-    public function decryptCredentials(array $data): array
+    public function obfuscateCredentials(array $data): array
     {
         foreach ($this->credentialsEncrypters as $credentialsEncrypter) {
             if ($credentialsEncrypter->support($data)) {
-                return $credentialsEncrypter->decryptCredentials($data);
+                return $credentialsEncrypter->obfuscateCredentials($data);
+            }
+        }
+
+        return $data;
+    }
+
+    public function mergeCredentials(JobInstance $initialJobInstance, array $data)
+    {
+        foreach ($this->credentialsEncrypters as $credentialsEncrypter) {
+            if ($credentialsEncrypter->support($data)) {
+                return $credentialsEncrypter->mergeCredentials($initialJobInstance, $data);
             }
         }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/normalizers.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/normalizers.yml
@@ -27,6 +27,8 @@ services:
 
     pim_versioning.serializer.normalizer.flat.job_instance:
         class: '%pim_serializer.normalizer.flat.job_instance.class%'
+        arguments:
+            - '@Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security\CredentialsEncrypterRegistry'
         tags:
             - { name: pim_versioning.serializer.normalizer, priority: 90 }
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/job/common/edit/storage-form.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/public/js/job/common/edit/storage-form.ts
@@ -70,6 +70,7 @@ class StorageFormController extends BaseView {
     const formData = this.getFormData();
 
     const props: StorageFormProps = {
+      jobInstanceCode: formData.code,
       storage: formData.configuration.storage ?? this.getDefaultStorage(),
       jobType: this.config.jobType,
       fileExtension: this.config.fileExtension,

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
@@ -210,7 +210,7 @@ test('it allows user to fill secret field', async () => {
   expect(onStorageChange).toHaveBeenLastCalledWith({...storage, secret: 'my_s3cr3t'});
 });
 
-test('it hide secret field if the secret is obfuscated', () => {
+test('it hides secret field if the secret is obfuscated', () => {
   const storage: AmazonS3Storage = {
     type: 'amazon_s3',
     file_path: '/tmp/file.xlsx',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
@@ -33,6 +33,7 @@ test('it renders the amazon s3 storage configurator', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -61,6 +62,7 @@ test('it allows user to fill file_path field', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -92,6 +94,7 @@ test('it allows user to fill region field', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -123,6 +126,7 @@ test('it allows user to fill bucket field', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -157,6 +161,7 @@ test('it allows user to fill key field', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -188,6 +193,7 @@ test('it allows user to fill secret field', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -215,6 +221,7 @@ test('it throws an exception when passing a non amazon s3 storage', async () => 
   expect(() =>
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -277,6 +284,7 @@ test('it displays validation errors', async () => {
   await act(async () => {
     renderWithProviders(
       <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={validationErrors}
@@ -306,6 +314,7 @@ test('it can check connection', async () => {
 
   renderWithProviders(
     <AmazonS3StorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -346,6 +355,7 @@ test('it can check connection, display message if error', async () => {
 
   renderWithProviders(
     <AmazonS3StorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.test.tsx
@@ -210,6 +210,61 @@ test('it allows user to fill secret field', async () => {
   expect(onStorageChange).toHaveBeenLastCalledWith({...storage, secret: 'my_s3cr3t'});
 });
 
+test('it hide secret field if the secret is obfuscated', () => {
+  const storage: AmazonS3Storage = {
+    type: 'amazon_s3',
+    file_path: '/tmp/file.xlsx',
+    region: 'eu-west-1',
+    bucket: '',
+    key: 'a_key',
+  };
+
+  act(() => {
+    renderWithProviders(
+      <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
+        storage={storage}
+        fileExtension="xlsx"
+        validationErrors={[]}
+        onStorageChange={jest.fn()}
+      />
+    );
+  });
+
+  const secretInput = screen.getByLabelText(
+    'pim_import_export.form.job_instance.storage_form.secret.label pim_common.required_label'
+  );
+
+  expect(secretInput).toBeDisabled();
+  expect(secretInput).toHaveValue('••••••••');
+});
+
+test('it can edit the secret field if the secret is obfuscated', () => {
+  const storage: AmazonS3Storage = {
+    type: 'amazon_s3',
+    file_path: '/tmp/file.xlsx',
+    region: 'eu-west-1',
+    bucket: '',
+    key: 'a_key',
+  };
+
+  const onStorageChange = jest.fn();
+  act(() => {
+    renderWithProviders(
+      <AmazonS3StorageConfigurator
+        jobInstanceCode="csv_product_export"
+        storage={storage}
+        fileExtension="xlsx"
+        validationErrors={[]}
+        onStorageChange={onStorageChange}
+      />
+    );
+  });
+
+  userEvent.click(screen.getByText('pim_common.edit'));
+  expect(onStorageChange).toHaveBeenLastCalledWith({...storage, secret: ''});
+});
+
 test('it throws an exception when passing a non amazon s3 storage', async () => {
   const mockedConsole = jest.spyOn(console, 'error').mockImplementation();
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import {EditIcon, Helper, Button, CheckIcon, getColor} from 'akeneo-design-system';
+import {Helper, Button, CheckIcon, getColor} from 'akeneo-design-system';
 import {TextField, useTranslate, filterErrors} from '@akeneo-pim-community/shared';
 import {StorageConfiguratorProps, isAmazonS3Storage} from './model';
 import {useCheckStorageConnection} from '../../hooks/useCheckStorageConnection';
-import {IconButton} from "akeneo-design-system/lib/components/IconButton/IconButton";
 
 const CheckStorageForm = styled.div`
   display: flex;
@@ -71,18 +70,25 @@ const AmazonS3StorageConfigurator = ({
         errors={filterErrors(validationErrors, '[key]')}
       />
       <TextField
-        actions={secretIsStoredOnServer && (
-          <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, secret: ''})}>
-            {translate('pim_common.edit')}
-          </Button>
-        )}
+        actions={
+          secretIsStoredOnServer && (
+            <Button
+              level="secondary"
+              ghost={true}
+              size="small"
+              onClick={() => onStorageChange({...storage, secret: ''})}
+            >
+              {translate('pim_common.edit')}
+            </Button>
+          )
+        }
         required={true}
         value={secretIsStoredOnServer ? '••••••••' : storage.secret}
         readOnly={secretIsStoredOnServer}
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.secret.label')}
         placeholder={translate('pim_import_export.form.job_instance.storage_form.secret.placeholder')}
-        onChange={(secret: string) => storage.secret !== undefined && onStorageChange({...storage, secret})}
+        onChange={(secret: string) => onStorageChange({...storage, secret})}
         errors={filterErrors(validationErrors, '[secret]')}
       />
       <CheckStorageForm>

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
-import {Helper, Button, CheckIcon, getColor} from 'akeneo-design-system';
+import {EditIcon, Helper, Button, CheckIcon, getColor} from 'akeneo-design-system';
 import {TextField, useTranslate, filterErrors} from '@akeneo-pim-community/shared';
 import {StorageConfiguratorProps, isAmazonS3Storage} from './model';
 import {useCheckStorageConnection} from '../../hooks/useCheckStorageConnection';
+import {IconButton} from "akeneo-design-system/lib/components/IconButton/IconButton";
 
 const CheckStorageForm = styled.div`
   display: flex;
@@ -19,6 +20,7 @@ const CheckStorageConnection = styled.div`
 `;
 
 const AmazonS3StorageConfigurator = ({
+  jobInstanceCode,
   storage,
   fileExtension,
   validationErrors,
@@ -29,7 +31,8 @@ const AmazonS3StorageConfigurator = ({
   }
 
   const translate = useTranslate();
-  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(storage);
+  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(jobInstanceCode, storage);
+  const secretIsStoredOnServer = storage.secret === undefined;
 
   return (
     <>
@@ -68,21 +71,20 @@ const AmazonS3StorageConfigurator = ({
         errors={filterErrors(validationErrors, '[key]')}
       />
       <TextField
+        actions={secretIsStoredOnServer && (
+          <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, secret: ''})}>
+            {translate('pim_common.edit')}
+          </Button>
+        )}
         required={true}
-        value={storage.secret === undefined ? '****' : storage.secret}
-        readOnly={storage.secret === undefined}
+        value={secretIsStoredOnServer ? '••••••••' : storage.secret}
+        readOnly={secretIsStoredOnServer}
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.secret.label')}
         placeholder={translate('pim_import_export.form.job_instance.storage_form.secret.placeholder')}
         onChange={(secret: string) => storage.secret !== undefined && onStorageChange({...storage, secret})}
         errors={filterErrors(validationErrors, '[secret]')}
-      >
-        {storage.secret === undefined && (
-          <Button level="primary" onClick={() => {onStorageChange({...storage, secret: ''})}}>
-            Edit password
-          </Button>
-        )}
-      </TextField>
+      />
       <CheckStorageForm>
         <CheckStorageConnection>
           <Button onClick={checkReliability} disabled={!canCheckConnection} level="primary">

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
@@ -74,12 +74,14 @@ const AmazonS3StorageConfigurator = ({
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.secret.label')}
         placeholder={translate('pim_import_export.form.job_instance.storage_form.secret.placeholder')}
-        onChange={(secret: string) => onStorageChange({...storage, secret})}
+        onChange={(secret: string) => storage.secret !== undefined && onStorageChange({...storage, secret})}
         errors={filterErrors(validationErrors, '[secret]')}
       >
-        <Button level="primary" onClick={function noRefCheck() {}}>
-          Primary
-        </Button>
+        {storage.secret === undefined && (
+          <Button level="primary" onClick={() => {onStorageChange({...storage, secret: ''})}}>
+            Edit password
+          </Button>
+        )}
       </TextField>
       <CheckStorageForm>
         <CheckStorageConnection>

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/AmazonS3StorageConfigurator.tsx
@@ -69,13 +69,18 @@ const AmazonS3StorageConfigurator = ({
       />
       <TextField
         required={true}
-        value={storage.secret}
+        value={storage.secret === undefined ? '****' : storage.secret}
+        readOnly={storage.secret === undefined}
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.secret.label')}
         placeholder={translate('pim_import_export.form.job_instance.storage_form.secret.placeholder')}
         onChange={(secret: string) => onStorageChange({...storage, secret})}
         errors={filterErrors(validationErrors, '[secret]')}
-      />
+      >
+        <Button level="primary" onClick={function noRefCheck() {}}>
+          Primary
+        </Button>
+      </TextField>
       <CheckStorageForm>
         <CheckStorageConnection>
           <Button onClick={checkReliability} disabled={!canCheckConnection} level="primary">

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/LocalStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/LocalStorageConfigurator.test.tsx
@@ -13,6 +13,7 @@ test('it renders the local storage configurator', () => {
 
   renderWithProviders(
     <LocalStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -32,6 +33,7 @@ test('it allows user to fill local storage file_path field', () => {
 
   renderWithProviders(
     <LocalStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -66,6 +68,7 @@ test('it throws an exception when passing a non-local storage', () => {
   expect(() =>
     renderWithProviders(
       <LocalStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -95,6 +98,7 @@ test('it displays validation errors', () => {
 
   renderWithProviders(
     <LocalStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={validationErrors}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {screen, act} from '@testing-library/react';
 import {renderWithProviders, ValidationError} from '@akeneo-pim-community/shared';
-import {AmazonS3Storage, LocalStorage, MicrosoftAzureStorage} from '../model';
+import {LocalStorage, MicrosoftAzureStorage} from '../model';
 import {MicrosoftAzureStorageConfigurator} from './MicrosoftAzureStorageConfigurator';
-import {AmazonS3StorageConfigurator} from "./AmazonS3StorageConfigurator";
 
 beforeEach(() => {
   global.fetch = mockFetch;
@@ -141,7 +140,7 @@ test('it allows user to fill container name field', async () => {
   });
 });
 
-test('it hide connection string field if the connection string is obfuscated', () => {
+test('it hides connection string field if the connection string is obfuscated', () => {
   const storage: MicrosoftAzureStorage = {
     type: 'microsoft_azure',
     file_path: '/tmp/file.xlsx',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.test.tsx
@@ -31,6 +31,7 @@ test('it renders the microsoft azure storage configurator', async () => {
   await act(async () => {
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -57,6 +58,7 @@ test('it allows user to fill file_path field', async () => {
   await act(async () => {
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -86,6 +88,7 @@ test('it allows user to fill connection string field', async () => {
   await act(async () => {
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -115,6 +118,7 @@ test('it allows user to fill container name field', async () => {
   await act(async () => {
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -147,6 +151,7 @@ test('it throws an exception when passing a non microsoft azure storage', async 
   expect(() =>
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -193,6 +198,7 @@ test('it displays validation errors', async () => {
   await act(async () => {
     renderWithProviders(
       <MicrosoftAzureStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={validationErrors}
@@ -218,6 +224,7 @@ test('it can check connection', async () => {
 
   renderWithProviders(
     <MicrosoftAzureStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -248,6 +255,7 @@ test('it cannot check connection if a field is empty', async () => {
 
   renderWithProviders(
     <MicrosoftAzureStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -283,6 +291,7 @@ test('it can check connection, display message if error', async () => {
 
   renderWithProviders(
     <MicrosoftAzureStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.tsx
@@ -46,11 +46,18 @@ const MicrosoftAzureStorageConfigurator = ({
         errors={filterErrors(validationErrors, '[file_path]')}
       />
       <TextField
-        actions={connectionStringIsStoredOnServer && (
-          <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, connection_string: ''})}>
-            {translate('pim_common.edit')}
-          </Button>
-        )}
+        actions={
+          connectionStringIsStoredOnServer && (
+            <Button
+              level="secondary"
+              ghost={true}
+              size="small"
+              onClick={() => onStorageChange({...storage, connection_string: ''})}
+            >
+              {translate('pim_common.edit')}
+            </Button>
+          )
+        }
         required={true}
         value={connectionStringIsStoredOnServer ? '••••••••' : storage.connection_string}
         readOnly={connectionStringIsStoredOnServer}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/MicrosoftAzureStorageConfigurator.tsx
@@ -19,6 +19,7 @@ const CheckStorageConnection = styled.div`
 `;
 
 const MicrosoftAzureStorageConfigurator = ({
+  jobInstanceCode,
   storage,
   fileExtension,
   validationErrors,
@@ -28,8 +29,9 @@ const MicrosoftAzureStorageConfigurator = ({
     throw new Error(`Invalid storage type "${storage.type}" for microsoft azure storage configurator`);
   }
 
+  const connectionStringIsStoredOnServer = storage.connection_string === undefined;
   const translate = useTranslate();
-  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(storage);
+  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(jobInstanceCode, storage);
 
   return (
     <>
@@ -44,8 +46,14 @@ const MicrosoftAzureStorageConfigurator = ({
         errors={filterErrors(validationErrors, '[file_path]')}
       />
       <TextField
+        actions={connectionStringIsStoredOnServer && (
+          <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, connection_string: ''})}>
+            {translate('pim_common.edit')}
+          </Button>
+        )}
         required={true}
-        value={storage.connection_string}
+        value={connectionStringIsStoredOnServer ? '••••••••' : storage.connection_string}
+        readOnly={connectionStringIsStoredOnServer}
         type="password"
         label={translate('pim_import_export.form.job_instance.storage_form.connection_string.label')}
         placeholder={translate('pim_import_export.form.job_instance.storage_form.connection_string.placeholder')}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {screen, act} from '@testing-library/react';
 import {renderWithProviders, ValidationError} from '@akeneo-pim-community/shared';
-import {LocalStorage, MicrosoftAzureStorage, SftpStorage} from '../model';
+import {LocalStorage, SftpStorage} from '../model';
 import {SftpStorageConfigurator} from './SftpStorageConfigurator';
-import {MicrosoftAzureStorageConfigurator} from "./MicrosoftAzureStorageConfigurator";
 
 beforeEach(() => {
   global.fetch = mockFetch;
@@ -390,7 +389,7 @@ test('it allows user to fill password field', async () => {
   expect(onStorageChange).toHaveBeenLastCalledWith({...storage, password: 'root'});
 });
 
-test('it hide password field if the password is obfuscated', async() => {
+test('it hides password field if the password is obfuscated', async () => {
   const storage: SftpStorage = {
     type: 'sftp',
     file_path: '',
@@ -420,7 +419,7 @@ test('it hide password field if the password is obfuscated', async() => {
   expect(connectionStringInput).toHaveValue('••••••••');
 });
 
-test('it can edit the password field if the password is obfuscated', async() => {
+test('it can edit the password field if the password is obfuscated', async () => {
   const storage: SftpStorage = {
     type: 'sftp',
     file_path: '',

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
@@ -40,6 +40,7 @@ test('it renders the sftp storage configurator', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -68,6 +69,7 @@ test('it allows user to fill file_path field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -100,6 +102,7 @@ test('it allows user to fill host field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -132,6 +135,7 @@ test('it allows user to fill fingerprint field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -168,6 +172,7 @@ test('it removes fingerprint from model when clearing input', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -200,6 +205,7 @@ test('it allows user to fill port field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -232,6 +238,7 @@ test('it allows user to change login type', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -265,6 +272,7 @@ test('it displays a public key field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -301,6 +309,7 @@ test('it copy to clipboard a public key', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -330,6 +339,7 @@ test('it allows user to fill username field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -362,6 +372,7 @@ test('it allows user to fill password field', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -389,6 +400,7 @@ test('it throws an exception when passing a non-sftp storage', async () => {
   expect(() =>
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={[]}
@@ -460,6 +472,7 @@ test('it displays validation errors', async () => {
   await act(async () => {
     renderWithProviders(
       <SftpStorageConfigurator
+        jobInstanceCode="csv_product_export"
         storage={storage}
         fileExtension="xlsx"
         validationErrors={validationErrors}
@@ -491,6 +504,7 @@ test('it can check connection', async () => {
 
   renderWithProviders(
     <SftpStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}
@@ -537,6 +551,7 @@ test('it can check connection, display message if error', async () => {
 
   renderWithProviders(
     <SftpStorageConfigurator
+      jobInstanceCode="csv_product_export"
       storage={storage}
       fileExtension="xlsx"
       validationErrors={[]}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
@@ -71,6 +71,7 @@ const CopyableIcon = styled(CopyIcon)`
 `;
 
 const SftpStorageConfigurator = ({
+  jobInstanceCode,
   storage,
   fileExtension,
   validationErrors,
@@ -82,8 +83,9 @@ const SftpStorageConfigurator = ({
 
   const translate = useTranslate();
   const portValidationErrors = filterErrors(validationErrors, '[port]');
-  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(storage);
+  const [isValid, canCheckConnection, checkReliability] = useCheckStorageConnection(jobInstanceCode, storage);
   const publicKey = useGetPublicKey();
+  const passwordIsStoredOnServer = storage.login_type === 'password' && storage.password === undefined;
 
   const canCopyToClipboard = (): boolean => 'clipboard' in navigator;
   const copyToClipboard = (publicKey: string) => canCopyToClipboard() && navigator.clipboard.writeText(publicKey);
@@ -168,7 +170,13 @@ const SftpStorageConfigurator = ({
       />
       {storage.login_type === 'password' ? (
         <TextField
-          value={storage.password ?? ''}
+          actions={passwordIsStoredOnServer && (
+            <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, password: ''})}>
+              {translate('pim_common.edit')}
+            </Button>
+          )}
+          value={passwordIsStoredOnServer ? '••••••••' : storage.password ?? ''}
+          readOnly={passwordIsStoredOnServer}
           required={true}
           type="password"
           label={translate('pim_import_export.form.job_instance.storage_form.password.label')}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
@@ -170,11 +170,18 @@ const SftpStorageConfigurator = ({
       />
       {storage.login_type === 'password' ? (
         <TextField
-          actions={passwordIsStoredOnServer && (
-            <Button level="secondary" ghost={true} size="small" onClick={() => onStorageChange({...storage, password: ''})}>
-              {translate('pim_common.edit')}
-            </Button>
-          )}
+          actions={
+            passwordIsStoredOnServer && (
+              <Button
+                level="secondary"
+                ghost={true}
+                size="small"
+                onClick={() => onStorageChange({...storage, password: ''})}
+              >
+                {translate('pim_common.edit')}
+              </Button>
+            )
+          }
           value={passwordIsStoredOnServer ? '••••••••' : storage.password ?? ''}
           readOnly={passwordIsStoredOnServer}
           required={true}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
@@ -19,6 +19,7 @@ type StorageLoginType = 'password' | 'private_key';
 const STORAGE_LOGIN_TYPES = ['password', 'private_key'];
 
 type StorageConfiguratorProps = {
+  jobInstanceCode: string;
   storage: Storage;
   fileExtension: string;
   onStorageChange: (storage: Storage) => void;

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/model.ts
@@ -78,28 +78,14 @@ const isAmazonS3Storage = (storage: Storage): storage is AmazonS3Storage => {
   return (
     'amazon_s3' === storage.type &&
     'file_path' in storage &&
-    typeof 'file_path' === 'string' &&
     'region' in storage &&
-    typeof 'region' === 'string' &&
     'bucket' in storage &&
-    typeof 'bucket' === 'string' &&
-    'key' in storage &&
-    typeof 'key' === 'string' &&
-    'secret' in storage &&
-    typeof 'secret' === 'string'
+    'key' in storage
   );
 };
 
 const isMicrosoftAzureStorage = (storage: Storage): storage is MicrosoftAzureStorage => {
-  return (
-    'microsoft_azure' === storage.type &&
-    'file_path' in storage &&
-    typeof 'file_path' === 'string' &&
-    'connection_string' in storage &&
-    typeof 'connection_string' === 'string' &&
-    'container_name' in storage &&
-    typeof 'container_name' === 'string'
-  );
+  return 'microsoft_azure' === storage.type && 'file_path' in storage && 'container_name' in storage;
 };
 
 export type {StorageConfiguratorProps, StorageLoginType};

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.test.tsx
@@ -44,6 +44,7 @@ test('it renders the storage form', async () => {
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -67,6 +68,7 @@ test('it triggers onStorageChange callback when storage configurator onStorageCh
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -96,6 +98,7 @@ test('it does not render the storage form configurator if storage is none', asyn
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -119,6 +122,7 @@ test('it renders the storage form configurator if storage is local', async () =>
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -148,6 +152,7 @@ test('it renders the storage form configurator if storage is sftp', async () => 
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -176,6 +181,7 @@ test('it can select a local storage', async () => {
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"
@@ -205,6 +211,7 @@ test('it can select a sftp storage', async () => {
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="csv"
@@ -254,6 +261,7 @@ test('it displays validation errors', async () => {
   await act(async () => {
     renderWithProviders(
       <StorageForm
+        jobInstanceCode="csv_product_export"
         jobType="export"
         storage={storage}
         fileExtension="xlsx"

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.tsx
@@ -13,7 +13,14 @@ type StorageFormProps = {
   onStorageChange: (storage: Storage) => void;
 };
 
-const StorageForm = ({jobInstanceCode, jobType, fileExtension, storage, validationErrors, onStorageChange}: StorageFormProps) => {
+const StorageForm = ({
+  jobInstanceCode,
+  jobType,
+  fileExtension,
+  storage,
+  validationErrors,
+  onStorageChange,
+}: StorageFormProps) => {
   const translate = useTranslate();
   const featureFlags = useFeatureFlags();
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageForm.tsx
@@ -5,6 +5,7 @@ import {Storage, isValidStorageType, getDefaultStorage, JobType, getEnabledStora
 import {getStorageConfigurator} from './StorageConfigurator';
 
 type StorageFormProps = {
+  jobInstanceCode: string;
   jobType: JobType;
   fileExtension: string;
   storage: Storage;
@@ -12,7 +13,7 @@ type StorageFormProps = {
   onStorageChange: (storage: Storage) => void;
 };
 
-const StorageForm = ({jobType, fileExtension, storage, validationErrors, onStorageChange}: StorageFormProps) => {
+const StorageForm = ({jobInstanceCode, jobType, fileExtension, storage, validationErrors, onStorageChange}: StorageFormProps) => {
   const translate = useTranslate();
   const featureFlags = useFeatureFlags();
 
@@ -49,6 +50,7 @@ const StorageForm = ({jobType, fileExtension, storage, validationErrors, onStora
       </Field>
       {null !== StorageConfigurator && (
         <StorageConfigurator
+          jobInstanceCode={jobInstanceCode}
           storage={storage}
           fileExtension={fileExtension}
           validationErrors={validationErrors}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/model.ts
@@ -16,7 +16,7 @@ type SftpStorage = {
   port: number;
   login_type: StorageLoginType;
   username: string;
-  password: string | null;
+  password?: string | null;
 };
 
 type AmazonS3Storage = {
@@ -25,13 +25,13 @@ type AmazonS3Storage = {
   region: string;
   bucket: string;
   key: string;
-  secret: string;
+  secret?: string;
 };
 
 type MicrosoftAzureStorage = {
   type: 'microsoft_azure';
   file_path: string;
-  connection_string: string;
+  connection_string?: string;
   container_name: string;
 };
 

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.test.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.test.ts
@@ -17,7 +17,7 @@ test('connection healthy', async () => {
     username: 'sftp',
     password: 'password',
   };
-  const {result} = renderHookWithProviders(() => useCheckStorageConnection(storage));
+  const {result} = renderHookWithProviders(() => useCheckStorageConnection("csv_product_export", storage));
   const [, , checkReliability] = result.current;
 
   await act(async () => {
@@ -44,7 +44,7 @@ test('connection not healthy returns false', async () => {
     username: 'sftp',
     password: 'password',
   };
-  const {result} = renderHookWithProviders(() => useCheckStorageConnection(storage));
+  const {result} = renderHookWithProviders(() => useCheckStorageConnection("csv_product_export", storage));
   const [, , checkReliability] = result.current;
 
   await act(async () => {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.test.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.test.ts
@@ -17,7 +17,7 @@ test('connection healthy', async () => {
     username: 'sftp',
     password: 'password',
   };
-  const {result} = renderHookWithProviders(() => useCheckStorageConnection("csv_product_export", storage));
+  const {result} = renderHookWithProviders(() => useCheckStorageConnection('csv_product_export', storage));
   const [, , checkReliability] = result.current;
 
   await act(async () => {
@@ -44,7 +44,7 @@ test('connection not healthy returns false', async () => {
     username: 'sftp',
     password: 'password',
   };
-  const {result} = renderHookWithProviders(() => useCheckStorageConnection("csv_product_export", storage));
+  const {result} = renderHookWithProviders(() => useCheckStorageConnection('csv_product_export', storage));
   const [, , checkReliability] = result.current;
 
   await act(async () => {

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.ts
@@ -27,10 +27,10 @@ const isMicrosoftAzureConnectionFieldFulfilled = (storage: MicrosoftAzureStorage
   return '' !== storage.connection_string && '' !== storage.container_name && '' !== storage.file_path;
 };
 
-const useCheckStorageConnection = (storage: SftpStorage | AmazonS3Storage | MicrosoftAzureStorage) => {
+const useCheckStorageConnection = (jobInstanceCode: string, storage: SftpStorage | AmazonS3Storage | MicrosoftAzureStorage) => {
   const [isValid, setValid] = useState<boolean | undefined>(undefined);
   const [isChecking, setIsChecking] = useState<boolean>(false);
-  const route = useRoute('pimee_job_automation_get_storage_connection_check');
+  const route = useRoute('pimee_job_automation_get_storage_connection_check', {jobInstanceCode});
 
   const canCheckConnection =
     !isChecking &&

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/hooks/useCheckStorageConnection.ts
@@ -27,7 +27,10 @@ const isMicrosoftAzureConnectionFieldFulfilled = (storage: MicrosoftAzureStorage
   return '' !== storage.connection_string && '' !== storage.container_name && '' !== storage.file_path;
 };
 
-const useCheckStorageConnection = (jobInstanceCode: string, storage: SftpStorage | AmazonS3Storage | MicrosoftAzureStorage) => {
+const useCheckStorageConnection = (
+  jobInstanceCode: string,
+  storage: SftpStorage | AmazonS3Storage | MicrosoftAzureStorage
+) => {
   const [isValid, setValid] = useState<boolean | undefined>(undefined);
   const [isChecking, setIsChecking] = useState<boolean>(false);
   const route = useRoute('pimee_job_automation_get_storage_connection_check', {jobInstanceCode});

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistrySpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistrySpec.php
@@ -3,6 +3,7 @@
 namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security;
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security\CredentialsEncrypter;
+use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use PhpSpec\ObjectBehavior;
 
 class CredentialsEncrypterRegistrySpec extends ObjectBehavior
@@ -31,6 +32,17 @@ class CredentialsEncrypterRegistrySpec extends ObjectBehavior
         ],
     ];
 
+    private const OBFUSCATED_DATA = [
+        'configuration' => [
+            'storage' => [
+                'type' => 'sftp',
+                'username' => 'username',
+                'host' => 'host',
+                'port' => '22',
+            ],
+        ],
+    ];
+
     public function let(
         CredentialsEncrypter $encrypter,
     ) {
@@ -49,12 +61,23 @@ class CredentialsEncrypterRegistrySpec extends ObjectBehavior
         $this->encryptCredentials(self::CLEAR_DATA)->shouldReturn(self::ENCRYPTED_DATA);
     }
 
-    public function it_decrypts_credentials(
+    public function it_obfuscates_credentials(
         CredentialsEncrypter $encrypter,
     ) {
         $this->beConstructedWith([$encrypter]);
-        $this->decryptCredentials(self::ENCRYPTED_DATA)->shouldReturn(self::CLEAR_DATA);
+        $this->obfuscateCredentials(self::CLEAR_DATA)->shouldReturn(self::OBFUSCATED_DATA);
     }
+
+//    public function it_merges_credentials(
+//        CredentialsEncrypter $encrypter,
+//    ) {
+//        $this->beConstructedWith([$encrypter]);
+//
+//        $jobInstance = new JobInstance();
+//        $jobInstance->setRawParameters();
+//
+//        $this->mergeCredentials(self::OBFUSCATED_DATA)->shouldReturn(self::CLEAR_DATA);
+//    }
 
     public function it_returns_data_as_it_is_if_no_encrypter_supports_it()
     {

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistrySpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/Security/CredentialsEncrypterRegistrySpec.php
@@ -8,6 +8,18 @@ use PhpSpec\ObjectBehavior;
 
 class CredentialsEncrypterRegistrySpec extends ObjectBehavior
 {
+    private const PREVIOUS_DATA = [
+        'configuration' => [
+            'storage' => [
+                'type' => 'sftp',
+                'username' => 'username',
+                'host' => 'host',
+                'port' => '22',
+                'password' => 'another_secret',
+            ],
+        ],
+    ];
+
     private const CLEAR_DATA = [
         'configuration' => [
             'storage' => [
@@ -50,15 +62,15 @@ class CredentialsEncrypterRegistrySpec extends ObjectBehavior
         $encrypter->support(self::CLEAR_DATA)->willReturn(true);
         $encrypter->support(self::ENCRYPTED_DATA)->willReturn(true);
 
-        $encrypter->encryptCredentials(self::CLEAR_DATA)->willReturn(self::ENCRYPTED_DATA);
-        $encrypter->decryptCredentials(self::ENCRYPTED_DATA)->willReturn(self::CLEAR_DATA);
+        $encrypter->encryptCredentials(self::PREVIOUS_DATA, self::CLEAR_DATA)->willReturn(self::ENCRYPTED_DATA);
+        $encrypter->obfuscateCredentials(self::CLEAR_DATA)->willReturn(self::OBFUSCATED_DATA);
     }
 
     public function it_encrypts_credentials(
         CredentialsEncrypter $encrypter,
     ) {
         $this->beConstructedWith([$encrypter]);
-        $this->encryptCredentials(self::CLEAR_DATA)->shouldReturn(self::ENCRYPTED_DATA);
+        $this->encryptCredentials(self::PREVIOUS_DATA, self::CLEAR_DATA)->shouldReturn(self::ENCRYPTED_DATA);
     }
 
     public function it_obfuscates_credentials(
@@ -68,20 +80,9 @@ class CredentialsEncrypterRegistrySpec extends ObjectBehavior
         $this->obfuscateCredentials(self::CLEAR_DATA)->shouldReturn(self::OBFUSCATED_DATA);
     }
 
-//    public function it_merges_credentials(
-//        CredentialsEncrypter $encrypter,
-//    ) {
-//        $this->beConstructedWith([$encrypter]);
-//
-//        $jobInstance = new JobInstance();
-//        $jobInstance->setRawParameters();
-//
-//        $this->mergeCredentials(self::OBFUSCATED_DATA)->shouldReturn(self::CLEAR_DATA);
-//    }
-
     public function it_returns_data_as_it_is_if_no_encrypter_supports_it()
     {
-        $this->encryptCredentials(self::CLEAR_DATA)->shouldReturn(self::CLEAR_DATA);
-        $this->decryptCredentials(self::ENCRYPTED_DATA)->shouldReturn(self::ENCRYPTED_DATA);
+        $this->encryptCredentials(self::PREVIOUS_DATA, self::CLEAR_DATA)->shouldReturn(self::CLEAR_DATA);
+        $this->obfuscateCredentials(self::CLEAR_DATA)->shouldReturn(self::CLEAR_DATA);
     }
 }

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizerSpec.php
@@ -77,7 +77,7 @@ class JobInstanceNormalizerSpec extends ObjectBehavior
         );
     }
 
-    function it_obfuscate_credentials_on_job_instance(JobInstance $jobinstance)
+    function it_obfuscates_credentials_on_job_instance(JobInstance $jobinstance)
     {
         $jobinstance->getCode()->willReturn('product_export');
         $jobinstance->getLabel()->willReturn('Product export');

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Normalizer/Versioning/JobInstanceNormalizerSpec.php
@@ -2,6 +2,8 @@
 
 namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Normalizer\Versioning;
 
+use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security\CredentialsEncrypter;
+use Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\Security\CredentialsEncrypterRegistry;
 use Akeneo\Platform\Bundle\ImportExportBundle\Normalizer\Versioning\JobInstanceNormalizer;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use PhpSpec\ObjectBehavior;
@@ -9,6 +11,29 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class JobInstanceNormalizerSpec extends ObjectBehavior
 {
+    const CLEAR_SFTP_STORAGE_CONFIGURATION = [
+        'type' => 'sftp',
+        'username' => 'username',
+        'host' => 'host',
+        'port' => '22',
+        'password' => 's3cr3t',
+    ];
+
+    const OBFUSCATED_SFTP_STORAGE_CONFIGURATION = [
+        'type' => 'sftp',
+        'username' => 'username',
+        'host' => 'host',
+        'port' => '22',
+    ];
+
+    function let(CredentialsEncrypter $credentialsEncrypter)
+    {
+        $credentialsEncrypterRegistry = new CredentialsEncrypterRegistry([$credentialsEncrypter->getWrappedObject()]);
+        $credentialsEncrypter->support(self::CLEAR_SFTP_STORAGE_CONFIGURATION)->willReturn(true);
+        $credentialsEncrypter->obfuscateCredentials(self::CLEAR_SFTP_STORAGE_CONFIGURATION)->willReturn(self::OBFUSCATED_SFTP_STORAGE_CONFIGURATION);
+        $this->beConstructedWith($credentialsEncrypterRegistry);
+    }
+
     function it_is_initializable()
     {
         $this->shouldHaveType(JobInstanceNormalizer::class);
@@ -48,6 +73,35 @@ class JobInstanceNormalizerSpec extends ObjectBehavior
                 'connector'     => 'myconnector',
                 'type'          => 'EXPORT',
                 'configuration' => '{"delimiter":";"}'
+            ]
+        );
+    }
+
+    function it_obfuscate_credentials_on_job_instance(JobInstance $jobinstance)
+    {
+        $jobinstance->getCode()->willReturn('product_export');
+        $jobinstance->getLabel()->willReturn('Product export');
+        $jobinstance->getConnector()->willReturn('myconnector');
+        $jobinstance->getType()->willReturn('EXPORT');
+        $jobinstance->getJobName()->willReturn('csv_product_export');
+        $jobinstance->getRawParameters()->willReturn(
+            [
+                'storage' => self::CLEAR_SFTP_STORAGE_CONFIGURATION,
+                'delimiter' => ';'
+            ]
+        );
+
+        $this->normalize($jobinstance)->shouldReturn(
+            [
+                'code'          => 'product_export',
+                'job_name'      => 'csv_product_export',
+                'label'         => 'Product export',
+                'connector'     => 'myconnector',
+                'type'          => 'EXPORT',
+                'configuration' => json_encode([
+                    'storage' => self::OBFUSCATED_SFTP_STORAGE_CONFIGURATION,
+                    'delimiter' => ';'
+                ])
             ]
         );
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR: 
- I removed the fact that the secret are displayed in the UI. The secret/password are not directly displayed to the user (the input type is password) but is available in network and in the DOM. Now the password is never returned to user, the secret key is not returned to the front. By doing this we can distinguish when the secret is empty because the user give an empty secret or because the secret is obfuscated. 

The used can edit the password without having the previous password displayed by clicking on edit

- I removed the fact that the hashed password is displayed into the history

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
