### PR TITLE
PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on op…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - PIM-10829: Fix case-sensitive locale on translatable business objects
 - PIM-10840: Fix attribute update date on attribute options change above 10000 options
 - PIM-10832: Fix compute completeness job after removing an attribute from a family
+- PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on options import
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -14,7 +14,7 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAt
  */
 class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 {
-    public function __construct(private GetExistingAttributeOptionCodes $getExistingAttributeOptionCodes)
+    public function __construct(private readonly GetExistingAttributeOptionCodes $getExistingAttributeOptionCodes)
     {
     }
 
@@ -26,18 +26,17 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
             return $onGoingFilteredRawValues;
         }
 
-        $optionCodes = $this->getExistingOptionCodes($selectValues);
+        $optionCodes = $this->getExistingCaseInsensitiveOptionCodes($selectValues);
 
         $filteredValues = [];
         foreach ($selectValues as $attributeCode => $productValueCollection) {
-            $existingCodes = $optionCodes[$attributeCode] ?? [];
             foreach ($productValueCollection as $productValues) {
                 $multiSelectValues = [];
 
                 foreach ($productValues['values'] as $channel => $channelValues) {
-                    foreach ($channelValues as $locale => $values) {
-                        if (\is_array($values)) {
-                            $multiSelectValues[$channel][$locale] = \array_values(\array_intersect($existingCodes, $values));
+                    foreach ($channelValues as $locale => $value) {
+                        if (\is_array($value)) {
+                            $multiSelectValues[$channel][$locale] = $this->arrayIntersectCaseInsensitive($value, $optionCodes[$attributeCode] ?? []);
                         }
                     }
                 }
@@ -54,26 +53,18 @@ class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
         return $onGoingFilteredRawValues->addFilteredValuesIndexedByType($filteredValues);
     }
 
-    private function getExistingOptionCodes(array $selectValues): array
+    private function getExistingCaseInsensitiveOptionCodes(array $selectValues): array
     {
         $optionCodes = $this->getOptionCodes($selectValues);
         $existingOptionCodes = $this->getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes);
-
-        foreach ($optionCodes as $attributeCode => $optionCodesForThisAttribute) {
-            $existingOptionCodesForAttribute = $existingOptionCodes[$attributeCode] ?? [];
-            if (empty($existingOptionCodesForAttribute)) {
-                $optionCodes[$attributeCode] = [];
-                continue;
+        $caseInsensitiveOptionsCodes = [];
+        foreach ($existingOptionCodes as $attributeCode => $optionCodesForThisAttribute) {
+            foreach ($optionCodesForThisAttribute as $optionCodeForThisAttribute) {
+                $caseInsensitiveOptionsCodes[$attributeCode][strtolower($optionCodeForThisAttribute)] = $optionCodeForThisAttribute;
             }
-
-            $existingOptionCodesForAttribute = \array_map('strtolower', $existingOptionCodesForAttribute);
-            $optionCodes[$attributeCode] = \array_filter(
-                $optionCodesForThisAttribute,
-                fn ($code) => \in_array(\strtolower($code), $existingOptionCodesForAttribute)
-            );
         }
 
-        return $optionCodes;
+        return $caseInsensitiveOptionsCodes;
     }
 
     private function getOptionCodes(array $selectValues): array

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilter.php
@@ -11,6 +11,10 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAt
  * @author    Anael Chardan <anael.chardan@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * This class is responsible for:
+ * - filters options that do not exist anymore
+ * - in case options were imported with the wrong case, puts back the right case for the option codes
  */
 class NonExistentMultiSelectValuesFilter implements NonExistentValuesFilter
 {

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
@@ -25,17 +25,16 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
             return $onGoingFilteredRawValues;
         }
 
-        $optionCodes = $this->getExistingOptionCodes($selectValues);
+        $optionCodes = $this->getExistingCaseInsensitiveOptionCodes($selectValues);
 
         $filteredValues = [];
         foreach ($selectValues as $attributeCode => $productValueCollection) {
-            $existingCodes = $optionCodes[$attributeCode] ?? [];
             foreach ($productValueCollection as $productValues) {
                 $simpleSelectValues = [];
                 foreach ($productValues['values'] as $channel => $channelValues) {
                     foreach ($channelValues as $locale => $value) {
                         if (!\is_array($value)) {
-                            $simpleSelectValues[$channel][$locale] = \in_array($value, $existingCodes) ? $value : '';
+                            $simpleSelectValues[$channel][$locale] = ($optionCodes[$attributeCode] ?? [])[strtolower($value ?? '')] ?? '';
                         }
                     }
                 }
@@ -52,26 +51,19 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
         return $onGoingFilteredRawValues->addFilteredValuesIndexedByType($filteredValues);
     }
 
-    private function getExistingOptionCodes(array $selectValues): array
+    private function getExistingCaseInsensitiveOptionCodes(array $selectValues): array
     {
         $optionCodes = $this->getOptionCodes($selectValues);
         $existingOptionCodes = $this->getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes);
 
-        foreach ($optionCodes as $attributeCode => $optionCodesForThisAttribute) {
-            $existingOptionCodesForAttribute = $existingOptionCodes[$attributeCode] ?? [];
-            if (empty($existingOptionCodesForAttribute)) {
-                $optionCodes[$attributeCode] = [];
-                continue;
+        $caseInsensitiveOptionsCodes = [];
+        foreach ($existingOptionCodes as $attributeCode => $optionCodesForThisAttribute) {
+            foreach ($optionCodesForThisAttribute as $optionCodeForThisAttribute) {
+                $caseInsensitiveOptionsCodes[$attributeCode][strtolower($optionCodeForThisAttribute)] = $optionCodeForThisAttribute;
             }
-
-            $existingOptionCodesForAttribute = \array_map('strtolower', $existingOptionCodesForAttribute);
-            $optionCodes[$attributeCode] = \array_filter(
-                $optionCodesForThisAttribute,
-                fn ($code) => \in_array(\strtolower($code), $existingOptionCodesForAttribute)
-            );
         }
 
-        return $optionCodes;
+        return $caseInsensitiveOptionsCodes;
     }
 
     private function getOptionCodes(array $selectValues): array
@@ -92,7 +84,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
 
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
-            $uniqueOptionCodes[$attributeCode] = \array_unique($optionCodeForThisAttribute);
+            $uniqueOptionCodes[$attributeCode] = array_unique($optionCodeForThisAttribute);
         }
 
         return $uniqueOptionCodes;

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilter.php
@@ -11,6 +11,10 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAt
  * @author    Anael Chardan <anael.chardan@akeneo.com>
  * @copyright 2019 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * This class is responsible for:
+ * - filters options that do not exist anymore
+ * - in case options were imported with the wrong case, puts back the right case for the option codes
  */
 class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
 {
@@ -84,7 +88,7 @@ class NonExistentSimpleSelectValuesFilter implements NonExistentValuesFilter
 
         $uniqueOptionCodes = [];
         foreach ($optionCodes as $attributeCode => $optionCodeForThisAttribute) {
-            $uniqueOptionCodes[$attributeCode] = array_unique($optionCodeForThisAttribute);
+            $uniqueOptionCodes[$attributeCode] = \array_unique($optionCodeForThisAttribute);
         }
 
         return $uniqueOptionCodes;

--- a/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
+++ b/tests/back/Pim/Enrichment/EndToEnd/Product/Product/ExternalApi/GetProductEndToEnd.php
@@ -159,7 +159,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
             'values' => [
                 'a_multi_select' => [
                     [
-                        'data' => ['OptiONB', 'optionA'],
+                        'data' => ['optionA', 'optionB'],
                         'locale' => null,
                         'scope' => null,
                         'linked_data' => [
@@ -170,7 +170,7 @@ class GetProductEndToEnd extends AbstractProductTestCase
                                     'en_US' => 'Option A',
                                 ],
                             ],
-                            'OptiONB' => [
+                            'optionB' => [
                                 'attribute' => 'a_multi_select',
                                 'code' => 'optionB',
                                 'labels' => [

--- a/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/LoadEntityWithValuesSubscriberIntegration.php
@@ -151,7 +151,7 @@ SQL;
         $product = $this->get('pim_catalog.repository.product')->findOneByIdentifier('product_with_duplicate_options');
 
         Assert::assertSame(
-            ['OPTIONA', 'OptionB', 'optionA', 'optionb'],
+            ['optionA', 'optionB'],
             $product->getValue('a_multi_select')->getData()
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentMultiSelectValuesFilterSpec.php
@@ -8,6 +8,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGo
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeOption\GetExistingAttributeOptionCodes;
 use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
 
 /**
  * @author    Anael Chardan <anael.chardan@akeneo.com>
@@ -71,25 +72,24 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
             ]
         );
 
-        $optionCodes =  [
-            'a_multi_select' =>
-                [
-                    'micHEL',
-                    'sardou',
-                    'jean',
-                    'claude',
-                    'van',
-                    'damm',
-                    'des',
-                    'Fraises',
-                    'MIChel',
-                    'FRAISES',
-                    'JEAN',
-                    'TOUrloupe',
-                ],
+        $optionCodes = [
+            'a_multi_select' => [
+                'micHEL',
+                'sardou',
+                'jean',
+                'claude',
+                'van',
+                'damm',
+                'des',
+                'Fraises',
+                'MIChel',
+                'FRAISES',
+                'JEAN',
+                'TOUrloupe',
+            ],
         ];
 
-        $getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes)->willReturn(
+        $getExistingAttributeOptionCodes->fromOptionCodesByAttributeCode($optionCodes)->shouldBeCalled()->willReturn(
             [
                 'a_multi_select' => ['michel', 'fraises', 'tourlOUPE'],
             ]
@@ -105,11 +105,11 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
                             'identifier' => 'product_A',
                             'values' => [
                                 'ecommerce' => [
-                                    'en_US' => ['micHEL'],
+                                    'en_US' => ['michel'],
                                 ],
                                 'tablet' => [
                                     'en_US' => [],
-                                    'fr_FR' => ['Fraises'],
+                                    'fr_FR' => ['fraises'],
                                 ],
                             ],
                         ],
@@ -117,10 +117,10 @@ final class NonExistentMultiSelectValuesFilterSpec extends ObjectBehavior
                             'identifier' => 'product_C',
                             'values' => [
                                 'ecommerce' => [
-                                    'en_US' => ['MIChel'],
+                                    'en_US' => ['michel'],
                                 ],
                                 'tablet' => [
-                                    '<all_locales>' => ['FRAISES', 'TOUrloupe'],
+                                    '<all_locales>' => ['fraises', 'tourlOUPE'],
                                 ],
                             ]
                         ],

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentSimpleSelectValuesFilterSpec.php
@@ -96,7 +96,7 @@ final class NonExistentSimpleSelectValuesFilterSpec extends ObjectBehavior
                             'identifier' => 'product_A',
                             'values' => [
                                 '<all_channels>' => [
-                                    '<all_locales>' => 'option_ToTo'
+                                    '<all_locales>' => 'option_toto'
                                 ],
                             ],
                         ],
@@ -112,7 +112,7 @@ final class NonExistentSimpleSelectValuesFilterSpec extends ObjectBehavior
                             'identifier' => 'product_C',
                             'values' => [
                                 '<all_channels>' => [
-                                    '<all_locales>' => 'OPTION_toto'
+                                    '<all_locales>' => 'option_toto'
                                 ],
                             ],
                         ],


### PR DESCRIPTION
…tions import

**Description (for Contributor and Core Developer)**

Due to this PR: https://github.com/akeneo/pim-community-dev/pull/16751/files
When importing a simple or multi select option with the wrong case, it updated the option case.
This issue it resolved was to not add a new version in product history.
It has been validated to partially revert this previous fix, and keep the versioning with both cases. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
