### PR TITLE
PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - PIM-10828: Fix search bars don't take into account special characters
 - PIM-10844: Filter empty attribute option labels
 - PIM-10831: Fix severe performance issues with the association product and product model picker
+- PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel  
 
 ## Improvements
 

--- a/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Sorter/CompletenessSorterIntegration.php
@@ -92,6 +92,20 @@ class CompletenessSorterIntegration extends AbstractProductQueryBuilderTestCase
         $this->assertOrder($result, ['empty_product', 'product_one', 'product_two', 'product_three', 'no_family']);
     }
 
+    public function testWithLocaleNotBoundToChannel(): void
+    {
+        $result = $this->executeSorter(
+            [
+                // the first sort clause will have no effect as there is no completeness for the ecommerce/fr_FR couple
+                ['completeness', Directions::ASCENDING, ['locale' => 'fr_FR', 'scope' => 'ecommerce']],
+                // so only the second clause will be taken into account
+                ['identifier', Directions::ASCENDING],
+            ],
+            ['default_locale' => 'fr_FR', 'default_scope' => 'ecommerce'],
+        );
+        $this->assertOrder($result, ['empty_product', 'no_family', 'product_one', 'product_three', 'product_two']);
+    }
+
     public function testErrorOperatorNotSupported()
     {
         $this->expectException(InvalidDirectionException::class);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Sorter/Field/CompletenessSorterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Sorter/Field/CompletenessSorterSpec.php
@@ -2,13 +2,13 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field;
 
-use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Sorter\Field\CompletenessSorter;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidDirectionException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\Directions;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Sorter\FieldSorterInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use PhpSpec\ObjectBehavior;
 
 class CompletenessSorterSpec extends ObjectBehavior
 {
@@ -40,9 +40,10 @@ class CompletenessSorterSpec extends ObjectBehavior
         $sqb->addSort(
             [
                 'completeness.mobile.en_US' => [
-                    "order"   => 'ASC',
-                    "missing" => "_last"
-                ]
+                    'order' => 'ASC',
+                    'missing' => '_last',
+                    'unmapped_type' => 'integer',
+                ],
             ]
         )->shouldBeCalled();
 
@@ -56,9 +57,10 @@ class CompletenessSorterSpec extends ObjectBehavior
         $sqb->addSort(
             [
                 'completeness.mobile.en_US' => [
-                    "order"   => 'DESC',
-                    "missing" => "_last"
-                ]
+                    'order' => 'DESC',
+                    'missing' => '_last',
+                    'unmapped_type' => 'integer',
+                ],
             ]
         )->shouldBeCalled();
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Adds an `unmapped_type`  parameter in the completeness sort clause, in order to avoid the "No mapping found for [completeness.channel.locale] in order to sort on" Elasticsearch error

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
