### PR TITLE
PIM-10840: Fix attribute update date on attribute options change above 10000 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel
 - PIM-10853: Fix type checking in SaveFamilyVariantOnFamilyUpdate bulk action
 - PIM-10829: Fix case-sensitive locale on translatable business objects
+- PIM-10840: Fix attribute update date on attribute options change above 10000 options
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/TimestampableAttributeSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/TimestampableAttributeSubscriber.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOptionInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * Updates the updated date of attributes on attribute option creation or removal
+ * This is already done by the TimestampableSubscriber unless the attribute has more than 10 000 options
+ *
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class TimestampableAttributeSubscriber implements EventSubscriberInterface
+{
+    public function __construct(private readonly ObjectManager $em)
+    {
+    }
+
+    /**
+     * Specifies the list of events to listen
+     *
+     * @return string[]
+     */
+    public static function getSubscribedEvents()
+    {
+        return [StorageEvents::PRE_SAVE => 'setAttributeUpdatedDate', StorageEvents::PRE_REMOVE => 'setAttributeUpdatedDate'];
+    }
+
+    public function setAttributeUpdatedDate(GenericEvent $event): void
+    {
+        $option = $event->getSubject();
+
+        if (!$option instanceof AttributeOptionInterface) {
+            return;
+        }
+
+        $attribute = $option->getAttribute();
+
+        if (!$attribute instanceof AttributeInterface || null === $attribute->getId()) {
+            return;
+        }
+
+        $attribute->setUpdated(new \DateTime('now', new \DateTimeZone('UTC')));
+        $this->em->persist($attribute);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -83,3 +83,9 @@ services:
             - '@database_connection'
         tags:
             - { name: kernel.event_subscriber }
+
+    Akeneo\Pim\Structure\Bundle\EventSubscriber\TimestampableAttributeSubscriber:
+        arguments:
+            - '@doctrine.orm.entity_manager'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/tests/back/Pim/Structure/Integration/Attribute/UpdateAttributeDateIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/UpdateAttributeDateIntegration.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\Attribute;
+
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Pim\Structure\Component\Model\AttributeOption;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\SaverInterface;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class UpdateAttributeDateIntegration extends TestCase
+{
+    public function testUpdateAttributeUpdateDateOnAttributeOptionEvents()
+    {
+        $attribute = $this->createSimpleSelectAttributeWithOptions('my_simple_select', []);
+        $initialUpdateDate = $this->getAttributeUpdateDate();
+
+        sleep(1);
+
+        //When I add another one
+        $this->createAttributeOption('last_option_code', $attribute, 10001);
+        $updateDateAfterAddingOption = $this->getAttributeUpdateDate();
+
+        Assert::assertNotEquals($initialUpdateDate, $updateDateAfterAddingOption);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function createSimpleSelectAttributeWithOptions(): AttributeInterface
+    {
+        $attribute = $this->createAttribute('my_simple_select', ['type' => AttributeTypes::OPTION_SIMPLE_SELECT]);
+        $options = [];
+        for ($i = 1; $i <= 10000; $i++) {
+            $option = new AttributeOption();
+            $option->setAttribute($attribute);
+            $option->setCode('option' . $i);
+            $option->setSortOrder($i);
+            $options[] = $option;
+        }
+        $this->get('pim_catalog.saver.attribute_option')->saveAll($options);
+
+        return $attribute;
+    }
+
+    private function createAttributeOption(string $optionCode, AttributeInterface $attribute, int $sortOrder): void
+    {
+        $option = $this->getAttributeOptionFactory()->create();
+        $option->setCode($optionCode);
+        $option->setAttribute($attribute);
+        $option->setSortOrder($sortOrder);
+        $this->getAttributeOptionSaver()->save($option);
+    }
+
+    private function createAttribute(string $code, array $data = []): AttributeInterface
+    {
+        $defaultData = [
+            'code' => $code,
+            'type' => AttributeTypes::TEXT,
+            'group' => 'other',
+        ];
+        $data = array_merge($defaultData, $data);
+
+        $attribute = $this->get('akeneo_integration_tests.base.attribute.builder')->build($data, true);
+        $this->getAttributeSaver()->save($attribute);
+
+        return $attribute;
+    }
+
+    private function getAttributeOptionFactory(): SimpleFactoryInterface
+    {
+        return $this->get('pim_catalog.factory.attribute_option');
+    }
+
+    private function getAttributeOptionSaver(): SaverInterface
+    {
+        return $this->get('pim_catalog.saver.attribute_option');
+    }
+
+    private function getAttributeSaver(): SaverInterface
+    {
+        return $this->get('pim_catalog.saver.attribute');
+    }
+
+    private function getAttributeUpdateDate(): string
+    {
+        return $this->getConnection()->fetchOne(
+            'SELECT updated from pim_catalog_attribute where code = :attributeCode;',
+            ['attributeCode' => 'my_simple_select'],
+        );
+    }
+
+    private function getConnection(): Connection
+    {
+        return $this->get('database_connection');
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

**Current behavior**:
The `update` column for the attribute is updated thanks to the `AddVersionSubscriber`.
The old version and new versions are compared and if there is a difference, a version is created and the column `update` is updated. But in the attribute options normalizer used for the AddVersionSubscriber, only the 10000 first options are retrieved.

**Problem**:
When an option is added to an attribute already having 10000 options, there is no change detected and the update column is not updated.

**Solution**:
We add a Subscriber on `preSave and `preRemove` for the AttributeOptionInterface. So that its attribute `update` property is updated every time an option is added/removed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
