### PR TITLE
Fix compiler pass broken due to FOSRestBundle upgrade

### DIFF
--- a/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/DependencyInjection/Compiler/ContentTypeNegotiatorPass.php
@@ -5,7 +5,9 @@ namespace Akeneo\Tool\Bundle\ApiBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\RequestMatcher;
 
 /**
  * Compiler pass to add rules to the content type negotiator.
@@ -64,9 +66,7 @@ class ContentTypeNegotiatorPass implements CompilerPassInterface
         $id = 'pim_api.content_type_negotiator.request_matcher.'.md5($serialized).sha1($serialized);
 
         if (!$container->hasDefinition($id)) {
-            $container
-                ->setDefinition($id, new ChildDefinition('fos_rest.format_request_matcher'))
-                ->setArguments($arguments);
+            $container->setDefinition($id, new Definition(RequestMatcher::class, $arguments));
         }
 
         return new Reference($id);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

We use a service of FOSRestBundle which was removed in the last version.

see https://github.com/FriendsOfSymfony/FOSRestBundle/pull/2377

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
