### PR TITLE
PIM-10823: Cannot import price and measurement with comma as decimal separator with value not saved as string in import file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - PIM-10796: Fix system-information endpoint with wrong answers
 - PIM-10806: Allow to delete product's attributes with type 'identifier' and ensure grey cross is displayed
 - PIM-10825: Fix transfer to external storage does not give enough information
+- PIM-10823: Fix cannot import price and measurement with comma as decimal separator with value not saved as string in import file
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/Product.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/Product.php
@@ -180,7 +180,7 @@ class Product implements ArrayConverterInterface
         $filteredItem = $this->filterFields($mappedItem, $options['with_associations']);
         $this->validateItem($filteredItem);
 
-        $mergedItem = $this->columnsMerger->merge($filteredItem);
+        $mergedItem = $this->columnsMerger->merge($filteredItem, $options);
         $convertedItem = $this->convertItem($mergedItem);
 
         return $convertedItem;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModel.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModel.php
@@ -78,7 +78,7 @@ class ProductModel implements ArrayConverterInterface
         $filteredItem = $this->filterFields($mappedFlatProductModel, isset($options['with_associations']) ? $options['with_associations'] : true);
         $this->validateItem($filteredItem);
 
-        $mergedFlatProductModel = $this->columnsMerger->merge($filteredItem);
+        $mergedFlatProductModel = $this->columnsMerger->merge($filteredItem, $options);
         $convertedProductModel = $this->convertItem($mergedFlatProductModel);
 
         return $convertedProductModel;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/Value.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/ArrayConverter/FlatToStandard/Value.php
@@ -114,7 +114,7 @@ class Value implements ArrayConverterInterface
      */
     public function convert(array $values, array $options = [])
     {
-        $mergedValues = $this->columnsMerger->merge($values);
+        $mergedValues = $this->columnsMerger->merge($values, $options);
         $convertedValues = [];
 
         foreach ($mergedValues as $column => $value) {

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductModelSpec.php
@@ -80,7 +80,7 @@ class ProductModelSpec extends ObjectBehavior
             'family' => 'family_variant',
         ])->willReturn($flatProductModel);
 
-        $columnsMerger->merge($flatProductModel)->willReturn($flatProductModel);
+        $columnsMerger->merge($flatProductModel, ['with_associations' => false, 'mapping' => ['family' => 'family_variant']])->willReturn($flatProductModel);
 
         $fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code'])->shouldBeCalled();
         $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name-en_US', 'description-en_US-ecommerce', '123456', '0123456', '12.33', '1234567']);
@@ -277,7 +277,7 @@ class ProductModelSpec extends ObjectBehavior
             'family' => 'family_variant',
         ])->willReturn($flatProductModel);
 
-        $columnsMerger->merge($flatProductModel)->willReturn($flatProductModel);
+        $columnsMerger->merge($flatProductModel, ['with_associations' => false, 'mapping' => ['family' => 'family_variant']])->willReturn($flatProductModel);
 
         $fieldsRequirementChecker->checkFieldsPresence($flatProductModel, ['code'])->shouldBeCalled();
         $attributeColumnsResolver->resolveAttributeColumns()->willReturn(['name', 'description-en_US-ecommerce']);

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ProductSpec.php
@@ -143,7 +143,7 @@ class ProductSpec extends ObjectBehavior
             ]
         );
 
-        $columnsMerger->merge($item)->willReturn($itemMerged);
+        $columnsMerger->merge($item, ['with_associations' => true, 'default_values' => []])->willReturn($itemMerged);
 
         $attrColumnsResolver->resolveIdentifierField()->willReturn('sku');
 
@@ -460,7 +460,7 @@ class ProductSpec extends ObjectBehavior
         $assocColumnsResolver->resolveAssociationColumns()->willReturn([]);
         $assocColumnsResolver->resolveQuantifiedAssociationColumns()->willReturn([]);
 
-        $columnsMerger->merge($filteredItem)->willReturn($filteredItem);
+        $columnsMerger->merge($filteredItem, ['with_associations' => false, 'default_values' => []])->willReturn($filteredItem);
 
         $attrColumnsResolver->resolveIdentifierField()->willReturn('sku');
 
@@ -526,7 +526,7 @@ class ProductSpec extends ObjectBehavior
         $assocColumnsResolver->resolveAssociationColumns()->willReturn([]);
         $assocColumnsResolver->resolveQuantifiedAssociationColumns()->willReturn([]);
 
-        $columnsMerger->merge($filteredProduct)->willReturn($filteredProduct);
+        $columnsMerger->merge($filteredProduct, ['with_associations' => false, 'default_values' => []])->willReturn($filteredProduct);
 
         $attrColumnsResolver->resolveIdentifierField()->willReturn('sku');
 

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ValueSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Connector/ArrayConverter/FlatToStandard/ValueSpec.php
@@ -56,7 +56,7 @@ class ValueSpec extends ObjectBehavior
             'price'                  => '15 EUR, 10 USD',
         ];
 
-        $columnsMerger->merge($item)->willReturn($itemMerged);
+        $columnsMerger->merge($item, [])->willReturn($itemMerged);
 
         $converterRegistry->getConverter(Argument::any())->willReturn($converter);
 
@@ -207,7 +207,7 @@ class ValueSpec extends ObjectBehavior
     ) {
         $item = ['sku' => '1069978', 'enabled' => true];
 
-        $columnsMerger->merge($item)->willReturn($item);
+        $columnsMerger->merge($item, [])->willReturn($item);
 
         $fieldExtractor->extractColumnInfo('sku')->willReturn(['attribute' => $attribute]);
         $attribute->getType()->willReturn('sku');
@@ -224,11 +224,11 @@ class ValueSpec extends ObjectBehavior
     {
         $item = ['sku' => '1069978', 'enabled' => true];
 
-        $columnsMerger->merge($item)->willReturn($item);
+        $columnsMerger->merge($item, [])->willReturn($item);
 
         $this->shouldThrow(new \LogicException('Unable to convert the given column "sku"'))->during(
             'convert',
-            [$item]
+            [$item],
         );
     }
 
@@ -243,7 +243,7 @@ class ValueSpec extends ObjectBehavior
         $attributeFieldInfo = ['attribute' => $attribute];
 
         $converterRegistry->getConverter($attributeType)->willReturn($converter);
-        $columnsMerger->merge($values)->willReturn($values);
+        $columnsMerger->merge($values, [])->willReturn($values);
         $fieldExtractor->extractColumnInfo($column)->willReturn($attributeFieldInfo);
         $converter->convert($attributeFieldInfo,$dateTime)->willThrow($e);
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

I fixed the fact that the product import standard does not work when the decimal separator is not `.` and the measurement/price value is a number in excel. We have this problem because in basic import we have to merge multiple column. When we do it we cast the number to string by default the cast contain a dot, now we cast with the decimal separator

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
