### PR TITLE
CXP-1408: Adds feature flag to Catalogs

### DIFF
--- a/.circleci/jobs/install_front_dependencies.yml
+++ b/.circleci/jobs/install_front_dependencies.yml
@@ -26,7 +26,7 @@ jobs:
                                 name: Build front shared libraries
                                 command: |
                                     [ -d ~/project/front-packages/akeneo-design-system/lib ] || docker-compose run -u node --rm node yarn dsm:build
-                                    [ -d ~/project/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn shared:build
+                                    [ -d ~/project/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
                         -   persist_to_workspace:
                                 root: ~/
                                 paths:
@@ -51,7 +51,7 @@ jobs:
                                 name: Build front shared libraries
                                 command: |
                                     [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/akeneo-design-system/lib ] || docker-compose run -u node --rm node yarn dsm:build
-                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn shared:build
+                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
                         -   persist_to_workspace:
                                 root: ~/
                                 paths:

--- a/components/catalogs/back/.php_cd.php
+++ b/components/catalogs/back/.php_cd.php
@@ -62,6 +62,7 @@ $rules = [
             'Akeneo\Tool\Bundle\MeasureBundle\ServiceApi',
             'Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException',
             'Akeneo\Pim\Enrichment\Component\Product\Event\Connector\ReadProductsEvent', // For data flow monitoring
+            'Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags',
 
             /**********************************************************************************************************/
             /* Below are dependencies that we have, but we shouldn't rely on them.

--- a/components/catalogs/back/rector.php
+++ b/components/catalogs/back/rector.php
@@ -6,6 +6,7 @@ use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
 use Rector\CodingStyle\Rector\FuncCall\CountArrayToEmptyArrayComparisonRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
@@ -32,5 +33,9 @@ return static function (RectorConfig $rectorConfig): void {
         FlipTypeControlToUseExclusiveTypeRector::class,
         CountArrayToEmptyArrayComparisonRector::class,
         AddLiteralSeparatorToNumberRector::class,
+        StringClassNameToClassConstantRector::class => [
+            __DIR__ . '/tests/Acceptance/AuthenticationContext.php',
+            __DIR__ . '/tests/Integration/IntegrationTestCase.php',
+        ],
     ]);
 };

--- a/components/catalogs/back/src/Application/Persistence/Channel/GetChannelQueryInterface.php
+++ b/components/catalogs/back/src/Application/Persistence/Channel/GetChannelQueryInterface.php
@@ -11,7 +11,7 @@ namespace Akeneo\Catalogs\Application\Persistence\Channel;
 interface GetChannelQueryInterface
 {
     /**
-     * @return array{code: string, label: string}
+     * @return array{code: string, label: string}|null
      */
     public function execute(string $code): ?array;
 }

--- a/components/catalogs/back/src/Infrastructure/Persistence/Attribute/SearchAttributesQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Attribute/SearchAttributesQuery.php
@@ -24,14 +24,14 @@ final class SearchAttributesQuery implements SearchAttributesQueryInterface
      */
     public function execute(?string $search = null, int $page = 1, int $limit = 20, array $types = []): array
     {
-        $types = \array_map(fn ($type) => \sprintf('pim_catalog_%s', $type), $types);
+        $types = \array_map(fn ($type): string => \sprintf('pim_catalog_%s', $type), $types);
 
         $attributes = $this->searchableAttributeRepository->findBySearch(
             $search,
             [
                 'limit' => $limit,
                 'page' => $page,
-                'types' => empty($types) ? null : $types,
+                'types' => $types === [] ? null : $types,
             ],
         );
 

--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductQuery.php
@@ -95,7 +95,7 @@ class GetProductQuery implements GetProductQueryInterface
         foreach ($product['values'] as &$values) {
             $values = \array_values(\array_filter(
                 $values,
-                static fn (array $value) => $value['scope'] === null || \in_array($value['scope'], $channels, true)
+                static fn (array $value): bool => $value['scope'] === null || \in_array($value['scope'], $channels, true)
             ));
         }
 
@@ -116,7 +116,7 @@ class GetProductQuery implements GetProductQueryInterface
         foreach ($product['values'] as &$values) {
             $values = \array_values(\array_filter(
                 $values,
-                static fn (array $value) => $value['locale'] === null || \in_array($value['locale'], $locales, true)
+                static fn (array $value): bool => $value['locale'] === null || \in_array($value['locale'], $locales, true)
             ));
         }
 
@@ -144,7 +144,7 @@ class GetProductQuery implements GetProductQueryInterface
                 $value['data'] = \array_values(
                     \array_filter(
                         $value['data'],
-                        static fn (array $price) => \in_array($price['currency'], $currencies, true)
+                        static fn (array $price): bool => \in_array($price['currency'], $currencies, true)
                     )
                 );
             }

--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductUuidsQuery.php
@@ -56,7 +56,7 @@ final class GetProductUuidsQuery implements GetProductUuidsQueryInterface
         $results = $pqb->execute();
 
         return \array_map(
-            fn (IdentifierResult $result) => $this->getUuidFromIdentifierResult($result->getId()),
+            fn (IdentifierResult $result): string => $this->getUuidFromIdentifierResult($result->getId()),
             \iterator_to_array($results)
         );
     }

--- a/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductsWithFilteredValuesQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Catalog/Product/GetProductsWithFilteredValuesQuery.php
@@ -109,7 +109,7 @@ class GetProductsWithFilteredValuesQuery implements GetProductsWithFilteredValue
             foreach ($product['values'] as &$values) {
                 $values = \array_values(\array_filter(
                     $values,
-                    static fn (array $value) => $value['scope'] === null || \in_array($value['scope'], $channels)
+                    static fn (array $value): bool => $value['scope'] === null || \in_array($value['scope'], $channels)
                 ));
             }
         }
@@ -139,7 +139,7 @@ class GetProductsWithFilteredValuesQuery implements GetProductsWithFilteredValue
                     $value['data'] = \array_values(
                         \array_filter(
                             $value['data'],
-                            static fn (array $price) => \in_array($price['currency'], $currencies)
+                            static fn (array $price): bool => \in_array($price['currency'], $currencies)
                         )
                     );
                 }

--- a/components/catalogs/back/src/Infrastructure/Persistence/Channel/GetChannelsByCodeQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Channel/GetChannelsByCodeQuery.php
@@ -34,7 +34,7 @@ final class GetChannelsByCodeQuery implements GetChannelsByCodeQueryInterface
         );
 
         return \array_map(
-            static fn (ChannelInterface $channel) => [
+            static fn (ChannelInterface $channel): array => [
                 'code' => $channel->getCode(),
                 'label' => $channel->getLabel(),
             ],

--- a/components/catalogs/back/src/Infrastructure/Persistence/Channel/GetChannelsQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Channel/GetChannelsQuery.php
@@ -32,7 +32,7 @@ final class GetChannelsQuery implements GetChannelsQueryInterface
         );
 
         return \array_map(
-            static fn (ChannelInterface $channel) => [
+            static fn (ChannelInterface $channel): array => [
                 'code' => $channel->getCode(),
                 'label' => $channel->getLabel(),
             ],

--- a/components/catalogs/back/src/Infrastructure/Persistence/Family/GetFamiliesByCodeQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Family/GetFamiliesByCodeQuery.php
@@ -35,7 +35,7 @@ final class GetFamiliesByCodeQuery implements GetFamiliesByCodeQueryInterface
         );
 
         return \array_map(
-            static fn (FamilyInterface $family) => ['code' => $family->getCode(), 'label' => $family->getLabel()],
+            static fn (FamilyInterface $family): array => ['code' => $family->getCode(), 'label' => $family->getLabel()],
             $families
         );
     }

--- a/components/catalogs/back/src/Infrastructure/Persistence/Family/SearchFamilyQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Family/SearchFamilyQuery.php
@@ -34,7 +34,7 @@ final class SearchFamilyQuery implements SearchFamilyQueryInterface
         );
 
         return \array_map(
-            static fn (FamilyInterface $family) => ['code' => $family->getCode(), 'label' => $family->getLabel()],
+            static fn (FamilyInterface $family): array => ['code' => $family->getCode(), 'label' => $family->getLabel()],
             $families
         );
     }

--- a/components/catalogs/back/src/Infrastructure/Security/CatalogScopeMapper.php
+++ b/components/catalogs/back/src/Infrastructure/Security/CatalogScopeMapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Catalogs\Infrastructure\Security;
 
 use Akeneo\Connectivity\Connection\Infrastructure\Apps\Security\ScopeMapperInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 
 /**
  * @copyright 2022 Akeneo SAS (http://www.akeneo.com)
@@ -56,11 +57,20 @@ class CatalogScopeMapper implements ScopeMapperInterface
         ],
     ];
 
+    public function __construct(
+        private FeatureFlags $featureFlags,
+    ) {
+    }
+
     /**
      * {@inheritDoc}
      */
     public function getScopes(): array
     {
+        if (!$this->featureFlags->isEnabled('catalogs')) {
+            return [];
+        }
+
         return [
             self::SCOPE_READ_CATALOGS,
             self::SCOPE_WRITE_CATALOGS,
@@ -73,6 +83,10 @@ class CatalogScopeMapper implements ScopeMapperInterface
      */
     public function getAcls(string $scopeName): array
     {
+        if (!$this->featureFlags->isEnabled('catalogs')) {
+            return [];
+        }
+
         return self::SCOPE_ACL_MAP[$scopeName] ?? [];
     }
 
@@ -81,6 +95,10 @@ class CatalogScopeMapper implements ScopeMapperInterface
      */
     public function getMessage(string $scopeName): ?array
     {
+        if (!$this->featureFlags->isEnabled('catalogs')) {
+            return null;
+        }
+
         return self::SCOPE_MESSAGE_MAP[$scopeName] ?? null;
     }
 
@@ -89,6 +107,10 @@ class CatalogScopeMapper implements ScopeMapperInterface
      */
     public function getLowerHierarchyScopes(string $scopeName): array
     {
+        if (!$this->featureFlags->isEnabled('catalogs')) {
+            return [];
+        }
+
         return self::SCOPE_HIERARCHY[$scopeName] ?? [];
     }
 }

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/routing.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/routing.yml
@@ -1,5 +1,6 @@
 akeneo_catalogs_public:
     resource: ./routing/public.yml
+    defaults: { _feature: 'catalogs' }
 
 akeneo_catalogs_internal:
     resource: ./routing/internal.yml

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
@@ -49,6 +49,9 @@ services:
     Akeneo\Tool\Component\Api\Pagination\OffsetHalPaginator:
         alias: 'pim_api.pagination.offset_hal_paginator'
 
+    Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags:
+        alias: 'feature_flags'
+
     # @todo CXP-1186 REMOVE
     Akeneo\Catalogs\Infrastructure\TemporaryEnrichmentBridge\SearchAfterSizeUuidResultCursorFactory:
         arguments:

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductMapping/AttributeSourceContainsValidLocaleValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductMapping/AttributeSourceContainsValidLocaleValidator.php
@@ -104,7 +104,7 @@ final class AttributeSourceContainsValidLocaleValidator extends ConstraintValida
 
         $locales = $this->getLocalesQuery->execute();
 
-        $exists = \count(\array_filter($locales, static fn (array $locale) => $locale['code'] === $value['locale'])) > 0;
+        $exists = \count(\array_filter($locales, static fn (array $locale): bool => $locale['code'] === $value['locale'])) > 0;
 
         if (!$exists) {
             $this->context
@@ -139,7 +139,7 @@ final class AttributeSourceContainsValidLocaleValidator extends ConstraintValida
             return;
         }
 
-        $exists = \count(\array_filter($locales, static fn (array $locale) => $locale['code'] === $value['locale'])) > 0;
+        $exists = \count(\array_filter($locales, static fn (array $locale): bool => $locale['code'] === $value['locale'])) > 0;
 
         if (!$exists) {
             $this->context

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidLocaleValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidLocaleValidator.php
@@ -104,7 +104,7 @@ final class AttributeCriterionContainsValidLocaleValidator extends ConstraintVal
 
         $locales = $this->getLocalesQuery->execute();
 
-        $exists = \count(\array_filter($locales, static fn (array $locale) => $locale['code'] === $value['locale'])) > 0;
+        $exists = \count(\array_filter($locales, static fn (array $locale): bool => $locale['code'] === $value['locale'])) > 0;
 
         if (!$exists) {
             $this->context
@@ -139,7 +139,7 @@ final class AttributeCriterionContainsValidLocaleValidator extends ConstraintVal
             return;
         }
 
-        $exists = \count(\array_filter($locales, static fn (array $locale) => $locale['code'] === $value['locale'])) > 0;
+        $exists = \count(\array_filter($locales, static fn (array $locale): bool => $locale['code'] === $value['locale'])) > 0;
 
         if (!$exists) {
             $this->context

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidMeasurementValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/AttributeCriterionContainsValidMeasurementValidator.php
@@ -54,7 +54,7 @@ final class AttributeCriterionContainsValidMeasurementValidator extends Constrai
             throw new \LogicException('Measurement family not found');
         }
 
-        $units = \array_map(static fn (array $row) => $row['code'], $measurementFamily['units']);
+        $units = \array_map(static fn (array $row): string => $row['code'], $measurementFamily['units']);
 
         if (!\in_array($value['value']['unit'], $units, true)) {
             $this->context

--- a/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/CriterionContainsScopeAndLocaleValidator.php
+++ b/components/catalogs/back/src/Infrastructure/Validation/ProductSelection/CriterionContainsScopeAndLocaleValidator.php
@@ -52,7 +52,7 @@ final class CriterionContainsScopeAndLocaleValidator extends ConstraintValidator
 
         $locales = $this->getChannelLocalesQuery->execute($value['scope']);
 
-        $exists = \count(\array_filter($locales, static fn (array $locale) => $locale['code'] === $value['locale'])) > 0;
+        $exists = \count(\array_filter($locales, static fn (array $locale): bool => $locale['code'] === $value['locale'])) > 0;
 
         if (!$exists) {
             $this->context

--- a/components/catalogs/back/tests/Acceptance/AuthenticationContext.php
+++ b/components/catalogs/back/tests/Acceptance/AuthenticationContext.php
@@ -95,7 +95,6 @@ class AuthenticationContext implements Context
     private function addAllPermissionsUserGroup(string $group): void
     {
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupAttributeGroupPermissionsSaver',
             group: $group,
             permissions: [
@@ -110,7 +109,6 @@ class AuthenticationContext implements Context
             ]
         );
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupLocalePermissionsSaver',
             group: $group,
             permissions: [
@@ -125,7 +123,6 @@ class AuthenticationContext implements Context
             ]
         );
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupCategoryPermissionsSaver',
             group: $group,
             permissions: [

--- a/components/catalogs/back/tests/Integration/Fakes/TimestampableSubscriber.php
+++ b/components/catalogs/back/tests/Integration/Fakes/TimestampableSubscriber.php
@@ -20,7 +20,7 @@ final class TimestampableSubscriber implements EventSubscriber
     ) {
     }
 
-    public function getSubscribedEvents()
+    public function getSubscribedEvents(): array
     {
         return [
             Events::prePersist,

--- a/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/UpdateProductMappingSchemaActionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Controller/Public/UpdateProductMappingSchemaActionTest.php
@@ -204,7 +204,7 @@ class UpdateProductMappingSchemaActionTest extends IntegrationTestCase
     /**
      * @dataProvider validVersionedProductMappingSchemaProvider
      */
-    public function testItCreatesTheProductMapping(string $productMappingSchema, $expectedProductMapping): void
+    public function testItCreatesTheProductMapping(string $productMappingSchema, array $expectedProductMapping): void
     {
         $this->client = $this->getAuthenticatedPublicApiClient([
             'write_catalogs',
@@ -277,7 +277,7 @@ class UpdateProductMappingSchemaActionTest extends IntegrationTestCase
     /**
      * @dataProvider validVersionedProductMappingSchemaProviderWithMoreAndLessTargets
      */
-    public function testItUpdatesTheProductMapping(string $productMappingSchema, $expectedProductMapping): void
+    public function testItUpdatesTheProductMapping(string $productMappingSchema, array $expectedProductMapping): void
     {
         $this->client = $this->getAuthenticatedPublicApiClient([
             'write_catalogs',

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/CatalogUpdatePayloadTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/CatalogUpdatePayloadTest.php
@@ -88,7 +88,7 @@ class CatalogUpdatePayloadTest extends IntegrationTestCase
     {
         $violations = $this->validator->validate([
             'enabled' => true,
-            'product_selection_criteria' => \array_map(fn () => [
+            'product_selection_criteria' => \array_map(fn (): array => [
                 'field' => 'enabled',
                 'operator' => '=',
                 'value' => true,

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/AttributeSource/AbstractAttributeSourceTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/AttributeSource/AbstractAttributeSourceTest.php
@@ -75,7 +75,7 @@ abstract class AbstractAttributeSourceTest extends IntegrationTestCase
         $this->getChannelQuery = $this->createMock(GetChannelQueryInterface::class);
         $this->getChannelQuery
             ->method('execute')
-            ->willReturnCallback(fn ($code) => $this->channels[$code] ?? null);
+            ->willReturnCallback(fn ($code): ?array => $this->channels[$code] ?? null);
         self::getContainer()->set(GetChannelQuery::class, $this->getChannelQuery);
 
         $this->getLocalesQuery = $this->createMock(GetLocalesQueryInterface::class);

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/SystemSource/UuidSourceTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/SystemSource/UuidSourceTest.php
@@ -42,7 +42,7 @@ class UuidSourceTest extends IntegrationTestCase
     /**
      * @dataProvider invalidDataProvider
      */
-    public function testItReturnsViolationsWhenInvalid(array $source, $expectedMessage): void
+    public function testItReturnsViolationsWhenInvalid(array $source, string $expectedMessage): void
     {
         $violations = $this->validator->validate($source, new UuidSource());
 

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AbstractAttributeCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/AttributeCriterion/AbstractAttributeCriterionTest.php
@@ -88,10 +88,10 @@ abstract class AbstractAttributeCriterionTest extends IntegrationTestCase
                 function ($code, $options): array {
                     $intersection = \array_filter(
                         $this->attributeOptions[$code] ?? [],
-                        static fn ($option) => \in_array($option, $options)
+                        static fn ($option): bool => \in_array($option, $options)
                     );
 
-                    return \array_map(static fn ($option) => [
+                    return \array_map(static fn ($option): array => [
                         'code' => $option,
                         'label' => '['.$option.']',
                     ], $intersection);
@@ -102,7 +102,7 @@ abstract class AbstractAttributeCriterionTest extends IntegrationTestCase
         $this->getChannelQuery = $this->createMock(GetChannelQueryInterface::class);
         $this->getChannelQuery
             ->method('execute')
-            ->willReturnCallback(fn ($code) => $this->channels[$code] ?? null);
+            ->willReturnCallback(fn ($code): ?array => $this->channels[$code] ?? null);
         self::getContainer()->set(GetChannelQuery::class, $this->getChannelQuery);
 
         $this->getLocalesQuery = $this->createMock(GetLocalesQueryInterface::class);

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/AbstractSystemCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/AbstractSystemCriterionTest.php
@@ -62,7 +62,7 @@ abstract class AbstractSystemCriterionTest extends IntegrationTestCase
         $this->getChannelQuery = $this->createMock(GetChannelQueryInterface::class);
         $this->getChannelQuery
             ->method('execute')
-            ->willReturnCallback(fn ($code) => $this->channels[$code] ?? null);
+            ->willReturnCallback(fn ($code): ?array => $this->channels[$code] ?? null);
         self::getContainer()->set(GetChannelQuery::class, $this->getChannelQuery);
     }
 
@@ -91,7 +91,7 @@ abstract class AbstractSystemCriterionTest extends IntegrationTestCase
             ->willReturnCallback(function (array $codes, int $page = 1, int $limit = 20): array {
                 $filteredFamilies = \array_filter(
                     $this->families,
-                    static fn (array $family) => \in_array($family['code'], $codes, true)
+                    static fn (array $family): bool => \in_array($family['code'], $codes, true)
                 );
                 return \array_slice($filteredFamilies, ($page - 1) * $limit, $limit);
             });
@@ -107,7 +107,7 @@ abstract class AbstractSystemCriterionTest extends IntegrationTestCase
             ->method('execute')
             ->willReturnCallback(fn (array $codes): array => \array_filter(
                 $this->categories,
-                static fn (array $category) => \in_array($category['code'], $codes, true)
+                static fn (array $category): bool => \in_array($category['code'], $codes, true)
             ));
         self::getContainer()->set(GetCategoriesByCodeQuery::class, $this->getCategoriesByCodeQuery);
     }

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/CompletenessCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/CompletenessCriterionTest.php
@@ -79,7 +79,7 @@ class CompletenessCriterionTest extends AbstractSystemCriterionTest
     /**
      * @dataProvider invalidDataProvider
      */
-    public function testItReturnsViolationsWhenInvalid(array $criterion, $expectedMessage): void
+    public function testItReturnsViolationsWhenInvalid(array $criterion, string $expectedMessage): void
     {
         $violations = $this->validator->validate($criterion, new CompletenessCriterion());
 

--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/EnabledCriterionTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductSelection/SystemCriterion/EnabledCriterionTest.php
@@ -57,7 +57,7 @@ class EnabledCriterionTest extends AbstractSystemCriterionTest
     /**
      * @dataProvider invalidDataProvider
      */
-    public function testItReturnsViolationsWhenInvalid(array $criterion, $expectedMessage): void
+    public function testItReturnsViolationsWhenInvalid(array $criterion, string $expectedMessage): void
     {
         $violations = $this->validator->validate($criterion, new EnabledCriterion());
 

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -28,6 +28,7 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use Akeneo\Test\IntegrationTestsBundle\Helper\ExperimentalTransactionHelper;
 use Akeneo\UserManagement\Component\Model\GroupInterface;
 use Akeneo\UserManagement\Component\Model\UserInterface;
@@ -81,6 +82,8 @@ abstract class IntegrationTestCase extends WebTestCase
 
         self::getContainer()->get('pim_connector.doctrine.cache_clearer')->clear();
         self::getContainer()->get(ExperimentalTransactionHelper::class)->beginTransactions();
+
+        self::getContainer()->get(FeatureFlags::class)->enable('catalogs');
     }
 
     protected function overrideServices(): void

--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -203,7 +203,6 @@ abstract class IntegrationTestCase extends WebTestCase
     private function addAllPermissionsUserGroup(string $group): void
     {
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupAttributeGroupPermissionsSaver',
             group: $group,
             permissions: [
@@ -218,7 +217,6 @@ abstract class IntegrationTestCase extends WebTestCase
             ]
         );
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupLocalePermissionsSaver',
             group: $group,
             permissions: [
@@ -233,7 +231,6 @@ abstract class IntegrationTestCase extends WebTestCase
             ]
         );
         $this->callPermissionsSaver(
-            /** @noRector StringClassNameToClassConstantRector */
             service: 'Akeneo\Pim\Permission\Bundle\Saver\UserGroupCategoryPermissionsSaver',
             group: $group,
             permissions: [
@@ -284,7 +281,7 @@ abstract class IntegrationTestCase extends WebTestCase
                 \implode(
                     '","',
                     \array_map(
-                        fn (ConstraintViolationInterface $violation) => $violation->getMessage(),
+                        fn (ConstraintViolationInterface $violation): string|\Stringable => $violation->getMessage(),
                         \iterator_to_array($violations)
                     )
                 )

--- a/components/catalogs/back/tests/Unit/Infrastructure/Security/CatalogScopeMapperTest.php
+++ b/components/catalogs/back/tests/Unit/Infrastructure/Security/CatalogScopeMapperTest.php
@@ -22,7 +22,7 @@ class CatalogScopeMapperTest extends TestCase
     {
         $this->featureFlagIsEnabled = true;
         $this->featureFlags = $this->createMock(FeatureFlags::class);
-        $this->featureFlags->method('isEnabled')->will($this->returnCallback(fn () => $this->featureFlagIsEnabled));
+        $this->featureFlags->method('isEnabled')->will($this->returnCallback(fn (): bool => $this->featureFlagIsEnabled));
 
         $this->mapper = new CatalogScopeMapper($this->featureFlags);
     }
@@ -46,7 +46,7 @@ class CatalogScopeMapperTest extends TestCase
     /**
      * @dataProvider acls
      */
-    public function testItReturnsAclsForOneScope(string $scope, $expected): void
+    public function testItReturnsAclsForOneScope(string $scope, array $expected): void
     {
         $this->assertEquals($expected, $this->mapper->getAcls($scope));
     }
@@ -76,7 +76,7 @@ class CatalogScopeMapperTest extends TestCase
     /**
      * @dataProvider messages
      */
-    public function testItReturnsMessagesForOneScope(string $scope, $expected): void
+    public function testItReturnsMessagesForOneScope(string $scope, ?array $expected): void
     {
         $this->assertEquals($expected, $this->mapper->getMessage($scope));
     }
@@ -118,7 +118,7 @@ class CatalogScopeMapperTest extends TestCase
     /**
      * @dataProvider hierarchy
      */
-    public function testItReturnsLowerHierarchyScopesForOneScope(string $scope, $expected): void
+    public function testItReturnsLowerHierarchyScopesForOneScope(string $scope, array $expected): void
     {
         $this->assertEquals($expected, $this->mapper->getLowerHierarchyScopes($scope));
     }

--- a/components/catalogs/back/tests/Unit/Infrastructure/Security/CatalogScopeMapperTest.php
+++ b/components/catalogs/back/tests/Unit/Infrastructure/Security/CatalogScopeMapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Catalogs\Test\Unit\Infrastructure\Security;
 
 use Akeneo\Catalogs\Infrastructure\Security\CatalogScopeMapper;
+use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlags;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,11 +14,24 @@ use PHPUnit\Framework\TestCase;
  */
 class CatalogScopeMapperTest extends TestCase
 {
+    private ?FeatureFlags $featureFlags;
+    private bool $featureFlagIsEnabled = true;
     private ?CatalogScopeMapper $mapper;
 
     protected function setUp(): void
     {
-        $this->mapper = new CatalogScopeMapper();
+        $this->featureFlagIsEnabled = true;
+        $this->featureFlags = $this->createMock(FeatureFlags::class);
+        $this->featureFlags->method('isEnabled')->will($this->returnCallback(fn () => $this->featureFlagIsEnabled));
+
+        $this->mapper = new CatalogScopeMapper($this->featureFlags);
+    }
+
+    public function testItReturnsNothingWhenTheFeatureIsDisabled(): void
+    {
+        $this->featureFlagIsEnabled = false;
+
+        $this->assertEquals([], $this->mapper->getScopes());
     }
 
     public function testItReturnsScopes(): void

--- a/config/packages/akeneo_feature_flag.yml
+++ b/config/packages/akeneo_feature_flag.yml
@@ -1,15 +1,15 @@
 akeneo_feature_flag:
     feature_flags:
-        - { feature: 'data_quality_insights', service: 'akeneo.pim.automation.data_quality_insights.feature' }
-        - { feature: 'data_quality_insights_all_criteria', service: 'akeneo.pim.automation.data_quality_insights.all_criteria.feature' }
-        - { feature: 'free_trial', service: 'akeneo.feature_flag.service.only_free_trial_feature' }
-        - { feature: 'marketplace_activate', service: 'akeneo_connectivity.connection.marketplace_activate.feature' }
-        - { feature: 'connect_app_with_permissions', service: 'akeneo_connectivity.connection.connect_app_with_permissions.feature' }
-        - { feature: 'communication_channel', service: 'akeneo_communication_channel.feature' }
-        - { feature: 'app_developer_mode', service: 'akeneo_connectivity.connection.app_developer_mode.feature' }
-        - { feature: 'reference_data', service: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature' }
-        - { feature: 'job_automation_local_storage', service: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature' }
-        - { feature: 'enriched_category', service: 'akeneo.feature_flag.service.only_saas_feature'}
-        - { feature: 'identifier_generator', service: 'akeneo.feature_flag.service.only_saas_feature' }
-        - { feature: 'import_export_local_storage', service: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature' }
-        - { feature: 'catalogs', service: 'akeneo.feature_flag.service.only_saas_feature' }
+        data_quality_insights: 'akeneo.pim.automation.data_quality_insights.feature'
+        data_quality_insights_all_criteria: 'akeneo.pim.automation.data_quality_insights.all_criteria.feature'
+        free_trial: 'akeneo.feature_flag.service.only_free_trial_feature'
+        marketplace_activate: 'akeneo_connectivity.connection.marketplace_activate.feature'
+        connect_app_with_permissions: 'akeneo_connectivity.connection.connect_app_with_permissions.feature'
+        communication_channel: 'akeneo_communication_channel.feature'
+        app_developer_mode: 'akeneo_connectivity.connection.app_developer_mode.feature'
+        reference_data: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature'
+        job_automation_local_storage: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature'
+        enriched_category: 'akeneo.feature_flag.service.only_saas_feature'
+        identifier_generator: 'akeneo.feature_flag.service.only_saas_feature'
+        import_export_local_storage: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature'
+        catalogs: 'akeneo.feature_flag.service.only_saas_feature'

--- a/config/packages/akeneo_feature_flag.yml
+++ b/config/packages/akeneo_feature_flag.yml
@@ -12,3 +12,4 @@ akeneo_feature_flag:
         - { feature: 'enriched_category', service: 'akeneo.feature_flag.service.only_saas_feature'}
         - { feature: 'identifier_generator', service: 'akeneo.feature_flag.service.only_saas_feature' }
         - { feature: 'import_export_local_storage', service: 'akeneo.feature_flag.service.only_flexibility_on_premise_feature' }
+        - { feature: 'catalogs', service: 'akeneo.feature_flag.service.only_saas_feature' }

--- a/config/packages/dev/akeneo_feature_flag.yml
+++ b/config/packages/dev/akeneo_feature_flag.yml
@@ -1,0 +1,3 @@
+akeneo_feature_flag:
+    feature_flags:
+        catalogs: 'akeneo.feature_flag.service.always_enabled_feature'

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/FakeFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/FakeFeatureFlag.php
@@ -15,7 +15,10 @@ use Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag;
  */
 final class FakeFeatureFlag implements FeatureFlag
 {
-    private bool $enabled = false;
+    public function __construct(
+        private bool $enabled = false,
+    ) {
+    }
 
     public function enable(): void
     {

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/AkeneoFeatureFlagExtension.php
@@ -4,7 +4,6 @@ namespace Akeneo\Platform\Bundle\FeatureFlagBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -31,9 +30,9 @@ class AkeneoFeatureFlagExtension extends Extension
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
         $registry = $container->getDefinition('akeneo.feature_flag.service.registry');
-        foreach ($config['feature_flags'] as $item) {
-            $reference = new Reference($item['service']);
-            $registry->addMethodCall('add', [$item['feature'], $reference]);
+        foreach ($config['feature_flags'] as $key => $service) {
+            $reference = new Reference($service);
+            $registry->addMethodCall('add', [$key, $reference]);
         }
     }
 }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/Configuration.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/DependencyInjection/Configuration.php
@@ -22,12 +22,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('feature_flags')
-                    ->arrayPrototype()
-                        ->children()
-                            ->scalarNode('feature')->isRequired()->cannotBeEmpty()->end()
-                            ->scalarNode('service')->isRequired()->cannotBeEmpty()->end()
-                        ->end()
-                    ->end()
+                    ->scalarPrototype()->end()
                 ->end()
             ->end()
         ;

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
@@ -20,9 +20,8 @@ Feature flags are defined by a _key_, representing the feature, and a _service_ 
 
 akeneo_feature_flag:
     feature_flags:
-        - { feature: 'myCoolFeature', service: '@service_that_defines_if_myCoolFeature_feature_is_enabled' }
-        - { feature: 'foo', service: '@service_that_defines_if_foo_feature_is_enabled' }
-        - ...
+        foo: 'service_that_defines_if_foo_feature_is_enabled'
+        bar: 'service_that_defines_if_bar_feature_is_enabled'
 ```
 
 The most important here is to decouple the decision point (the place where I need to know if a feature is enabled) from the decision logic (how do I know if this feature is enabled). 

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Resources/config/services.yml
@@ -55,3 +55,9 @@ services:
         arguments:
             - '%env(string:PIM_EDITION)%'
         public: true
+
+    akeneo.feature_flag.service.always_enabled_feature:
+        class: Akeneo\Platform\Bundle\FeatureFlagBundle\Configuration\FakeFeatureFlag
+        arguments:
+            - 'true'
+        public: true


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

New feature flag `catalogs` available only in SaaS by default.

This PR should be reviewed commit by commit.

I've changed the format of `akeneo_feature_flag.yml`, using the feature as the array key.
This way, we can override it in different Symfony environments.

Example:
By default, `catalogs` is enabled only in SaaS (Serenity, Trial, Growth).
We can override this configuration in `config/packages/dev/` to enable it by default when working locally.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
