### PR TITLE
Revert "RAB-1124-divers: Add --workerIdleMemoryLimit=300MB"

### DIFF
--- a/components/catalogs/front/jest.config.js
+++ b/components/catalogs/front/jest.config.js
@@ -9,5 +9,4 @@ module.exports = {
             ...require('./jest.integration'),
         },
     ],
-    workerIdleMemoryLimit: '300MB'
 };

--- a/front-packages/shared/jest.config.js
+++ b/front-packages/shared/jest.config.js
@@ -1,27 +1,26 @@
 module.exports = {
-    preset: 'ts-jest',
-    moduleNameMapper: {
-        '\\.(svg|css)$': '<rootDir>/tests/fileMock.ts',
+  preset: 'ts-jest',
+  moduleNameMapper: {
+    '\\.(svg|css)$': '<rootDir>/tests/fileMock.ts',
+  },
+  setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
+  testMatch: ['<rootDir>/src/**/?(*.)+(unit).ts?(x)'],
+  collectCoverage: true,
+  collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
+  coverageReporters: ['text-summary', 'html'],
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: [
+    'tests',
+    'src/microfrontend',
+    'src/components/PimView.tsx',
+    'index.ts',
+    'src/components/CategoryTree'
+  ],
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      functions: 100,
+      lines: 100,
     },
-    setupFilesAfterEnv: ['<rootDir>/tests/setupTests.ts'],
-    testMatch: ['<rootDir>/src/**/?(*.)+(unit).ts?(x)'],
-    collectCoverage: true,
-    collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
-    coverageReporters: ['text-summary', 'html'],
-    coverageDirectory: 'coverage',
-    coveragePathIgnorePatterns: [
-        'tests',
-        'src/microfrontend',
-        'src/components/PimView.tsx',
-        'index.ts',
-        'src/components/CategoryTree'
-    ],
-    coverageThreshold: {
-        global: {
-            statements: 100,
-            functions: 100,
-            lines: 100,
-        },
-    },
-    workerIdleMemoryLimit: '300MB'
+  },
 };

--- a/src/Akeneo/Connectivity/Connection/front/jest.config.js
+++ b/src/Akeneo/Connectivity/Connection/front/jest.config.js
@@ -12,5 +12,4 @@ module.exports = {
     },
     setupFiles: ['./tests/mocks/fetch-mock.ts'],
     collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}'],
-    workerIdleMemoryLimit: "300MB"
 };

--- a/src/Akeneo/Connectivity/Connection/workspaces/permission-form/jest.config.js
+++ b/src/Akeneo/Connectivity/Connection/workspaces/permission-form/jest.config.js
@@ -25,6 +25,5 @@ module.exports = {
             lines: 100,
             statements: 100,
         },
-    },
-    workerIdleMemoryLimit: "300MB"
+    }
 };

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/jest.config.json
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/jest.config.json
@@ -21,6 +21,5 @@
   },
   "moduleNameMapper": {
     "\\.(svg|css)$": "<rootDir>/src/__mocks__/fileMock.ts"
-  },
-  "workerIdleMemoryLimit": "300MB"
+  }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

I removed an option we added few weeks ago to mitigate a memory leak inside jest. This option was unused due to incorrect jest version and we found another way to mitigate the memory leak.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
