### PR TITLE
PIM-10834: Fix regression on parent filter in LIST products endpoint

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,10 +1,14 @@
 # 6.0.x
 
+## Bug fixes:
+
+- PIM-10834: Fix regression on parent filter in LIST products endpoint
+
 # 6.0.68 (2023-02-09)
 
 ## Bug fixes
 
-- Pim 10810: Optimize completeness saving
+- PIM-10810: Optimize completeness saving
 
 # 6.0.67 (2023-02-06)
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Connector/UseCase/Validator/ValidateProperties.php
@@ -48,21 +48,7 @@ final class ValidateProperties
             $propertyCode = (string) $propertyCode;
             $isExistingAttribute = $this->isExistingAttribute($propertyCode);
 
-            if ($this->isProductField($propertyCode)) {
-                if ('parent' === $propertyCode) {
-                    foreach ($filters as $filter) {
-                        if (Operators::EQUALS === $filter['operator']) {
-                            throw new InvalidQueryException(
-                                sprintf(
-                                    'Filter on property "%s" is not supported or does not support operator "%s"',
-                                    $propertyCode,
-                                    $filter['operator']
-                                )
-                            );
-                        }
-                    }
-                }
-            } elseif (!$isExistingAttribute) {
+            if (!$this->isProductField($propertyCode) && !$isExistingAttribute) {
                 throw new InvalidQueryException(
                     sprintf(
                         '"%s" does not exist or you do not have permission to access it.',

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/ListProducts/SuccessListProductEndToEnd.php
@@ -900,6 +900,7 @@ JSON;
         $standardizedProducts = $this->getStandardizedProducts();
 
         $searchFilters = [
+            '{"parent":[{"operator":"=","value":"prod_mod_optA"}]}',
             '{"parent":[{"operator":"NOT EMPTY","value":null}]}',
             '{"parent":[{"operator":"IN","value":["prod_mod_optA"]}]}',
         ];


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Fixes a regression that prevented from searching on the "parent" property in the "list products" endpoints

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
