### PR TITLE
PIM-10828: Search bars don't take into account special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - PIM-10843: Rework get association query to avoid group concat max lenght limit
 - PIM-10835: Fix command publish-job-to-queue does not work
 - PIM-10778: Add limit to the number of options to display on the attribute option page
+- PIM-10828: Fix search bars don't take into account special characters
 
 ## Improvements
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/abstract-filter.js
@@ -260,6 +260,10 @@ define(['jquery', 'underscore', 'backbone', 'oro/app'], function ($, _, Backbone
      * @protected
      */
     _formatDisplayValue: function (value) {
+      if (value.value !== undefined && typeof value.value === 'string') {
+        value.value = value.value.replace('\\', '');
+      }
+
       return value;
     },
 

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
@@ -105,7 +105,9 @@ define([
      * Executes the search by setting the value.
      */
     doSearch: function () {
-      this.setValue(this._readDOMValue());
+      const readDOMValue = this._readDOMValue();
+      readDOMValue.value = readDOMValue.value.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, "\\$&");
+      this.setValue(readDOMValue);
     },
   });
 });

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
@@ -106,7 +106,11 @@ define([
      */
     doSearch: function () {
       const readDOMValue = this._readDOMValue();
-      readDOMValue.value = readDOMValue.value.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, "\\$&");
+
+      if (readDOMValue.value !== undefined && typeof readDOMValue.value === 'string') {
+        readDOMValue.value = readDOMValue.value.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, "\\$&");
+      }
+
       this.setValue(readDOMValue);
     },
   });

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datafilter/filter/search-filter.js
@@ -108,7 +108,7 @@ define([
       const readDOMValue = this._readDOMValue();
 
       if (readDOMValue.value !== undefined && typeof readDOMValue.value === 'string') {
-        readDOMValue.value = readDOMValue.value.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, "\\$&");
+        readDOMValue.value = readDOMValue.value.replace(/[!@#$%^&*()+=\-[\]\\';,./{}|":<>?~_]/g, '\\$&');
       }
 
       this.setValue(readDOMValue);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add a `\` before special characters.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
