### PR TITLE
Pim 10810: Optimize completeness saving

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- Pim 10810: Optimize completeness saving
+
 # 6.0.67 (2023-02-06)
 
 # 6.0.66 (2023-02-02)

--- a/tests/back/Pim/Enrichment/EndToEnd/RemoveLocaleFromChannelEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/RemoveLocaleFromChannelEndToEnd.php
@@ -108,13 +108,13 @@ class RemoveLocaleFromChannelEndToEnd extends InternalApiTestCase
 
         $this->createProduct('blue_jean', 'jeans',
             [
-            'values' => [
-                'a_scopable_localizable_text' => [
-                    ['data' => 'blue', 'locale' => 'en_US', 'scope' => 'ecommerce'],
-                    ['data' => 'bleu', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                'values' => [
+                    'a_scopable_localizable_text' => [
+                        ['data' => 'blue', 'locale' => 'en_US', 'scope' => 'ecommerce'],
+                        ['data' => 'bleu', 'locale' => 'fr_FR', 'scope' => 'ecommerce'],
+                    ]
                 ]
-            ]
-        ]);
+            ]);
 
 
         $this->createProduct('yellow_jean', 'jeans', [


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

### Context
Fixes database lock issues that occur when multiple parallel processing changes a lot of completeness rows.
This can happen especially when a lot of completeness records have to be updated at once (for instance, when the catalog contains a lot of channels/locales)

### Solution
This fix tries to mitigate this issue by upserting rows in the completeness table, rather than deleting every row and re-inserting them. Identical rows are not updated anymore, thus resulting in less pressure on MySQL.

### Results (on an env with ~50 channels/locales couples):

- without fix
    - 33 deadlock
    - 93 lock times
    - 1 locking (Table lock)
    - 37 lockwait dbal exception (DB lock timeout)

- with fix
    - 115 deadlock
    - 0 lock time
    - 3 locking (Table lock) 
    - 0 lockwait dbal exception (DB lock timeout)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
