### PR TITLE
CXP-1390: avoid 'any' in typescript

### DIFF
--- a/components/catalogs/front/src/components/ProductMapping/components/SourcePanel.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourcePanel.tsx
@@ -86,7 +86,7 @@ export const SourcePanel: FC<Props> = ({target, source, onChange, errors}) => {
                     <SectionTitle>
                         <SectionTitle.Title>{target.label}</SectionTitle.Title>
                     </SectionTitle>
-                    <RequirementsCollapse selectedTarget={target} />
+                    <RequirementsCollapse target={target} />
                     <SectionTitle>
                         <Tag tint='purple'>1</Tag>
                         <SectionTitle.Title level='secondary'>

--- a/components/catalogs/front/src/components/ProductMapping/models/Target.d.ts
+++ b/components/catalogs/front/src/components/ProductMapping/models/Target.d.ts
@@ -1,5 +1,4 @@
 export type Target = {
-    [key: string]: any;
     code: string;
     label: string;
     type: string;


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

First, really useful link when you are struggling with weird typescript stuff: https://www.typescriptlang.org/docs/handbook/utility-types.html

Then, instead of going into `[key: string]: any;` territory...
I'm proposing another version, which is more strict and will prevent us to have errors due to `any`.
I've commented the code in the PR because it's not obvious at first sight.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
