### PR TITLE
GRF-728 Update snapshot parent when the category is root

### DIFF
--- a/src/Akeneo/Category/back/Domain/ValueObject/Version/CategoryVersion.php
+++ b/src/Akeneo/Category/back/Domain/ValueObject/Version/CategoryVersion.php
@@ -10,7 +10,7 @@ namespace Akeneo\Category\Domain\ValueObject\Version;
  *
  * @phpstan-type Snapshot array{
  *     code: string,
- *     parent: string,
+ *     parent: string|null,
  *     updated: string
  * }&array<string, string>
  */

--- a/src/Akeneo/Category/back/Infrastructure/Builder/CategoryVersionBuilder.php
+++ b/src/Akeneo/Category/back/Infrastructure/Builder/CategoryVersionBuilder.php
@@ -39,10 +39,17 @@ class CategoryVersionBuilder
      */
     public function buildSnapshot(Category $category): array
     {
-        if (null !== $category->getParentId()) {
+        $snapshotParent = null;
+
+        if (!$category->isRoot() && null !== $category->getParentId()) {
             $parent = $this->getCategory->byId($category->getParentId()->getValue());
+            $snapshotParent = (string) $parent->getCode();
         }
-        $parent = !empty($parent) ? (string) $parent->getCode() : '';
+
+        if (!$category->isRoot() && empty($snapshotParent) && null !== $category->getRootId()) {
+            $root = $this->getCategory->byId($category->getRootId()->getValue());
+            $snapshotParent = (string) $root->getCode();
+        }
 
         $snapshotLabels = [];
         foreach ($category->getLabels()?->normalize() as $locale => $label) {
@@ -59,7 +66,7 @@ class CategoryVersionBuilder
 
         $snapshot = [
             'code' => (string) $category->getCode(),
-            'parent' => $parent,
+            'parent' => $snapshotParent,
             'updated' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c') ?? '',
         ];
 

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/Builder/CategoryVersionBuilderIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/Builder/CategoryVersionBuilderIntegration.php
@@ -81,12 +81,12 @@ class CategoryVersionBuilderIntegration extends CategoryTestCase
 
         $categoryVersion = $builder->create($givenCategory);
 
-
         $expectedCategoryVersion = CategoryVersion::fromBuilder(
             resourceId: '2',
+            /** @phpstan-ignore-next-line  */
             snapshot: [
                 'code' => 'category_test',
-                'parent' => '',
+                'parent' => null,
                 'updated' => $updated->format('c'),
                 'label-en_US' => 'test category',
                 'label-fr_FR' => 'catégorie de test'


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Update the parent snapshot when the category is root. 
Means that when the category is root the snapshot parent has to be null and not an empty string. 

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
