### PR TITLE
PIM-10855: Fix products and models with empty attribute values are counted by CountItemsWithAttributeValueAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - PIM-10823: Fix cannot import price and measurement with comma as decimal separator with value not saved as string in import file
 - PIM-10843: Rework get association query to avoid group concat max lenght limit
 - PIM-10835: Fix command publish-job-to-queue does not work
+- PIM-10855: Fix products and models with empty attribute values are counted by CountItemsWithAttributeValueAction
 - PIM-10778: Add limit to the number of options to display on the attribute option page
 - PIM-10828: Fix search bars don't take into account special characters
 - PIM-10858: Fix password is set on sftp storage using private key

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/CountItemsWithAttributeValueAction.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/CountItemsWithAttributeValueAction.php
@@ -12,15 +12,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CountItemsWithAttributeValueAction
 {
-    private CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute;
-    private CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute;
-
     public function __construct(
-        CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute,
-        CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute
+        private readonly CountProductsWithRemovedAttributeInterface $countProductsWithRemovedAttribute,
+        private readonly CountProductModelsWithRemovedAttributeInterface $countProductModelsWithRemovedAttribute
     ) {
-        $this->countProductsWithRemovedAttribute = $countProductsWithRemovedAttribute;
-        $this->countProductModelsWithRemovedAttribute = $countProductModelsWithRemovedAttribute;
     }
 
     public function __invoke(Request $request): Response
@@ -30,8 +25,8 @@ class CountItemsWithAttributeValueAction
             return new JsonResponse(null, Response::HTTP_BAD_REQUEST);
         }
 
-        $productCount = $this->countProductsWithRemovedAttribute->count([$code]);
-        $productModelCount = $this->countProductModelsWithRemovedAttribute->count([$code]);
+        $productCount = $this->countProductsWithRemovedAttribute->count([$code], false);
+        $productModelCount = $this->countProductModelsWithRemovedAttribute->count([$code], false);
 
         return new JsonResponse([
             'products' => $productCount,

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttribute.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttribute.php
@@ -9,15 +9,15 @@ use Akeneo\Tool\Bundle\ElasticsearchBundle\Client;
 
 final class CountProductModelsWithRemovedAttribute implements CountProductModelsWithRemovedAttributeInterface
 {
-    private SearchQueryBuilder $searchQueryBuilder;
+    private readonly SearchQueryBuilder $searchQueryBuilder;
 
     public function __construct(
-        private Client $elasticsearchClient
+        private readonly Client $elasticsearchClient
     ) {
         $this->searchQueryBuilder = new SearchQueryBuilder();
     }
 
-    public function count(array $attributesCodes): int
+    public function count(array $attributesCodes, bool $includeProductModelsWithoutValue = true): int
     {
         $this->searchQueryBuilder->addFilter([
             'term' => [
@@ -29,6 +29,14 @@ final class CountProductModelsWithRemovedAttribute implements CountProductModels
                 'attributes_for_this_level' => $attributesCodes,
             ],
         ]);
+
+        if (!$includeProductModelsWithoutValue) {
+            foreach ($attributesCodes as $attributeCode) {
+                $this->searchQueryBuilder->addShould([
+                    'exists' => ['field' => sprintf('values.%s-*', $attributeCode)],
+                ]);
+            }
+        }
 
         $body = $this->searchQueryBuilder->getQuery();
         unset($body['_source']);

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/CountProductModelsWithRemovedAttributeInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/CountProductModelsWithRemovedAttributeInterface.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 
 interface CountProductModelsWithRemovedAttributeInterface
 {
-    public function count(array $attributesCodes): int;
+    public function count(array $attributesCodes, bool $includeProductModelsWithoutValue = true): int;
 
     public function getQueryBuilder(): SearchQueryBuilder;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/CountProductsWithRemovedAttributeInterface.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/CountProductsWithRemovedAttributeInterface.php
@@ -6,7 +6,7 @@ use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 
 interface CountProductsWithRemovedAttributeInterface
 {
-    public function count(array $attributesCodes): int;
+    public function count(array $attributesCodes, bool $includeProductsWithoutValue = true): int;
 
     public function getQueryBuilder(): SearchQueryBuilder;
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -235,9 +235,10 @@ pim_enrich.entity.attribute:
             select_locale: Select your locale
         delete:
             confirm: Are you sure you want to delete this attribute?
+            attribute_removal: The attribute will be removed from all products.
             product_count: '{0}0 products|{1}1 product|]1, Inf[{{ count }} products'
             product_model_count: '{0}0 product models|{1}1 product model|]1, Inf[{{ count }} product models'
-            used: ']-Inf,1]currently has values set for this attribute, they will be removed.|]1, Inf[currently have values set for this attribute, they will be removed.'
+            used: ']-Inf,1]currently has values set for this attribute.|]1, Inf[currently have values set for this attribute.'
             helper:
                 content: If you need to change your attribute type, to make it localizable or scopable, while keeping access to your existing attribute values,
                 link: check out our Help Center (for more information).

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/attribute/form/delete/DeleteModal.tsx
@@ -113,6 +113,7 @@ const DeleteModal = ({onCancel, onSuccess, attributeCode}: DeleteModalProps) => 
       {translate('pim_enrich.entity.attribute.module.delete.confirm')}
       {(0 < productCount || 0 < productModelCount) && (
         <p>
+          {translate('pim_enrich.entity.attribute.module.delete.attribute_removal')}{' '}
           <Highlight>{impactedItemsText}</Highlight>{' '}
           {translate('pim_enrich.entity.attribute.module.delete.used', {}, productCount + productModelCount)}
         </p>

--- a/tests/back/Pim/Enrichment/Integration/Fixture/ProductAndProductModelWithRemovedAttributeLoader.php
+++ b/tests/back/Pim/Enrichment/Integration/Fixture/ProductAndProductModelWithRemovedAttributeLoader.php
@@ -220,6 +220,14 @@ class ProductAndProductModelWithRemovedAttributeLoader
             ],
         ]);
 
+
+        // Simple product
+        $this->createProduct([
+            'identifier' => 'product_5',
+            'family' => 'a_family',
+            'values' => [],
+        ]);
+
         // Product model with only one level of variations
         $this->createProductModel([
             'code' => 'a_product_model',
@@ -264,6 +272,21 @@ class ProductAndProductModelWithRemovedAttributeLoader
                 'a_forth_attribute' => [
                     [
                         'data' => true,
+                        'locale' => null,
+                        'scope' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        //Sub product model for the second level of variations
+        $this->createProductModel([
+            'code' => 'a_second_sub_product_model',
+            'parent' => 'a_second_product_model',
+            'values' => [
+                'a_forth_attribute' => [
+                    [
+                        'data' => false,
                         'locale' => null,
                         'scope' => null,
                     ],

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductModelsWithRemovedAttributeIntegration.php
@@ -19,6 +19,13 @@ class CountProductModelsWithRemovedAttributeIntegration extends TestCase
     {
         $count = $this->getCountProductModelsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
+        self::assertEquals(3, $count);
+    }
+
+    public function test_it_only_counts_product_models_with_a_removed_attribute_only_with_value()
+    {
+        $count = $this->getCountProductModelsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute'], false);
+
         self::assertEquals(2, $count);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/CountProductsWithRemovedAttributeIntegration.php
@@ -19,6 +19,13 @@ class CountProductsWithRemovedAttributeIntegration extends TestCase
     {
         $count = $this->getCountProductsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute']);
 
+        self::assertEquals(4, $count);
+    }
+
+    public function test_it_only_count_products_with_a_removed_attribute_only_if_products_have_value()
+    {
+        $count = $this->getCountProductsWithRemovedAttribute()->count(['an_attribute', 'a_third_attribute'], false);
+
         self::assertEquals(3, $count);
     }
 

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetAllProductIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetAllProductIntegration.php
@@ -6,7 +6,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\Prod
 
 use Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\GetAllProductUuids;
 use Akeneo\Test\Integration\TestCase;
-use Ramsey\Uuid\Lazy\LazyUuidFromString;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -26,9 +26,10 @@ final class GetAllProductIntegration extends TestCase
         $productUuids = $this->getAllProduct()->byBatchesOf(2);
         $result = [...$productUuids];
 
-        $this->assertCount(2, $result);
-        $this->assertContainsOnlyInstancesOf(LazyUuidFromString::class, $result[0]);
-        $this->assertContainsOnlyInstancesOf(LazyUuidFromString::class, $result[1]);
+        $this->assertCount(3, $result);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[0]);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[1]);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[2]);
     }
 
     private function getAllProduct(): GetAllProductUuids

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductExistingAmongIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductExistingAmongIntegration.php
@@ -6,7 +6,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\Prod
 
 use Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\GetExistingProductUuids;
 use Akeneo\Test\Integration\TestCase;
-use Ramsey\Uuid\Lazy\LazyUuidFromString;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -26,7 +26,7 @@ final class GetProductExistingAmongIntegration extends TestCase
         $productUuids = $this->getProductExistingAmong()->among(['product_1', 'product_2', 'product_unknown']);
 
         $this->assertCount(2, $productUuids);
-        $this->assertContainsOnlyInstancesOf(LazyUuidFromString::class, $productUuids);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $productUuids);
     }
 
     private function getProductExistingAmong(): GetExistingProductUuids

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductIdentifiersWithRemovedAttributeIntegration.php
@@ -22,7 +22,7 @@ class GetProductIdentifiersWithRemovedAttributeIntegration extends TestCase
         $batchCount = 0;
         foreach ($result as $batch) {
             $batchCount++;
-            self::assertEquals(['product_1', 'product_2', 'product_4'], $batch);
+            self::assertEquals(['product_1', 'product_2', 'product_4', 'product_5'], $batch);
         }
         self::assertEquals(1, $batchCount);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductModelIdentifiersWithRemovedAttributeIntegration.php
@@ -22,7 +22,7 @@ class GetProductModelIdentifiersWithRemovedAttributeIntegration extends TestCase
         $batchCount = 0;
         foreach ($result as $batch) {
             $batchCount++;
-            self::assertEquals(['a_product_model', 'a_sub_product_model'], $batch);
+            self::assertEquals(['a_product_model', 'a_second_sub_product_model', 'a_sub_product_model'], $batch);
         }
         self::assertEquals(1, $batchCount);
     }

--- a/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductNotSynchronisedBetweenEsAndMysqlIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/ElasticsearchAndSql/ProductAndProductModel/GetProductNotSynchronisedBetweenEsAndMysqlIntegration.php
@@ -7,7 +7,7 @@ namespace AkeneoTest\Pim\Enrichment\Integration\Storage\ElasticsearchAndSql\Prod
 use Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\GetProductUuidsNotSynchronisedBetweenEsAndMysql;
 use Akeneo\Test\Integration\TestCase;
 use Doctrine\DBAL\Connection;
-use Ramsey\Uuid\Lazy\LazyUuidFromString;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
@@ -41,9 +41,10 @@ SQL;
         $diff = $this->getProductNotSynchronisedBetweenEsAndMysql()->byBatchesOf(2);
         $result = [...$diff];
 
-        $this->assertCount(2, $result);
-        $this->assertContainsOnlyInstancesOf(LazyUuidFromString::class, $result[0]);
-        $this->assertContainsOnlyInstancesOf(LazyUuidFromString::class, $result[1]);
+        $this->assertCount(3, $result);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[0]);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[1]);
+        $this->assertContainsOnlyInstancesOf(UuidInterface::class, $result[2]);
     }
 
     private function getProductNotSynchronisedBetweenEsAndMysql(): GetProductUuidsNotSynchronisedBetweenEsAndMysql


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I fixed a regression introduced by a previous fix on completeness calculation. This query should be able to count products with or without values for attribute codes passed in params.
see https://akeneo.atlassian.net/browse/PIM-10791

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
