### PR TITLE
PIM-10846: PIM installer does not drop database/schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ check-requirements:
 
 .PHONY: database
 database:
+	$(PHP_RUN) bin/console doctrine:database:drop --force
+	$(PHP_RUN) bin/console doctrine:database:create --if-not-exists
 	$(PHP_RUN) bin/console pim:installer:db ${O}
 
 .PHONY: start-job-worker

--- a/bin/benchmark_products_api.sh
+++ b/bin/benchmark_products_api.sh
@@ -38,6 +38,8 @@ boot_and_install_pim()
     rm -rf var/cache/*
     bin/docker/pim-setup.sh
     docker-compose exec -T fpm bin/console cache:warmup -e behat
+    docker-compose exec -T fpm bin/console doctrine:database:drop --force
+    docker-compose exec -T fpm bin/console doctrine:database:create --if-not-exists
     docker-compose exec -T fpm bin/console pim:installer:db -e behat
     CREDENTIALS=$(docker-compose exec -T fpm bin/console pim:oauth-server:create-client --no-ansi -e behat generator | tr -d '\r ')
     export API_CLIENT=$(echo $CREDENTIALS | cut -d " " -f 2 | cut -d ":" -f 2)

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -108,12 +108,19 @@ class DatabaseCommand extends Command
     {
         $this->logger->info('Prepare database schema');
 
-        $this->commandExecutor
-            ->runCommand('doctrine:schema:create')
-            ->runCommand(
-                'doctrine:schema:update',
-                ['--force' => true, '--no-interaction' => true]
-            );
+        try {
+            $this->commandExecutor
+                ->runCommand('doctrine:schema:create')
+                ->runCommand(
+                    'doctrine:schema:update',
+                    ['--force' => true, '--no-interaction' => true]
+                );
+        } catch (\Exception $e) {
+            $this->logger->critical('Trying to install PIM on an existing database is impossible.');
+            $this->logger->critical($e->getMessage());
+
+            return Command::FAILURE;
+        }
 
         if (false === $input->getOption('withoutIndexes')) {
             $this->resetElasticsearchIndex($output);
@@ -124,7 +131,7 @@ class DatabaseCommand extends Command
 
         $this->eventDispatcher->dispatch(
             new InstallerEvent($this->commandExecutor, null, [
-                'catalog' => $input->getOption('catalog')
+                'catalog' => $input->getOption('catalog'),
             ]),
             InstallerEvents::POST_DB_CREATE
         );
@@ -134,7 +141,7 @@ class DatabaseCommand extends Command
         if (false === $input->getOption('withoutFixtures')) {
             $this->eventDispatcher->dispatch(
                 new InstallerEvent($this->commandExecutor, null, [
-                    'catalog' => $input->getOption('catalog')
+                    'catalog' => $input->getOption('catalog'),
                 ]),
                 InstallerEvents::PRE_LOAD_FIXTURES
             );
@@ -143,7 +150,7 @@ class DatabaseCommand extends Command
 
             $this->eventDispatcher->dispatch(
                 new InstallerEvent($this->commandExecutor, null, [
-                    'catalog' => $input->getOption('catalog')
+                    'catalog' => $input->getOption('catalog'),
                 ]),
                 InstallerEvents::POST_LOAD_FIXTURES
             );
@@ -182,20 +189,21 @@ class DatabaseCommand extends Command
         $jobInstances = $this->fixtureJobLoader->getLoadedJobInstances();
         foreach ($jobInstances as $jobInstance) {
             $params = [
-                'code'       => $jobInstance->getCode(),
+                'code' => $jobInstance->getCode(),
                 '--no-debug' => true,
-                '--no-log'   => true,
-                '-v'         => true,
+                '--no-log' => true,
+                '-v' => true,
             ];
 
             $this->eventDispatcher->dispatch(
                 new InstallerEvent($this->commandExecutor, $jobInstance->getCode(), [
-                    'catalog' => $catalog
+                    'catalog' => $catalog,
                 ]),
                 InstallerEvents::PRE_LOAD_FIXTURE
             );
 
-            $this->logger->info(sprintf('Please wait, the "%s" are processing...',$jobInstance->getCode())
+            $this->logger->info(
+                sprintf('Please wait, the "%s" are processing...', $jobInstance->getCode())
             );
             $this->commandExecutor->runCommand('akeneo:batch:job', $params);
             $this->eventDispatcher->dispatch(

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -9,7 +9,6 @@ use Akeneo\Platform\Bundle\InstallerBundle\Persistence\Sql\InstallData;
 use Akeneo\Tool\Bundle\ElasticsearchBundle\ClientRegistry;
 use Akeneo\Tool\Component\Console\CommandExecutor;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception\ConnectionException;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;

--- a/std-build/Makefile
+++ b/std-build/Makefile
@@ -53,6 +53,8 @@ front: assets css front-packages javascript-dev
 
 .PHONY: database
 database:
+	$(PHP_RUN) bin/console doctrine:database:drop --force
+	$(PHP_RUN) bin/console doctrine:database:create --if-not-exists
 	$(PHP_RUN) bin/console pim:installer:db ${O}
 
 .PHONY: cache

--- a/upgrades/test_schema/Version_7_0_20220429131804_execute_uuid_migration_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220429131804_execute_uuid_migration_Integration.php
@@ -79,6 +79,14 @@ final class Version_7_0_20220429131804_execute_uuid_migration_Integration extend
         $consoleApp->setAutoExit(false);
 
         $input = new ArrayInput([
+            'command' => 'doctrine:schema:drop',
+            '--force' => true,
+            '--full-database' => true,
+        ]);
+        $output = new BufferedOutput();
+        $consoleApp->run($input, $output);
+
+        $input = new ArrayInput([
             'command' => 'pim:installer:db',
         ]);
         $output = new BufferedOutput();

--- a/upgrades/test_schema/Version_7_0_20220927080024_add_identifier_generator_table_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20220927080024_add_identifier_generator_table_Integration.php
@@ -63,6 +63,14 @@ final class Version_7_0_20220927080024_add_identifier_generator_table_Integratio
         $consoleApp->setAutoExit(false);
 
         $input = new ArrayInput([
+            'command' => 'doctrine:schema:drop',
+            '--force' => true,
+            '--full-database' => true,
+        ]);
+        $output = new BufferedOutput();
+        $consoleApp->run($input, $output);
+
+        $input = new ArrayInput([
             'command' => 'pim:installer:db',
         ]);
         $output = new BufferedOutput();

--- a/upgrades/test_schema/Version_7_0_20230201143400_drop_product_id_columns_and_clean_versioning_resource_uuid_columns_Integration.php
+++ b/upgrades/test_schema/Version_7_0_20230201143400_drop_product_id_columns_and_clean_versioning_resource_uuid_columns_Integration.php
@@ -176,6 +176,14 @@ SQL;
         $consoleApp->setAutoExit(false);
 
         $input = new ArrayInput([
+            'command' => 'doctrine:schema:drop',
+            '--force' => true,
+            '--full-database' => true,
+        ]);
+        $output = new BufferedOutput();
+        $consoleApp->run($input, $output);
+
+        $input = new ArrayInput([
             'command' => 'pim:installer:db',
         ]);
         $output = new BufferedOutput();


### PR DESCRIPTION
### Context

![danger gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMzY1ZGIxM2UxNzM0YjgwZTAzOThiMGVlNWRhMzUzZDI0M2E2YjE1MiZjdD1n/l1KsOBPB2dWNPcikM/giphy.gif)

When launching PIM installation, the default behavior is to drop the whole existing database.

 :warning: **_It can be very dangerous if launched on client data._**

There is a `doNotDropDatabase` option, but this option will also drop the schema (not the database). 

:warning: **_It is still very dangerous, not less than previous one in fact._**

### Proposed solution

Dropping database and/or schema is a developer need, and we can remove the dangerous SQL commands from the PIM installer command and move them in Makefile used by developers.