### PR TITLE
CPM-928: Transform IdentifierGenerator into an Immutable Object

### DIFF
--- a/components/identifier-generator/back/src/Application/Update/UpdateGeneratorHandler.php
+++ b/components/identifier-generator/back/src/Application/Update/UpdateGeneratorHandler.php
@@ -21,8 +21,8 @@ use Webmozart\Assert\Assert;
 final class UpdateGeneratorHandler
 {
     public function __construct(
-        private IdentifierGeneratorRepository $identifierGeneratorRepository,
-        private CommandValidatorInterface $validator
+        private readonly IdentifierGeneratorRepository $identifierGeneratorRepository,
+        private readonly CommandValidatorInterface $validator
     ) {
     }
 
@@ -33,13 +33,14 @@ final class UpdateGeneratorHandler
         $identifierGenerator = $this->identifierGeneratorRepository->get($command->code);
         Assert::notNull($identifierGenerator, sprintf("Identifier generator \"%s\" does not exist or you do not have permission to access it.", $command->code));
 
-        $identifierGenerator->setDelimiter(Delimiter::fromString($command->delimiter));
-        $identifierGenerator->setLabelCollection(LabelCollection::fromNormalized($command->labels));
-        $identifierGenerator->setTarget(Target::fromString($command->target));
-        $identifierGenerator->setStructure(Structure::fromNormalized($command->structure));
-        $identifierGenerator->setConditions(Conditions::fromNormalized($command->conditions));
-        $identifierGenerator->setTextTransformation(TextTransformation::fromString($command->textTransformation));
+        $updatedIdentifierGenerator = $identifierGenerator
+            ->withStructure(Structure::fromNormalized($command->structure))
+            ->withConditions(Conditions::fromNormalized($command->conditions))
+            ->withLabelCollection(LabelCollection::fromNormalized($command->labels))
+            ->withTarget(Target::fromString($command->target))
+            ->withDelimiter(Delimiter::fromString($command->delimiter))
+            ->withTextTransformation(TextTransformation::fromString($command->textTransformation));
 
-        $this->identifierGeneratorRepository->update($identifierGenerator);
+        $this->identifierGeneratorRepository->update($updatedIdentifierGenerator);
     }
 }

--- a/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
+++ b/components/identifier-generator/back/src/Domain/Model/IdentifierGenerator.php
@@ -20,14 +20,14 @@ use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Condition\EmptyIdenti
 final class IdentifierGenerator
 {
     public function __construct(
-        private IdentifierGeneratorId $id,
-        private IdentifierGeneratorCode $code,
-        private Conditions $conditions,
-        private Structure $structure,
-        private LabelCollection $labelCollection,
-        private Target $target,
-        private ?Delimiter $delimiter,
-        private TextTransformation $textTransformation,
+        private readonly IdentifierGeneratorId $id,
+        private readonly IdentifierGeneratorCode $code,
+        private readonly Conditions $conditions,
+        private readonly Structure $structure,
+        private readonly LabelCollection $labelCollection,
+        private readonly Target $target,
+        private readonly ?Delimiter $delimiter,
+        private readonly TextTransformation $textTransformation,
     ) {
     }
 
@@ -66,29 +66,93 @@ final class IdentifierGenerator
         return $this->delimiter;
     }
 
-    public function setStructure(Structure $structure): void
+    public function textTransformation(): TextTransformation
     {
-        $this->structure = $structure;
+        return $this->textTransformation;
     }
 
-    public function setConditions(Conditions $conditions): void
+    public function withStructure(Structure $structure): self
     {
-        $this->conditions = $conditions;
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $this->conditions,
+            $structure,
+            $this->labelCollection,
+            $this->target,
+            $this->delimiter,
+            $this->textTransformation
+        );
     }
 
-    public function setLabelCollection(LabelCollection $labelCollection): void
+    public function withConditions(Conditions $conditions): self
     {
-        $this->labelCollection = $labelCollection;
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $conditions,
+            $this->structure,
+            $this->labelCollection,
+            $this->target,
+            $this->delimiter,
+            $this->textTransformation
+        );
     }
 
-    public function setTarget(Target $target): void
+    public function withLabelCollection(LabelCollection $labelCollection): self
     {
-        $this->target = $target;
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $this->conditions,
+            $this->structure,
+            $labelCollection,
+            $this->target,
+            $this->delimiter,
+            $this->textTransformation
+        );
     }
 
-    public function setDelimiter(?Delimiter $delimiter): void
+    public function withTarget(Target $target): self
     {
-        $this->delimiter = $delimiter;
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $this->conditions,
+            $this->structure,
+            $this->labelCollection,
+            $target,
+            $this->delimiter,
+            $this->textTransformation
+        );
+    }
+
+    public function withDelimiter(?Delimiter $delimiter): self
+    {
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $this->conditions,
+            $this->structure,
+            $this->labelCollection,
+            $this->target,
+            $delimiter,
+            $this->textTransformation
+        );
+    }
+
+    public function withTextTransformation(TextTransformation $textTransformation): self
+    {
+        return new IdentifierGenerator(
+            $this->id,
+            $this->code,
+            $this->conditions,
+            $this->structure,
+            $this->labelCollection,
+            $this->target,
+            $this->delimiter,
+            $textTransformation
+        );
     }
 
     /**
@@ -132,15 +196,5 @@ final class IdentifierGenerator
         $conditions = [new EmptyIdentifier($this->target()->asString())];
 
         return \array_merge($conditions, $this->structure->getImplicitConditions());
-    }
-
-    public function textTransformation(): TextTransformation
-    {
-        return $this->textTransformation;
-    }
-
-    public function setTextTransformation(TextTransformation $textTransformation): void
-    {
-        $this->textTransformation = $textTransformation;
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/IdentifierGeneratorSpec.php
@@ -12,7 +12,6 @@ use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\IdentifierGeneratorCo
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\IdentifierGeneratorId;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\LabelCollection;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\ProductProjection;
-use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\AutoNumber;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FamilyProperty;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Property\FreeText;
 use Akeneo\Pim\Automation\IdentifierGenerator\Domain\Model\Structure;
@@ -81,6 +80,7 @@ class IdentifierGeneratorSpec extends ObjectBehavior
             $textTransformation,
         );
         $this->shouldBeAnInstanceOf(IdentifierGenerator::class);
+        $this->delimiter()->shouldBeNull();
     }
 
     public function it_returns_an_indentifier_generator_id(): void
@@ -100,9 +100,11 @@ class IdentifierGeneratorSpec extends ObjectBehavior
 
     public function it_sets_a_delimiter(): void
     {
-        $this->delimiter()->asString()->shouldBeLike('-');
-        $this->setDelimiter(Delimiter::fromString('='));
-        $this->delimiter()->asString()->shouldBeLike('=');
+        $this->delimiter()->asString()->shouldReturn('-');
+        $result = $this->withDelimiter(Delimiter::fromString('='));
+        $result->delimiter()->asString()->shouldReturn('=');
+        $result->shouldNotBe($this);
+        $this->delimiter()->asString()->shouldReturn('-');
     }
 
     public function it_returns_a_target(): void
@@ -112,9 +114,11 @@ class IdentifierGeneratorSpec extends ObjectBehavior
 
     public function it_sets_a_target(): void
     {
-        $this->target()->asString()->shouldBeLike('sku');
-        $this->setTarget(Target::fromString('gtin'));
-        $this->target()->asString()->shouldBeLike('gtin');
+        $this->target()->asString()->shouldReturn('sku');
+        $result = $this->withTarget(Target::fromString('gtin'));
+        $result->target()->asString()->shouldReturn('gtin');
+        $result->shouldNotBe($this);
+        $this->target()->asString()->shouldReturn('sku');
     }
 
     public function it_returns_a_conditions(): void
@@ -132,14 +136,20 @@ class IdentifierGeneratorSpec extends ObjectBehavior
 
     public function it_sets_a_structure(): void
     {
-        $this->setStructure(Structure::fromArray([
-            FreeText::fromString('cba'),
-            AutoNumber::fromValues(3, 2),
-        ]));
-        $this->structure()->shouldBeLike(Structure::fromArray([
-            FreeText::fromString('cba'),
-            AutoNumber::fromValues(3, 2),
-        ]));
+        $previousStructure = Structure::fromArray([
+            FreeText::fromString('abc'),
+            FamilyProperty::fromNormalized(['type' => 'family', 'process' => ['type' => 'no']]),
+        ]);
+        $updatedStructure = Structure::fromArray([
+            FreeText::fromString('def'),
+            FamilyProperty::fromNormalized(['type' => 'family', 'process' => ['type' => 'truncate', 'operator' => 'EQUALS', 'value' => 3]]),
+        ]);
+
+        $this->structure()->shouldBeLike($previousStructure);
+        $result = $this->withStructure($updatedStructure);
+        $result->structure()->shouldBeLike($updatedStructure);
+        $result->shouldNotBe($this);
+        $this->structure()->shouldBeLike($previousStructure);
     }
 
     public function it_returns_a_labels_collection(): void
@@ -149,15 +159,17 @@ class IdentifierGeneratorSpec extends ObjectBehavior
 
     public function it_sets_a_labels_collection(): void
     {
-        $this->labelCollection()->shouldBeLike(LabelCollection::fromNormalized(['fr' => 'Générateur']));
-        $this->setLabelCollection(LabelCollection::fromNormalized([
+        $previousLabelCollection = LabelCollection::fromNormalized(['fr' => 'Générateur']);
+        $updatedLabelCollection = LabelCollection::fromNormalized([
             'fr' => 'Générateur',
             'en' => 'generator',
-        ]));
-        $this->labelCollection()->shouldBeLike(LabelCollection::fromNormalized([
-            'fr' => 'Générateur',
-            'en' => 'generator',
-        ]));
+        ]);
+
+        $this->labelCollection()->shouldBeLike($previousLabelCollection);
+        $result = $this->withLabelCollection($updatedLabelCollection);
+        $result->labelCollection()->shouldBeLike($updatedLabelCollection);
+        $result->shouldNotBe($this);
+        $this->labelCollection()->shouldBeLike($previousLabelCollection);
     }
 
     public function it_can_be_normalized(): void


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Remove setters to make IdentifierGenerator immutable

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
