### PR TITLE
Fix error 500 on login page when username length > 4096 characters

### DIFF
--- a/src/Akeneo/UserManagement/Bundle/EventListener/LoginRateLimitListener.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/LoginRateLimitListener.php
@@ -9,6 +9,7 @@ use Akeneo\UserManagement\Bundle\Model\LockedAccountException;
 use Akeneo\UserManagement\Component\Model\UserInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
+use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
@@ -81,7 +82,7 @@ final class LoginRateLimitListener implements EventSubscriberInterface
 
     private function getUserFromPassport($passport): ?UserInterface
     {
-        if (empty($passport) || !$passport->hasBadge(UserBadge::class)) {
+        if (!$passport instanceof Passport || !$passport->hasBadge(UserBadge::class)) {
             return null;
         }
 

--- a/src/Akeneo/UserManagement/Bundle/EventListener/LoginRateLimitListener.php
+++ b/src/Akeneo/UserManagement/Bundle/EventListener/LoginRateLimitListener.php
@@ -81,7 +81,7 @@ final class LoginRateLimitListener implements EventSubscriberInterface
 
     private function getUserFromPassport($passport): ?UserInterface
     {
-        if (!$passport->hasBadge(UserBadge::class)) {
+        if (empty($passport) || !$passport->hasBadge(UserBadge::class)) {
             return null;
         }
 

--- a/tests/back/UserManagement/Specification/Bundle/EventListener/LoginRateLimitListenerSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/EventListener/LoginRateLimitListenerSpec.php
@@ -102,6 +102,16 @@ class LoginRateLimitListenerSpec extends ObjectBehavior
         $this->lockStateShouldBeUpdated($userManager, $user, self::ALLOWED_FAILED_ATTEMPTS);
     }
 
+    public function it_consider_login_has_failed_when_passport_is_empty(
+        UserInterface $user,
+        LoginFailureEvent $event,
+    ): void {
+        $this->initUser($user,self::ALLOWED_FAILED_ATTEMPTS - 1, $this->getAuthenticationFailureResetDateFromNow(self::ACCOUNT_LOCK_DURATION - 1));
+        $event->getPassport()->willReturn(null);
+
+        $this->onFailureLogin($event)->shouldReturn(null);
+    }
+
     public function it_reset_failed_attempts_on_login_success(
         UserInterface $user,
         LoginSuccessEvent $event,

--- a/tests/back/UserManagement/Specification/Bundle/EventListener/LoginRateLimitListenerSpec.php
+++ b/tests/back/UserManagement/Specification/Bundle/EventListener/LoginRateLimitListenerSpec.php
@@ -10,6 +10,7 @@ use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
+use Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface;
 use Symfony\Component\Security\Http\Event\CheckPassportEvent;
 use Symfony\Component\Security\Http\Event\LoginFailureEvent;
 use Symfony\Component\Security\Http\Event\LoginSuccessEvent;
@@ -108,6 +109,18 @@ class LoginRateLimitListenerSpec extends ObjectBehavior
     ): void {
         $this->initUser($user,self::ALLOWED_FAILED_ATTEMPTS - 1, $this->getAuthenticationFailureResetDateFromNow(self::ACCOUNT_LOCK_DURATION - 1));
         $event->getPassport()->willReturn(null);
+
+        $this->onFailureLogin($event)->shouldReturn(null);
+    }
+
+    public function it_consider_login_has_failed_when_passport_is_not_a_symfony_passport_instance(
+        PassportInterface $passport,
+        UserBadge $badge,
+        UserInterface $user,
+        LoginFailureEvent $event,
+    ): void {
+        $this->initUser($user,self::ALLOWED_FAILED_ATTEMPTS - 1, $this->getAuthenticationFailureResetDateFromNow(self::ACCOUNT_LOCK_DURATION - 1));
+        $event->getPassport()->willReturn($passport);
 
         $this->onFailureLogin($event)->shouldReturn(null);
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

An 500 error has been detected on demo cluster (all region) and prod cluster (only Australia/Asia) and the deployment in production has been suspended.
We found that, in some login failure case we were not able to identify clearly, the new Symfony authentication system threw an exception, resulting in an empty "User Passport" and then manipulation of an empty object.
This fix manage this case and consider this as a failed login attempt.

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests

