### PR TITLE
PIM-10787: Do not run the remove completeness job when there is no need

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -414,6 +414,7 @@
 - PIM-10217: Fix cannot quick export product model when id is not present in grid context
 - PIM-10212: Prevent spaces in locale codes
 - PIM-10218: Remove previous scope filter before moving the new one
+- PIM-10787 [Backport PIM-10516]: Do not run the remove completeness job when there is no need
 
 ## New features
 

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -199,6 +199,7 @@ $rules = [
 
         // TIP-931: SearchQueryBuilder design problem
         'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder',
+        'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult',
 
         // TIP-932: KeepOnlyValuesForVariation should use the public API related to the root aggregate Family Variant
         'Akeneo\Pim\Structure\Component\Model\CommonAttributeCollection',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -127,9 +127,8 @@ services:
             - '@pim_notification.notifier'
             - '@pim_notification.factory.notification'
             - '@pim_catalog.query.product_query_builder_factory'
+            - '@pim_catalog.repository.product'
             - '@pim_catalog.repository.channel'
-            - '@pim_catalog.repository.locale'
-            - '@pim_catalog.saver.locale'
             - '@pim_catalog.saver.product'
             - '%pim_job_product_batch_size%'
         public: false

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTasklet.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTasklet.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Job;
 
+use Akeneo\Channel\Component\Model\ChannelInterface;
+use Akeneo\Channel\Component\Model\LocaleInterface;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
-use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Platform\Bundle\NotificationBundle\NotifierInterface;
 use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\Connector\Step\TaskletInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * When a channel is updated, products completenesses related to channel and locales need to be cleaned.
@@ -24,56 +26,18 @@ use Psr\Log\LoggerInterface;
  */
 class RemoveCompletenessForChannelAndLocaleTasklet implements TaskletInterface
 {
-    /** @var EntityManagerClearerInterface */
-    private $cacheClearer;
-
-    /** @var NotifierInterface */
-    private $notifier;
-
-    /** @var SimpleFactoryInterface */
-    private $notificationFactory;
-
-    /** @var ProductQueryBuilderFactoryInterface */
-    private $productQueryBuilderFactory;
-
-    /** @var ChannelRepositoryInterface */
-    private $channelRepository;
-
-    /** @var LocaleRepositoryInterface */
-    private $localeRepository;
-
-    /** @var BulkSaverInterface */
-    private $localeBulkSaver;
-
-    /** @var int */
-    private $productBatchSize;
-
-    /** @var StepExecution */
-    private $stepExecution;
-
-    /** @var BulkSaverInterface */
-    private $productBulkSaver;
+    private StepExecution $stepExecution;
 
     public function __construct(
-        EntityManagerClearerInterface $cacheClearer,
-        NotifierInterface $notifier,
-        SimpleFactoryInterface $notificationFactory,
-        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
-        ChannelRepositoryInterface $channelRepository,
-        LocaleRepositoryInterface $localeRepository,
-        BulkSaverInterface $localeBulkSaver,
-        BulkSaverInterface $productBulkSaver,
-        int $productBatchSize
+        private EntityManagerClearerInterface $cacheClearer,
+        private NotifierInterface $notifier,
+        private SimpleFactoryInterface $notificationFactory,
+        private ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        private CursorableRepositoryInterface $productRepository,
+        private ChannelRepositoryInterface $channelRepository,
+        private BulkSaverInterface $productBulkSaver,
+        private int $productBatchSize
     ) {
-        $this->cacheClearer = $cacheClearer;
-        $this->notifier = $notifier;
-        $this->notificationFactory = $notificationFactory;
-        $this->productQueryBuilderFactory = $productQueryBuilderFactory;
-        $this->channelRepository = $channelRepository;
-        $this->localeRepository = $localeRepository;
-        $this->localeBulkSaver = $localeBulkSaver;
-        $this->productBatchSize = $productBatchSize;
-        $this->productBulkSaver = $productBulkSaver;
     }
 
     public function setStepExecution(StepExecution $stepExecution)
@@ -83,43 +47,37 @@ class RemoveCompletenessForChannelAndLocaleTasklet implements TaskletInterface
 
     public function execute(): void
     {
-        $jobParameters = $this->stepExecution->getJobParameters();
-        $localesIdentifiers = $jobParameters->get('locales_identifier');
-        $channelCode = $jobParameters->get('channel_code');
+        if (!$this->shouldRun()) {
+            return;
+        }
 
-        $usersToNotify = [$jobParameters->get('username')];
+        $usersToNotify = [$this->stepExecution->getJobParameters()->get('username')];
         $this->notifyUsersItBegins($usersToNotify);
 
-        $products = $this->productQueryBuilderFactory->create()->execute();
-        $productsToClean = [];
-        foreach ($products as $product) {
-            $productsToClean[] = $product;
+        $productIdentifiers = $this->productQueryBuilderFactory->create()->execute();
+        $productIdentifiersToClean = [];
+        /** @var IdentifierResult $productIdentifier */
+        foreach ($productIdentifiers as $productIdentifier) {
+            $productIdentifiersToClean[] = $productIdentifier->getIdentifier();
 
-            if (count($productsToClean) >= $this->productBatchSize) {
-                $this->cleanProducts($productsToClean);
+            if (count($productIdentifiersToClean) >= $this->productBatchSize) {
+                $products = $this->productRepository->getItemsFromIdentifiers($productIdentifiersToClean);
+                $this->cleanProducts($products);
                 $this->cacheClearer->clear();
-                $productsToClean = [];
+                $productIdentifiersToClean = [];
             }
         }
 
-        if (!empty($productsToClean)) {
-            $this->cleanProducts($productsToClean);
-        }
-        $channel = $this->channelRepository->findOneByIdentifier($channelCode);
-        $locales = $this->localeRepository->findBy(['code' => $localesIdentifiers]);
-        foreach ($locales as $locale) {
-            $locale->removeChannel($channel);
-        }
-
-        if (!empty($locales)) {
-            $this->localeBulkSaver->saveAll($locales);
+        if (!empty($productIdentifiersToClean)) {
+            $products = $this->productRepository->getItemsFromIdentifiers($productIdentifiersToClean);
+            $this->cleanProducts($products);
         }
         $this->notifyUsersItIsDone($usersToNotify);
     }
 
-    private function cleanProducts(array $productIdentifiers): void
+    private function cleanProducts(array $products): void
     {
-        $this->productBulkSaver->saveAll($productIdentifiers, ['force_save' => true]);
+        $this->productBulkSaver->saveAll($products, ['force_save' => true]);
     }
 
     private function notifyUsersItBegins(array $users): void
@@ -146,5 +104,28 @@ class RemoveCompletenessForChannelAndLocaleTasklet implements TaskletInterface
                 'showReportButton' => false
             ]);
         $this->notifier->notify($doneNotif, $users);
+    }
+
+    private function shouldRun(): bool
+    {
+        $jobParameters = $this->stepExecution->getJobParameters();
+        $channelCode = $jobParameters->get('channel_code');
+        /** @var ?ChannelInterface $channel */
+        $channel = $this->channelRepository->findOneByIdentifier($channelCode);
+        if (null === $channel) {
+            return true;
+        }
+
+        $localeCodes = $jobParameters->get('locales_identifier');
+        $currentLocaleCodes = $channel->getLocales()->map(
+            static fn (LocaleInterface $locale): string => $locale->getCode()
+        );
+        foreach ($localeCodes as $localeCode) {
+            if (!$currentLocaleCodes->contains($localeCode)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/RemoveCompletenessForChannelAndLocaleTaskletSpec.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Job;
 
-use Akeneo\Channel\Component\Model\ChannelInterface;
-use Akeneo\Channel\Component\Model\LocaleInterface;
+use Akeneo\Channel\Component\Model\Channel;
+use Akeneo\Channel\Component\Model\Locale;
 use Akeneo\Channel\Component\Repository\ChannelRepositoryInterface;
-use Akeneo\Channel\Component\Repository\LocaleRepositoryInterface;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderFactoryInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\ProductQueryBuilderInterface;
 use Akeneo\Platform\Bundle\NotificationBundle\Entity\Notification;
@@ -18,49 +19,80 @@ use Akeneo\Tool\Component\Batch\Model\StepExecution;
 use Akeneo\Tool\Component\StorageUtils\Cache\EntityManagerClearerInterface;
 use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\CursorableRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
 {
-    public function it_executes_the_job_cleans_products_and_channel(
-        StepExecution $stepExecution,
+    public function let(
+        EntityManagerClearerInterface $cacheClearer,
         NotifierInterface $notifier,
         SimpleFactoryInterface $notificationFactory,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
-        ProductQueryBuilderInterface $pqb,
-        CursorInterface $productsCursor,
-        EntityManagerClearerInterface $cacheClearer,
+        CursorableRepositoryInterface $productRepository,
         ChannelRepositoryInterface $channelRepository,
-        LocaleRepositoryInterface $localeRepository,
-        ChannelInterface $ecommerce,
-        LocaleInterface $enUs,
-        LocaleInterface $frFR,
-        BulkSaverInterface $localeBulkSaver,
-        BulkSaverInterface $productBulkSaver
-    ): void {
+        BulkSaverInterface $productBulkSaver,
+        StepExecution $stepExecution,
+        JobParameters $jobParameters
+    ) {
+        $enUS = new Locale();
+        $enUS->setCode('en_US');
+        $frFr = new Locale();
+        $frFr->setCode('fr_FR');
+        $esEs = new Locale();
+        $esEs->setCode('es_ES');
+        $channel = new Channel();
+        $channel->addLocale($enUS);
+        $channel->addLocale($frFr);
+        $channel->addLocale($esEs);
+
+        $channelRepository->findOneByIdentifier('ecommerce')->willReturn($channel);
+        $channelRepository->findOneByIdentifier(Argument::not('ecommerce'))->willReturn(null);
+
         $this->beConstructedWith(
             $cacheClearer,
             $notifier,
             $notificationFactory,
             $productQueryBuilderFactory,
+            $productRepository,
             $channelRepository,
-            $localeRepository,
-            $localeBulkSaver,
             $productBulkSaver,
             2
         );
+        $stepExecution->getJobParameters()->willReturn($jobParameters);
         $this->setStepExecution($stepExecution);
+    }
+
+    function it_does_nothing_if_locales_are_still_bound_to_channel(
+        NotifierInterface $notifier,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        JobParameters $jobParameters
+    ) {
+        $jobParameters->get('channel_code')->willReturn('ecommerce');
+        $jobParameters->get('locales_identifier')->willReturn(['en_US', 'fr_FR']);
+        $productQueryBuilderFactory->create()->shouldNotBeCalled();
+        $notifier->notify(Argument::cetera())->shouldNotBeCalled();
+
+        $this->execute();
+    }
+
+    function it_executes_the_job_if_channel_does_not_exist_anymore(
+        NotifierInterface $notifier,
+        SimpleFactoryInterface $notificationFactory,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        CursorableRepositoryInterface $productRepository,
+        BulkSaverInterface $productBulkSaver,
+        JobParameters $jobParameters,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor,
+    ) {
+        $jobParameters->get('channel_code')->willReturn('unknown');
+        $jobParameters->get('locales_identifier')->willReturn(['de_DE', 'it_IT']);
+        $jobParameters->get('username')->willReturn('willypapa');
 
         $jeanProduct = (new Product())->setIdentifier('jean');
-        $shoeProduct = (new Product())->setIdentifier('shoe');
-        $hatProduct = (new Product())->setIdentifier('hat');
-        $jobParameters = new JobParameters([
-            'locales_identifier' => ['en_US', 'fr_FR'],
-            'channel_code' => 'ecommerce',
-            'username' => 'willypapa'
-        ]);
-        $stepExecution->getJobParameters()->willReturn($jobParameters);
 
         $startNotification = new Notification();
         $doneNotification = new Notification();
@@ -72,18 +104,62 @@ class RemoveCompletenessForChannelAndLocaleTaskletSpec extends ObjectBehavior
         $pqb->execute()->willReturn($productsCursor);
 
         $productsCursor->rewind()->shouldBeCalled();
-        $productsCursor->current()->willReturn($jeanProduct, $shoeProduct, $hatProduct);
+        $productsCursor->current()->willReturn(
+            new IdentifierResult('jean', ProductInterface::class),
+        );
+        $productsCursor->next()->shouldBeCalled();
+        $productsCursor->valid()->willReturn(true, false);
+
+        $productRepository->getItemsFromIdentifiers(['jean'])->willReturn([$jeanProduct]);
+
+        $productBulkSaver->saveAll([$jeanProduct], ['force_save' => true])->shouldBeCalledOnce();
+
+        $this->execute();
+    }
+
+    function it_executes_the_job_cleans_products_and_channel(
+        EntityManagerClearerInterface $cacheClearer,
+        NotifierInterface $notifier,
+        SimpleFactoryInterface $notificationFactory,
+        ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
+        CursorableRepositoryInterface $productRepository,
+        BulkSaverInterface $productBulkSaver,
+        JobParameters $jobParameters,
+        ProductQueryBuilderInterface $pqb,
+        CursorInterface $productsCursor
+    ): void {
+        $jeanProduct = (new Product())->setIdentifier('jean');
+        $shoeProduct = (new Product())->setIdentifier('shoe');
+        $hatProduct = (new Product())->setIdentifier('hat');
+
+        $jobParameters->get('channel_code')->willReturn('ecommerce');
+        $jobParameters->get('locales_identifier')->willReturn(['de_DE', 'it_IT']);
+        $jobParameters->get('username')->willReturn('willypapa');
+
+        $startNotification = new Notification();
+        $doneNotification = new Notification();
+        $notificationFactory->create()->willReturn($startNotification, $doneNotification);
+        $notifier->notify($startNotification, ['willypapa'])->shouldBeCalled();
+        $notifier->notify($doneNotification, ['willypapa'])->shouldBeCalled();
+
+        $productQueryBuilderFactory->create()->willReturn($pqb);
+        $pqb->execute()->willReturn($productsCursor);
+
+        $productsCursor->rewind()->shouldBeCalled();
+        $productsCursor->current()->willReturn(
+            new IdentifierResult('jean', ProductInterface::class),
+            new IdentifierResult('shoe', ProductInterface::class),
+            new IdentifierResult('hat', ProductInterface::class)
+        );
         $productsCursor->next()->shouldBeCalled();
         $productsCursor->valid()->willReturn(true, true, true, false);
 
+        $productRepository->getItemsFromIdentifiers(['jean', 'shoe'])->willReturn([$jeanProduct, $shoeProduct]);
+        $productRepository->getItemsFromIdentifiers(['hat'])->willReturn([$hatProduct]);
         $cacheClearer->clear()->shouldBeCalled();
 
-        $channelRepository->findOneByIdentifier('ecommerce')->willReturn($ecommerce);
-        $localeRepository->findBy(['code' => ['en_US', 'fr_FR']])->willReturn([$enUs, $frFR]);
-        $enUs->removeChannel($ecommerce)->shouldBeCalled();
-        $frFR->removeChannel($ecommerce)->shouldBeCalled();
-
-        $localeBulkSaver->saveAll([$enUs, $frFR])->shouldBeCalled();
+        $productBulkSaver->saveAll([$jeanProduct, $shoeProduct], ['force_save' => true])->shouldBeCalledOnce();
+        $productBulkSaver->saveAll([$hatProduct], ['force_save' => true])->shouldBeCalledOnce();
 
         $this->execute();
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

[[BACKPORT PIM-10516]](https://github.com/akeneo/pim-community-dev/pull/17366)

When removing a locale from a channel, and re-adding it before the remove_completeness_for_channel_and_locale, the job would re-remove it, possibly deactivating the locale if it's not bound to another channel
This PR:

- ensures the job does nothing if the provided locales are still in the channel
- and moreover, ensures the job DOES NOT update the locales, as it's not its role (it's only here to clean product values, recompute completeness and reindex products)

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [x] Changelog (maintenance bug fixes)