### PR TITLE
RAB-1353: Add script to check elasticsearch index have been created with Elasticsearch 7

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Improvements
+
+- PIM-1353: Add script to check that PIM is ready to be upgraded to v7
+
 # 6.0.70 (2023-02-16)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
+++ b/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Akeneo\Platform\Bundle\FrameworkBundle\Command;
+
+use Akeneo\Tool\Bundle\ElasticsearchBundle\ClientRegistry;
+use Elasticsearch\ClientBuilder;
+use Elasticsearch\Client;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Requirements\Requirement;
+use Symfony\Requirements\RequirementCollection;
+
+class CheckUpdateRequirementsCommand extends Command
+{
+    protected static $defaultName = 'pim:update:check-requirements';
+    private Client $client;
+
+    public function __construct(
+        private ClientRegistry $clientRegistry,
+        ClientBuilder $clientBuilder,
+        private array $elasticsearchHosts
+    ) {
+        parent::__construct();
+
+        $this->client = $clientBuilder->setHosts($elasticsearchHosts)->build();
+    }
+
+    function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $requirements = new RequirementCollection();
+
+        $this->validateThatElasticsearchIndexesAreCompliant($requirements);
+        $this->renderRequirements($requirements, $output);
+
+        if (count($requirements->getFailedRequirements())) {
+            $this->renderFailedRequirements($requirements, $output);
+
+            $output->writeln('<error>Some update requirements are not fulfilled. Please check output messages and fix them.</error>');
+
+            return self::FAILURE;
+        }
+
+        $output->writeln('<info>Update requirements are fulfilled</info>');
+
+        return self::SUCCESS;
+    }
+
+    private function validateThatElasticsearchIndexesAreCompliant(RequirementCollection $requirements): void
+    {
+        $firstElasticsearchHost = current($this->elasticsearchHosts);
+        $registeredIndexes = $this->getIndexesUsedByThePIM();
+
+        $indexConfigurations = $this->client->indices()->get(['index' => '*']);
+        foreach ($indexConfigurations as $indexName => $indexConfiguration) {
+            $aliasName = $indexName;
+            if (!empty($indexConfiguration['aliases'])) {
+                $aliasName = array_keys($indexConfiguration['aliases'])[0];
+            }
+
+            $versionCreated = $indexConfiguration['settings']['index']["version"]["created"];
+            $requirements->add(
+                new Requirement(
+                    str_starts_with($versionCreated, '7') || str_starts_with($versionCreated, '8'),
+                    "Index $indexName creation version",
+                    !in_array($indexName, $registeredIndexes) ?
+                        "The index $indexName seems to not be used by the PIM, please check if you use it.\n   If you didn't use it delete it: curl --location --request DELETE 'http://$firstElasticsearchHost/$indexName'. \n   If you want to keep it, reindex it with ElasticSearch 7: bin/console akeneo:elasticsearch:update-index-version $aliasName"
+                        : "The index $indexName should be re-indexed in order to be created with Elasticsearch 7, run: bin/console akeneo:elasticsearch:update-index-version $aliasName"
+                )
+            );
+        }
+    }
+
+    private function getIndexesUsedByThePIM(): array
+    {
+        $registeredIndexNames = [];
+        $clients = $this->clientRegistry->getClients();
+        foreach ($clients as $client) {
+            $registeredIndexNames[] = $client->getIndexName();
+        }
+
+        return $registeredIndexNames;
+    }
+
+    protected function renderRequirements(RequirementCollection $requirements, OutputInterface $output): void
+    {
+        $table = new Table($output);
+
+        $table->setHeaders(['Check', 'Status']);
+        foreach ($requirements->all() as $requirement) {
+            if ($requirement->isFulfilled()) {
+                $table->addRow([$requirement->getTestMessage(), 'OK']);
+                continue;
+            }
+
+            $table->addRow([$requirement->getTestMessage(), 'ERROR']);
+        }
+
+        $table->render();
+    }
+
+    protected function renderFailedRequirements(RequirementCollection $requirements, OutputInterface $output): void
+    {
+        $table = new Table($output);
+
+        $table->setHeaders(['Recommendation']);
+        foreach ($requirements->getFailedRequirements() as $failedRequirement) {
+            $table->addRow([$failedRequirement->getHelpText()]);
+        }
+
+        $table->render();
+    }
+}

--- a/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
+++ b/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
@@ -3,8 +3,8 @@
 namespace Akeneo\Platform\Bundle\FrameworkBundle\Command;
 
 use Akeneo\Tool\Bundle\ElasticsearchBundle\ClientRegistry;
-use Elasticsearch\ClientBuilder;
 use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,7 +27,7 @@ class CheckUpdateRequirementsCommand extends Command
         $this->client = $clientBuilder->setHosts($elasticsearchHosts)->build();
     }
 
-    function execute(InputInterface $input, OutputInterface $output): int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $requirements = new RequirementCollection();
 
@@ -65,7 +65,7 @@ class CheckUpdateRequirementsCommand extends Command
                     str_starts_with($versionCreated, '7') || str_starts_with($versionCreated, '8'),
                     "Index $indexName creation version",
                     !in_array($indexName, $registeredIndexes) ?
-                        "The index $indexName seems to not be used by the PIM, please check if you use it.\n   If you didn't use it delete it: curl --location --request DELETE 'http://$firstElasticsearchHost/$indexName'. \n   If you want to keep it, reindex it with ElasticSearch 7: bin/console akeneo:elasticsearch:update-index-version $aliasName"
+                        "The index $indexName seems to not be used by the PIM, please check if you use it. If you didn't use it delete it: curl --location --request DELETE 'http://$firstElasticsearchHost/$indexName'. If you want to keep it, reindex it with ElasticSearch 7: bin/console akeneo:elasticsearch:update-index-version $aliasName"
                         : "The index $indexName should be re-indexed in order to be created with Elasticsearch 7, run: bin/console akeneo:elasticsearch:update-index-version $aliasName"
                 )
             );
@@ -83,7 +83,7 @@ class CheckUpdateRequirementsCommand extends Command
         return $registeredIndexNames;
     }
 
-    protected function renderRequirements(RequirementCollection $requirements, OutputInterface $output): void
+    private function renderRequirements(RequirementCollection $requirements, OutputInterface $output): void
     {
         $table = new Table($output);
 
@@ -100,7 +100,7 @@ class CheckUpdateRequirementsCommand extends Command
         $table->render();
     }
 
-    protected function renderFailedRequirements(RequirementCollection $requirements, OutputInterface $output): void
+    private function renderFailedRequirements(RequirementCollection $requirements, OutputInterface $output): void
     {
         $table = new Table($output);
 

--- a/src/Akeneo/Platform/Bundle/FrameworkBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/FrameworkBundle/Resources/config/services.yml
@@ -1,4 +1,12 @@
 services:
+    Akeneo\Platform\Bundle\FrameworkBundle\Command\CheckUpdateRequirementsCommand:
+        arguments:
+            - '@akeneo_elasticsearch.registry.clients'
+            - '@akeneo_elasticsearch.client_builder'
+            - ['%index_hosts%']
+        tags:
+            - { name: console.command }
+
     pim_framework.service.pim_url:
         class: Akeneo\Platform\Bundle\FrameworkBundle\Service\PimUrl
         public: true

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
@@ -60,11 +60,21 @@ class UpdateIndexVersionCommand extends Command
                 return Command::SUCCESS;
             }
 
-            $this->updateIndexWithoutDowntime(
-                $sourceAliasName,
-                $destinationAliasName,
-                $destinationIndexName
-            );
+            try {
+                $this->updateIndexWithoutDowntime(
+                    $sourceAliasName,
+                    $destinationAliasName,
+                    $destinationIndexName
+                );
+            } catch (\Exception $e) {
+                $output->writeln(sprintf(
+                    "<error>Index %s have not been updated du to the following error: \n%s</error>",
+                    $sourceAliasName,
+                    $e->getMessage()
+                ));
+
+                return Command::FAILURE;
+            }
 
             $output->writeln("<info>Index $sourceAliasName have been updated</info>");
         }
@@ -72,7 +82,7 @@ class UpdateIndexVersionCommand extends Command
         return Command::SUCCESS;
     }
 
-    function updateIndexWithoutDowntime(
+    private function updateIndexWithoutDowntime(
         string $sourceAliasName,
         string $destinationAliasName,
         string $destinationIndexName,

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Command;
+
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\ClientRegistry;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\IndexConfiguration\UpdateIndexMapping;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client\ClientMigration;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client\ClientMigrationInterface;
+use Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client\IndexUpdaterClient;
+use Elasticsearch\ClientBuilder;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateIndexVersionCommand extends Command
+{
+    protected static $defaultName = 'akeneo:elasticsearch:update-index-version';
+
+    public function __construct(private IndexUpdaterClient $indexUpdaterClient)
+    {
+        parent::__construct();
+    }
+
+    public function configure()
+    {
+        $this
+            ->addArgument(
+                'indices',
+                InputArgument::IS_ARRAY | InputArgument::REQUIRED,
+                'Elasticsearch indices name to update, separated by spaces'
+            );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $sourceAliasNames = $input->getArgument('indices');
+        foreach ($sourceAliasNames as $sourceAliasName) {
+            $destinationAliasName = sprintf('%s_alias_%s', $sourceAliasName, Uuid::uuid4());
+            $destinationIndexName = sprintf('%s_%s', $sourceAliasName, Uuid::uuid4());
+            $output->writeln("<info>Recapitulation of the operation:
+    - Source alias: $sourceAliasName
+    - Destination alias: $destinationAliasName
+    - Destination index: $destinationIndexName
+    </info>");
+
+            $question = new ConfirmationQuestion("<question>Are you sure to update $sourceAliasName index? [Y/n]</question>", true);
+            if (!$this->getHelper('question')->ask($input, $output, $question)) {
+                return Command::SUCCESS;
+            }
+
+            $this->updateIndexWithoutDowntime(
+                $sourceAliasName,
+                $destinationAliasName,
+                $destinationIndexName
+            );
+
+            $output->writeln("<info>Index $sourceAliasName have been updated</info>");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    function updateIndexWithoutDowntime(
+        string $sourceAliasName,
+        string $destinationAliasName,
+        string $destinationIndexName,
+    ): void {
+        $sourceIndexConfiguration = $this->indexUpdaterClient->getIndexConfiguration($sourceAliasName);
+        $sourceIndexHaveAlias = $this->indexUpdaterClient->indexHaveAlias($sourceAliasName);
+        if (!$sourceIndexHaveAlias) {
+            $newSourceAliasName = sprintf('%s_migration_alias', $sourceAliasName);
+            $this->indexUpdaterClient->createAlias($newSourceAliasName, $sourceAliasName);
+            $sourceAliasName = $newSourceAliasName;
+        }
+
+        $sourceIndexName = $this->indexUpdaterClient->getIndexNameFromAlias($sourceAliasName);
+        $this->indexUpdaterClient->createDestinationIndex($destinationIndexName, $destinationAliasName, $sourceIndexConfiguration);
+        $this->indexUpdaterClient->reindexAllDocuments($sourceAliasName, $destinationAliasName);
+
+        $this->indexUpdaterClient->resetIndexSettings($destinationIndexName, $sourceIndexName);
+        $this->indexUpdaterClient->switchIndexAliasToNewIndex(
+            $sourceAliasName,
+            $sourceIndexName,
+            $destinationAliasName,
+            $destinationIndexName
+        );
+
+        $this->indexUpdaterClient->reindexDocumentsAfterSwitch($destinationAliasName, $sourceAliasName);
+        $this->indexUpdaterClient->removeIndex($sourceIndexName);
+        if (!$sourceIndexHaveAlias) {
+            $this->indexUpdaterClient->renameAlias($sourceAliasName, $sourceIndexName, $destinationIndexName);
+        }
+    }
+}

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
@@ -175,8 +175,8 @@ final class IndexUpdaterClient
                         ],
                     ],
                 ]
-            ]
-        ));
+            ])
+        );
     }
 
     public function resetIndexSettings(string $destinationIndexName, string $sourceIndexName): void

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client;
+
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+use Monolog\Logger;
+use Webmozart\Assert\Assert;
+
+final class IndexUpdaterClient
+{
+    private Client $client;
+
+    public function __construct(private Logger $logger, ClientBuilder $clientBuilder, array $hosts)
+    {
+        $this->client = $clientBuilder->setHosts($hosts)->build();
+    }
+
+    public function switchIndexAliasToNewIndex(
+        string $sourceAliasName,
+        string $sourceIndexName,
+        string $destinationAliasName,
+        string $destinationIndexName
+    ) {
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->updateAliases([
+                'body' => [
+                    'actions' => [
+                        [
+                            'add' => [
+                                'alias' => $sourceAliasName,
+                                'index' => $destinationIndexName,
+                            ],
+                        ],
+                        [
+                            'remove' => [
+                                'alias' => $sourceAliasName,
+                                'index' => $sourceIndexName,
+                            ],
+                        ],
+                        [
+                            'add' => [
+                                'alias' => $destinationAliasName,
+                                'index' => $sourceIndexName,
+                            ]
+                        ],
+                        [
+                            'remove' => [
+                                'alias' => $destinationAliasName,
+                                'index' => $destinationIndexName,
+                            ]
+                        ],
+                    ]
+                ]
+            ])
+        );
+    }
+
+    public function reindexAllDocuments(string $sourceAliasName, string $destinationAliasName)
+    {
+        $this->logger->notice("First indexation into the new elasticsearch index");
+        $reindexResponse = $this->client->reindex([
+            'wait_for_completion' => true,
+            'body' => [
+                "source" => [
+                    "index" => $sourceAliasName,
+                ],
+                "dest" => [
+                    "index" => $destinationAliasName,
+                    "version_type" => "external_gt",
+                ]
+            ]
+        ]);
+
+        $this->logger->notice('Indexation result', ['response' => json_encode($reindexResponse)]);
+
+        $this->logger->notice("Reindex document indexed during first indexation");
+        $reindexResponse = $this->client->reindex([
+            'wait_for_completion' => true,
+            'body' => [
+                "conflicts" => "proceed",
+                "source" => [
+                    "index" => $sourceAliasName,
+                ],
+                "dest" => [
+                    "index" => $destinationAliasName,
+                    "version_type" => "external_gt",
+                ]
+            ]
+        ]);
+
+        $this->logger->notice('Indexation result', ['response' => json_encode($reindexResponse)]);
+    }
+
+    public function reindexDocumentsAfterSwitch(string $sourceAliasName, string $destinationAliasName)
+    {
+        $this->logger->notice("Reindex document indexed before the index switch");
+        $reindexResponse = $this->client->reindex([
+            'wait_for_completion' => true,
+            'body' => [
+                "conflicts" => "proceed",
+                "source" => [
+                    "index" => $sourceAliasName,
+                ],
+                "dest" => [
+                    "index" => $destinationAliasName,
+                    "version_type" => "external_gt",
+                ]
+            ]
+        ]);
+
+        $this->logger->notice('Indexation result', ['response' => json_encode($reindexResponse)]);
+    }
+
+    public function createDestinationIndex(string $destinationIndexName, string $destinationAliasName, array $sourceIndexConfiguration)
+    {
+        $sourceIndexConfiguration['settings']['index']['number_of_replicas'] = 0;
+        $sourceIndexConfiguration['settings']['index']['refresh_interval'] = -1;
+        $sourceIndexConfiguration['aliases'] = [$destinationAliasName => (object) []];
+
+        $this->client->indices()->create([
+            'index' => $destinationIndexName,
+            'body' => $sourceIndexConfiguration,
+        ]);
+    }
+
+    public function getIndexNameFromAlias(string $aliasName): string
+    {
+        $aliasConfiguration = $this->client->indices()->get(['index' => $aliasName]);
+        $indexNames = array_keys($aliasConfiguration);
+
+        if (count($indexNames) !== 1) {
+            throw new \Exception('There is multiple index behind the index alias or there is no alias behind the alias');
+        }
+
+        if ($indexNames[0] === $aliasName) {
+            throw new \Exception('The index alias have the same index name');
+        }
+
+        return $indexNames[0];
+    }
+
+    public function getIndexConfiguration(string $aliasToReindex): array
+    {
+        $aliasConfiguration = $this->client->indices()->get(['index' => $aliasToReindex]);
+        $indexName = array_keys($aliasConfiguration)[0];
+        $indexConfiguration = $aliasConfiguration[$indexName];
+        unset($indexConfiguration['aliases']);
+        unset($indexConfiguration['settings']['index']['provided_name']);
+        unset($indexConfiguration['settings']['index']['creation_date']);
+        unset($indexConfiguration['settings']['index']['uuid']);
+        unset($indexConfiguration['settings']['index']['version']);
+
+        return $indexConfiguration;
+    }
+
+    public function createAlias(string $aliasName, string $indexName): void
+    {
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->updateAliases([
+                'body' => [
+                    'actions' => [
+                        [
+                            'add' => [
+                                'alias' => $aliasName,
+                                'index' => $indexName,
+                            ],
+                        ],
+                    ],
+                ]
+            ]
+        ));
+    }
+
+    public function resetIndexSettings(string $destinationIndexName, string $sourceIndexName): void
+    {
+        $sourceIndexSettingsResponse = $this->client->indices()->getSettings(['index' => $sourceIndexName]);
+        $sourceIndexSettings = $sourceIndexSettingsResponse[$sourceIndexName]['settings']['index'];
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->putSettings([
+                'index' => $destinationIndexName,
+                'body' => [
+                    'refresh_interval' => $sourceIndexSettings['refresh_interval'] ?? null,
+                    'number_of_replicas' => $sourceIndexSettings['number_of_replicas'] ?? 1,
+                ]
+            ])
+        );
+
+        $this->client->indices()->refresh(['index' => $destinationIndexName]);
+    }
+
+    public function removeIndex(string $indexName): void
+    {
+        $this->assertResponseIsAcknowledged($this->client->indices()->delete(['index' => $indexName]));
+    }
+
+    public function indexHaveAlias(string $indexName): bool
+    {
+        return $this->client->indices()->existsAlias(['name' => $indexName]);
+    }
+
+    public function renameAlias(string $sourceAliasName, string $sourceIndexName, string $destinationIndexName): void
+    {
+        $this->assertResponseIsAcknowledged(
+            $this->client->indices()->updateAliases([
+                'body' => [
+                    'actions' => [
+                        [
+                            'add' => [
+                                'alias' => $sourceIndexName,
+                                'index' => $destinationIndexName,
+                            ],
+                        ],
+                        [
+                            'remove' => [
+                                'alias' => $sourceAliasName,
+                                'index' => $destinationIndexName,
+                            ],
+                        ],
+                    ]
+                ]
+            ])
+        );
+    }
+
+    private function assertResponseIsAcknowledged(array $response): void
+    {
+        Assert::true($response['acknowledged']);
+    }
+}

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/commands.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/commands.yml
@@ -7,6 +7,12 @@ services:
         tags:
             - {name: console.command}
 
+    Akeneo\Tool\Bundle\ElasticsearchBundle\Command\UpdateIndexVersionCommand:
+        arguments:
+            - '@Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client\IndexUpdaterClient'
+        tags:
+            - {name: console.command}
+
     Akeneo\Tool\Bundle\ElasticsearchBundle\Command\UpdateTotalFieldsLimitCommand:
         arguments:
             - '@akeneo_elasticsearch.registry.clients'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/services.yml
@@ -48,6 +48,11 @@ services:
             - '@akeneo_elasticsearch.client_builder'
             - ['%index_hosts%']
 
+    Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Client\IndexUpdaterClient:
+        - '@logger'
+        - '@akeneo_elasticsearch.client_builder'
+        - ['%index_hosts%']
+
     Akeneo\Tool\Bundle\ElasticsearchBundle\Infrastructure\Repository\IndexMigrationRepository:
         arguments:
             - '@database_connection'

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Akeneo PIM Enterprise Edition.
+ *
+ * (c) 2022 Akeneo SAS (https://www.akeneo.com)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Akeneo\Tool\Bundle\ElasticsearchBundle\tests\integration;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UpdateIndexVersionIntegration extends TestCase
+{
+    public function testCommandResetsAllIndexes()
+    {
+        $productIndexNameBeforeMigration = $this->getProductAndProductModelIndexName();
+        $numberOfDocumentBeforeMigration = $this->getNumberOfIndexedProductAndProductModel();
+        $firstDocumentBeforeMigration = $this->getFirstProductAndProductModel();
+
+        $this->runUpdateIndexVersionCommand();
+
+        $productIndexNameAfterMigration = $this->getProductAndProductModelIndexName();
+        $numberOfDocumentAfterMigration = $this->getNumberOfIndexedProductAndProductModel();
+        $firstDocumentAfterMigration = $this->getFirstProductAndProductModel();
+
+        $this->assertNotEquals($productIndexNameBeforeMigration, $productIndexNameAfterMigration);
+        $this->assertEquals($numberOfDocumentBeforeMigration, $numberOfDocumentAfterMigration);
+        $this->assertEquals($firstDocumentBeforeMigration, $firstDocumentAfterMigration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    private function runUpdateIndexVersionCommand(): void
+    {
+        $application = new Application(self::$kernel);
+        $command = $application->find('akeneo:elasticsearch:update-index-version');
+        $commandTester = new CommandTester($command);
+        $exitCode = $commandTester->execute([
+            'command' => $command->getName(),
+            'indices' => ['akeneo_pim_product_and_product_model']
+        ]);
+
+        $this->assertSame(0, $exitCode);
+    }
+
+    private function getClient(): Client
+    {
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->setHosts([$this->getParameter('index_hosts')]);
+
+        return $clientBuilder->build();
+    }
+
+    private function getProductAndProductModelIndexName(): string
+    {
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->setHosts([$this->getParameter('index_hosts')]);
+        $client = $clientBuilder->build();
+
+        $aliasConfiguration = $client->indices()->get(['index' => 'akeneo_pim_product_and_product_model']);
+        $indexNames = array_keys($aliasConfiguration);
+
+        if (count($indexNames) !== 1) {
+            throw new \Exception('There is multiple index behind the index alias or there is no alias behind the alias');
+        }
+
+        return $indexNames[0];
+    }
+
+    private function getNumberOfIndexedProductAndProductModel(): int
+    {
+        $response = $this->getClient()->count(['index' => 'akeneo_pim_product_and_product_model']);
+
+        return $response['count'];
+    }
+
+    private function getFirstProductAndProductModel()
+    {
+        $response = $this->getClient()->search(['index' => 'akeneo_pim_product_and_product_model', "size" => 1]);
+
+        return $response['hits']['hits'][0]['_source'];
+    }
+}

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
@@ -22,6 +22,14 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class UpdateIndexVersionIntegration extends TestCase
 {
+    private string $productAndProductModelIndexName;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->productAndProductModelIndexName = $this->getParameter('product_and_product_model_index_name');
+    }
+
     public function testCommandResetsAllIndexes()
     {
         $productIndexNameBeforeMigration = $this->getProductAndProductModelIndexName();
@@ -54,7 +62,7 @@ class UpdateIndexVersionIntegration extends TestCase
         $commandTester = new CommandTester($command);
         $exitCode = $commandTester->execute([
             'command' => $command->getName(),
-            'indices' => ['akeneo_pim_product_and_product_model']
+            'indices' => [$this->productAndProductModelIndexName]
         ]);
 
         $this->assertSame(0, $exitCode);
@@ -74,7 +82,7 @@ class UpdateIndexVersionIntegration extends TestCase
         $clientBuilder->setHosts([$this->getParameter('index_hosts')]);
         $client = $clientBuilder->build();
 
-        $aliasConfiguration = $client->indices()->get(['index' => 'akeneo_pim_product_and_product_model']);
+        $aliasConfiguration = $client->indices()->get(['index' => $this->productAndProductModelIndexName]);
         $indexNames = array_keys($aliasConfiguration);
 
         if (count($indexNames) !== 1) {
@@ -86,14 +94,14 @@ class UpdateIndexVersionIntegration extends TestCase
 
     private function getNumberOfIndexedProductAndProductModel(): int
     {
-        $response = $this->getClient()->count(['index' => 'akeneo_pim_product_and_product_model']);
+        $response = $this->getClient()->count(['index' => $this->productAndProductModelIndexName]);
 
         return $response['count'];
     }
 
     private function getFirstProductAndProductModel()
     {
-        $response = $this->getClient()->search(['index' => 'akeneo_pim_product_and_product_model', "size" => 1]);
+        $response = $this->getClient()->search(['index' => $this->productAndProductModelIndexName, "size" => 1]);
 
         return $response['hits']['hits'][0]['_source'];
     }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
In this PR, I added a command in order to check elasticsearch index creation version. 

**Why ?** 
Because in flex v7 the elasticsearch version have been bump to 8.4 before updating the elasticsearch version we need to check that all elasticsearch version have been created with at least elasticsearch 7.

This command will display the elasticsearch indexes to migrate if there is some index have been created with Elasticsearch 6

**Example of display (Error)**
![Screenshot from 2023-02-20 18-41-40](https://user-images.githubusercontent.com/7239572/220172075-0963f7b8-f6b2-411a-ac60-52fb7b7be0d4.png)

**Example of display (Success)**
![Screenshot from 2023-02-20 18-42-21](https://user-images.githubusercontent.com/7239572/220172070-ff637794-3475-4596-bd6b-aec0e8b8ddaa.png)


<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
