### PR TITLE
Edit link not visible with Wysiwyg field

### DIFF
--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -107,7 +107,7 @@ define(['jquery', 'pim/field', 'underscore', 'pim/template/product/field/textare
 
       const source = jqueryEvent.originalEvent.path
         ? $(jqueryEvent.originalEvent.path[0])
-        : $(jqueryEvent.originalEvent.originalTarget);
+        : $(jqueryEvent.originalEvent.target);
 
       if (
         source.hasClass('icon-link') ||


### PR DESCRIPTION
Fixed edit link not visible with Wysiwyg field

**Description (for Contributor and Core Developer)**

This pull request addresses the issue of the edit link not being visible when using the Wysiwyg field. The solution involves updating the CSS code to properly display the edit link when using the Wysiwyg field, ensuring that it is clearly visible to users. 

![image003](https://user-images.githubusercontent.com/22136028/216110659-aacfadf3-5fae-4230-9298-b137da25dc45.png)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
