### PR TITLE
Improve performance completeness table's UUID Migration

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCommand.php
@@ -36,6 +36,7 @@ class MigrateToUuidCommand extends Command
         MigrateToUuidStep $migrateToUuidFillJson,
         MigrateToUuidStep $migrateToUuidSetNotNullableUuidColumns,
         MigrateToUuidStep $migrateToUuidAddConstraints,
+        MigrateToUuidStep $migrateToUuidCompletenessTable,
         MigrateToUuidStep $migrateToUuidReindexElasticsearch,
         private LoggerInterface $logger,
         private Connection $connection
@@ -50,6 +51,7 @@ class MigrateToUuidCommand extends Command
             $migrateToUuidFillJson,
             $migrateToUuidSetNotNullableUuidColumns,
             $migrateToUuidAddConstraints,
+            $migrateToUuidCompletenessTable,
             $migrateToUuidReindexElasticsearch,
         ];
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCompletenessTable.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidCompletenessTable.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid;
+
+use Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\Utils\StatusAwareTrait;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The process is different for completeness
+ * Creating a temporary table without indexes and foreign keys allows us to speed up the process
+ *
+ * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class MigrateToUuidCompletenessTable implements MigrateToUuidStep
+{
+    use MigrateToUuidTrait;
+    use StatusAwareTrait;
+
+    const TABLE_NAME = 'pim_catalog_completeness';
+    const INSERT_BATCH_SIZE = 100000;
+
+    public function __construct(private Connection $connection, private LoggerInterface $logger)
+    {
+    }
+
+    public function getDescription(): string
+    {
+        return 'Migrates the completeness table';
+    }
+
+    public function getName(): string
+    {
+        return 'migrate_completeness_table';
+    }
+
+    public function shouldBeExecuted(): bool
+    {
+        return (bool) $this->connection->executeQuery(
+            <<<SQL
+SELECT EXISTS(SELECT * FROM pim_catalog_completeness WHERE product_uuid is null)
+SQL
+        )->fetchOne();
+    }
+
+    public function getMissingCount(): int
+    {
+        return $this->getMissingForeignUuidCount(
+            'pim_catalog_completeness',
+            'product_uuid',
+            'product_id'
+        );
+    }
+
+    private function getMissingForeignUuidCount(string $tableName, string $uuidColumnName, string $idColumnName): int
+    {
+        if (!$this->tableExists($tableName)) {
+            return 0;
+        }
+
+        return $this->getNullForeignUuidCellsCount($tableName, $uuidColumnName);
+    }
+
+    public function addMissing(Context $context): bool
+    {
+        $logContext = $context->logContext;
+        if ($context->dryRun()) {
+            return true;
+        }
+
+        if ($this->getMissingForeignUuidCount('pim_catalog_completeness', 'product_uuid', '') === 0) {
+            return true;
+        }
+
+        $this->connection->executeQuery(
+            <<<SQL
+DROP TABLE IF EXISTS pim_catalog_completeness_temp
+SQL
+        );
+
+        $this->logger->notice(sprintf('Will create the temporary completeness table'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+CREATE TABLE pim_catalog_completeness_temp (SELECT id, locale_id, channel_id, missing_count, required_count, product_uuid FROM pim_catalog_completeness WHERE 1 = 0)
+SQL
+        );
+
+        // Add primary key to speed up the lookup during inserts
+        $this->logger->notice(sprintf('Will set the primary key'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+ALTER TABLE pim_catalog_completeness_temp ADD PRIMARY KEY (id)
+SQL
+        );
+
+        // Insert uuids
+        $this->logger->notice(sprintf('Will insert data into temporary table'), $logContext->toArray());
+        do {
+            $count = $this->connection->executeQuery(
+                <<<SQL
+INSERT INTO pim_catalog_completeness_temp
+SELECT c.id, c.locale_id, c.channel_id, c.missing_count, c.required_count, p.uuid as product_uuid
+FROM pim_catalog_completeness c
+JOIN pim_catalog_product p on c.product_id = p.id
+WHERE c.id > :max_migrated_id
+LIMIT :batch_size
+SQL,
+                [
+                    'max_migrated_id' => $this->getMaxMigratedId() ?? 0,
+                    'batch_size' => self::INSERT_BATCH_SIZE
+                ],
+                [
+                    'batch_size' => Types::INTEGER
+                ]
+            )->rowCount();
+        } while ($count > 0);
+
+        // Put index on the uuid column
+        $this->logger->notice(sprintf('Will index on the temporary completeness table uuid column'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+CREATE INDEX product_uuid ON pim_catalog_completeness_temp (product_uuid)
+SQL
+        );
+
+        // Set uuids as not nullable
+        $this->logger->notice(sprintf('Will set the uuid column as not nullable'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+ALTER TABLE pim_catalog_completeness_temp
+MODIFY `product_uuid` BINARY(16) NOT NULL;
+SQL
+        );
+
+        // Drop original table
+        $this->logger->notice(sprintf('Will drop the original table'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+DROP TABLE pim_catalog_completeness;
+SQL
+        );
+
+        // Replace with temporary table which is now ready
+        $this->logger->notice(sprintf('Will rename the temporary table'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+RENAME TABLE pim_catalog_completeness_temp TO pim_catalog_completeness;
+SQL
+        );
+
+        // Temporarily disable foreign key checks
+        $this->logger->notice(sprintf('Will disable foreign key checks'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+SET FOREIGN_KEY_CHECKS=0
+SQL
+        );
+
+        // Add channel foreign key
+        $this->logger->notice(sprintf('Will add foreign key towards channels'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+ALTER TABLE pim_catalog_completeness
+    ADD CONSTRAINT `FK_113BA85472F5A1AA` FOREIGN KEY (`channel_id`)
+    REFERENCES `pim_catalog_channel` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE RESTRICT
+SQL
+        );
+
+        // Add locale foreign key
+        $this->logger->notice(sprintf('Will add foreign key towards locales'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+ALTER TABLE pim_catalog_completeness
+    ADD CONSTRAINT `FK_113BA854E559DFD1` FOREIGN KEY (`locale_id`)
+    REFERENCES `pim_catalog_locale` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE RESTRICT
+SQL
+        );
+
+        // Temporarily disable unique checks
+        $this->logger->notice(sprintf('Will disable unique checks'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+SET UNIQUE_CHECKS=0
+SQL
+        );
+
+        $this->logger->notice(sprintf('Will create unique constraint'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+ALTER TABLE pim_catalog_completeness
+    ADD CONSTRAINT `channel_locale_product_unique_idx` UNIQUE (`channel_id`,`locale_id`,`product_uuid`)
+SQL
+        );
+
+        // Re-enable checks
+        $this->logger->notice(sprintf('Will re-enable checks'), $logContext->toArray());
+        $this->connection->executeQuery(
+            <<<SQL
+SET UNIQUE_CHECKS=1
+SQL
+        );
+        $this->connection->executeQuery(
+            <<<SQL
+SET FOREIGN_KEY_CHECKS=1
+SQL
+        );
+
+        return true;
+    }
+
+    private function getNullForeignUuidCellsCount(string $tableName, string $uuidColumnName): int
+    {
+        $sql = <<<SQL
+SELECT COUNT(*)
+FROM {table_name}
+WHERE {table_name}.{uuid_column_name} IS NULL
+SQL;
+
+        $query = \strtr($sql, [
+            '{table_name}' => $tableName,
+            '{uuid_column_name}' => $uuidColumnName
+        ]);
+
+        return (int) $this->connection->fetchOne($query);
+    }
+
+    private function getMaxMigratedId(): mixed
+    {
+        return $this->connection->executeQuery(
+            <<<SQL
+SELECT MAX(id) from pim_catalog_completeness_temp
+SQL
+        )->fetchOne();
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidStep.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/MigrateToUuid/MigrateToUuidStep.php
@@ -79,16 +79,6 @@ interface MigrateToUuidStep
             self::INDEXES_INDEX => ['IDX_E0768BA35C977207' => ['product_uuid']],
             self::TEMPORARY_INDEXES_INDEX => [],
         ],
-        'pim_catalog_completeness' => [
-            self::ID_COLUMN_INDEX => 'product_id',
-            self::UUID_COLUMN_INDEX => 'product_uuid',
-            self::UUID_COLUMN_INDEX_NAME_INDEX => 'product_uuid',
-            self::PRIMARY_KEY_UUID_INDEX => null,
-            self::FOREIGN_KEY_INDEX => null,
-            self::UNIQUE_CONSTRAINTS_INDEX => ['channel_locale_product_unique_idx' => ['channel_id', 'locale_id', 'product_uuid']],
-            self::INDEXES_INDEX => [],
-            self::TEMPORARY_INDEXES_INDEX => [],
-        ],
         'pim_data_quality_insights_product_criteria_evaluation' => [
             self::ID_COLUMN_INDEX => 'product_id',
             self::UUID_COLUMN_INDEX => 'product_uuid',

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -60,6 +60,9 @@ services:
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidAddConstraints:
         parent: base_uuid_migration_step
 
+    Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCompletenessTable:
+        parent: base_uuid_migration_step
+
     Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidReindexElasticsearch:
         arguments:
             - '@database_connection'
@@ -78,6 +81,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidFillJson'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidSetNotNullableUuidColumns'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidAddConstraints'
+            - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidCompletenessTable'
             - '@Akeneo\Pim\Enrichment\Bundle\Command\MigrateToUuid\MigrateToUuidReindexElasticsearch'
             - '@monolog.logger'
             - '@database_connection'

--- a/upgrades/test_schema/Version_7_0_20220429131804_execute_uuid_migration_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220429131804_execute_uuid_migration_Integration.php
@@ -53,7 +53,7 @@ final class Version_7_0_20220429131804_execute_uuid_migration_Integration extend
         $this->assertJsonHaveUuid();
         $this->assertProductsAreReindexed();
         $this->assertColumnsAreNullable();
-        $this->assertNoGhostCompletenessRecords();
+        $this->assertCompletenessProductIdColumnNoLongerExists();
     }
 
     protected function setUp(): void
@@ -207,16 +207,16 @@ final class Version_7_0_20220429131804_execute_uuid_migration_Integration extend
         }
     }
 
-    private function assertNoGhostCompletenessRecords(): void
+    private function assertCompletenessProductIdColumnNoLongerExists(): void
     {
         Assert::assertSame(
             0,
             (int) $this->connection->executeQuery(<<<SQL
-            SELECT COUNT(c.id)
-            FROM pim_catalog_completeness c
-                LEFT JOIN pim_catalog_product p ON p.id = c.product_id
-            WHERE p.id IS NULL
-            SQL)->fetchOne()
+SELECT COUNT(*)
+FROM information_schema.columns
+WHERE table_name='pim_catalog_completeness' AND column_name='product_id'
+SQL
+            )->fetchOne()
         );
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Full process documentation : https://www.notion.so/akeneo/Accelerate-UUID-Migration-2de3f82092984c7cab713723531da46d#261a915eafef438fa0226565e8eed3e9

Short version : When upgrading database from v6 to v7, the process can take a very long time. One of the longest steps in a big database is the copy of product uuids to the pim_catalog_completeness table.

This PR changes how this table is populated, instead of inserting the uuid into the table, we create an empty copy of the table, in order to be able to insert the data without indexes/foreign keys to speed up the process.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
