### PR TITLE
Run tests against an upgraded dump in CI

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Event/InstallerEvents.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Event/InstallerEvents.php
@@ -12,11 +12,18 @@ namespace Akeneo\Platform\Bundle\InstallerBundle\Event;
 final class InstallerEvents
 {
     /**
-     * This event is dispatched after having installed the database
+     * This event is dispatched after having installed the database from the doctrine schema
      *
      * You can use it to create new tables that are not managed with doctrine.
      */
     const POST_DB_CREATE = 'pim_installer.post_db_create';
+
+    /**
+     * This event is dispatched after having installed the database from an empty dump and executed migrations on it
+     *
+     * You can use it to populate some tables with default values
+     */
+    const POST_DB_CREATE_FROM_DUMP = 'pim_installer.post_db_create_from_dump';
 
     /**
      * This event is dispatched before launching any assets dump command

--- a/src/Akeneo/Tool/Bundle/MeasureBundle/Installer/MeasurementInstaller.php
+++ b/src/Akeneo/Tool/Bundle/MeasureBundle/Installer/MeasurementInstaller.php
@@ -29,6 +29,7 @@ class MeasurementInstaller implements EventSubscriberInterface
     {
         return [
             InstallerEvents::POST_DB_CREATE => ['createMeasurementTableAndStandardMeasurementFamilies'],
+            InstallerEvents::POST_DB_CREATE_FROM_DUMP => ['createMeasurementTableAndStandardMeasurementFamilies'],
         ];
     }
 

--- a/upgrades/schema/Version_6_0_20210211141311_add_attribute_guidelines.php
+++ b/upgrades/schema/Version_6_0_20210211141311_add_attribute_guidelines.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -10,12 +12,14 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version_6_0_20210211141311_add_attribute_guidelines extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('pim_catalog_attribute')->hasColumn('guidelines'), 'nothing to do');
+
         $this->addSql('ALTER TABLE pim_catalog_attribute ADD guidelines JSON NOT NULL DEFAULT (JSON_OBJECT());');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20210222120000_create_events_api_debug_index.php
+++ b/upgrades/schema/Version_6_0_20210222120000_create_events_api_debug_index.php
@@ -41,6 +41,9 @@ implements ContainerAwareInterface
         );
 
         $client = new Client($builder, $configurationLoader, $hosts, $index);
+
+        $this->skipIf($client->hasIndexForAlias(), 'index already exists');
+
         $client->createIndex();
     }
 

--- a/upgrades/schema/Version_6_0_20210505180000_add_updated_to_category.php
+++ b/upgrades/schema/Version_6_0_20210505180000_add_updated_to_category.php
@@ -15,6 +15,8 @@ final class Version_6_0_20210505180000_add_updated_to_category extends AbstractM
 {
     public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('pim_catalog_category')->hasColumn('updated'), 'nothing to do');
+
         $this->addSql("ALTER TABLE pim_catalog_category ADD updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '(DC2Type:datetime)' AFTER created");
         $this->addSql("UPDATE pim_catalog_category SET updated = created");
         $this->addSql("CREATE INDEX updated_idx ON pim_catalog_category (updated)");

--- a/upgrades/schema/Version_6_0_20210524121906_add_profile_to_user.php
+++ b/upgrades/schema/Version_6_0_20210524121906_add_profile_to_user.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -7,12 +9,14 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version_6_0_20210524121906_add_profile_to_user extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('oro_user')->hasColumn('profile'), 'nothing to do');
+
         $this->addSql('ALTER TABLE oro_user ADD profile VARCHAR(255) NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20210727080505_add_client_id_and_user_id.php
+++ b/upgrades/schema/Version_6_0_20210727080505_add_client_id_and_user_id.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -11,8 +13,10 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version_6_0_20210727080505_add_client_id_and_user_id extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('pim_api_auth_code')->hasColumn('client_id'), 'nothing to do');
+
         $this->addSql('ALTER TABLE pim_api_auth_code ADD client_id INT DEFAULT NULL, ADD user_id INT DEFAULT NULL');
         $this->addSql('ALTER TABLE pim_api_auth_code ADD CONSTRAINT FK_AD5DC7C619EB6921 FOREIGN KEY (client_id) REFERENCES pim_api_client (id)');
         $this->addSql('ALTER TABLE pim_api_auth_code ADD CONSTRAINT FK_AD5DC7C6A76ED395 FOREIGN KEY (user_id) REFERENCES oro_user (id)');
@@ -20,7 +24,7 @@ final class Version_6_0_20210727080505_add_client_id_and_user_id extends Abstrac
         $this->addSql('CREATE INDEX IDX_USER_ID ON pim_api_auth_code (user_id)');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20210817135301_add_role_type_column.php
+++ b/upgrades/schema/Version_6_0_20210817135301_add_role_type_column.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -10,12 +12,14 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version_6_0_20210817135301_add_role_type_column extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('oro_access_role')->hasColumn('type'), 'nothing to do');
+
         $this->addSql('ALTER TABLE oro_access_role ADD type VARCHAR(30) DEFAULT NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20210818084017_add_marketplace_public_app_id.php
+++ b/upgrades/schema/Version_6_0_20210818084017_add_marketplace_public_app_id.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -11,12 +13,14 @@ use Doctrine\Migrations\AbstractMigration;
  */
 final class Version_6_0_20210818084017_add_marketplace_public_app_id extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
+        $this->skipIf($schema->getTable('pim_api_client')->hasColumn('marketplace_public_app_id'), 'nothing to do');
+
         $this->addSql('ALTER TABLE pim_api_client ADD marketplace_public_app_id VARCHAR(255) NULL DEFAULT NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20210819080024_add_warning_count_in_step_execution.php
+++ b/upgrades/schema/Version_6_0_20210819080024_add_warning_count_in_step_execution.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Pim\Upgrade\Schema;
 
@@ -7,15 +9,19 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version_6_0_20210819080024_add_warning_count_in_step_execution extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
-        $this->addSql(<<<SQL
-ALTER TABLE akeneo_batch_step_execution 
+        $this->skipIf($schema->getTable('akeneo_batch_step_execution')->hasColumn('warning_count'), 'nothing to do');
+
+        $this->addSql(
+            <<<SQL
+ALTER TABLE akeneo_batch_step_execution
 ADD COLUMN warning_count INT NOT NULL DEFAULT 0;
 SQL
         );
 
-        $this->addSql(<<<SQL
+        $this->addSql(
+            <<<SQL
 CREATE TABLE IF NOT EXISTS pim_one_time_task (
     `code` VARCHAR(100) PRIMARY KEY,
     `status` VARCHAR(100) NOT NULL,
@@ -27,7 +33,7 @@ SQL
         );
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_6_0_20211028125410_add_type_to_connection.php
+++ b/upgrades/schema/Version_6_0_20211028125410_add_type_to_connection.php
@@ -9,12 +9,14 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version_6_0_20211028125410_add_type_to_connection extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(schema $schema): void
     {
+        $this->skipIf($schema->getTable('akeneo_connectivity_connection')->hasColumn('type'), 'nothing to do');
+
         $this->addSql("ALTER TABLE akeneo_connectivity_connection ADD type VARCHAR(30) NOT NULL DEFAULT 'default'");
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
     }

--- a/upgrades/schema/Version_7_0_20220214101647_add_dqi_product_model_score_table.php
+++ b/upgrades/schema/Version_7_0_20220214101647_add_dqi_product_model_score_table.php
@@ -13,7 +13,7 @@ final class Version_7_0_20220214101647_add_dqi_product_model_score_table extends
     public function up(Schema $schema): void
     {
         $this->addSql(<<<SQL
-CREATE TABLE pim_data_quality_insights_product_model_score (
+CREATE TABLE IF NOT EXISTS pim_data_quality_insights_product_model_score (
     product_model_id INT NOT NULL PRIMARY KEY,
     evaluated_at DATE NOT NULL,
     scores JSON NOT NULL,

--- a/upgrades/schema/Version_7_0_20220616074214_add_product_selection_criteria_field_to_catalogs.php
+++ b/upgrades/schema/Version_7_0_20220616074214_add_product_selection_criteria_field_to_catalogs.php
@@ -15,11 +15,10 @@ final class Version_7_0_20220616074214_add_product_selection_criteria_field_to_c
 {
     public function up(Schema $schema): void
     {
-        if ($schema->getTable('akeneo_catalog')->hasColumn('product_selection_criteria')) {
-            $this->disableMigrationWarning();
-        }
+        $this->skipIf($schema->getTable('akeneo_catalog')->hasColumn('product_selection_criteria'), 'nothing to do');
 
-        $this->addSql(<<<SQL
+        $this->addSql(
+            <<<SQL
         ALTER TABLE akeneo_catalog
         ADD product_selection_criteria JSON NOT NULL DEFAULT (JSON_ARRAY()) AFTER is_enabled;
         SQL
@@ -29,10 +28,5 @@ final class Version_7_0_20220616074214_add_product_selection_criteria_field_to_c
     public function down(Schema $schema): void
     {
         $this->throwIrreversibleMigrationException();
-    }
-
-    private function disableMigrationWarning(): void
-    {
-        $this->addSql('SELECT 1');
     }
 }

--- a/upgrades/schema/Version_7_0_20220803111111_add_created_and_updated_date_to_connected_app_table.php
+++ b/upgrades/schema/Version_7_0_20220803111111_add_created_and_updated_date_to_connected_app_table.php
@@ -11,10 +11,13 @@ final class Version_7_0_20220803111111_add_created_and_updated_date_to_connected
 {
     public function up(Schema $schema): void
     {
-        $this->addSql(<<<SQL
+        $this->skipIf($schema->getTable('akeneo_connectivity_connected_app')->hasColumn('updated'), 'nothing to do');
+
+        $this->addSql(
+            <<<SQL
             ALTER TABLE akeneo_connectivity_connected_app
                 ADD updated DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER has_outdated_scopes,
-                ADD created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER has_outdated_scopes                
+                ADD created DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP AFTER has_outdated_scopes
             SQL
         );
     }


### PR DESCRIPTION
Run tests against a dump upgraded with migrations instead of doctrine schema. The goal is to run tests against something closer to what we actually have in production.

WIP