### PR TITLE
PIM-10826: Fix GET system-information endpoint with wrong answers

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10826: Fix GET system-information endpoint with wrong answers
+
 # 6.0.69 (2023-02-13)
 
 ## Bug fixes:

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationController.php
@@ -23,7 +23,7 @@ class GetSystemInformationController
         $edition = $this->versionProvider->getEdition();
         $response = [
             'version' => strtolower($this->versionProvider->getVersion()),
-            'edition' => $edition === CommunityVersion::EDITION ? strtolower($edition) : 'ee',
+            'edition' => $edition === CommunityVersion::EDITION ? 'CE' : 'EE',
         ];
 
         return new JsonResponse($response);

--- a/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
+++ b/tests/back/Platform/EndToEnd/ExternalApi/GetSystemInformationEndToEnd.php
@@ -16,7 +16,7 @@ class GetSystemInformationEndToEnd extends ApiTestCase
     /**
      * @group ce
      */
-    public function test_to_get_system_information_through_the_api(): void
+    public function test_to_get_ce_system_information_through_the_api(): void
     {
         $apiConnectionEcommerce = $this->createConnection('ecommerce', 'Ecommerce');
         $apiClient = $this->createAuthenticatedClient(
@@ -37,7 +37,7 @@ class GetSystemInformationEndToEnd extends ApiTestCase
         Assert::assertSame(
             [
                 'version' => strtolower(constant(sprintf('%s::VERSION', $this->versionClass))),
-                'edition' => strtolower(constant(sprintf('%s::EDITION', $this->versionClass))),
+                'edition' => 'CE',
             ],
             $content
         );

--- a/tests/back/Platform/Specification/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationControllerSpec.php
+++ b/tests/back/Platform/Specification/Bundle/AnalyticsBundle/Controller/ExternalApi/GetSystemInformationControllerSpec.php
@@ -29,7 +29,7 @@ class GetSystemInformationControllerSpec extends ObjectBehavior
         $response->getContent()->shouldReturn(json_encode(
             [
                 'version' => '12345678',
-                'edition' => 'ce'
+                'edition' => 'CE'
             ]
         ));
     }
@@ -45,7 +45,7 @@ class GetSystemInformationControllerSpec extends ObjectBehavior
         $response->getContent()->shouldReturn(json_encode(
             [
                 'version' => '12345678',
-                'edition' => 'ee'
+                'edition' => 'EE'
             ]
         ));
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Backport of https://github.com/akeneo/pim-community-dev/pull/18980

As described in the [6.0 documentation](https://api.akeneo.com/api-reference-60.html#System):

- In a PaaS EE env, do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'EE'
- In a PaaS CE env, do a GET {{url}}/api/rest/v1/system-information call, the edition returned should be 'CE'

related EE PR: https://github.com/akeneo/pim-enterprise-dev/pull/16389

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
