### PR TITLE
CXP-1419 Updated custom apps routes

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/CustomApps/Controller/Internal/DeleteCustomAppAction.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/CustomApps/Controller/Internal/DeleteCustomAppAction.php
@@ -32,7 +32,7 @@ final class DeleteCustomAppAction
     ) {
     }
 
-    public function __invoke(Request $request, string $testAppId): Response
+    public function __invoke(Request $request, string $customAppId): Response
     {
         if (!$this->appDevModeFeatureFlag->isEnabled()) {
             throw new NotFoundHttpException();
@@ -46,15 +46,15 @@ final class DeleteCustomAppAction
             throw new AccessDeniedHttpException();
         }
 
-        $customAppData = $this->getCustomAppQuery->execute($testAppId);
+        $customAppData = $this->getCustomAppQuery->execute($customAppId);
         if (null === $customAppData) {
-            throw new NotFoundHttpException(\sprintf('Custom app with id %s was not found.', $testAppId));
+            throw new NotFoundHttpException(\sprintf('Custom app with id %s was not found.', $customAppId));
         }
 
-        $this->deleteCustomAppHandler->handle(new DeleteCustomAppCommand($testAppId));
+        $this->deleteCustomAppHandler->handle(new DeleteCustomAppCommand($customAppId));
 
         if ($customAppData['connected']) {
-            $this->deleteAppHandler->handle(new DeleteAppCommand($testAppId));
+            $this->deleteAppHandler->handle(new DeleteAppCommand($customAppId));
         }
 
         return new Response(null, Response::HTTP_NO_CONTENT);

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
@@ -1,6 +1,6 @@
 # Internal API
-akeneo_connectivity_connection_marketplace_rest_get_all_test_apps:
-    path: '/rest/marketplace/test-apps'
+akeneo_connectivity_connection_custom_apps_rest_get_all:
+    path: '/rest/custom-apps'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\GetAllCustomAppsAction
     methods: [GET]
 
@@ -20,19 +20,19 @@ akeneo_connectivity_connection_custom_apps_rest_get_secret:
     methods: [GET]
 
 # External API
-akeneo_connectivity_connection_marketplace_api_test_apps_list:
+akeneo_connectivity_connection_custom_apps_api_list:
     path: '/api/rest/v1/test-apps'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\External\GetCustomAppsAction
     methods: [GET]
     defaults: { _list_in_root_endpoint: false }
 
-akeneo_connectivity_connection_marketplace_api_test_apps_create:
+akeneo_connectivity_connection_custom_apps_api_create:
     path: '/api/rest/v1/test-apps'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\External\CreateCustomAppAction
     methods: [POST]
     defaults: { _list_in_root_endpoint: false }
 
-akeneo_connectivity_connection_marketplace_api_test_apps_delete:
+akeneo_connectivity_connection_custom_apps_api_delete:
     path: '/api/rest/v1/test-apps/{clientId}'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\External\DeleteCustomAppAction
     methods: [DELETE]

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
@@ -15,7 +15,7 @@ akeneo_connectivity_connection_custom_apps_rest_delete:
     methods: [DELETE]
 
 akeneo_connectivity_connection_custom_apps_rest_get_secret:
-    path: '/rest/marketplace/custom-apps/{customAppId}/secret'
+    path: '/rest/custom-apps/{customAppId}/secret'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\GetCustomAppSecretAction
     methods: [GET]
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
@@ -4,8 +4,8 @@ akeneo_connectivity_connection_custom_apps_rest_get_all:
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\GetAllCustomAppsAction
     methods: [GET]
 
-akeneo_connectivity_connection_marketplace_rest_test_apps_create:
-    path: '/rest/marketplace/test-apps'
+akeneo_connectivity_connection_custom_apps_rest_create:
+    path: '/rest/custom-apps'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\CreateCustomAppAction
     methods: [POST]
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
@@ -9,8 +9,8 @@ akeneo_connectivity_connection_custom_apps_rest_create:
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\CreateCustomAppAction
     methods: [POST]
 
-akeneo_connectivity_connection_marketplace_rest_test_apps_delete:
-    path: '/rest/marketplace/test-apps/{testAppId}'
+akeneo_connectivity_connection_custom_apps_rest_delete:
+    path: '/rest/custom-apps/{customAppId}'
     controller: Akeneo\Connectivity\Connection\Infrastructure\CustomApps\Controller\Internal\DeleteCustomAppAction
     methods: [DELETE]
 

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/CustomApps/routing.yml
@@ -39,10 +39,10 @@ akeneo_connectivity_connection_custom_apps_api_delete:
     defaults: { _list_in_root_endpoint: false }
 
 # Front API
-akeneo_connectivity_connection_connect_marketplace_test_app_create:
-    path: '/connect/app-store/test-apps/create'
+akeneo_connectivity_connection_connect_custom_apps_create:
+    path: '/connect/custom-apps/create'
 
-akeneo_connectivity_connection_connect_marketplace_test_app_delete:
-    path: '/connect/app-store/test-apps/{testAppId}/delete'
+akeneo_connectivity_connection_connect_custom_apps_delete:
+    path: '/connect/custom-apps/:customAppId/delete'
     requirements:
-        testAppId: '[a-zA-Z0-9_-]+'
+        customAppId: '[a-zA-Z0-9_-]+'

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/requirejs.yml
@@ -6,10 +6,10 @@ config:
                     module: pim/controller/connectivity/connection/connect/marketplace
                 akeneo_connectivity_connection_connect_marketplace_profile:
                     module: pim/controller/connectivity/connection/connect/marketplace
-                akeneo_connectivity_connection_connect_marketplace_test_app_create:
-                    module: pim/controller/connectivity/connection/connect/marketplace
-                akeneo_connectivity_connection_connect_marketplace_test_app_delete:
-                    module: pim/controller/connectivity/connection/connect/marketplace
+                akeneo_connectivity_connection_connect_custom_apps_create:
+                    module: pim/controller/connectivity/connection/connect/custom-apps
+                akeneo_connectivity_connection_connect_custom_apps_delete:
+                    module: pim/controller/connectivity/connection/connect/custom-apps
                 akeneo_connectivity_connection_connect_apps_activate:
                     module: pim/controller/connectivity/connection/connect/apps
                 akeneo_connectivity_connection_connect_apps_authorize:
@@ -57,6 +57,7 @@ config:
     paths:
         pim/controller/connectivity/connection/connect/apps: akeneoconnectivityconnection/js/controller/apps.tsx
         pim/controller/connectivity/connection/connect/marketplace: akeneoconnectivityconnection/js/controller/marketplace.tsx
+        pim/controller/connectivity/connection/connect/custom-apps: akeneoconnectivityconnection/js/controller/custom-apps.tsx
         pim/controller/connectivity/connection/settings: akeneoconnectivityconnection/js/controller/settings.tsx
         pim/controller/connectivity/connection/error-management: akeneoconnectivityconnection/js/controller/error-management.tsx
         pim/controller/connectivity/connection/webhook: akeneoconnectivityconnection/js/controller/webhook.tsx

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/controller/custom-apps.tsx
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/public/js/controller/custom-apps.tsx
@@ -1,0 +1,31 @@
+import {CustomApps} from '@akeneo-pim-community/connectivity-connection';
+import React from 'react';
+import {dependencies} from '../dependencies';
+import ReactController from '../react/react-controller';
+
+const mediator = require('oro/mediator');
+
+class CustomAppsController extends ReactController {
+  reactElementToMount() {
+    return <CustomApps dependencies={dependencies} />;
+  }
+
+  routeGuardToUnmount() {
+    return /^akeneo_connectivity_connection_connect_custom_apps/;
+  }
+
+  initialize() {
+    this.$el.addClass('AknConnectivityConnection-view');
+
+    return super.initialize();
+  }
+
+  renderRoute(route: {name: string}) {
+    mediator.trigger('pim_menu:highlight:tab', {extension: 'pim-menu-connect'});
+    mediator.trigger('pim_menu:highlight:item', {extension: 'pim-menu-connect-marketplace'});
+
+    return super.renderRoute(route);
+  }
+}
+
+export = CustomAppsController;

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/translations/jsmessages.en_US.yml
@@ -40,8 +40,8 @@ pim_title:
     akeneo_connectivity_connection_connect_connected_apps: Connected Apps
     akeneo_connectivity_connection_connect_connected_apps_edit: App settings
     akeneo_connectivity_connection_connect_connected_apps_delete: App delete
-    akeneo_connectivity_connection_connect_marketplace_test_app_create: Create a test app
-    akeneo_connectivity_connection_connect_marketplace_test_app_delete: Delete test app
+    akeneo_connectivity_connection_custom_apps_create: Create a custom app
+    akeneo_connectivity_connection_custom_apps_delete: Delete custom app
     akeneo_connectivity_connection_connect_connected_apps_open: Open App
     akeneo_connectivity_connection_connect_connected_apps_catalogs_edit: Edit catalog
 akeneo_connectivity.connection:

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/CreateCustomAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/CreateCustomAppActionEndToEnd.php
@@ -45,7 +45,7 @@ class CreateCustomAppActionEndToEnd extends WebTestCase
 
         $this->client->request(
             'POST',
-            'rest/marketplace/test-apps',
+            '/rest/custom-apps',
             [],
             [],
             [

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/DeleteCustomAppActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/DeleteCustomAppActionEndToEnd.php
@@ -50,7 +50,7 @@ class DeleteCustomAppActionEndToEnd extends WebTestCase
 
         $this->client->request(
             'DELETE',
-            '/rest/marketplace/test-apps/100eedac-ff5c-497b-899d-e2d64b6c59f9',
+            '/rest/custom-apps/100eedac-ff5c-497b-899d-e2d64b6c59f9',
             [],
             [],
             [

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/GetAllCustomAppsActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/GetAllCustomAppsActionEndToEnd.php
@@ -40,7 +40,7 @@ class GetAllCustomAppsActionEndToEnd extends WebTestCase
 
         $this->client->request(
             'GET',
-            '/rest/marketplace/test-apps',
+            '/rest/custom-apps',
             [],
             [],
             [

--- a/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/GetCustomAppSecretActionEndToEnd.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/EndToEnd/CustomApps/Controller/Internal/GetCustomAppSecretActionEndToEnd.php
@@ -56,7 +56,7 @@ class GetCustomAppSecretActionEndToEnd extends WebTestCase
 
         $this->client->request(
             'GET',
-            '/rest/marketplace/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret',
+            '/rest/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret',
             [],
             [],
             [
@@ -74,7 +74,7 @@ class GetCustomAppSecretActionEndToEnd extends WebTestCase
     {
         $this->client->request(
             'GET',
-            '/rest/marketplace/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret',
+            '/rest/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret',
             [],
             [],
             [
@@ -93,7 +93,7 @@ class GetCustomAppSecretActionEndToEnd extends WebTestCase
 
         $this->client->request(
             'GET',
-            '/rest/marketplace/custom-apps/0dfce574-2238-4b13-b8cc-000000000/secret',
+            '/rest/custom-apps/0dfce574-2238-4b13-b8cc-000000000/secret',
             [],
             [],
             [

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/TestAppCard.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/components/TestApp/TestAppCard.tsx
@@ -81,7 +81,7 @@ export const TestAppCard: FC<Props> = ({testApp, additionalActions}) => {
 
     const onDelete = () => {
         history.push(
-            generateUrl('akeneo_connectivity_connection_connect_marketplace_test_app_delete', {
+            generateUrl('akeneo_connectivity_connection_custom_apps_delete', {
                 testAppId: testApp.id,
             })
         );

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-create-test-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-create-test-app.ts
@@ -8,7 +8,7 @@ export type TestApp = {
 };
 
 export const useCreateTestApp = () => {
-    const url = useRoute('akeneo_connectivity_connection_marketplace_rest_test_apps_create');
+    const url = useRoute('akeneo_connectivity_connection_custom_apps_rest_create');
 
     return useCallback(
         async (testApp: TestApp) => {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-delete-test-app.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-delete-test-app.ts
@@ -3,8 +3,8 @@ import {useCallback} from 'react';
 
 type CallbackType = () => Promise<void>;
 
-export const useDeleteTestApp = (testAppId: string): CallbackType => {
-    const url = useRoute('akeneo_connectivity_connection_marketplace_rest_test_apps_delete', {testAppId});
+export const useDeleteTestApp = (customAppId: string): CallbackType => {
+    const url = useRoute('akeneo_connectivity_connection_custom_apps_rest_delete', {customAppId});
 
     return useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-custom-app-secret.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-custom-app-secret.ts
@@ -10,7 +10,7 @@ type Result = {
 
 export const useFetchCustomAppSecret = (customAppId: string): Result => {
     return useQuery<string, Error, string>(['custom_app_secret', customAppId], async () => {
-        const response = await fetch(`/rest/marketplace/custom-apps/${customAppId}/secret`, {
+        const response = await fetch(`/rest/custom-apps/${customAppId}/secret`, {
             headers: {
                 'X-Requested-With': 'XMLHttpRequest',
             },

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-test-apps.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/hooks/use-fetch-test-apps.ts
@@ -5,7 +5,7 @@ import {useAppDeveloperMode} from './use-app-developer-mode';
 
 export const useFetchTestApps = (): (() => Promise<TestApps>) => {
     const isAppDeveloperModeEnabled = useAppDeveloperMode();
-    const url = useRoute('akeneo_connectivity_connection_marketplace_rest_get_all_test_apps');
+    const url = useRoute('akeneo_connectivity_connection_custom_apps_rest_get_all');
 
     const fetchTestApps = useCallback(async () => {
         const response = await fetch(url, {

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/DeleteTestAppPromptPage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/DeleteTestAppPromptPage.tsx
@@ -39,8 +39,8 @@ export const DeleteTestAppPromptPage: FC = () => {
     const notify = useNotify();
     const isAppDeveloperModeEnabled = useAppDeveloperMode();
 
-    const {testAppId} = useParams<{testAppId: string}>();
-    const deleteTestApp = useDeleteTestApp(testAppId);
+    const {customAppId} = useParams<{customAppId: string}>();
+    const deleteTestApp = useDeleteTestApp(customAppId);
 
     if (!isAppDeveloperModeEnabled) {
         history.push(generateUrl('akeneo_connectivity_connection_connect_marketplace'));

--- a/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/connect/pages/MarketplacePage.tsx
@@ -66,7 +66,7 @@ export const MarketplacePage: FC = () => {
     const isLoading = null === extensions || null === apps || isTestAppsLoading;
     const isUnreachable = false === extensions || false === apps;
     const handleCreateTestApp = () => {
-        history.push(generateUrl('akeneo_connectivity_connection_connect_marketplace_test_app_create'));
+        history.push(generateUrl('akeneo_connectivity_connection_custom_apps_create'));
     };
 
     const breadcrumb = (

--- a/src/Akeneo/Connectivity/Connection/front/src/index.ts
+++ b/src/Akeneo/Connectivity/Connection/front/src/index.ts
@@ -5,5 +5,6 @@ import {Settings} from './infrastructure/Settings';
 import {Marketplace} from './infrastructure/Marketplace';
 import {Apps} from './infrastructure/Apps';
 import {ConnectedApps} from './infrastructure/ConnectedApps';
+import {CustomApps} from './infrastructure/CustomApps';
 
-export {Settings, Audit, ErrorManagement, WebhookSettings, Marketplace, Apps, ConnectedApps};
+export {Settings, Audit, ErrorManagement, WebhookSettings, Marketplace, Apps, ConnectedApps, CustomApps};

--- a/src/Akeneo/Connectivity/Connection/front/src/infrastructure/CustomApps.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/infrastructure/CustomApps.tsx
@@ -1,0 +1,23 @@
+import React, {StrictMode} from 'react';
+import {HashRouter as Router, Route, Switch} from 'react-router-dom';
+import {AkeneoThemeProvider} from './akeneo-theme-provider';
+import {withDependencies} from './dependencies-provider';
+import {TestAppCreatePage} from '../connect/pages/TestAppCreatePage';
+import {DeleteTestAppPromptPage} from '../connect/pages/DeleteTestAppPromptPage';
+
+export const CustomApps = withDependencies(() => (
+    <StrictMode>
+        <AkeneoThemeProvider>
+            <Router>
+                <Switch>
+                    <Route path='/connect/custom-apps/create'>
+                        <TestAppCreatePage/>
+                    </Route>
+                    <Route path='/connect/custom-apps/:customAppId/delete'>
+                        <DeleteTestAppPromptPage/>
+                    </Route>
+                </Switch>
+            </Router>
+        </AkeneoThemeProvider>
+    </StrictMode>
+));

--- a/src/Akeneo/Connectivity/Connection/front/src/infrastructure/Marketplace.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/src/infrastructure/Marketplace.tsx
@@ -4,25 +4,12 @@ import {AkeneoThemeProvider} from './akeneo-theme-provider';
 import {withDependencies} from './dependencies-provider';
 import {SelectUserProfilePage} from '../connect/pages/SelectUserProfilePage';
 import {MarketplacePage} from '../connect/pages/MarketplacePage';
-import {TestAppCreatePage} from '../connect/pages/TestAppCreatePage';
-import {DeleteTestAppPromptPage} from '../connect/pages/DeleteTestAppPromptPage';
 
 export const Marketplace = withDependencies(() => (
     <StrictMode>
         <AkeneoThemeProvider>
             <Router>
                 <Switch>
-                    <Redirect from='/connect/marketplace/test-apps/create' to='/connect/app-store/test-apps/create' />
-                    <Route path='/connect/app-store/test-apps/create'>
-                        <TestAppCreatePage />
-                    </Route>
-                    <Redirect
-                        from='/connect/marketplace/test-apps/:testAppId/delete'
-                        to='/connect/app-store/test-apps/:testAppId/delete'
-                    />
-                    <Route path='/connect/app-store/test-apps/:testAppId/delete'>
-                        <DeleteTestAppPromptPage />
-                    </Route>
                     <Redirect from='/connect/marketplace/profile' to='/connect/app-store/profile' />
                     <Route path='/connect/app-store/profile'>
                         <SelectUserProfilePage />

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppCredentials.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/components/ConnectedApp/ConnectedAppCredentials.test.tsx
@@ -13,7 +13,7 @@ beforeEach(() => {
 
 test('The connected app credentials renders with secret', async () => {
     mockFetchResponses({
-        '/rest/marketplace/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret': {
+        '/rest/custom-apps/0dfce574-2238-4b13-b8cc-8d257ce7645b/secret': {
             json: '******************************ZmNQ',
         },
     });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-connected-apps.test.ts
@@ -236,7 +236,7 @@ test('it fetches connected test apps', async () => {
                 apps: [],
             },
         },
-        akeneo_connectivity_connection_marketplace_rest_get_all_test_apps: {
+        akeneo_connectivity_connection_custom_apps_rest_get_all: {
             json: {
                 total: 1,
                 apps: [testApp],

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-create-test-app.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-create-test-app.test.tsx
@@ -16,7 +16,7 @@ test('it creates the test app and returns credentials', async done => {
         callbackUrl: 'http://activate.test',
     });
 
-    expect(fetchMock).toBeCalledWith('akeneo_connectivity_connection_marketplace_rest_test_apps_create', {
+    expect(fetchMock).toBeCalledWith('akeneo_connectivity_connection_custom_apps_rest_create', {
         body: '{"name":"Test app bynder","activateUrl":"http://any_url.test","callbackUrl":"http://activate.test"}',
         headers: [
             ['Content-type', 'application/json'],
@@ -38,7 +38,7 @@ test('it returns errors when fields are not valid', async done => {
     };
 
     mockFetchResponses({
-        akeneo_connectivity_connection_marketplace_rest_test_apps_create: {
+        akeneo_connectivity_connection_custom_apps_rest_create: {
             json: expectedTestApp,
             status: 422,
         },
@@ -52,7 +52,7 @@ test('it returns errors when fields are not valid', async done => {
         callbackUrl: '',
     });
 
-    expect(fetchMock).toBeCalledWith('akeneo_connectivity_connection_marketplace_rest_test_apps_create', {
+    expect(fetchMock).toBeCalledWith('akeneo_connectivity_connection_custom_apps_rest_create', {
         body: '{"name":"","activateUrl":"foo","callbackUrl":""}',
         headers: [
             ['Content-type', 'application/json'],

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-test-apps.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-fetch-test-apps.test.tsx
@@ -42,7 +42,7 @@ test('it fetches the test apps', async () => {
         ],
     };
     mockFetchResponses({
-        akeneo_connectivity_connection_marketplace_rest_get_all_test_apps: {
+        akeneo_connectivity_connection_custom_apps_rest_get_all: {
             json: expected,
         },
     });

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-test-apps.test.ts
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/hooks/use-test-apps.test.ts
@@ -44,7 +44,7 @@ test('it returns loading status and testApps values', async () => {
     }));
 
     mockFetchResponses({
-        akeneo_connectivity_connection_marketplace_rest_get_all_test_apps: {
+        akeneo_connectivity_connection_custom_apps_rest_get_all: {
             json: testApps,
         },
     });
@@ -74,7 +74,7 @@ test('it returns loading status and empty values on fetch error ', async () => {
     }));
 
     mockFetchResponses({
-        akeneo_connectivity_connection_marketplace_rest_get_all_test_apps: {
+        akeneo_connectivity_connection_custom_apps_rest_get_all: {
             reject: true,
             json: {},
         },

--- a/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/MarketplacePage.test.tsx
+++ b/src/Akeneo/Connectivity/Connection/front/tests/src/connect/pages/MarketplacePage.test.tsx
@@ -63,6 +63,6 @@ test('It redirect when the "create a test app" button is clicked', async () => {
     );
 
     expect(historyMock.history.location.pathname).toBe(
-        '/akeneo_connectivity_connection_connect_marketplace_test_app_create'
+        '/akeneo_connectivity_connection_custom_apps_create'
     );
 });


### PR DESCRIPTION
Renamed back-end route path and names so that test apps are not mentioned
Moved and renamed front-end routes into a dedicated controller for custom apps