### PR TITLE
PIM-10832: Fix compute completeness job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - PIM-10853: Fix type checking in SaveFamilyVariantOnFamilyUpdate bulk action
 - PIM-10829: Fix case-sensitive locale on translatable business objects
 - PIM-10840: Fix attribute update date on attribute options change above 10000 options
+- PIM-10832: Fix compute completeness job after removing an attribute from a family
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -207,6 +207,10 @@ $rules = [
         'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder',
         'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult',
 
+        // PIM-10832: Remove coupling with indexer and completeness persistence
+        'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer',
+        'Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses',
+
         // TIP-932: KeepOnlyValuesForVariation should use the public API related to the root aggregate Family Variant
         'Akeneo\Pim\Structure\Component\Model\CommonAttributeCollection',
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/jobs.yml
@@ -69,9 +69,8 @@ services:
         arguments:
             - '@pim_catalog.repository.family'
             - '@pim_catalog.query.product_identifier_query_builder_factory'
-            - '@pim_catalog.repository.product'
-            - '@pim_catalog.saver.product'
-            - '@pim_connector.doctrine.cache_clearer'
+            - '@pim_catalog.completeness.product.compute_and_persist'
+            - '@akeneo.pim.enrichment.elasticsearch.indexer.product_and_ancestors'
         public: false
 
     pim_catalog.step.compute_completeness_of_products_family:

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Job/ComputeCompletenessOfProductsFamilyTaskletSpec.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Job;
 
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\IdentifierResult;
+use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Indexer\ProductAndAncestorsIndexer;
+use Akeneo\Pim\Enrichment\Bundle\Product\ComputeAndPersistProductCompletenesses;
 use Akeneo\Pim\Enrichment\Component\Product\Job\ComputeCompletenessOfProductsFamilyTasklet;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
@@ -20,6 +22,7 @@ use Akeneo\Tool\Component\StorageUtils\Cursor\CursorInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
 
 class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
@@ -27,16 +30,14 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
     function let(
         IdentifiableObjectRepositoryInterface $familyRepository,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
-        ProductRepositoryInterface $productRepository,
-        BulkSaverInterface $bulkProductSaver,
-        EntityManagerClearerInterface $cacheClearer
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        ProductAndAncestorsIndexer $productAndAncestorsIndexer,
     ) {
         $this->beConstructedWith(
             $familyRepository,
             $productQueryBuilderFactory,
-            $productRepository,
-            $bulkProductSaver,
-            $cacheClearer
+            $computeAndPersistProductCompletenesses,
+            $productAndAncestorsIndexer,
         );
     }
 
@@ -53,17 +54,13 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
     function it_recomputes_the_completeness_of_all_the_products_belonging_the_given_family(
         IdentifiableObjectRepositoryInterface $familyRepository,
         ProductQueryBuilderFactoryInterface $productQueryBuilderFactory,
-        ProductRepositoryInterface $productRepository,
-        BulkSaverInterface $bulkProductSaver,
-        EntityManagerClearerInterface $cacheClearer,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        ProductAndAncestorsIndexer $productAndAncestorsIndexer,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
         FamilyInterface $family,
         ProductQueryBuilderInterface $pqb,
         CursorInterface $cursor,
-        ProductInterface $product1,
-        ProductInterface $product2,
-        ProductInterface $product3
     ) {
         $uuid1 = Uuid::uuid4();
         $uuid2 = Uuid::uuid4();
@@ -87,12 +84,8 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $cursor->next()->shouldBeCalled();
         $cursor->rewind()->shouldBeCalled();
 
-        $productRepository->getItemsFromUuids([$uuid1->toString(), $uuid2->toString(), $uuid3->toString()])->willReturn(
-            [$product1, $product2, $product3]
-        );
-
-        $bulkProductSaver->saveAll([$product1, $product2, $product3], ['force_save' => true])->shouldBeCalled();
-        $cacheClearer->clear()->shouldBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids([$uuid1, $uuid2, $uuid3])->shouldBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids([$uuid1, $uuid2, $uuid3])->shouldBeCalled();
 
         $this->setStepExecution($stepExecution);
         $this->execute();
@@ -100,7 +93,8 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
 
     function it_does_not_recompute_if_the_given_family_code_is_invalid(
         IdentifiableObjectRepositoryInterface $familyRepository,
-        BulkSaverInterface $bulkProductSaver,
+        ComputeAndPersistProductCompletenesses $computeAndPersistProductCompletenesses,
+        ProductAndAncestorsIndexer $productAndAncestorsIndexer,
         StepExecution $stepExecution,
         JobParameters $jobParameters
     ) {
@@ -108,7 +102,8 @@ class ComputeCompletenessOfProductsFamilyTaskletSpec extends ObjectBehavior
         $stepExecution->getJobParameters()->willReturn($jobParameters);
         $familyRepository->findOneByIdentifier('unknown_family')->willReturn(null);
 
-        $bulkProductSaver->saveAll()->shouldNotBeCalled();
+        $computeAndPersistProductCompletenesses->fromProductUuids(Argument::any())->shouldNotBeCalled();
+        $productAndAncestorsIndexer->indexFromProductUuids(Argument::any())->shouldNotBeCalled();
 
         $this->setStepExecution($stepExecution);
         $this->shouldThrow(new \InvalidArgumentException('Family not found, "unknown_family" given'))


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

When removing an attribute from a family, two jobs are launched : 
- compute_completeness_of_products_family
- compute_family_variant_structure_changes

in some cases the former could override the changes performed by the latter because it would force save the concerned products.  
In this fix, the product are not saved anymore, we only recompute the completeness and reindex them.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
