### PR TITLE
PIM-10796: Fix system-information endpoint with wrong answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 - PIM-10785: Fix case-insensitive patch product model
 - PIM-10808: Fix Error message on the family modification when an attribute is as required=0
 - PIM-10802: Fix wysiwyg-field add link event 
+- PIM-10796: Fix system-information endpoint with wrong answers
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Platform\Bundle\AnalyticsBundle\Controller\ExternalApi;
 
+use Akeneo\Platform\Bundle\PimVersionBundle\Version\GrowthVersion;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,14 +13,16 @@ class GetSystemInformationController
 {
     public function __construct(
         private VersionProviderInterface $versionProvider,
+        private GrowthVersion $growthVersion,
     ) {
     }
 
     public function __invoke(Request $request): JsonResponse
     {
+        $edition = $this->versionProvider->getEdition();
         $response = [
             'version' => strtolower($this->versionProvider->getVersion()),
-            'edition' => $this->versionProvider->getEdition(),
+            'edition' => $edition === $this->growthVersion->editionName() ? 'GE' : $edition,
         ];
 
         return new JsonResponse($response);

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
@@ -17,10 +17,9 @@ class GetSystemInformationController
 
     public function __invoke(Request $request): JsonResponse
     {
-        $edition = $this->versionProvider->getEdition();
         $response = [
             'version' => strtolower($this->versionProvider->getVersion()),
-            'edition' => $edition === 'CE' ? strtolower($edition) : 'ee',
+            'edition' => $this->versionProvider->getEdition(),
         ];
 
         return new JsonResponse($response);

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/controllers.yml
@@ -21,3 +21,4 @@ services:
         public: true
         arguments:
             - '@pim_catalog.version_provider'
+            - '@Akeneo\Platform\Bundle\PimVersionBundle\Version\GrowthVersion'

--- a/src/Akeneo/Platform/Bundle/PimVersionBundle/Version/GrowthVersion.php
+++ b/src/Akeneo/Platform/Bundle/PimVersionBundle/Version/GrowthVersion.php
@@ -21,7 +21,7 @@ final class GrowthVersion implements PimVersion
     private const VERSION_CODENAME = 'Growth Edition';
 
     /** @staticvar string */
-    private const EDITION_NAME = 'Growth Edition';
+    private const EDITION_NAME = 'GE';
 
     /** @staticvar string **/
     private const EDITION_CODE = 'growth_edition_instance';

--- a/src/Akeneo/Platform/Bundle/PimVersionBundle/Version/GrowthVersion.php
+++ b/src/Akeneo/Platform/Bundle/PimVersionBundle/Version/GrowthVersion.php
@@ -21,7 +21,7 @@ final class GrowthVersion implements PimVersion
     private const VERSION_CODENAME = 'Growth Edition';
 
     /** @staticvar string */
-    private const EDITION_NAME = 'GE';
+    private const EDITION_NAME = 'Growth Edition';
 
     /** @staticvar string **/
     private const EDITION_CODE = 'growth_edition_instance';

--- a/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
+++ b/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
@@ -43,6 +43,9 @@ class GetSystemInformationEndToEnd extends ApiTestCase
         );
     }
 
+    /**
+     * @group ce
+     */
     public function test_to_get_ge_system_information_through_the_api(): void
     {
         putenv('PIM_EDITION=growth_edition_instance');
@@ -72,6 +75,9 @@ class GetSystemInformationEndToEnd extends ApiTestCase
         );
     }
 
+    /**
+     * @group ce
+     */
     public function test_to_get_ee_system_information_through_the_api(): void
     {
         putenv('PIM_EDITION=flexibility_instance');
@@ -101,6 +107,9 @@ class GetSystemInformationEndToEnd extends ApiTestCase
         );
     }
 
+    /**
+     * @group ce
+     */
     public function test_to_get_serenity_system_information_through_the_api(): void
     {
         putenv('PIM_EDITION=serenity_instance');

--- a/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
+++ b/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
@@ -14,7 +14,7 @@ class GetSystemInformationEndToEnd extends ApiTestCase
     /**
      * @group ce
      */
-    public function test_to_get_system_information_through_the_api(): void
+    public function test_to_get_ce_system_information_through_the_api(): void
     {
         putenv('PIM_EDITION=community_edition_instance');
 
@@ -37,7 +37,94 @@ class GetSystemInformationEndToEnd extends ApiTestCase
         Assert::assertSame(
             [
                 'version' => 'master',
-                'edition' => 'ce',
+                'edition' => 'CE',
+            ],
+            $content
+        );
+    }
+
+    public function test_to_get_ge_system_information_through_the_api(): void
+    {
+        putenv('PIM_EDITION=growth_edition_instance');
+
+        $apiConnectionEcommerce = $this->createConnection('ecommerce', 'Ecommerce');
+        $apiClient = $this->createAuthenticatedClient(
+            [],
+            [],
+            $apiConnectionEcommerce->clientId(),
+            $apiConnectionEcommerce->secret(),
+            $apiConnectionEcommerce->username(),
+            $apiConnectionEcommerce->password()
+        );
+
+        $apiClient->request('GET', 'api/rest/v1/system-information');
+        $response = $apiClient->getResponse();
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        Assert::assertCount(2, $content);
+        Assert::assertSame(
+            [
+                'version' => 'master',
+                'edition' => 'GE',
+            ],
+            $content
+        );
+    }
+
+    public function test_to_get_ee_system_information_through_the_api(): void
+    {
+        putenv('PIM_EDITION=flexibility_instance');
+
+        $apiConnectionEcommerce = $this->createConnection('ecommerce', 'Ecommerce');
+        $apiClient = $this->createAuthenticatedClient(
+            [],
+            [],
+            $apiConnectionEcommerce->clientId(),
+            $apiConnectionEcommerce->secret(),
+            $apiConnectionEcommerce->username(),
+            $apiConnectionEcommerce->password()
+        );
+
+        $apiClient->request('GET', 'api/rest/v1/system-information');
+        $response = $apiClient->getResponse();
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        Assert::assertCount(2, $content);
+        Assert::assertSame(
+            [
+                'version' => 'master',
+                'edition' => 'EE',
+            ],
+            $content
+        );
+    }
+
+    public function test_to_get_serenity_system_information_through_the_api(): void
+    {
+        putenv('PIM_EDITION=serenity_instance');
+
+        $apiConnectionEcommerce = $this->createConnection('ecommerce', 'Ecommerce');
+        $apiClient = $this->createAuthenticatedClient(
+            [],
+            [],
+            $apiConnectionEcommerce->clientId(),
+            $apiConnectionEcommerce->secret(),
+            $apiConnectionEcommerce->username(),
+            $apiConnectionEcommerce->password()
+        );
+
+        $apiClient->request('GET', 'api/rest/v1/system-information');
+        $response = $apiClient->getResponse();
+
+        Assert::assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $content = json_decode($response->getContent(), true);
+        Assert::assertCount(2, $content);
+        Assert::assertSame(
+            [
+                'version' => 'master',
+                'edition' => 'Serenity',
             ],
             $content
         );

--- a/tests/back/Platform/Specification/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationControllerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationControllerSpec.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Platform\Bundle\AnalyticsBundle\Controller\ExternalApi;
 
 use Akeneo\Platform\Bundle\AnalyticsBundle\Controller\ExternalApi\GetSystemInformationController;
+use Akeneo\Platform\Bundle\PimVersionBundle\Version\GrowthVersion;
 use Akeneo\Platform\Bundle\PimVersionBundle\VersionProviderInterface;
 use PhpSpec\ObjectBehavior;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -12,15 +13,20 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GetSystemInformationControllerSpec extends ObjectBehavior
 {
-    public function it_is_a_system_information_controller(VersionProviderInterface $versionProvider): void
+    public function it_is_a_system_information_controller(
+        VersionProviderInterface $versionProvider
+    ): void
     {
-        $this->beConstructedWith($versionProvider);
+        $this->beConstructedWith($versionProvider, new GrowthVersion());
         $this->shouldHaveType(GetSystemInformationController::class);
     }
 
-    public function it_provides_system_information_for_community(VersionProviderInterface $versionProvider, Request $request): void
+    public function it_provides_system_information_for_community(
+        VersionProviderInterface $versionProvider,
+        Request $request
+    ): void
     {
-        $this->beConstructedWith($versionProvider);
+        $this->beConstructedWith($versionProvider, new GrowthVersion());
         $versionProvider->getVersion()->willReturn('12345678');
         $versionProvider->getEdition()->willReturn('CE');
 
@@ -29,23 +35,42 @@ class GetSystemInformationControllerSpec extends ObjectBehavior
         $response->getContent()->shouldReturn(json_encode(
             [
                 'version' => '12345678',
-                'edition' => 'ce'
+                'edition' => 'CE'
             ]
         ));
     }
 
-    public function it_provides_system_information_enterprise(VersionProviderInterface $versionProvider, Request $request): void
+    public function it_provides_system_information_for_enterprise(
+        VersionProviderInterface $versionProvider,
+        Request $request
+    ): void
     {
-        $this->beConstructedWith($versionProvider);
+        $this->beConstructedWith($versionProvider, new GrowthVersion());
         $versionProvider->getVersion()->willReturn('12345678');
-        $versionProvider->getEdition()->willReturn('Serenity');
+        $versionProvider->getEdition()->willReturn('EE');
 
         $response = $this->__invoke($request);
         $response->shouldBeAnInstanceOf(JsonResponse::class);
         $response->getContent()->shouldReturn(json_encode(
             [
                 'version' => '12345678',
-                'edition' => 'ee'
+                'edition' => 'EE'
+            ]
+        ));
+    }
+
+    public function it_provides_system_information_for_growthedition(VersionProviderInterface $versionProvider, Request $request): void
+    {
+        $this->beConstructedWith($versionProvider, new GrowthVersion());
+        $versionProvider->getVersion()->willReturn('12345678');
+        $versionProvider->getEdition()->willReturn('Growth Edition');
+
+        $response = $this->__invoke($request);
+        $response->shouldBeAnInstanceOf(JsonResponse::class);
+        $response->getContent()->shouldReturn(json_encode(
+            [
+                'version' => '12345678',
+                'edition' => 'GE'
             ]
         ));
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

As per the https://api.akeneo.com/api-reference.html#System: 

In a Saas env, do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'Serenity'

In a GE env, do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'GE'

In an EE env, do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'EE'

In a CE env,do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'CE'

