### PR TITLE
PH-799: DatabaseCommand should not write on output

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -11,6 +11,7 @@ use Akeneo\Tool\Component\Console\CommandExecutor;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -46,6 +47,7 @@ class DatabaseCommand extends Command
         private readonly FixtureJobLoader $fixtureJobLoader,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly InstallData $installTimeQuery,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
     }
@@ -110,7 +112,7 @@ class DatabaseCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $output->writeln('<info>Prepare database schema</info>');
+        $this->logger->info('Prepare database schema');
 
         // Needs to try if database already exists or not
         try {
@@ -118,12 +120,15 @@ class DatabaseCommand extends Command
                 $this->connection->connect();
             }
             if ($input->getOption('doNotDropDatabase')) {
-                $this->commandExecutor->runCommand('doctrine:schema:drop', ['--force' => true, '--full-database' => true]);
+                $this->commandExecutor->runCommand(
+                    'doctrine:schema:drop',
+                    ['--force' => true, '--full-database' => true]
+                );
             } else {
                 $this->commandExecutor->runCommand('doctrine:database:drop', ['--force' => true]);
             }
         } catch (ConnectionException $e) {
-            $output->writeln('<error>Database does not exist yet</error>');
+            $this->logger->error('Database does not exist yet');
         }
 
         $this->commandExecutor->runCommand('doctrine:database:create', ['--if-not-exists' => true]);
@@ -185,7 +190,7 @@ class DatabaseCommand extends Command
      */
     protected function resetElasticsearchIndex(OutputInterface $output)
     {
-        $output->writeln('<info>Reset elasticsearch indexes</info>');
+        $this->logger->info('Reset elasticsearch indexes');
 
         $clients = $this->clientRegistry->getClients();
 
@@ -201,7 +206,7 @@ class DatabaseCommand extends Command
             $input->setOption('fixtures', self::LOAD_BASE);
         }
 
-        $output->writeln(
+        $this->logger->info(
             sprintf(
                 '<info>Load jobs for fixtures. (data set: %s)</info>',
                 $catalog
@@ -224,14 +229,12 @@ class DatabaseCommand extends Command
                 ]),
                 InstallerEvents::PRE_LOAD_FIXTURE
             );
-            if ($input->getOption('verbose')) {
-                $output->writeln(
-                    sprintf(
-                        'Please wait, the <comment>%s</comment> are processing...',
-                        $jobInstance->getCode()
-                    )
-                );
-            }
+            $this->logger->info(
+                sprintf(
+                    'Please wait, the <comment>%s</comment> are processing...',
+                    $jobInstance->getCode()
+                )
+            );
             $this->commandExecutor->runCommand('akeneo:batch:job', $params);
             $this->eventDispatcher->dispatch(
                 new InstallerEvent($this->commandExecutor, $jobInstance->getCode(), [
@@ -241,10 +244,8 @@ class DatabaseCommand extends Command
                 InstallerEvents::POST_LOAD_FIXTURE
             );
         }
-        $output->writeln('');
 
-
-        $output->writeln('<info>Delete jobs for fixtures.</info>');
+        $this->logger->info('Delete jobs for fixtures');
         $this->fixtureJobLoader->deleteJobInstances();
 
         return $this;
@@ -281,7 +282,9 @@ class DatabaseCommand extends Command
         $latestMigrationProcess->run();
 
         if ($latestMigrationProcess->getExitCode() !== 0) {
-            throw new \RuntimeException("Impossible to get the latest migration {$latestMigrationProcess->getErrorOutput()}");
+            throw new \RuntimeException(
+                "Impossible to get the latest migration {$latestMigrationProcess->getErrorOutput()}"
+            );
         }
 
         return $latestMigrationProcess->getOutput();

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -131,7 +131,9 @@ class DatabaseCommand extends Command
             $this->logger->error('Database does not exist yet');
         }
 
-        $this->commandExecutor->runCommand('doctrine:database:create', ['--if-not-exists' => true]);
+        if (!$input->getOption('doNotDropDatabase')) {
+            $this->commandExecutor->runCommand('doctrine:database:create', ['--if-not-exists' => true]);
+        }
 
         // Needs to close connection if always open
         if ($this->connection->isConnected()) {

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
@@ -31,6 +31,7 @@ services:
             - '@pim_installer.fixture_loader.job_loader'
             - '@event_dispatcher'
             - '@Akeneo\Platform\Bundle\InstallerBundle\Persistence\Sql\InstallData'
+            - '@logger'
         tags:
             - { name: console.command }
 


### PR DESCRIPTION
We should use the logger instead of direct console output.

Console output is always detected as `error` on Datadog.

Advantages for using the logger:
- more correct log levels
- real logs with all the context information
- possibility to not ingest if not needed
- etc.

Cons:
- not displayed by default in the dev console, but it can be easily displayed by using a higher verbosity with the `-vv` parameter
 
In brief, more log control (and in the end maybe a lower billing :wink: )