### PR TITLE
CPM-881: Forbid auto number properties to be added twice

### DIFF
--- a/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/StructureTab.tsx
@@ -107,7 +107,7 @@ const StructureTab: React.FC<StructureTabProps> = ({
           <SectionTitle>
             <SectionTitle.Title>{translate('pim_identifier_generator.structure.title')}</SectionTitle.Title>
             <SectionTitle.Spacer />
-            {!isLimitReached && <AddPropertyButton onAddProperty={onAddProperty} />}
+            {!isLimitReached && <AddPropertyButton onAddProperty={onAddProperty} structure={structure} />}
           </SectionTitle>
           {structure.length > 0 && (
             <>

--- a/components/identifier-generator/front/src/feature/tabs/structure/__tests__/AddPropertyButton.test.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/structure/__tests__/AddPropertyButton.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import {fireEvent, render, screen, waitFor} from '../../../tests/test-utils';
 import {AddPropertyButton} from '../AddPropertyButton';
 import userEvent from '@testing-library/user-event';
-import {PROPERTY_NAMES} from '../../../models';
+import {PROPERTY_NAMES, Structure} from '../../../models';
 
 describe('AddPropertyButton', () => {
   it('allows search', async () => {
-    render(<AddPropertyButton onAddProperty={jest.fn()} />);
+    render(<AddPropertyButton onAddProperty={jest.fn()} structure={[]} />);
     const button = screen.getByRole('button');
     expect(screen.getByText('pim_identifier_generator.structure.add_element')).toBeInTheDocument();
     expect(button).toBeInTheDocument();
@@ -39,7 +39,7 @@ describe('AddPropertyButton', () => {
 
   it('adds a property', async () => {
     const onAddProperty = jest.fn();
-    render(<AddPropertyButton onAddProperty={onAddProperty} />);
+    render(<AddPropertyButton onAddProperty={onAddProperty} structure={[]} />);
     const button = screen.getByRole('button');
     expect(screen.getByText('pim_identifier_generator.structure.add_element')).toBeInTheDocument();
     expect(button).toBeInTheDocument();
@@ -48,11 +48,32 @@ describe('AddPropertyButton', () => {
     await waitFor(() => {
       expect(screen.getByText('pim_identifier_generator.structure.property_type.free_text')).toBeInTheDocument();
     });
+    expect(screen.getByText('pim_identifier_generator.structure.property_type.free_text')).toBeInTheDocument();
+    expect(screen.getByText('pim_identifier_generator.structure.property_type.auto_number')).toBeInTheDocument();
 
     fireEvent.click(screen.getByText('pim_identifier_generator.structure.property_type.free_text'));
     expect(onAddProperty).toBeCalledWith({
       type: PROPERTY_NAMES.FREE_TEXT,
       string: '',
     });
+  });
+
+  it('should not be able to add an auto number twice', () => {
+    const structureWithAutoNumber: Structure = [
+      {
+        type: PROPERTY_NAMES.AUTO_NUMBER,
+        digitsMin: 0,
+        numberMin: 5
+      }
+    ];
+    render(<AddPropertyButton onAddProperty={jest.fn()} structure={structureWithAutoNumber} />);
+
+    const button = screen.getByRole('button');
+    expect(screen.getByText('pim_identifier_generator.structure.add_element')).toBeInTheDocument();
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.getByText('pim_identifier_generator.structure.property_type.free_text')).toBeInTheDocument();
+    expect(screen.queryByText('pim_identifier_generator.structure.property_type.auto_number')).not.toBeInTheDocument();
   });
 });

--- a/components/identifier-generator/front/src/feature/tabs/structure/__tests__/AddPropertyButton.test.tsx
+++ b/components/identifier-generator/front/src/feature/tabs/structure/__tests__/AddPropertyButton.test.tsx
@@ -63,8 +63,8 @@ describe('AddPropertyButton', () => {
       {
         type: PROPERTY_NAMES.AUTO_NUMBER,
         digitsMin: 0,
-        numberMin: 5
-      }
+        numberMin: 5,
+      },
     ];
     render(<AddPropertyButton onAddProperty={jest.fn()} structure={structureWithAutoNumber} />);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Auto number can now only be added once in the structure

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
