### PR TITLE
PIM-10835: Fix command publish-job-to-queue does not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PIM-10806: Allow to delete product's attributes with type 'identifier' and ensure grey cross is displayed
 - PIM-10825: Fix transfer to external storage does not give enough information
 - PIM-10823: Fix cannot import price and measurement with comma as decimal separator with value not saved as string in import file
+- PIM-10835: Fix command publish-job-to-queue does not work
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/PublishJobToQueueCommand.php
@@ -85,7 +85,7 @@ class PublishJobToQueueCommand extends Command
             ->addOption(
                 'email',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'The email to notify at the end of the job execution'
             )
             ->addOption(

--- a/src/Akeneo/Tool/Component/BatchQueue/Queue/PublishJobToQueue.php
+++ b/src/Akeneo/Tool/Component/BatchQueue/Queue/PublishJobToQueue.php
@@ -47,7 +47,7 @@ class PublishJobToQueue implements PublishJobToQueueInterface
     ): JobExecution {
         $jobInstance = $this->getJobInstance($jobInstanceCode);
         $jobExecution = $this->createJobExecutionHandler->createFromJobInstance($jobInstance, $config, $username);
-        $options = $this->getOptions($noLog, $emails);
+        $options = $this->getOptions($noLog, $emails ?? []);
 
         $this->batchLogHandler->setSubDirectory((string) $jobExecution->getId());
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I fixed the `akeneo:batch:publish-job-to-queue` that does not work anymore since email is an email

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
