### PR TITLE
Fix workerIdleMemoryLimit only work on jest 29, as we did not success to upgrade jest we used max_old_space_size

### DIFF
--- a/components/identifier-generator/front/package.json
+++ b/components/identifier-generator/front/package.json
@@ -37,7 +37,7 @@
   "proxy": "http://httpd",
   "scripts": {
     "app:start": "yarn translation:build && yarn route:build && yarn packages:build && react-scripts --openssl-legacy-provider start",
-    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3",
     "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3",
     "lib:build": "tsc -p ./tsconfig.build.json",
     "translation:build": "cp ../../../public/js/translation/en_US.js ./src/translations.json",

--- a/front-packages/akeneo-design-system/package.json
+++ b/front-packages/akeneo-design-system/package.json
@@ -7,7 +7,7 @@
     "lib:build": "tsc -p ./tsconfig.build.json",
     "lib:watch": "tsc -p ./tsconfig.build.json --watch",
     "test": "yarn lint:check && yarn test:unit:run && yarn test:visual:run",
-    "test:unit:run": "jest --config ./jest.unit.config.js --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "jest --config ./jest.unit.config.js --maxWorkers=3",
     "test:unit:watch": "jest --config ./jest.unit.config.js --watch --maxWorkers=3",
     "test:visual:run": "yarn storybook:extract && jest --config ./jest.visual.config.js",
     "test:visual:update": "yarn storybook:extract && jest --config ./jest.visual.config.js -u",

--- a/front-packages/measurement/package.json
+++ b/front-packages/measurement/package.json
@@ -33,7 +33,7 @@
   "proxy": "http://localhost:8080",
   "scripts": {
     "app:start": "yarn route:build && yarn packages:build && react-scripts --openssl-legacy-provider start",
-    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3",
     "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3",
     "lib:build": "tsc -p ./tsconfig.build.json",
     "route:build": "cp ../../public/js/fos_js_routes.json ./src/routes.json",

--- a/front-packages/shared/package.json
+++ b/front-packages/shared/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "lib:build": "tsc -p ./tsconfig.json",
-    "test:unit:run": "jest --no-cache --config ./jest.config.js --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "jest --no-cache --config ./jest.config.js --maxWorkers=3",
     "lint:fix": "prettier --config .prettierrc.json --parser typescript --write \"./src/**/*.{ts,tsx}\"",
     "lint:check": "prettier --config .prettierrc.json --parser typescript --check \"./src/**/*.{ts,tsx}\""
   },

--- a/src/Akeneo/Category/front/package.json
+++ b/src/Akeneo/Category/front/package.json
@@ -33,7 +33,7 @@
         "lib:build": "tsc -p ./tsconfig.build.json",
         "lint:fix": "prettier --config .prettierrc.json --parser typescript --write \"./src/**/*.{ts,tsx}\"",
         "lint:check": "prettier --config .prettierrc.json --parser typescript --check \"./src/**/*.{ts,tsx}\" && yarn eslint --max-warnings 0 --ext .tsx,.ts ./src",
-        "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+        "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3",
         "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3"
     },
     "eslintConfig": {

--- a/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/front/package.json
+++ b/src/Akeneo/Platform/Bundle/CatalogVolumeMonitoringBundle/front/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "app:start": "yarn translation:build && yarn route:build && yarn packages:build && react-scripts --openssl-legacy-provider start",
-    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --maxWorkers=3",
     "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3",
     "lib:build": "tsc -p ./tsconfig.build.json",
     "translation:build": "cp $npm_package_config_application_path/public/js/translation/en_US.js ./src/translations.json",

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/package.json
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "main": "lib/index.js",
     "scripts": {
-        "test:unit:run": "jest --config jest.config.json --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+        "test:unit:run": "jest --config jest.config.json --coverage --coverageDirectory=coverage --maxWorkers=3",
         "test:unit:watch": "jest --config jest.config.json --watch",
         "lib:build": "tsc -p ./tsconfig.build.json",
         "lint:fix": "prettier --config .prettierrc.json --parser typescript --write \"./src/**/*.{ts,tsx}\"",

--- a/src/Akeneo/Platform/Job/front/process-tracker/package.json
+++ b/src/Akeneo/Platform/Job/front/process-tracker/package.json
@@ -73,7 +73,7 @@
   },
   "scripts": {
     "app:start": "yarn route:build && yarn packages:build && react-scripts --openssl-legacy-provider start",
-    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3",
     "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3",
     "lib:build": "tsc -p ./tsconfig.build.json",
     "route:build": "cp ../../../../../../public/js/fos_js_routes.json ./src/routes.json",

--- a/src/Oro/Bundle/ConfigBundle/front/package.json
+++ b/src/Oro/Bundle/ConfigBundle/front/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "app:start": "yarn translation:build && yarn route:build && yarn packages:build && react-scripts --openssl-legacy-provider start",
-    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3 --workerIdleMemoryLimit=300MB",
+    "test:unit:run": "react-scripts --openssl-legacy-provider test --watchAll=false --coverage --coverageDirectory=coverage --maxWorkers=3",
     "test:unit:watch": "react-scripts --openssl-legacy-provider test --maxWorkers=3",
     "lib:build": "tsc -p ./tsconfig.build.json",
     "translation:build": "cp $npm_package_config_application_path/public/js/translation/en_US.js ./src/translations.json",


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, 

I fixed the memory leak that random fail CI, as --workerIdleMemoryLimit=300MB is only available on jest 29 and we are in jest 26, first we try to bump the jest version (https://akeneo.atlassian.net/browse/RAB-1311) but we didn't succeeded (dependency hell) since 1 week so we decided to use the node parameter.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
