### PR TITLE
Replace `docker-compose` commands with `docker compose` plugin commands

### DIFF
--- a/.circleci/config/commands.yml
+++ b/.circleci/config/commands.yml
@@ -23,19 +23,19 @@ commands:
                     name: Load php docker image
                     command: |
                         [ ! -f ~/project/php-pim-image.tar ] || docker load -i php-pim-image.tar
-                        [ -f ~/project/php-pim-image.tar ] || docker-compose pull php
+                        [ -f ~/project/php-pim-image.tar ] || docker compose pull php
 
     load_docker_image_node:
         steps:
             -   run:
                     name: Load node docker image
-                    command: docker-compose pull node
+                    command: docker compose pull node
 
     start_test_containers:
         steps:
             -   run:
                     name: Pull docker images
-                    command: docker-compose pull mysql elasticsearch object-storage pubsub-emulator
+                    command: docker compose pull mysql elasticsearch object-storage pubsub-emulator
             -   run:
                     name: Start containers
                     command: |

--- a/.circleci/detect_structure_changes.sh
+++ b/.circleci/detect_structure_changes.sh
@@ -58,8 +58,8 @@ cp -R vendor/akeneo/pim-community-dev/upgrades/schema/* upgrades/schema
 
 echo "Enable Onboarder bundle on 5.0 branch..."
 sudo chown 1000:1000 composer.json
-docker-compose run --rm php composer config repositories.onboarder '{ "type": "vcs", "url": "https://github.com/akeneo/pim-onboarder.git", "branch": "master" }'
-docker-compose run --rm php php -d memory_limit=5G /usr/local/bin/composer require "akeneo/pim-onboarder:^4.2.1"
+docker compose run --rm php composer config repositories.onboarder '{ "type": "vcs", "url": "https://github.com/akeneo/pim-onboarder.git", "branch": "master" }'
+docker compose run --rm php php -d memory_limit=5G /usr/local/bin/composer require "akeneo/pim-onboarder:^4.2.1"
 if [ -d "vendor/akeneo/pim-onboarder" ]; then
     sed -i "s~];~    Akeneo\\\Onboarder\\\Bundle\\\PimOnboarderBundle::class => ['all' => true],\n];~g" ./config/bundles.php
 fi
@@ -115,13 +115,13 @@ echo "Clean cache..."
 APP_ENV=test make cache
 
 echo "Launch branch migrations..."
-docker-compose run --rm php bin/console doctrine:migrations:migrate --env=test --no-interaction
+docker compose run --rm php bin/console doctrine:migrations:migrate --env=test --no-interaction
 
 echo "Dump 5.0 with migrations database..."
-docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_50_database_with_migrations.sql
+docker compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_50_database_with_migrations.sql
 
 echo "Dump 5.0 with migrations index..."
-docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_50_index_with_migrations.json
+docker compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_50_index_with_migrations.json
 
 
 ## STEP 3: install fresh branch database and indexes
@@ -133,10 +133,10 @@ echo "Install fresh branch database and indexes..."
 APP_ENV=test make database
 
 echo "Dump branch database..."
-docker-compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_branch_database.sql
+docker compose exec -T mysql mysqldump --no-data --skip-opt --skip-comments --password=$APP_DATABASE_PASSWORD --user=$APP_DATABASE_USER $APP_DATABASE_NAME | sed 's/ AUTO_INCREMENT=[0-9]*\b//g' > /tmp/structure_changes/dump_branch_database.sql
 
 echo "Dump branch index..."
-docker-compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_branch_index.json
+docker compose exec -T elasticsearch curl -XGET "$APP_INDEX_HOSTS/_all/_mapping"|json_pp --json_opt=canonical,pretty > /tmp/structure_changes/dump_branch_index.json
 
 
 ## STEP 4: compare the results

--- a/.circleci/jobs/features/catalogs/test_performance_catalogs_ce.yml
+++ b/.circleci/jobs/features/catalogs/test_performance_catalogs_ce.yml
@@ -11,10 +11,10 @@ jobs:
             -   start_test_containers
             -   run:
                     name: Start blackfire
-                    command: docker-compose up -d blackfire
+                    command: docker compose up -d blackfire
             -   run:
                     name: Warmup cache
-                    command: docker-compose run --rm php bin/console cache:warmup --env=test
+                    command: docker compose run --rm php bin/console cache:warmup --env=test
             -   run:
                     name: Performance back
                     command: APP_ENV=test make catalogs-performance-back

--- a/.circleci/jobs/features/connectivity.yml
+++ b/.circleci/jobs/features/connectivity.yml
@@ -16,10 +16,10 @@ jobs:
                     command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             -   run:
                     name: Pull docker image for node
-                    command: docker-compose pull node
+                    command: docker compose pull node
             -   run:
                     name: Build other front libraries
-                    command: docker-compose run -u node --rm node yarn catalogs:build
+                    command: docker compose run -u node --rm node yarn catalogs:build
             -   run:
                     name: Lint front
                     command: make connectivity-connection-lint-front
@@ -56,10 +56,10 @@ jobs:
                     command: sudo chown -R 1000:1000 ../project ~/.cache/yarn
             -   run:
                     name: Pull docker image for node
-                    command: docker-compose pull node
+                    command: docker compose pull node
             -   run:
                     name: Build other front libraries
-                    command: docker-compose run -u node --rm node yarn catalogs:build
+                    command: docker compose run -u node --rm node yarn catalogs:build
             -   run:
                     name: Unit front
                     command: make connectivity-connection-unit-front
@@ -76,7 +76,7 @@ jobs:
                     command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker image for php
-                    command: docker-compose pull php
+                    command: docker compose pull php
             -   run:
                     name: Coupling back
                     command: make connectivity-connection-coupling-back
@@ -102,7 +102,7 @@ jobs:
                     command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker images
-                    command: docker-compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
+                    command: docker compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
             -   run:
                     name: Start containers
                     command: |
@@ -132,7 +132,7 @@ jobs:
                     command: sudo chown -R 1000:1000 ../project
             -   run:
                     name: Pull docker images
-                    command: docker-compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
+                    command: docker compose pull php fpm mysql elasticsearch object-storage pubsub-emulator
             -   run:
                     name: Start containers
                     command: |
@@ -163,7 +163,7 @@ jobs:
                     name: Start containers
                     command: |
                         docker load -i php-pim-image.tar
-                        APP_ENV=behat docker-compose -f docker-compose.yml -f src/Akeneo/Connectivity/Connection/tests/docker-compose.yml up -d --remove-orphans fpm mysql elasticsearch httpd object-storage selenium pubsub-emulator
+                        APP_ENV=behat docker compose -f docker-compose.yml -f src/Akeneo/Connectivity/Connection/tests/docker-compose.yml up -d --remove-orphans fpm mysql elasticsearch httpd object-storage selenium pubsub-emulator
                         docker/wait_docker_up.sh
             -   run:
                     name: Install database

--- a/.circleci/jobs/features/other.yml
+++ b/.circleci/jobs/features/other.yml
@@ -305,14 +305,14 @@ jobs:
                   command: PIM_CONTEXT=onboarder make add-bundle-specific-dev-dependencies
             - run:
                   name: Composer update for tests dependencies
-                  command: docker-compose run --rm php composer update --no-interaction
+                  command: docker compose run --rm php composer update --no-interaction
             - run:
                   name: Add configuration files to run the bundle tests from the PIM
                   command: |
                       rm -f docker-compose.override.yml
                       PIM_VERSION=master SETUP_FOR_CI=1 PIM_CONTEXT=onboarder make setup-onboarder-parameters
                       PIM_VERSION=master PIM_CONTEXT=onboarder make setup-onboarder-tests
-                      docker-compose run --rm php php /usr/local/bin/composer dumpautoload --no-interaction
+                      docker compose run --rm php php /usr/local/bin/composer dumpautoload --no-interaction
             - run:
                   name: Change owner of PIM as some files have been created with wrong owner
                   command: sudo chown -R 1000:1000 ~/project

--- a/.circleci/jobs/install_front_dependencies.yml
+++ b/.circleci/jobs/install_front_dependencies.yml
@@ -25,8 +25,8 @@ jobs:
                         -   run:
                                 name: Build front shared libraries
                                 command: |
-                                    [ -d ~/project/front-packages/akeneo-design-system/lib ] || docker-compose run -u node --rm node yarn dsm:build
-                                    [ -d ~/project/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
+                                    [ -d ~/project/front-packages/akeneo-design-system/lib ] || docker compose run -u node --rm node yarn dsm:build
+                                    [ -d ~/project/front-packages/shared/lib ] || docker compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
                         -   persist_to_workspace:
                                 root: ~/
                                 paths:
@@ -50,8 +50,8 @@ jobs:
                         -   run:
                                 name: Build front shared libraries
                                 command: |
-                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/akeneo-design-system/lib ] || docker-compose run -u node --rm node yarn dsm:build
-                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/shared/lib ] || docker-compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
+                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/akeneo-design-system/lib ] || docker compose run -u node --rm node yarn dsm:build
+                                    [ -d ~/project/vendor/akeneo/pim-community-dev/front-packages/shared/lib ] || docker compose run -u node --rm node yarn workspace @akeneo-pim-community/shared lib:build
                         -   persist_to_workspace:
                                 root: ~/
                                 paths:

--- a/.circleci/run_behat.sh
+++ b/.circleci/run_behat.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 TEST_SUITE=$1
 
-TEST_FILES=$(docker-compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s $TEST_SUITE | circleci tests split --split-by=timings)
+TEST_FILES=$(docker compose run --rm -T php vendor/bin/behat --list-scenarios -p legacy -s $TEST_SUITE | circleci tests split --split-by=timings)
 echo "TEST FILES ON THIS CONTAINER: $TEST_FILES"
 
 fail=0
@@ -16,11 +16,11 @@ for TEST_FILE in $TEST_FILES; do
     output=$(basename $TEST_FILE)_$(uuidgen)
 
     set +e
-    docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
+    docker compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE ||
     (
       echo Retrying $TEST_FILE &&
-      docker-compose exec -u www-data -T fpm /bin/bash -c "echo $TEST_FILE >> var/tests/behat/behats_retried.txt" &&
-      docker-compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
+      docker compose exec -u www-data -T fpm /bin/bash -c "echo $TEST_FILE >> var/tests/behat/behats_retried.txt" &&
+      docker compose exec -u www-data -T fpm ./vendor/bin/behat --strict --format pim --out var/tests/behat/${output} --format pretty --out std --colors -p legacy -s $TEST_SUITE $TEST_FILE
     )
 
     fail=$(($fail + $?))

--- a/.circleci/run_phpunit.sh
+++ b/.circleci/run_phpunit.sh
@@ -10,14 +10,14 @@ CONFIG_DIRECTORY=$1
 FIND_PHPUNIT_SCRIPT=$2
 TEST_SUITES=$3
 
-TEST_FILES=$(docker-compose run --rm -T php php $FIND_PHPUNIT_SCRIPT -c $CONFIG_DIRECTORY --testsuite $TEST_SUITES | circleci tests split --split-by=timings)
+TEST_FILES=$(docker compose run --rm -T php php $FIND_PHPUNIT_SCRIPT -c $CONFIG_DIRECTORY --testsuite $TEST_SUITES | circleci tests split --split-by=timings)
 
 fail=0
 for TEST_FILE in $TEST_FILES; do
     echo $TEST_FILE
 
     set +e
-    APP_ENV=test docker-compose run -T php ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
+    APP_ENV=test docker compose run -T php ./vendor/bin/phpunit -c $CONFIG_DIRECTORY --log-junit var/tests/phpunit/phpunit_$(uuidgen).xml $TEST_FILE
     TEST_RESULT=$?
     if [ $TEST_RESULT -ne 0 ]; then
         echo "Test has failed (with code $TEST_RESULT): $TEST_FILE"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_COMPOSE = docker-compose
+DOCKER_COMPOSE = docker compose
 NODE_RUN = $(DOCKER_COMPOSE) run -u node --rm -e YARN_REGISTRY -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=1 -e PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome node
 YARN_RUN = $(NODE_RUN) yarn
 PHP_RUN = $(DOCKER_COMPOSE) run --rm php php

--- a/bin/benchmark_products_api.sh
+++ b/bin/benchmark_products_api.sh
@@ -33,13 +33,13 @@ boot_and_install_pim()
     message "Boot and install PIM in test environment"
     cd $PIM_PATH
     export ES_JAVA_OPTS='-Xms2g -Xmx2g'
-    docker-compose up -d --remove-orphans
-    PUBLIC_PIM_HTTP_PORT=$(docker-compose port httpd-behat 80 | cut -d ':' -f 2)
+    docker compose up -d --remove-orphans
+    PUBLIC_PIM_HTTP_PORT=$(docker compose port httpd-behat 80 | cut -d ':' -f 2)
     rm -rf var/cache/*
     bin/docker/pim-setup.sh
-    docker-compose exec -T fpm bin/console cache:warmup -e behat
-    docker-compose exec -T fpm bin/console pim:installer:db -e behat
-    CREDENTIALS=$(docker-compose exec -T fpm bin/console pim:oauth-server:create-client --no-ansi -e behat generator | tr -d '\r ')
+    docker compose exec -T fpm bin/console cache:warmup -e behat
+    docker compose exec -T fpm bin/console pim:installer:db -e behat
+    CREDENTIALS=$(docker compose exec -T fpm bin/console pim:oauth-server:create-client --no-ansi -e behat generator | tr -d '\r ')
     export API_CLIENT=$(echo $CREDENTIALS | cut -d " " -f 2 | cut -d ":" -f 2)
     export API_SECRET=$(echo $CREDENTIALS | cut -d " " -f 3 | cut -d ":" -f 2)
     export API_URL="http://$DOCKER_BRIDGE_IP:$PUBLIC_PIM_HTTP_PORT"
@@ -75,8 +75,8 @@ boot_and_install_pim
 generate_reference_catalog
 
 cd $PIM_PATH
-PRODUCT_SIZE=$(docker-compose exec -T mysql mysql -uakeneo_pim -pakeneo_pim akeneo_pim -N -s -e "SELECT AVG(JSON_LENGTH(JSON_EXTRACT(raw_values, '$.*.*.*'))) avg_product_values FROM pim_catalog_product;" | tail -n 1 | tr -d '\r \n')
-PRODUCT_COUNT=$(docker-compose exec -T mysql mysql -uakeneo_pim -pakeneo_pim akeneo_pim -N -s -e "SELECT COUNT(*) FROM pim_catalog_product;" | tail -n 1 | tr -d '\r \n')
+PRODUCT_SIZE=$(docker compose exec -T mysql mysql -uakeneo_pim -pakeneo_pim akeneo_pim -N -s -e "SELECT AVG(JSON_LENGTH(JSON_EXTRACT(raw_values, '$.*.*.*'))) avg_product_values FROM pim_catalog_product;" | tail -n 1 | tr -d '\r \n')
+PRODUCT_COUNT=$(docker compose exec -T mysql mysql -uakeneo_pim -pakeneo_pim akeneo_pim -N -s -e "SELECT COUNT(*) FROM pim_catalog_product;" | tail -n 1 | tr -d '\r \n')
 message "Start bench products with 120 attributes"
 
 sleep 10

--- a/docker/wait_docker_up.sh
+++ b/docker/wait_docker_up.sh
@@ -6,7 +6,7 @@ MAX_COUNTER=45
 COUNTER=1
 
 echo "Waiting for MySQL server…"
-while ! docker-compose exec mysql mysql --protocol TCP -uroot -proot -e "show databases;" > /dev/null 2>&1; do
+while ! docker compose exec mysql mysql --protocol TCP -uroot -proot -e "show databases;" > /dev/null 2>&1; do
     COUNTER=$((${COUNTER} + 1))
     if [ ${COUNTER} -gt ${MAX_COUNTER} ]; then
         echo "We have been waiting for MySQL too long already; failing." >&2
@@ -19,7 +19,7 @@ echo "MySQL server is running!"
 
 COUNTER=1
 echo "Waiting for Elasticsearch server…"
-while ! docker-compose exec elasticsearch curl -s -k --fail "http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=1s" > /dev/null; do
+while ! docker compose exec elasticsearch curl -s -k --fail "http://elasticsearch:9200/_cluster/health?wait_for_status=yellow&timeout=1s" > /dev/null; do
     COUNTER=$((${COUNTER} + 1))
     if [ ${COUNTER} -gt ${MAX_COUNTER} ]; then
         echo "We have been waiting for Elasticsearch too long already; failing." >&2

--- a/front-packages/akeneo-design-system/CONTRIBUTING.md
+++ b/front-packages/akeneo-design-system/CONTRIBUTING.md
@@ -16,7 +16,7 @@ As a general advice, you should ask the assigned designer what to do and make su
 $ front-packages/akeneo-design-system/bin/dsm generate ComponentName
 $ yarn --cwd=front-packages/akeneo-design-system storybook:start
 # Or with Docker
-$ docker-compose run --rm -p 6006:6006 node yarn --cwd=front-packages/akeneo-design-system storybook:start
+$ docker compose run --rm -p 6006:6006 node yarn --cwd=front-packages/akeneo-design-system storybook:start
 ```
 
 - Then implement your Component logic in the newly created file `src/components/ComponentName/ComponentName.tsx`

--- a/make-file/dev.mk
+++ b/make-file/dev.mk
@@ -47,7 +47,7 @@ xdebug-on:
 
 .PHONY: cypress-interactive
 cypress-interactive:
-	docker-compose -f docker-compose-cypress.yml run --rm -u 1000:1000 -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --entrypoint cypress cypress open --project .
+	docker compose -f docker-compose-cypress.yml run --rm -u 1000:1000 -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix --entrypoint cypress cypress open --project .
 
 .PHONY: lint-fix-back
 lint-fix-back: #Doc: run php-cs-fixer with symfony codestyle

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -2,9 +2,9 @@
 # This file is a template Makefile. Some targets are presented here as examples.
 # Feel free to customize it to your needs!
 #
-CMD_ON_PROJECT = docker-compose run -u www-data --rm php
+CMD_ON_PROJECT = docker compose run -u www-data --rm php
 PHP_RUN = $(CMD_ON_PROJECT) php
-YARN_RUN = docker-compose run -u node --rm -e YARN_REGISTRY -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD node yarn
+YARN_RUN = docker compose run -u node --rm -e YARN_REGISTRY -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD node yarn
 
 ifdef NO_DOCKER
   CMD_ON_PROJECT =
@@ -108,11 +108,11 @@ endif
 
 .PHONY: up
 up:
-	docker-compose up -d --remove-orphans
+	docker compose up -d --remove-orphans
 
 .PHONY: down
 down:
-	docker-compose down -v
+	docker compose down -v
 
 .PHONY: upgrade-front
 upgrade-front:

--- a/std-build/migration/40_to_50/rector.php
+++ b/std-build/migration/40_to_50/rector.php
@@ -12,8 +12,8 @@ use Rector\Renaming\Rector\Name\RenameClassRector;
 
 /*
  * This is not meant to be automated: we want to generated renamed-classes.php and perform tests on rector configuration.
- * Install:  docker-compose run  -u www-data --rm php composer require --dev rector/rector-prefixed
- * Test:  docker-compose run  -u www-data --rm php vendor/bin/rector -c std-build/migration/40_to_50/rector.php process ./std-build/migration/40_to_50/test-src
+ * Install:  docker compose run  -u www-data --rm php composer require --dev rector/rector-prefixed
+ * Test:  docker compose run  -u www-data --rm php vendor/bin/rector -c std-build/migration/40_to_50/rector.php process ./std-build/migration/40_to_50/test-src
  */
 
 return static function (ContainerConfigurator $containerConfigurator): void {

--- a/tests/parallel_api_calls/README.md
+++ b/tests/parallel_api_calls/README.md
@@ -15,7 +15,7 @@ in order to detect dysfunctions in the handling of parallel API write calls
 3. Create an API connection
 
 ```
-$ APP_ENV=test docker-compose run php bin/console akeneo:connectivity-connection:create parallel_api_calls
+$ APP_ENV=test docker compose run php bin/console akeneo:connectivity-connection:create parallel_api_calls
 Code: parallel_api_calls
 Client ID: 1_6coeumqtx64owcg0oosg4k0www0g0wssswsgcw44g4csowwgck
 Secret: 2pu2c79qn6yok8kcgocs4okw4wgsw4w48wwws0sww88080co0c
@@ -25,7 +25,7 @@ Password: 5dde2008e
 
 4. Run the test program
 ```
-$ APP_ENV=test docker-compose run php php tests/parallel_api_calls/parallel_api_calls.php \
+$ APP_ENV=test docker compose run php php tests/parallel_api_calls/parallel_api_calls.php \
     -c 1_6coeumqtx64owcg0oosg4k0www0g0wssswsgcw44g4csowwgck
     -s 2pu2c79qn6yok8kcgocs4okw4wgsw4w48wwws0sww88080co0c
     -u admin -p admin -P 10


### PR DESCRIPTION
`docker-compose`is deprecated and will be replaced by the `compose` plugin.

https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/#:~:text=Compose%20V1%20support%20will%20no,all%20future%20Docker%20Desktop%20versions.

> Compose V1 support will no longer be provided after June 2023 and will be removed from all future Docker Desktop versions. If you’re still on Compose V1, we recommend you switch as soon as possible to leave time to address any issues with running your Compose applications. (Until the end of June 2023, we’ll monitor [Compose issues](https://github.com/docker/compose/issues) to address challenges related to V1 migration to V2.)

https://www.docker.com/blog/announcing-compose-v2-general-availability/

> What’ll happen to Compose V1?
We’ve now marked Compose V1 as deprecated. Only high-priority security patches and critical bug fixes will apply to V1 until the next milestone. Later in this blog, we’ll outline a [proposed timeline](https://www.docker.com/blog/announcing-compose-v2-general-availability/#proposed-compose-v1-end-of-lie-timeline) for Docker Compose V1’s end of life (EOL) — which includes six months of critical security-and-bug fixes, and a one year grace period for opting out of V2.

https://docs.docker.com/compose/compose-v2/

> From the end of June 2023 Compose V1 won’t be supported anymore and will be removed from all Docker Desktop versions.
>
> Make sure you switch to [Compose V2](https://docs.docker.com/compose/compose-file/) with the docker compose CLI plugin or by activating the Use Docker Compose V2 setting in Docker Desktop. For more information, see the [Evolution of Compose](https://docs.docker.com/compose/compose-v2/)