### PR TITLE
PIM-10843: Rework query to avoid issue with group concat max lenght limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - PIM-10806: Allow to delete product's attributes with type 'identifier' and ensure grey cross is displayed
 - PIM-10825: Fix transfer to external storage does not give enough information
 - PIM-10823: Fix cannot import price and measurement with comma as decimal separator with value not saved as string in import file
+- PIM-10843: Rework get association query to avoid group concat max lenght limit
 - PIM-10835: Fix command publish-job-to-queue does not work
 - PIM-10778: Add limit to the number of options to display on the attribute option page
 

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Association/Sql/SqlGetAssociationTypes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Association/Sql/SqlGetAssociationTypes.php
@@ -34,9 +34,9 @@ SELECT
     association_type.is_quantified, 
     association_type.is_two_way,
     labels
-FROM
-    pim_catalog_association_type association_type
-LEFT JOIN association_type_labels ON association_type_id = id
+FROM pim_catalog_association_type association_type
+LEFT JOIN association_type_labels ON association_type_id = association_type.id
+WHERE association_type.code IN (:association_type_code)
 SQL;
 
         $rows = $this->connection->executeQuery(

--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Association/Sql/SqlGetAssociationTypes.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Association/Sql/SqlGetAssociationTypes.php
@@ -24,18 +24,19 @@ final class SqlGetAssociationTypes implements GetAssociationTypesInterface
     public function forCodes(array $associationTypeCodes): array
     {
         $query = <<<SQL
+WITH association_type_labels AS (
+    SELECT foreign_key as association_type_id, JSON_OBJECTAGG(locale, label) as labels
+    FROM pim_catalog_association_type_translation
+    GROUP BY foreign_key
+)
 SELECT
     association_type.code,
-    is_quantified, 
-    is_two_way,
-    CONCAT('{', GROUP_CONCAT(CONCAT('"', translation.locale, '":"',translation.label,'"')), '}') labels
+    association_type.is_quantified, 
+    association_type.is_two_way,
+    labels
 FROM
     pim_catalog_association_type association_type
-LEFT JOIN pim_catalog_association_type_translation translation
-          ON association_type.id = translation.foreign_key
-WHERE association_type.code IN (:association_type_code)
-GROUP BY
-    association_type.code;
+LEFT JOIN association_type_labels ON association_type_id = id
 SQL;
 
         $rows = $this->connection->executeQuery(

--- a/tests/back/Pim/Structure/Integration/AssociationType/Query/SqlGetAssociationTypesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AssociationType/Query/SqlGetAssociationTypesIntegration.php
@@ -11,7 +11,7 @@ use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Webmozart\Assert\Assert;
 
-final class SqlGetAssociationTypesIntegrationTest extends TestCase
+final class SqlGetAssociationTypesIntegration extends TestCase
 {
     public function test_it_gets_association_type_indexed_by_association_type_codes(): void
     {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR I reworked the SqlGetAssociationTypes query to avoid the GROUP_CONCAT limit
