### PR TITLE
CPM-909: Add implicit conditions

### DIFF
--- a/components/identifier-generator/back/src/Domain/Model/Condition/Conditions.php
+++ b/components/identifier-generator/back/src/Domain/Model/Condition/Conditions.php
@@ -72,4 +72,12 @@ final class Conditions
             true
         );
     }
+
+    /**
+     * @param ConditionInterface[] $otherConditions
+     */
+    public function and(array $otherConditions): Conditions
+    {
+        return new self(\array_merge($this->conditions, $otherConditions));
+    }
 }

--- a/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
+++ b/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition;
+
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class EmptyIdentifier implements ConditionInterface
+{
+    public function __construct(
+    ) {
+    }
+
+    public function normalize(): array
+    {
+        return [];
+    }
+
+    public function match(ProductProjection $productProjection): bool
+    {
+        $identifierValue = $productProjection->identifier();
+
+        return (null === $identifierValue || '' === $identifierValue);
+    }
+}

--- a/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
+++ b/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
@@ -13,6 +13,7 @@ use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
 final class EmptyIdentifier implements ConditionInterface
 {
     public function __construct(
+        private readonly string $identifierCode
     ) {
     }
 
@@ -23,7 +24,7 @@ final class EmptyIdentifier implements ConditionInterface
 
     public function match(ProductProjection $productProjection): bool
     {
-        $identifierValue = $productProjection->identifier();
+        $identifierValue = $productProjection->value($this->identifierCode);
 
         return (null === $identifierValue || '' === $identifierValue);
     }

--- a/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
+++ b/components/identifier-generator/back/src/Domain/Model/Condition/EmptyIdentifier.php
@@ -19,7 +19,7 @@ final class EmptyIdentifier implements ConditionInterface
 
     public function normalize(): array
     {
-        return [];
+        throw new \LogicException('This component should not be normalized');
     }
 
     public function match(ProductProjection $productProjection): bool

--- a/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
+++ b/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Conditions;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\EmptyIdentifier;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -117,9 +119,19 @@ final class IdentifierGenerator
 
     public function match(ProductProjection $productProjection): bool
     {
-        $identifierValue = $productProjection->identifier();
+        $conditionsWithImplicitOnes = $this->conditions->and($this->getImplicitConditions());
 
-        return (null === $identifierValue || '' === $identifierValue) && $this->conditions->match($productProjection);
+        return $conditionsWithImplicitOnes->match($productProjection);
+    }
+
+    /**
+     * @return ConditionInterface[]
+     */
+    private function getImplicitConditions(): array
+    {
+        $conditions = [new EmptyIdentifier()];
+
+        return \array_merge($conditions, $this->structure->getImplicitConditions());
     }
 
     public function textTransformation(): TextTransformation

--- a/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
+++ b/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
@@ -129,7 +129,7 @@ final class IdentifierGenerator
      */
     private function getImplicitConditions(): array
     {
-        $conditions = [new EmptyIdentifier()];
+        $conditions = [new EmptyIdentifier($this->target()->asString())];
 
         return \array_merge($conditions, $this->structure->getImplicitConditions());
     }

--- a/components/identifier-generator/back/src/Domain/Model/ProductProjection.php
+++ b/components/identifier-generator/back/src/Domain/Model/ProductProjection.php
@@ -21,17 +21,11 @@ final class ProductProjection
      * ]
      */
     public function __construct(
-        private readonly ?string $identifier,
         private readonly bool $enabled,
         private readonly ?string $familyCode,
         private readonly array $productValues,
     ) {
         Assert::isMap($productValues);
-    }
-
-    public function identifier(): ?string
-    {
-        return $this->identifier;
     }
 
     public function enabled(): bool
@@ -44,7 +38,7 @@ final class ProductProjection
         return $this->familyCode;
     }
 
-    public function value(string $attributeCode, ?string $localeCode, ?string $channelCode): mixed
+    public function value(string $attributeCode, ?string $localeCode = null, ?string $channelCode = null): mixed
     {
         $key = \sprintf(
             '%s-%s-%s',

--- a/components/identifier-generator/back/src/Domain/Model/Property/AutoNumber.php
+++ b/components/identifier-generator/back/src/Domain/Model/Property/AutoNumber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -73,5 +74,10 @@ final class AutoNumber implements PropertyInterface
     public function digitsMin(): int
     {
         return $this->digitsMin;
+    }
+
+    public function getImplicitCondition(): ?ConditionInterface
+    {
+        return null;
     }
 }

--- a/components/identifier-generator/back/src/Domain/Model/Property/FamilyProperty.php
+++ b/components/identifier-generator/back/src/Domain/Model/Property/FamilyProperty.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Family;
 use Webmozart\Assert\Assert;
 
 /**
@@ -51,5 +53,13 @@ final class FamilyProperty implements PropertyInterface
         Assert::isArray($normalizedProperty['process']);
 
         return new self(Process::fromNormalized($normalizedProperty['process']));
+    }
+
+    public function getImplicitCondition(): ?ConditionInterface
+    {
+        return Family::fromNormalized([
+            'type' => Family::type(),
+            'operator' => 'NOT EMPTY',
+        ]);
     }
 }

--- a/components/identifier-generator/back/src/Domain/Model/Property/FreeText.php
+++ b/components/identifier-generator/back/src/Domain/Model/Property/FreeText.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
 use Webmozart\Assert\Assert;
 
 /**
@@ -63,5 +64,10 @@ final class FreeText implements PropertyInterface
     public function asString(): string
     {
         return $this->value;
+    }
+
+    public function getImplicitCondition(): ?ConditionInterface
+    {
+        return null;
     }
 }

--- a/components/identifier-generator/back/src/Domain/Model/Property/PropertyInterface.php
+++ b/components/identifier-generator/back/src/Domain/Model/Property/PropertyInterface.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
+
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
@@ -27,4 +29,6 @@ interface PropertyInterface
     public static function fromNormalized(array $fromNormalized): self;
 
     public static function type(): string;
+
+    public function getImplicitCondition(): ?ConditionInterface;
 }

--- a/components/identifier-generator/back/src/Domain/Model/Structure.php
+++ b/components/identifier-generator/back/src/Domain/Model/Structure.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model;
 
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
-use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Conditions;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\AutoNumber;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FreeText;

--- a/components/identifier-generator/back/src/Domain/Model/Structure.php
+++ b/components/identifier-generator/back/src/Domain/Model/Structure.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Conditions;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\AutoNumber;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FreeText;
@@ -75,5 +77,21 @@ final class Structure
     public function getProperties(): array
     {
         return $this->properties;
+    }
+
+    /**
+     * @return ConditionInterface[]
+     */
+    public function getImplicitConditions(): array
+    {
+        $result = [];
+        foreach ($this->properties as $property) {
+            $implicitCondition = $property->getImplicitCondition();
+            if (null !== $implicitCondition) {
+                $result[] = $implicitCondition;
+            }
+        }
+
+        return $result;
     }
 }

--- a/components/identifier-generator/back/src/Infrastructure/Subscriber/SetIdentifiersSubscriber.php
+++ b/components/identifier-generator/back/src/Infrastructure/Subscriber/SetIdentifiersSubscriber.php
@@ -70,15 +70,7 @@ final class SetIdentifiersSubscriber implements EventSubscriberInterface
         }
 
         foreach ($this->getIdentifierGenerators() as $identifierGenerator) {
-            $identifier = null;
-            $identifierValue = $product->getValue($identifierGenerator->target()->asString());
-            if (null !== $identifierValue) {
-                Assert::isInstanceOf($identifierValue, ScalarValue::class);
-                $identifier = $identifierValue->getData();
-                Assert::string($identifier);
-            }
             $productProjection = new ProductProjection(
-                $identifier,
                 $product->isEnabled(),
                 $product->getFamily()?->getCode(),
                 $this->flatValues($product),

--- a/components/identifier-generator/back/tests/Specification/Application/Generate/GenerateIdentifierHandlerSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Application/Generate/GenerateIdentifierHandlerSpec.php
@@ -39,7 +39,7 @@ class GenerateIdentifierHandlerSpec extends ObjectBehavior
         $identifierGenerator = $this->getIdentifierGenerator(Delimiter::fromString(null));
         $generateIdentifierCommand = GenerateIdentifierCommand::fromIdentifierGenerator(
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
         );
 
         $getNextIdentifierQuery
@@ -108,7 +108,7 @@ class GenerateIdentifierHandlerSpec extends ObjectBehavior
         );
         $generateIdentifierCommand = GenerateIdentifierCommand::fromIdentifierGenerator(
             $identifierGenerator,
-            new ProductProjection(null, true, null, [])
+            new ProductProjection(true, null, [])
         );
 
         $getNextIdentifierQuery

--- a/components/identifier-generator/back/tests/Specification/Application/Generate/GenerateIdentifierHandlerSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Application/Generate/GenerateIdentifierHandlerSpec.php
@@ -56,7 +56,7 @@ class GenerateIdentifierHandlerSpec extends ObjectBehavior
         $identifierGenerator = $this->getIdentifierGenerator(Delimiter::fromString('a'));
         $generateIdentifierCommand = GenerateIdentifierCommand::fromIdentifierGenerator(
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
         );
 
         $getNextIdentifierQuery
@@ -73,7 +73,7 @@ class GenerateIdentifierHandlerSpec extends ObjectBehavior
         $identifierGenerator = $this->getIdentifierGenerator(Delimiter::fromString('x'), 'uppercase');
         $generateIdentifierCommand = GenerateIdentifierCommand::fromIdentifierGenerator(
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
         );
 
         $getNextIdentifierQuery

--- a/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateAutoNumberHandlerSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateAutoNumberHandlerSpec.php
@@ -47,7 +47,7 @@ class GenerateAutoNumberHandlerSpec extends ObjectBehavior
             ->during('__invoke', [
                 $freeText,
                 $identifierGenerator,
-                new ProductProjection(null, true, null, []),
+                new ProductProjection(true, null, []),
                 'AKN-'
             ]);
     }
@@ -71,7 +71,7 @@ class GenerateAutoNumberHandlerSpec extends ObjectBehavior
         $this->__invoke(
             $autoNumber,
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
             'AKN-'
         )->shouldReturn('42');
     }
@@ -95,7 +95,7 @@ class GenerateAutoNumberHandlerSpec extends ObjectBehavior
         $this->__invoke(
             $autoNumber,
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
             'AKN-'
         )->shouldReturn('50');
     }
@@ -118,7 +118,7 @@ class GenerateAutoNumberHandlerSpec extends ObjectBehavior
         $this->__invoke(
             $autoNumber,
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
             'AKN-'
         )->shouldReturn('00042');
     }
@@ -141,7 +141,7 @@ class GenerateAutoNumberHandlerSpec extends ObjectBehavior
         $this->__invoke(
             $autoNumber,
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
             'AKN-'
         )->shouldReturn('426942');
     }

--- a/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateFamilyHandlerSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateFamilyHandlerSpec.php
@@ -47,7 +47,7 @@ class GenerateFamilyHandlerSpec extends ObjectBehavior
             ->during('__invoke', [
                 $autoNumber,
                 $identifierGenerator,
-                new ProductProjection(null, true, null, []),
+                new ProductProjection(true, null, []),
                 'AKN-'
             ]);
     }
@@ -159,7 +159,7 @@ class GenerateFamilyHandlerSpec extends ObjectBehavior
 
     private function getProductProjection(string $familyCode): ProductProjection
     {
-        return new ProductProjection(null, true, $familyCode, []);
+        return new ProductProjection(true, $familyCode, []);
     }
 
     private function getIdentifierGenerator(PropertyInterface $property): IdentifierGenerator

--- a/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateFreeTextHandlerSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Application/Generate/Property/GenerateFreeTextHandlerSpec.php
@@ -58,7 +58,7 @@ class GenerateFreeTextHandlerSpec extends ObjectBehavior
             ->during('__invoke', [
                 $autoNumber,
                 $identifierGenerator,
-                new ProductProjection(null, true, null, []),
+                new ProductProjection(true, null, []),
                 'AKN-'
             ]);
     }
@@ -84,7 +84,7 @@ class GenerateFreeTextHandlerSpec extends ObjectBehavior
         $this->__invoke(
             $freeText,
             $identifierGenerator,
-            new ProductProjection(null, true, null, []),
+            new ProductProjection(true, null, []),
             'AKN-'
         )->shouldReturn('AKN-');
     }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/ConditionsSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/ConditionsSpec.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Conditions;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Enabled;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Family;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
 use PhpSpec\ObjectBehavior;
 
@@ -56,5 +58,13 @@ class ConditionsSpec extends ObjectBehavior
     {
         $this->beConstructedThrough('fromArray', [[new Enabled(true)]]);
         $this->match(new ProductProjection('', false, '', []))->shouldReturn(false);
+    }
+
+    public function it_should_return_conjunction(): void
+    {
+        $condition1 = new Enabled(true);
+        $condition2 = Family::fromNormalized(['type' => 'family', 'operator' => 'EMPTY']);
+        $this->beConstructedThrough('fromArray', [[$condition1]]);
+        $this->and([$condition2])->shouldBeLike(Conditions::fromArray([$condition1, $condition2]));
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/ConditionsSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/ConditionsSpec.php
@@ -51,13 +51,13 @@ class ConditionsSpec extends ObjectBehavior
     public function it_matches_if_condition_matches(): void
     {
         $this->beConstructedThrough('fromArray', [[new Enabled(true)]]);
-        $this->match(new ProductProjection('', true, '', []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, '', []))->shouldReturn(true);
     }
 
     public function it_does_not_match_if_condition_doest_not_match(): void
     {
         $this->beConstructedThrough('fromArray', [[new Enabled(true)]]);
-        $this->match(new ProductProjection('', false, '', []))->shouldReturn(false);
+        $this->match(new ProductProjection(false, '', []))->shouldReturn(false);
     }
 
     public function it_should_return_conjunction(): void

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EmptyIdentifierSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EmptyIdentifierSpec.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition;
+
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\ConditionInterface;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\EmptyIdentifier;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class EmptyIdentifierSpec extends ObjectBehavior
+{
+    public function it_is_a_condition()
+    {
+        $this->shouldBeAnInstanceOf(EmptyIdentifier::class);
+        $this->shouldImplement(ConditionInterface::class);
+    }
+
+    public function it_should_match_product_without_identifier()
+    {
+        $this->match(new ProductProjection(null, true, null, []))->shouldReturn(true);
+    }
+
+    public function it_should_match_product_with_empty_identifier()
+    {
+        $this->match(new ProductProjection('', true, null, []))->shouldReturn(true);
+    }
+
+    public function it_should_not_match_product_with_filled_identifier()
+    {
+        $this->match(new ProductProjection('productidentifier', true, null, []))->shouldReturn(false);
+    }
+}

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EmptyIdentifierSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EmptyIdentifierSpec.php
@@ -15,6 +15,11 @@ use PhpSpec\ObjectBehavior;
  */
 class EmptyIdentifierSpec extends ObjectBehavior
 {
+    public function let()
+    {
+        $this->beConstructedWith('sku');
+    }
+
     public function it_is_a_condition()
     {
         $this->shouldBeAnInstanceOf(EmptyIdentifier::class);
@@ -23,16 +28,20 @@ class EmptyIdentifierSpec extends ObjectBehavior
 
     public function it_should_match_product_without_identifier()
     {
-        $this->match(new ProductProjection(null, true, null, []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(true);
     }
 
     public function it_should_match_product_with_empty_identifier()
     {
-        $this->match(new ProductProjection('', true, null, []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, null, [
+            'sku-<all_channels>-<all_locales>' => ''
+        ]))->shouldReturn(true);
     }
 
     public function it_should_not_match_product_with_filled_identifier()
     {
-        $this->match(new ProductProjection('productidentifier', true, null, []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, null, [
+            'sku-<all_channels>-<all_locales>' => 'productidentifier'
+        ]))->shouldReturn(false);
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EnabledSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/EnabledSpec.php
@@ -69,7 +69,7 @@ class EnabledSpec extends ObjectBehavior
     public function it_matches_only_enabled_products(): void
     {
         $this->beConstructedThrough('fromBoolean', [true]);
-        $this->match(new ProductProjection('', true, '', []))->shouldReturn(true);
-        $this->match(new ProductProjection('', false, '', []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, '', []))->shouldReturn(true);
+        $this->match(new ProductProjection(false, '', []))->shouldReturn(false);
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/FamilySpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/FamilySpec.php
@@ -123,7 +123,7 @@ class FamilySpec extends ObjectBehavior
             'type' => 'family',
             'operator' => 'EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(true);
     }
 
     public function it_should_not_match_empty()
@@ -132,7 +132,7 @@ class FamilySpec extends ObjectBehavior
             'type' => 'family',
             'operator' => 'EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'familyCode', []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, 'familyCode', []))->shouldReturn(false);
     }
 
     public function it_should_match_not_empty()
@@ -141,7 +141,7 @@ class FamilySpec extends ObjectBehavior
             'type' => 'family',
             'operator' => 'NOT EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'familyCode', []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, 'familyCode', []))->shouldReturn(true);
     }
 
     public function it_should_not_match_not_empty()
@@ -150,7 +150,7 @@ class FamilySpec extends ObjectBehavior
             'type' => 'family',
             'operator' => 'NOT EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(false);
     }
 
     public function it_should_match_in()
@@ -160,7 +160,7 @@ class FamilySpec extends ObjectBehavior
             'operator' => 'IN',
             'value' => ['shirts', 'jeans'],
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'shirts', []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, 'shirts', []))->shouldReturn(true);
     }
 
     public function it_should_not_match_in()
@@ -170,7 +170,7 @@ class FamilySpec extends ObjectBehavior
             'operator' => 'IN',
             'value' => ['shirts', 'jeans'],
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'jackets', []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, 'jackets', []))->shouldReturn(false);
     }
 
     public function it_should_match_not_in()
@@ -180,7 +180,7 @@ class FamilySpec extends ObjectBehavior
             'operator' => 'NOT IN',
             'value' => ['shirts', 'jeans'],
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'jackets', []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, 'jackets', []))->shouldReturn(true);
     }
 
     public function it_should_not_match_not_in()
@@ -190,7 +190,7 @@ class FamilySpec extends ObjectBehavior
             'operator' => 'NOT IN',
             'value' => ['shirts', 'jeans'],
         ]]);
-        $this->match(new ProductProjection('identifier', true, 'shirts', []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, 'shirts', []))->shouldReturn(false);
     }
 
     public function it_should_not_match_not_in_when_product_has_no_family()
@@ -200,6 +200,6 @@ class FamilySpec extends ObjectBehavior
             'operator' => 'NOT IN',
             'value' => ['shirts', 'jeans'],
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(false);
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/SimpleSelectSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Condition/SimpleSelectSpec.php
@@ -213,8 +213,8 @@ class SimpleSelectSpec extends ObjectBehavior
             'attributeCode' => 'color',
             'operator' => 'EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(true);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(true);
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'red',
         ]))->shouldReturn(false);
     }
@@ -226,8 +226,8 @@ class SimpleSelectSpec extends ObjectBehavior
             'attributeCode' => 'color',
             'operator' => 'NOT EMPTY',
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(false);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'red',
         ]))->shouldReturn(true);
     }
@@ -240,10 +240,10 @@ class SimpleSelectSpec extends ObjectBehavior
             'operator' => 'IN',
             'value' => ['red', 'pink']
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'red',
         ]))->shouldReturn(true);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'blue',
         ]))->shouldReturn(false);
     }
@@ -256,12 +256,12 @@ class SimpleSelectSpec extends ObjectBehavior
             'operator' => 'NOT IN',
             'value' => ['red', 'pink']
         ]]);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'red',
         ]))->shouldReturn(false);
-        $this->match(new ProductProjection('identifier', true, null, [
+        $this->match(new ProductProjection(true, null, [
             'color-<all_channels>-<all_locales>' => 'blue',
         ]))->shouldReturn(true);
-        $this->match(new ProductProjection('identifier', true, null, []))->shouldReturn(false);
+        $this->match(new ProductProjection(true, null, []))->shouldReturn(false);
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
@@ -195,14 +195,12 @@ class IdentifierGeneratorSpec extends ObjectBehavior
     {
         // Structure contains Family property, which imply family should not be empty.
         $this->match(new ProductProjection(
-            '',
             true,
             'a_family',
             [],
         ))->shouldReturn(true);
 
         $this->match(new ProductProjection(
-            '',
             true,
             null,
             [],

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
@@ -13,6 +13,7 @@ use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\IdentifierGeneratorId
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\LabelCollection;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\AutoNumber;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FreeText;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Structure;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Target;
@@ -31,8 +32,9 @@ class IdentifierGeneratorSpec extends ObjectBehavior
         $identifierGeneratorCode = IdentifierGeneratorCode::fromString('abcdef');
 
         $freeText = FreeText::fromString('abc');
+        $family = FamilyProperty::fromNormalized(['type' => 'family', 'process' => ['type' => 'no']]);
         $enabled = Enabled::fromBoolean(true);
-        $structure = Structure::fromArray([$freeText]);
+        $structure = Structure::fromArray([$freeText, $family]);
         $conditions = Conditions::fromArray([$enabled]);
 
         $label = LabelCollection::fromNormalized(['fr' => 'Générateur']);
@@ -122,12 +124,14 @@ class IdentifierGeneratorSpec extends ObjectBehavior
 
     public function it_returns_a_structure(): void
     {
-        $this->structure()->shouldBeLike(Structure::fromArray([FreeText::fromString('abc')]));
+        $this->structure()->shouldBeLike(Structure::fromArray([
+            FreeText::fromString('abc'),
+            FamilyProperty::fromNormalized(['type' => 'family', 'process' => ['type' => 'no']]),
+        ]));
     }
 
     public function it_sets_a_structure(): void
     {
-        $this->structure()->shouldBeLike(Structure::fromArray([FreeText::fromString('abc')]));
         $this->setStructure(Structure::fromArray([
             FreeText::fromString('cba'),
             AutoNumber::fromValues(3, 2),
@@ -171,6 +175,11 @@ class IdentifierGeneratorSpec extends ObjectBehavior
                 [
                     'type' => 'free_text',
                     'string' => 'abc',
+                ], [
+                    'type' => 'family',
+                    'process' => [
+                        'type' => 'no',
+                    ],
                 ],
             ],
             'labels' => [
@@ -182,42 +191,20 @@ class IdentifierGeneratorSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_should_match_empty_identifier(): void
+    public function it_should_add_conditions_from_structure(): void
     {
+        // Structure contains Family property, which imply family should not be empty.
         $this->match(new ProductProjection(
             '',
             true,
-            '',
+            'a_family',
             [],
         ))->shouldReturn(true);
-    }
 
-    public function it_should_match_null_identifier(): void
-    {
         $this->match(new ProductProjection(
-            null,
+            '',
             true,
-            '',
-            [],
-        ))->shouldReturn(true);
-    }
-
-    public function it_should_not_match_filled_identifier(): void
-    {
-        $this->match(new ProductProjection(
-            'a_product_identifier',
-            true,
-            '',
-            [],
-        ))->shouldReturn(false);
-    }
-
-    public function it_should_not_match_disabled_product(): void
-    {
-        $this->match(new ProductProjection(
             null,
-            false,
-            '',
             [],
         ))->shouldReturn(false);
     }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Property/FamilyPropertySpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Property/FamilyPropertySpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Family;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\Process;
 use PhpSpec\ObjectBehavior;
@@ -51,5 +52,12 @@ class FamilyPropertySpec extends ObjectBehavior
                 'value' => 3
             ]
         ]);
+    }
+
+    public function it_should_return_an_implicit_condition(): void
+    {
+        $this->getImplicitCondition()->shouldBeLike(
+            Family::fromNormalized(['type' => 'family', 'operator' => 'NOT EMPTY']),
+        );
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/StructureSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/StructureSpec.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model;
 
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\Family;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\AutoNumber;
+use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FreeText;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\PropertyInterface;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Structure;
@@ -20,7 +22,8 @@ class StructureSpec extends ObjectBehavior
     {
         $freeText = FreeText::fromString('ABC');
         $autoNumber = AutoNumber::fromValues(5, 2);
-        $this->beConstructedThrough('fromArray', [[$freeText, $autoNumber]]);
+        $family = FamilyProperty::fromNormalized(['type' => 'family', 'process' => ['type' => 'no']]);
+        $this->beConstructedThrough('fromArray', [[$freeText, $autoNumber, $family]]);
     }
 
     public function it_is_a_structure(): void
@@ -43,9 +46,10 @@ class StructureSpec extends ObjectBehavior
     public function it_has_properties_values(): void
     {
         $properties = $this->getProperties();
-        $properties->shouldHaveCount(2);
+        $properties->shouldHaveCount(3);
         $properties[0]->shouldBeAnInstanceOf(PropertyInterface::class);
         $properties[1]->shouldBeAnInstanceOf(PropertyInterface::class);
+        $properties[2]->shouldBeAnInstanceOf(PropertyInterface::class);
     }
 
     public function it_normalize_a_structure(): void
@@ -54,11 +58,15 @@ class StructureSpec extends ObjectBehavior
             [
                 'type' => 'free_text',
                 'string' => 'ABC',
-            ],
-            [
+            ], [
                 'type' => 'auto_number',
                 'numberMin' => 5,
                 'digitsMin' => 2,
+            ], [
+                'type' => 'family',
+                'process' => [
+                    'type' => 'no',
+                ],
             ],
         ]);
     }
@@ -79,5 +87,12 @@ class StructureSpec extends ObjectBehavior
             FreeText::fromString('CBA'),
             AutoNumber::fromValues(5, 6),
         ]));
+    }
+
+    public function it_should_get_implicit_conditions(): void
+    {
+        $this->getImplicitConditions()->shouldBeLike([
+            Family::fromNormalized(['type' => 'family', 'operator' => 'NOT EMPTY']),
+        ]);
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Infrastructure/Subscriber/SetIdentifiersSubscriberSpec.php
@@ -80,7 +80,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ClassMetadataInterface $productMetadata,
         PropertyMetadataInterface $productPropertyMetadata,
     ): void {
-        $product->getValue('sku')->shouldBeCalled()->willReturn(null);
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = ScalarValue::value('sku', 'AKN');
         $product->addValue($value)->shouldBeCalled();
@@ -119,7 +118,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ClassMetadataInterface $valueMetadata,
         PropertyMetadataInterface $valuePropertyMetadata,
     ): void {
-        $product->getValue('sku')->shouldBeCalled()->willReturn(null);
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = ScalarValue::value('sku', 'AKN');
         $product->addValue($value)->shouldBeCalled();
@@ -162,7 +160,6 @@ class SetIdentifiersSubscriberSpec extends ObjectBehavior
         ClassMetadataInterface $productMetadata,
         PropertyMetadataInterface $productPropertyMetadata,
     ): void {
-        $product->getValue('sku')->shouldBeCalled()->willReturn(null);
         $identifierGeneratorRepository->getAll()->shouldBeCalled()->willReturn([$this->getIdentifierGenerator()]);
         $value = ScalarValue::value('sku', 'AKN');
         $product->addValue($value)->shouldBeCalled();


### PR DESCRIPTION
When adding structure properties, some of them have implicit conditions.
For example, when you want to generate a code with a Family, you need the product to have a family.