### PR TITLE
JEL-239: Create User System for tagged commands

### DIFF
--- a/make-file/user-management.mk
+++ b/make-file/user-management.mk
@@ -55,6 +55,7 @@
 .PHONY: user-management-unit-back
 user-management-unit-back: #Doc: launch PHPSpec for user-management bounded context
 	$(PHP_RUN) vendor/bin/phpspec run tests/back/UserManagement/Specification
+	$(PHP_RUN) vendor/bin/phpspec run src/Akeneo/UserManagement/back/tests/Specification
 
 .PHONY: user-management-coupling-back
 user-management-coupling-back:

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -242,11 +242,17 @@ suites:
         psr4_prefix: Akeneo\Tool\Bundle\ConnectorBundle
         spec_path: src/Akeneo/Tool/Bundle/ConnectorBundle
         src_path: src/Akeneo/Tool/Bundle/ConnectorBundle
-    User:
+    LegacyUser:
         namespace: Akeneo\UserManagement
         psr4_prefix: Akeneo\UserManagement
         spec_path: tests/back/UserManagement
         src_path: src/Akeneo/UserManagement
+        spec_prefix: Specification
+    User:
+        namespace: Akeneo\UserManagement
+        psr4_prefix: Akeneo\UserManagement
+        spec_path: src/Akeneo/UserManagement/back/tests
+        src_path: src/Akeneo/UserManagement/back
         spec_prefix: Specification
     ## Oro bundles
     OroFilterBundle:

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Apps/commands.yml
@@ -4,3 +4,4 @@ services:
             - '@Akeneo\Connectivity\Connection\Application\Apps\Command\GenerateAsymmetricKeysHandler'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Audit/commands.yml
@@ -4,6 +4,7 @@ services:
             - '@Akeneo\Connectivity\Connection\Infrastructure\Audit\Persistence\PurgeAuditErrorQuery'
         tags:
             - {name: 'console.command'}
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Connectivity\Connection\Infrastructure\Audit\Command\UpdateAuditDataCommand:
         arguments:
@@ -11,3 +12,4 @@ services:
             - '@logger'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Connections/command.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Connections/command.yml
@@ -5,3 +5,4 @@ services:
             - '@translator'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/ErrorManagement/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/ErrorManagement/commands.yml
@@ -6,3 +6,4 @@ services:
             - '@logger'
         tags:
             - {name: 'console.command'}
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Symfony/Resources/config/Webhook/commands.yml
@@ -6,6 +6,7 @@ services:
             - '@logger'
         tags:
             - {name: 'console.command'}
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Connectivity\Connection\Infrastructure\Webhook\Command\SendBusinessEventToWebhooks:
         arguments:
@@ -15,4 +16,4 @@ services:
             - '@logger'
         tags:
             - { name: console.command }
-
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/cli_command.yml
@@ -7,6 +7,7 @@ services:
             - '@database_connection'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     akeneo.pim.enrichment.command.index_product:
         class: 'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductCommand'
@@ -18,6 +19,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\GetAllProductUuids'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     akeneo.pim.enrichment.command.index_product_model:
         class: 'Akeneo\Pim\Enrichment\Bundle\Command\IndexProductModelCommand'
@@ -29,6 +31,7 @@ services:
             - '@Akeneo\Pim\Enrichment\Bundle\Storage\ElasticsearchAndSql\ProductAndProductModel\GetProductModelCodesNotSynchronisedBetweenEsAndMysql'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     base_uuid_migration_step:
         arguments:
@@ -87,6 +90,7 @@ services:
             - '@database_connection'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Pim\Enrichment\Bundle\Command\ZddMigrations\V20220516171405SetProductIdentifierNullableZddMigration:
         arguments:
@@ -110,4 +114,4 @@ services:
             - '@database_connection'
         tags:
             - { name: 'console.command' }
-
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/command.yml
@@ -23,6 +23,7 @@ services:
             - '@pim_catalog.manager.attribute_code_blacklister'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Pim\Enrichment\Bundle\Command\QueryHelpProductCommand:
         arguments:
@@ -30,6 +31,7 @@ services:
             - '@pim_catalog.query.filter.product.attribute_dumper'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Pim\Enrichment\Bundle\Command\QueryHelpProductModelCommand:
         arguments:
@@ -37,6 +39,7 @@ services:
             - '@pim_catalog.query.filter.product_model.attribute_dumper'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Pim\Enrichment\Bundle\Command\RefreshProductCommand:
         arguments:
@@ -45,3 +48,4 @@ services:
             - '@pim_catalog.query.product_and_product_model_query_builder_factory'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/commands.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/commands.yml
@@ -6,4 +6,4 @@ services:
             - '%pim_reference_data.model.reference_data.interface%'
         tags:
             - { name: 'console.command' }
-
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/commands.yml
+++ b/src/Akeneo/Platform/Bundle/AnalyticsBundle/Resources/config/commands.yml
@@ -5,3 +5,4 @@ services:
             - '@pim_analytics.data_collector.chained'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
+++ b/src/Akeneo/Platform/Bundle/ImportExportBundle/Resources/config/services.yml
@@ -19,6 +19,7 @@ services:
             - '@akeneo.platform.import_export.purge_job_execution'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\ImportExportBundle\Domain\ResolveScheduledJobRunningUsername: ~
 

--- a/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
+++ b/src/Akeneo/Platform/Bundle/InstallerBundle/Resources/config/cli_command.yml
@@ -8,6 +8,7 @@ services:
             - '@pim_installer.install_status_manager'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\InstallerBundle\Command\AssetsCommand:
         arguments:
@@ -17,10 +18,12 @@ services:
             - '%kernel.project_dir%/src'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\InstallerBundle\Command\CheckRequirementsCommand:
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\InstallerBundle\Command\DatabaseCommand:
         class: '%installer_bundle.command.database_command.class%'
@@ -34,6 +37,7 @@ services:
             - '@logger'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\InstallerBundle\Command\DumpRequirePathsCommand:
         arguments:
@@ -41,6 +45,7 @@ services:
             - '%kernel.bundles%'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Platform\Bundle\InstallerBundle\Command\MigrateZddCommand:
         arguments:
@@ -49,3 +54,4 @@ services:
             - !tagged_iterator { tag: 'akeneo.pim.zdd_migration' }
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/ApiBundle/Resources/config/cli_commands.yml
@@ -4,18 +4,21 @@ services:
             - '@fos_oauth_server.client_manager.default'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\ApiBundle\Command\ListClientsCommand:
         arguments:
             - '@pim_api.repository.client'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\ApiBundle\Command\RevokeClientCommand:
         arguments:
             - '@fos_oauth_server.client_manager.default'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\ApiBundle\Command\DeleteExpiredApiTokens:
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
@@ -9,6 +9,7 @@ services:
             - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandlerInterface'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\BatchBundle\Command\CreateJobInstanceCommand:
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/cli_commands.yml
@@ -16,12 +16,14 @@ services:
             - '@Akeneo\Platform\Job\Application\CreateJobInstanceHandler'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\BatchBundle\Command\ListJobsCommand:
         arguments:
             - '@akeneo_batch.job_repository'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\BatchBundle\Command\MarkJobExecutionAsFailedWhenInterruptedCommand:
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -66,6 +66,7 @@ services:
             - '%akeneo_batch.entity.job_instance.class%'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\BatchQueueBundle\Command\JobExecutionWatchdogCommand:
         arguments:

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -76,6 +76,7 @@ services:
             - '@pim_framework.lock.factory'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     akeneo_batch_queue.factory.job_execution_message:
         class: Akeneo\Tool\Component\BatchQueue\Factory\JobExecutionMessageFactory

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/commands.yml
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Resources/config/commands.yml
@@ -6,6 +6,7 @@ services:
             $hosts: '%index_hosts%'
         tags:
             - {name: console.command}
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\ElasticsearchBundle\Command\UpdateIndexVersionCommand:
         arguments:
@@ -21,3 +22,4 @@ services:
             - '%index_list_changed_total_field_limit%'
         tags:
             - { name: 'console.command' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/cli_commands.yml
@@ -5,3 +5,4 @@ services:
             - '@akeneo_file_storage.file_storage.filesystem_provider'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/VersioningBundle/Resources/config/cli_commands.yml
@@ -6,6 +6,7 @@ services:
             - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandlerInterface'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
 
     Akeneo\Tool\Bundle\VersioningBundle\Command\RefreshCommand:
         arguments:
@@ -13,3 +14,4 @@ services:
             - '@Akeneo\Tool\Bundle\BatchBundle\JobExecution\CreateJobExecutionHandlerInterface'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/UserManagement/Bundle/DependencyInjection/Compiler/RegisterCommandsThatNeedUserSystemPass.php
+++ b/src/Akeneo/UserManagement/Bundle/DependencyInjection/Compiler/RegisterCommandsThatNeedUserSystemPass.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\UserManagement\Bundle\DependencyInjection\Compiler;
+
+use Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RegisterCommandsThatNeedUserSystemPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $registerDefinition = $container->findDefinition(AuthenticatedAsAdminCommandRegistry::class);
+        $commandServiceIds = $container->findTaggedServiceIds('akeneo.command.authenticated_as_admin_user');
+
+        foreach (\array_keys($commandServiceIds) as $commandServiceId) {
+            // Get the command name by calling the static method "getDefaultName" so the command service is not instantiated, because there are "lazy" by default
+            $commandClass = $container->findDefinition($commandServiceId)->getClass();
+            if (\method_exists($commandClass, 'getDefaultName') &&  null !== $commandClass::getDefaultName()) {
+                $registerDefinition->addMethodCall('registerCommand', [$commandClass::getDefaultName()]);
+            }
+        }
+    }
+}

--- a/src/Akeneo/UserManagement/Bundle/PimUserBundle.php
+++ b/src/Akeneo/UserManagement/Bundle/PimUserBundle.php
@@ -2,6 +2,7 @@
 
 namespace Akeneo\UserManagement\Bundle;
 
+use Akeneo\UserManagement\Bundle\DependencyInjection\Compiler\RegisterCommandsThatNeedUserSystemPass;
 use Akeneo\UserManagement\Bundle\DependencyInjection\Compiler\ResolveDoctrineTargetModelPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -32,5 +33,7 @@ class PimUserBundle extends Bundle
                 false
             )
         );
+
+        $container->addCompilerPass(new RegisterCommandsThatNeedUserSystemPass());
     }
 }

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/commands.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/commands.yml
@@ -17,3 +17,4 @@ services:
             - '@Akeneo\UserManagement\Application\RestoreAdminRolePermissions'
         tags:
             - { name: console.command }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/commands.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/commands.yml
@@ -10,6 +10,7 @@ services:
             - '@pim_catalog.repository.locale'
         tags:
             - { name: console.command }
+            - { name: akeneo.command.authenticated_as_admin_user }
 
     Akeneo\UserManagement\Infrastructure\Cli\RestoreAdminRolePermissionsCommand:
         arguments:

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
@@ -42,7 +42,7 @@ services:
 
     Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry: ~
 
-    Akeneo\UserManagement\Infrastructure\Cli\EventListener\AuthenticateCommandAsAdminUser:
+    Akeneo\UserManagement\Infrastructure\Cli\EventListener\AuthenticateCommandAsAdminUserListener:
         arguments:
             - '@security.token_storage'
             - '@pim_user.repository.group'

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/event_subscribers.yml
@@ -4,7 +4,6 @@ parameters:
     pim_user.event_subscriber.remove_role.class:      Akeneo\UserManagement\Bundle\EventListener\RemoveRoleSubscriber
     # Move this class
     pim_locale.locale_subscriber.class:               Akeneo\UserManagement\Bundle\EventListener\LocaleSubscriber
-    pim_user.event_listener.create_user_system.class: Akeneo\UserManagement\Bundle\EventListener\CreateUserSystemListener
 
 services:
     pim_user.event_listener.user_preferences:
@@ -41,13 +40,15 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    pim_user.event_listener.create_user_system:
-        class: '%pim_user.event_listener.create_user_system.class%'
+    Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry: ~
+
+    Akeneo\UserManagement\Infrastructure\Cli\EventListener\AuthenticateCommandAsAdminUser:
         arguments:
             - '@security.token_storage'
             - '@pim_user.repository.group'
             - '@pim_user.repository.role'
             - '@pim_user.factory.user'
+            - '@Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry'
         tags:
             - { name: kernel.event_listener, event: console.command, method: createUserSystem }
 

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListener.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * @copyright 2017 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class AuthenticateCommandAsAdminUser
+class AuthenticateCommandAsAdminUserListener
 {
     public function __construct(
         private readonly TokenStorageInterface $tokenStorage,

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListener.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListener.php
@@ -35,7 +35,7 @@ class AuthenticateCommandAsAdminUserListener
      */
     public function createUserSystem(ConsoleCommandEvent $event): void
     {
-        if (!$this->commandRegistry->isCommandAuthenticatedAsAdminUser($event->getCommand()->getName())) {
+        if (!$this->commandRegistry->isCommandRegistered($event->getCommand()->getName())) {
             return;
         }
 

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
@@ -13,15 +13,15 @@ final class AuthenticatedAsAdminCommandRegistry
     /**
      * @var array<string, bool>
      */
-    private array $commandsAuthenticatedAsAdminUser = [];
+    private array $commands = [];
 
     public function registerCommand(string $commandName): void
     {
-        $this->commandsAuthenticatedAsAdminUser[$commandName] = true;
+        $this->commands[$commandName] = true;
     }
 
-    public function isCommandAuthenticatedAsAdminUser(string $commandName): bool
+    public function isCommandRegistered(string $commandName): bool
     {
-        return \array_key_exists($commandName, $this->commandsAuthenticatedAsAdminUser);
+        return \array_key_exists($commandName, $this->commands);
     }
 }

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
@@ -10,15 +10,18 @@ namespace Akeneo\UserManagement\Infrastructure\Cli\Registry;
  */
 final class AuthenticatedAsAdminCommandRegistry
 {
+    /**
+     * @var array<string, bool>
+     */
     private array $commandsAuthenticatedAsAdminUser = [];
 
     public function registerCommand(string $commandName): void
     {
-        $this->commandsAuthenticatedAsAdminUser[] = $commandName;
+        $this->commandsAuthenticatedAsAdminUser[$commandName] = true;
     }
 
     public function isCommandAuthenticatedAsAdminUser(string $commandName): bool
     {
-        return \in_array($commandName, $this->commandsAuthenticatedAsAdminUser);
+        return \array_key_exists($commandName, $this->commandsAuthenticatedAsAdminUser);
     }
 }

--- a/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistry.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\UserManagement\Infrastructure\Cli\Registry;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AuthenticatedAsAdminCommandRegistry
+{
+    private array $commandsAuthenticatedAsAdminUser = [];
+
+    public function registerCommand(string $commandName): void
+    {
+        $this->commandsAuthenticatedAsAdminUser[] = $commandName;
+    }
+
+    public function isCommandAuthenticatedAsAdminUser(string $commandName): bool
+    {
+        return \in_array($commandName, $this->commandsAuthenticatedAsAdminUser);
+    }
+}

--- a/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserIntegration.php
+++ b/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserIntegration.php
@@ -67,7 +67,7 @@ final class AuthenticateCommandAsAdminUserIntegration extends TestCase
     private function assertAuthenticatedUserNameEquals(string $expectedUserName): void
     {
         $token = $this->tokenStorage->getToken();
-        $userName = $token?->getUser()?->getUsername();
+        $userName = $token?->getUser()?->getUserIdentifier();
 
         Assert::assertSame($expectedUserName, $userName);
     }

--- a/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserIntegration.php
+++ b/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserIntegration.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Test\UserManagement\Integration\Infrastructure\Cli\EventListener;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\UserManagement\Bundle\Security\SystemUserToken;
+use Akeneo\UserManagement\Component\Model\UserInterface;
+use Akeneo\UserManagement\Infrastructure\Cli\Registry\AuthenticatedAsAdminCommandRegistry;
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AuthenticateCommandAsAdminUserIntegration extends TestCase
+{
+    private TokenStorageInterface $tokenStorage;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tokenStorage = $this->get('security.token_storage');
+
+        $this->authenticateNotSystemUser();
+    }
+
+    public function testItAuthenticatesRegisteredCommandAsAdminUser(): void
+    {
+        $this->assertAuthenticatedUserNameEquals('not_system_user');
+
+        $fakeCommand = new Command('test:authenticate-user-system');
+        $event = new ConsoleCommandEvent($fakeCommand, new ArrayInput([]), new ConsoleOutput());
+
+        $this->get(AuthenticatedAsAdminCommandRegistry::class)->registerCommand($fakeCommand->getName());
+
+        $this->get('event_dispatcher')->dispatch($event, 'console.command');
+
+        $this->assertAuthenticatedUserNameEquals(UserInterface::SYSTEM_USER_NAME);
+    }
+
+    public function testItDoesNotAuthenticateNotRegisteredCommandAsAdminUser(): void
+    {
+        $this->assertAuthenticatedUserNameEquals('not_system_user');
+
+        $fakeCommand = new Command('test:whatever');
+        $event = new ConsoleCommandEvent($fakeCommand, new ArrayInput([]), new ConsoleOutput());
+
+        $this->get('event_dispatcher')->dispatch($event, 'console.command');
+
+        $this->assertAuthenticatedUserNameEquals('not_system_user');
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function assertAuthenticatedUserNameEquals(string $expectedUserName): void
+    {
+        $token = $this->tokenStorage->getToken();
+        $userName = $token?->getUser()?->getUsername();
+
+        Assert::assertSame($expectedUserName, $userName);
+    }
+
+    private function authenticateNotSystemUser(): void
+    {
+        $otherUser = $this->get('pim_user.factory.user')->create();
+        $otherUser->setUsername('not_system_user');
+
+        $token = new SystemUserToken($otherUser);
+        $this->tokenStorage->setToken($token);
+    }
+}

--- a/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListenerIntegration.php
+++ b/src/Akeneo/UserManagement/back/tests/Integration/Infrastructure/Cli/EventListener/AuthenticateCommandAsAdminUserListenerIntegration.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class AuthenticateCommandAsAdminUserIntegration extends TestCase
+final class AuthenticateCommandAsAdminUserListenerIntegration extends TestCase
 {
     private TokenStorageInterface $tokenStorage;
 

--- a/src/Akeneo/UserManagement/back/tests/Specification/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistrySpec.php
+++ b/src/Akeneo/UserManagement/back/tests/Specification/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistrySpec.php
@@ -14,12 +14,12 @@ final class AuthenticatedAsAdminCommandRegistrySpec extends ObjectBehavior
 {
     public function it_registers_authenticated_as_admin_commands(): void
     {
-        $this->isCommandAuthenticatedAsAdminUser('akeneo:batch:job')->shouldReturn(false);
+        $this->isCommandRegistered('akeneo:batch:job')->shouldReturn(false);
 
         $this->registerCommand('akeneo:batch:job');
         $this->registerCommand('pim:install');
 
-        $this->isCommandAuthenticatedAsAdminUser('akeneo:batch:job')->shouldReturn(true);
-        $this->isCommandAuthenticatedAsAdminUser('debug:router')->shouldReturn(false);
+        $this->isCommandRegistered('akeneo:batch:job')->shouldReturn(true);
+        $this->isCommandRegistered('debug:router')->shouldReturn(false);
     }
 }

--- a/src/Akeneo/UserManagement/back/tests/Specification/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistrySpec.php
+++ b/src/Akeneo/UserManagement/back/tests/Specification/Infrastructure/Cli/Registry/AuthenticatedAsAdminCommandRegistrySpec.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\UserManagement\Infrastructure\Cli\Registry;
+
+use PhpSpec\ObjectBehavior;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class AuthenticatedAsAdminCommandRegistrySpec extends ObjectBehavior
+{
+    public function it_registers_authenticated_as_admin_commands(): void
+    {
+        $this->isCommandAuthenticatedAsAdminUser('akeneo:batch:job')->shouldReturn(false);
+
+        $this->registerCommand('akeneo:batch:job');
+        $this->registerCommand('pim:install');
+
+        $this->isCommandAuthenticatedAsAdminUser('akeneo:batch:job')->shouldReturn(true);
+        $this->isCommandAuthenticatedAsAdminUser('debug:router')->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
While benchmarking a simple Symfony command execution in the PIM, we detected that a significant number of undesirable services (as Doctrine ORM) were called and took a significant amount of time. At the origin of this is a legacy listener that automatically authenticate an admin system user to every Akeneo/PIM Symfony commands (command names that started by `pim` or `akeneo`)  https://github.com/akeneo/pim-community-dev/blob/master/src/Akeneo/UserManagement/Bundle/EventListener/CreateUserSystemListener.php

In our case we need to be able to run a command as fast as possible, so we don't want to trigger this listener. And in a more global case, this authentication is useless for most of the PIM commands. It's mandatory only for process that involve permissions.

So we decided to trigger this listener from a new dedicated tag. To take minimum risks, we added this tag to all commands, except for those that we are sure they don't need this authentication. Then each team can remove the tag for commands they are in charge.