### PR TITLE
CPM-924: Be able to work with previous database version

### DIFF
--- a/components/identifier-generator/back/src/Infrastructure/Repository/SqlIdentifierGeneratorRepository.php
+++ b/components/identifier-generator/back/src/Infrastructure/Repository/SqlIdentifierGeneratorRepository.php
@@ -266,7 +266,7 @@ SQL;
     private function isPreviousDatabaseVersion(): bool
     {
         $rows = $this->connection->fetchAllAssociative(<<<SQL
-SHOW COLUMNS FROM pim_catalog_identifier_generator LIKE target
+SHOW COLUMNS FROM pim_catalog_identifier_generator LIKE 'target'
 SQL);
 
         return count($rows) >= 1;


### PR DESCRIPTION
How it works
- Our code is deployed
- PHP container are restarted
- Migration are started.

During the little gap between "PHP new code is active" and "migration are not finished", we can have the scenario of a user saves a product. It implies a SELECT from the "pim_catalog_identifier_generator" table. These queries are looking for a "target_id" column, which will not be migrated and not existing.
In this case, we fallback in the previous query using "target".