### PR TITLE
PIM-10858: Fix password is set on sftp storage using private key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - PIM-10835: Fix command publish-job-to-queue does not work
 - PIM-10778: Add limit to the number of options to display on the attribute option page
 - PIM-10828: Fix search bars don't take into account special characters
+- PIM-10858: Fix password is set on sftp storage using private key
 - PIM-10844: Filter empty attribute option labels
 - PIM-10831: Fix severe performance issues with the association product and product model picker
 - PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel  

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.test.tsx
@@ -198,8 +198,8 @@ test('it allows user to fill port field', () => {
   expect(onStorageChange).toHaveBeenLastCalledWith({...storage, port: 22});
 });
 
-test('it allows user to change login type', () => {
-  const storage: SftpStorage = {
+test('it allows user to change login type from password to private key', () => {
+  const passwordStorage: SftpStorage = {
     type: 'sftp',
     file_path: '',
     host: 'example.com',
@@ -209,12 +209,21 @@ test('it allows user to change login type', () => {
     password: '',
   };
 
+  const privateKeyStorage: SftpStorage = {
+    type: 'sftp',
+    file_path: '',
+    host: 'example.com',
+    port: 22,
+    login_type: 'private_key',
+    username: '',
+  };
+
   const onStorageChange = jest.fn();
 
   renderWithProviders(
     <SftpStorageConfigurator
       jobInstanceCode="csv_product_export"
-      storage={storage}
+      storage={passwordStorage}
       fileExtension="xlsx"
       validationErrors={[]}
       onStorageChange={onStorageChange}
@@ -224,10 +233,45 @@ test('it allows user to change login type', () => {
   userEvent.click(screen.getByLabelText('pim_import_export.form.job_instance.storage_form.login_type.label'));
   userEvent.click(screen.getByText('pim_import_export.form.job_instance.storage_form.login_type.private_key'));
 
-  expect(onStorageChange).toHaveBeenLastCalledWith({
-    ...storage,
+  expect(onStorageChange).toHaveBeenLastCalledWith(privateKeyStorage);
+});
+
+test('it allows user to change login type from private key to password', () => {
+  const passwordStorage: SftpStorage = {
+    type: 'sftp',
+    file_path: '',
+    host: 'example.com',
+    port: 22,
+    login_type: 'password',
+    username: '',
+    password: '',
+  };
+
+  const privateKeyStorage: SftpStorage = {
+    type: 'sftp',
+    file_path: '',
+    host: 'example.com',
+    port: 22,
     login_type: 'private_key',
-  });
+    username: '',
+  };
+
+  const onStorageChange = jest.fn();
+
+  renderWithProviders(
+    <SftpStorageConfigurator
+      jobInstanceCode="csv_product_export"
+      storage={privateKeyStorage}
+      fileExtension="xlsx"
+      validationErrors={[]}
+      onStorageChange={onStorageChange}
+    />
+  );
+
+  userEvent.click(screen.getByLabelText('pim_import_export.form.job_instance.storage_form.login_type.label'));
+  userEvent.click(screen.getByText('pim_import_export.form.job_instance.storage_form.login_type.password'));
+
+  expect(onStorageChange).toHaveBeenLastCalledWith(passwordStorage);
 });
 
 test('it displays a public key field', () => {
@@ -238,7 +282,6 @@ test('it displays a public key field', () => {
     port: 22,
     login_type: 'private_key',
     username: '',
-    password: '',
   };
 
   const onStorageChange = jest.fn();
@@ -266,7 +309,6 @@ test('it copy to clipboard a public key', () => {
     port: 22,
     login_type: 'private_key',
     username: '',
-    password: '',
   };
 
   const onStorageChange = jest.fn();

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/components/StorageConfigurator/SftpStorageConfigurator.tsx
@@ -4,7 +4,13 @@ import {Field, Helper, NumberInput, Button, getColor, getFontSize, SelectInput, 
 import {TextField, useTranslate, filterErrors} from '@akeneo-pim-community/shared';
 import {StorageConfiguratorProps} from './model';
 import {useGetPublicKey} from '../../hooks/';
-import {isSftpStorage, isValidSftpLoginType, SFTP_STORAGE_LOGIN_TYPES} from '../../models';
+import {
+  isSftpPasswordStorage,
+  isSftpStorage,
+  isValidSftpLoginType,
+  SFTP_STORAGE_LOGIN_TYPES,
+  SftpStorageLoginType,
+} from '../../models';
 import {CheckStorageConnection} from './CheckStorageConnection';
 
 const CopyableInputContainer = styled.div`
@@ -67,6 +73,20 @@ const SftpStorageConfigurator = ({
   const canCopyToClipboard = (): boolean => 'clipboard' in navigator;
   const copyToClipboard = (publicKey: string) => canCopyToClipboard() && navigator.clipboard.writeText(publicKey);
 
+  const handleLoginTypeChange = (newLoginType: SftpStorageLoginType) => {
+    if ('password' === newLoginType) {
+      onStorageChange({...storage, login_type: newLoginType, password: ''});
+    } else if ('private_key' === newLoginType) {
+      const newStorage = {...storage};
+
+      if (isSftpPasswordStorage(newStorage)) {
+        delete newStorage.password;
+      }
+
+      onStorageChange({...newStorage, login_type: newLoginType});
+    }
+  };
+
   return (
     <>
       <TextField
@@ -123,7 +143,7 @@ const SftpStorageConfigurator = ({
           value={storage.login_type}
           onChange={login_type => {
             if (isValidSftpLoginType(login_type)) {
-              onStorageChange({...storage, login_type});
+              handleLoginTypeChange(login_type);
             }
           }}
           emptyResultLabel={translate('pim_common.no_result')}

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/models/Storage.ts
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/front/src/models/Storage.ts
@@ -11,16 +11,28 @@ type LocalStorage = {
   file_path: string;
 };
 
-type SftpStorage = {
+type SftpPasswordStorage = {
   type: 'sftp';
   file_path: string;
   host: string;
   fingerprint?: string;
   port: number;
-  login_type: SftpStorageLoginType;
   username: string;
-  password?: string | null;
+  login_type: 'password';
+  password?: string;
 };
+
+type SftpPrivateKeyStorage = {
+  type: 'sftp';
+  file_path: string;
+  host: string;
+  fingerprint?: string;
+  port: number;
+  username: string;
+  login_type: 'private_key';
+};
+
+type SftpStorage = SftpPasswordStorage | SftpPrivateKeyStorage;
 
 type AmazonS3Storage = {
   type: 'amazon_s3';
@@ -156,6 +168,9 @@ const isSftpStorage = (storage: Storage): storage is SftpStorage => {
   );
 };
 
+const isSftpPasswordStorage = (sftpStorage: SftpStorage): sftpStorage is SftpPasswordStorage =>
+  sftpStorage.login_type === 'password';
+
 const isAmazonS3Storage = (storage: Storage): storage is AmazonS3Storage => {
   return (
     'amazon_s3' === storage.type &&
@@ -223,6 +238,7 @@ export type {
   SftpStorage,
   Storage,
   StorageType,
+  SftpStorageLoginType,
 };
 export {
   additionalStorageIsEnabled,
@@ -243,4 +259,5 @@ export {
   isValidStorageType,
   localStorageIsEnabled,
   SFTP_STORAGE_LOGIN_TYPES,
+  isSftpPasswordStorage,
 };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

see https://akeneo.atlassian.net/browse/PIM-10858

We don't remove password property from a storage when we pass from a password type storage to a private key storage. That leads to validation error in back and disallow user to save a valid form.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
