### PR TITLE
Fix PublishJobToQueueCommand for array of emails

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
@@ -86,7 +86,14 @@ class PublishJobToQueueCommand extends Command
                 'email',
                 null,
                 InputOption::VALUE_REQUIRED,
-                'The email to notify at the end of the job execution'
+                'Deprecated: use "emails" option instead'
+            )
+            ->addOption(
+                'emails',
+                null,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                'The email to notify at the end of the job execution',
+                []
             )
             ->addOption(
                 'no-log',
@@ -106,13 +113,14 @@ class PublishJobToQueueCommand extends Command
         $noLog = $input->getOption('no-log') ? true : false;
         $username = $input->getOption('username');
         $email = $input->getOption('email');
+        $emails = $input->getOption('emails', $email ? [$email] : []);
 
         $this->publishJobToQueue->publish(
             $jobInstanceCode,
             $config,
             $noLog,
             $username,
-            $email
+            $emails
         );
 
         $jobInstance = $this->getJobManager()->getRepository($this->jobInstanceClass)->findOneBy(['code' => $jobInstanceCode]);

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Command/PublishJobToQueueCommandSpec.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/spec/Command/PublishJobToQueueCommandSpec.php
@@ -80,20 +80,20 @@ class PublishJobToQueueCommandSpec extends ObjectBehavior
         $inputConfig = '{"key": "data", "superkey": 50}';
         $inputNoLog = null;
         $inputUsername = 'admin';
-        $inputEmail = null;
+        $inputEmails = [];
 
         $input->getArgument('code')->willReturn($inputCode);
         $input->getOption('config')->willReturn($inputConfig);
         $input->getOption('no-log')->willReturn($inputNoLog);
         $input->getOption('username')->willReturn($inputUsername);
-        $input->getOption('email')->willReturn($inputEmail);
+        $input->getOption('emails')->willReturn($inputEmails);
 
         $publishJobToQueue->publish(
             $inputCode,
             json_decode($inputConfig, true),
             false,
             $inputUsername,
-            $inputEmail
+            $inputEmails
         )->shouldBeCalled();
 
         $jobInstanceRepository->findOneBy(['code' => $inputCode])->willReturn($jobInstance);
@@ -129,13 +129,13 @@ class PublishJobToQueueCommandSpec extends ObjectBehavior
         $inputConfig = '{{invalid_config}';
         $inputNoLog = null;
         $inputUsername = 'admin';
-        $inputEmail = null;
+        $inputEmails = [];
 
         $input->getArgument('code')->willReturn($inputCode);
         $input->getOption('config')->willReturn($inputConfig);
         $input->getOption('no-log')->willReturn($inputNoLog);
         $input->getOption('username')->willReturn($inputUsername);
-        $input->getOption('email')->willReturn($inputEmail);
+        $input->getOption('emails')->willReturn($inputEmails);
 
         $this->shouldThrow(\InvalidArgumentException::class)->during(
             'run', [$input, $output]


### PR DESCRIPTION


<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

With this change (https://github.com/akeneo/pim-community-dev/commit/4fbfc4331b43ca7caa2de135b4822a7569fc03a3#diff-5bcc4402fff91e61f7036f663e07160f0fdbaad9e604cff8f6f5d87557bcae20L56) `Akeneo\Tool\Component\BatchQueue\Queue\PublishJobToQueue::publish()` contract was changed and `$email` argument has been replaced from single string to an array of strings.

This PR adds new `emails` option for PublishJobToQueueCommand. 
Current option `email` is marked as deprecated and fallback logic implemented.

| Q                                 | A
| --------------------------------- | ---
| Added Specs                       | yes
| Added acceptance tests            | no
| Added integration tests           | no
| Added legacy Behats               | no
| Changelog updated                 | no
| Review and 2 GTM                  | no
| Migration script                  | no
| Tech Doc                          | no

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
