### PR TITLE
RAB-1266: Introduce a new param for VersionProvider

### DIFF
--- a/config/services/services.yml
+++ b/config/services/services.yml
@@ -5,6 +5,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     pim_ce_dev_src_folder_location: '%kernel.project_dir%'
+    version_file_folder_location: '%pim_ce_dev_src_folder_location%'
     index_hosts: '%env(APP_INDEX_HOSTS)%'
     product_and_product_model_index_name: '%env(APP_PRODUCT_AND_PRODUCT_MODEL_INDEX_NAME)%'
     connection_error_index_name: '%env(APP_CONNECTION_ERROR_INDEX_NAME)%'

--- a/src/Akeneo/Platform/Bundle/PimVersionBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/PimVersionBundle/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
         arguments:
             - !tagged_iterator pim_version
             - '%env(string:PIM_EDITION)%'
-            - '%kernel.project_dir%'
+            - '%version_file_folder_location%'
 
     Akeneo\Platform\Bundle\PimVersionBundle\Version\CommunityVersion:
         public: true


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

I introduced a new param for VersionProvider : `version_file_folder_location`.
Using kernel.project_dir does not work for standard edition, we have to search version.txt in the CE project path.
I used a new param instead of `pim_ce_dev_src_folder_location` because the location will change in EE.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
