### PR TITLE
PIM-10853: Fix type checking in SaveFamilyVariantOnFamilyUpdate bulk action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@
 - PIM-10858: Fix password is set on sftp storage using private key
 - PIM-10844: Filter empty attribute option labels
 - PIM-10831: Fix severe performance issues with the association product and product model picker
-- PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel  
+- PIM-10849: Fix sorting datagrid on completeness when the selected locale is not supported by the channel
+- PIM-10853: Fix type checking in SaveFamilyVariantOnFamilyUpdate bulk action
 
 ## Improvements
 

--- a/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
+++ b/tests/back/Pim/Structure/Specification/Bundle/EventSubscriber/SaveFamilyVariantOnFamilyUpdateSubscriberSpec.php
@@ -164,7 +164,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
             [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
-        $event->getSubject()->willReturn($family);
+        $event->getSubject()->willReturn([$family]);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(false);
         $this->onBulkSave($event);
@@ -208,7 +208,7 @@ class SaveFamilyVariantOnFamilyUpdateSubscriberSpec extends ObjectBehavior
             [ComputeFamilyVariantStructureChangesSubscriber::DISABLE_JOB_LAUNCHING => true]
         )->shouldBeCalled();
 
-        $event->getSubject()->willReturn($family);
+        $event->getSubject()->willReturn([$family]);
         $event->hasArgument('unitary')->willReturn(true);
         $event->getArgument('unitary')->willReturn(false);
         $errorMessage = 'One or more errors occurred while updating the following family variants:\n' .

--- a/tests/legacy/features/pim/structure/family/mass_edit_families.feature
+++ b/tests/legacy/features/pim/structure/family/mass_edit_families.feature
@@ -41,3 +41,24 @@ Feature: Mass Edit Families
     And attributes "price, rate_sale and rating" should be optional in family "boots" for channel "Mobile"
     And attributes "price, rate_sale and rating" should be optional in family "sneakers" for channel "Mobile"
     And attributes "price, rate_sale and rating" should be optional in family "sandals" for channel "Mobile"
+
+# @jira https://akeneo.atlassian.net/browse/PIM-10853
+  Scenario: Successfully mass edit unique value attributes to many families
+    Given the "footwear" catalog configuration
+    And the following family variants:
+      | code           | family | variant-axes_1 | variant-attributes_1 |
+      | family_variant | boots  | color          | description          |
+    And the following attributes:
+      | code                  | type             | group | unique |
+      | my_unique_attribute   | pim_catalog_text | other | 1      |
+    And I am logged in as "Julia"
+    And I am on the families grid
+    When I select rows Boots
+    And I press the "Bulk actions" button
+    And I choose the "Set attributes requirements" operation
+    And I add available attributes my_unique_attribute
+    And I confirm mass edit
+    And I wait for the "set_attribute_requirements" job to finish
+    Then there should be the following family variants:
+      | code                | family   | variant-axes_1| variant-attributes_1                      |
+      | family_variant      | boots    | color         | color,description,sku,my_unique_attribute |


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When unique attributes are added through the Mass Action workflow, the family variant were not updated.
It was due to the fact that the subject in `onBulkSave` was considered to be a FamilyInterface but was really an array of FamilyInterface.

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
