### PR TITLE
Revert "PH-430: Use Application::find() to run the command in Command…

### DIFF
--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Command/DatabaseCommand.php
@@ -250,10 +250,7 @@ class DatabaseCommand extends Command
     {
         $latestMigration = $this->getLatestMigration($input);
 
-        $this->commandExecutor->runCommand(
-            'doctrine:migrations:sync-metadata-storage',
-            ['-q' => true]
-        );
+        $this->commandExecutor->runCommand('doctrine:migrations:sync-metadata-storage', ['-q' => true]);
 
         $this->commandExecutor->runCommand(
             'doctrine:migrations:version',

--- a/src/Akeneo/Tool/Component/Console/CommandExecutor.php
+++ b/src/Akeneo/Tool/Component/Console/CommandExecutor.php
@@ -5,44 +5,45 @@ namespace Akeneo\Tool\Component\Console;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command executor
  *
  * @author    Romain Monceau <romain@akeneo.com>
- * @author    JM Leroux <jean-marie.leroux@akeneo.com>
  * @copyright 2013 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 class CommandExecutor
 {
     public function __construct(
-        protected readonly InputInterface $input,
-        protected readonly OutputInterface $output,
-        protected readonly Application $application
+        protected InputInterface $input,
+        protected OutputInterface $output,
+        protected Application $application
     ) {
     }
 
-    public function runCommand(string $commandName, array $params = []): static
+    /**
+     * {@inheritdoc}
+     */
+    public function runCommand($command, $params = []): static
     {
         $params = array_merge(
+            ['command' => $command],
             $params,
             $this->getDefaultParams()
         );
 
-        $command = $this->application->find($commandName);
+        $this->application->setAutoExit(false);
+        $exitCode = $this->application->run(new ArrayInput($params), $this->output);
 
-        $commandInput = new ArrayInput($params);
-        $commandInput->setInteractive(false);
-
-        $quiet = isset($params['--quiet']) || isset($params['-q']);
-
-        $command->run(
-            $commandInput,
-            $quiet ? new NullOutput() : $this->output
-        );
+        if (0 !== $exitCode) {
+            $this->application->setAutoExit(true);
+            $errorMessage = sprintf('The command terminated with an error code: %u.', $exitCode);
+            $this->output->writeln("<error>$errorMessage</error>");
+            $e = new \Exception($errorMessage, $exitCode);
+            throw $e;
+        }
 
         return $this;
     }


### PR DESCRIPTION
Revert PH-430: Use Application::find() to run the command in CommandExecutorExecutor (#18690)"

This reverts commit 569ab7610c499bfd7227c971623c988dd0725bdc.

We detected an issue with GrantedQuantifiedAssociationsValidator and the console.command event triggered by `application::run()` but not by `console::run()`

https://github.com/akeneo/pim-community-dev/blob/211d348822a7c60779da3f953ac84bac75628c85/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml#L52
