### PR TITLE
CXP-1431: Map number attributes (string)

### DIFF
--- a/components/catalogs/back/src/Application/Mapping/TargetTypeConverter.php
+++ b/components/catalogs/back/src/Application/Mapping/TargetTypeConverter.php
@@ -18,6 +18,7 @@ final class TargetTypeConverter
         ],
         'string' => [
             'pim_catalog_identifier',
+            'pim_catalog_number',
             'pim_catalog_simpleselect',
             'pim_catalog_text',
             'pim_catalog_textarea',

--- a/components/catalogs/back/tests/Acceptance/ApiContext.php
+++ b/components/catalogs/back/tests/Acceptance/ApiContext.php
@@ -30,8 +30,6 @@ use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
 use Akeneo\Pim\Structure\Component\Model\AttributeOptionValue;
 use Behat\Behat\Context\Context;
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Types\Types;
 use PHPUnit\Framework\Assert;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;

--- a/components/catalogs/back/tests/Unit/Application/Mapping/TargetTypeConverterTest.php
+++ b/components/catalogs/back/tests/Unit/Application/Mapping/TargetTypeConverterTest.php
@@ -43,6 +43,7 @@ class TargetTypeConverterTest extends TestCase
                 '',
                 [
                     'pim_catalog_identifier',
+                    'pim_catalog_number',
                     'pim_catalog_simpleselect',
                     'pim_catalog_text',
                     'pim_catalog_textarea',


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

![image](https://user-images.githubusercontent.com/4290650/216649796-d24aff8c-6b9c-4482-8a7f-cde0f6b74efb.png)

In the above API response, I mapped the PIM attribute "optical zoom" which is a number to the targets "zoom" and "description":

![image](https://user-images.githubusercontent.com/4290650/216650567-75cfeafb-2b0f-4774-a043-4e119ad50b8c.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
