### PR TITLE
PIM-10791: Fix product and product model completeness compute on fami…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@
 - PIM-10750: Fix category code validation to allow '0'
 - PIM-10789: Fix password is displayed in SFTP and Amazon S3 form and encrypted password is displayed on history
 - PIM-10779: Fix lowercase on get attribute group code for dqi activation
+- PIM-10791: Fix product and product model completeness compute on attribute removal
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttribute.php
@@ -29,11 +29,6 @@ final class CountProductModelsWithRemovedAttribute implements CountProductModels
                 'attributes_for_this_level' => $attributesCodes,
             ],
         ]);
-        foreach ($attributesCodes as $attributeCode) {
-            $this->searchQueryBuilder->addShould([
-                'exists' => ['field' => sprintf('values.%s-*', $attributeCode)],
-            ]);
-        }
 
         $body = $this->searchQueryBuilder->getQuery();
         unset($body['_source']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttribute.php
@@ -29,11 +29,6 @@ final class CountProductsWithRemovedAttribute implements CountProductsWithRemove
                 'attributes_for_this_level' => $attributesCodes,
             ],
         ]);
-        foreach ($attributesCodes as $attributeCode) {
-            $this->searchQueryBuilder->addShould([
-                'exists' => ['field' => sprintf('values.%s-*', $attributeCode)],
-            ]);
-        }
 
         $body = $this->searchQueryBuilder->getQuery();
         unset($body['_source']);

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttribute.php
@@ -29,11 +29,6 @@ final class GetProductIdentifiersWithRemovedAttribute implements GetProductIdent
                 'attributes_for_this_level' => $attributesCodes,
             ],
         ]);
-        foreach ($attributesCodes as $attributeCode) {
-            $this->searchQueryBuilder->addShould([
-                'exists' => ['field' => sprintf('values.%s-*', $attributeCode)],
-            ]);
-        }
 
         $this->searchQueryBuilder->addSort([
             'identifier' => 'asc',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttribute.php
@@ -29,11 +29,6 @@ final class GetProductModelIdentifiersWithRemovedAttribute implements GetProduct
                 'attributes_for_this_level' => $attributesCodes,
             ],
         ]);
-        foreach ($attributesCodes as $attributeCode) {
-            $this->searchQueryBuilder->addShould([
-                'exists' => ['field' => sprintf('values.%s-*', $attributeCode)],
-            ]);
-        }
 
         $this->searchQueryBuilder->addSort([
             'identifier' => 'asc',


### PR DESCRIPTION
…ly's attribute removal

**Description (for Contributor and Core Developer)**

Issue before:
When a required attribute for a family was deleted, the completeness was not re-calculated on them.
Only products and product models having values for this deleted attribute were computed, although the completeness also changes for products/models without value (if the attribute was required, then the completeness raises).

Solution:
We retrieve all products and product models so they all get re-computed even if they have values or not.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
