### PR TITLE
OCT-207: limit catalogs coverage to unit & inte, not perfs

### DIFF
--- a/components/catalogs/Makefile
+++ b/components/catalogs/Makefile
@@ -123,7 +123,8 @@ catalogs-coverage-back:
 		--bootstrap $(CATALOGS_BOOTSTRAP_PATH) \
 		--log-junit var/tests/phpunit/phpunit_catalogs_global.xml \
 		--coverage-html coverage/Catalogs/Back/Global/ \
-		--coverage-filter $(CATALOGS_PATH)/back/src/
+		--coverage-filter $(CATALOGS_PATH)/back/src/ \
+		--testsuite Catalogs_Unit,Catalogs_Integration
 
 .PHONY: catalogs-mutation-back
 catalogs-mutation-back: var/infection.phar


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
