### PR TITLE
PIM-10844: Filter empty attribute option labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PIM-10835: Fix command publish-job-to-queue does not work
 - PIM-10778: Add limit to the number of options to display on the attribute option page
 - PIM-10828: Fix search bars don't take into account special characters
+- PIM-10844: Filter empty attribute option labels
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptions.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Connector/SqlGetConnectorProductsWithOptions.php
@@ -134,6 +134,7 @@ class SqlGetConnectorProductsWithOptions implements Query\GetConnectorProducts
                 JOIN pim_catalog_attribute_option ao ON  ao.attribute_id = a.id
                 JOIN pim_catalog_attribute_option_value aov ON aov.option_id = ao.id
                 WHERE (a.code, ao.code) IN (%s)
+                AND aov.value IS NOT NULL
                 GROUP BY attribute_code, ao.code
             ),
             aggregated_option_per_attribute AS (

--- a/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionType.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Form/Type/AttributeOptionType.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\Pim\Structure\Bundle\Form\Type;
 
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionValueInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -76,6 +77,8 @@ class AttributeOptionType extends AbstractType
                 'allow_add'    => true,
                 'allow_delete' => true,
                 'by_reference' => false,
+                'delete_empty' =>
+                    static fn (AttributeOptionValueInterface $optionValue = null) => null === $optionValue?->getValue()
             ]
         );
     }

--- a/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AttributeOptionNormalizer.php
+++ b/src/Akeneo/Pim/Structure/Component/Normalizer/Standard/AttributeOptionNormalizer.php
@@ -14,12 +14,8 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class AttributeOptionNormalizer implements NormalizerInterface, CacheableSupportsMethodInterface
 {
-    /** @var IdentifiableObjectRepositoryInterface */
-    private $localeRepository;
-
-    public function __construct(IdentifiableObjectRepositoryInterface $localeRepository)
+    public function __construct(private readonly IdentifiableObjectRepositoryInterface $localeRepository)
     {
-        $this->localeRepository = $localeRepository;
     }
 
     /**
@@ -65,7 +61,7 @@ class AttributeOptionNormalizer implements NormalizerInterface, CacheableSupport
         foreach ($attributeOption->getOptionValues() as $translation) {
             if (empty($locales) || in_array($translation->getLocale(), $locales)) {
                 $locale = $this->localeRepository->findOneByIdentifier($translation->getLocale());
-                if (null === $locale || !$locale->isActivated()) {
+                if (null === $locale || !$locale->isActivated() || null === $translation->getValue()) {
                     continue;
                 }
 

--- a/tests/back/Pim/Structure/Specification/Bundle/Form/Type/AttributeOptionTypeSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/Form/Type/AttributeOptionTypeSpec.php
@@ -5,6 +5,7 @@ namespace Specification\Akeneo\Pim\Structure\Bundle\Form\Type;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Structure\Component\Model\AttributeOption;
 use Akeneo\Pim\Structure\Bundle\Form\Type\AttributeOptionValueType;
+use Prophecy\Argument;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -36,12 +37,14 @@ class AttributeOptionTypeSpec extends ObjectBehavior
         $builder->add(
             'optionValues',
             CollectionType::class,
-            [
-                'entry_type'   => AttributeOptionValueType::class,
-                'allow_add'    => true,
-                'allow_delete' => true,
-                'by_reference' => false,
-            ]
+            Argument::that(
+                fn ($arg): bool => \is_array($arg) &&
+                    ($arg['entry_type'] ?? null === AttributeOptionValueType::class) &&
+                    ($arg['allow_add'] ?? null) === true &&
+                    ($arg['allow_delete'] ?? null) === true &&
+                    ($arg['by_reference'] ?? null) === false &&
+                    \is_callable($arg['delete_empty'] ?? null)
+            )
         )->shouldBeCalled();
 
         $builder->add('code', TextType::class, ['required' => true])->shouldBeCalled();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When updating an attribute option from the attribute edit form UI, empty labels were inserted anyway in the `pim_catalog_attribute_option_value` table (with value = NULL). This happened only in the UI, because it still uses a Symfony form, as opposed to import and API (which use the repo/factory/updater/saver stack)
This led to inconsistencies in the API, because such null labels were returned, unlike for other PIM entities

In this PR:
- I make sure null attribute option labels are not returned anymore
- and that null labels are not inserted anymore when using the UI

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
