### PR TITLE
PIM-10802: Fix wysiwyg-field add link event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - PIM-10784: Fix API error 500 when filtering for identifier with null value
 - PIM-10785: Fix case-insensitive patch product model
 - PIM-10808: Fix Error message on the family modification when an attribute is as required=0
+- PIM-10802: Fix wysiwyg-field add link event 
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -107,7 +107,7 @@ define(['jquery', 'pim/field', 'underscore', 'pim/template/product/field/textare
 
       const source = jqueryEvent.originalEvent.path
         ? $(jqueryEvent.originalEvent.path[0])
-        : $(jqueryEvent.originalEvent.originalTarget);
+        : $(jqueryEvent.originalEvent.target);
 
       if (
         source.hasClass('icon-link') ||


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Event name changed after navigator update (from chrome 108 to 109)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
