### PR TITLE
PIM-10861: Fix calcuation of completeness channel ratio on Activity Dashboard

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/ElasticsearchAndSql/FollowUp/GetCompletenessPerChannelAndLocale.php
@@ -142,8 +142,9 @@ SQL;
 
         $body = [];
         foreach ($categoriesCodeAndLocalesByChannels as $categoriesCodeAndLocalesByChannel) {
+            // As we use locale codes as aggregation name later, adding "--" in aggregation name for "all locales" ensure that there will be no conflict
             $aggregations = [
-                'all_locales' => [
+                '--all_locales--' => [
                     'filter' => [
                         'bool' => [
                             'filter' => [],
@@ -153,7 +154,7 @@ SQL;
             ];
             foreach ($categoriesCodeAndLocalesByChannel['locales'] as $localeCode) {
                 $completenessField = sprintf('completeness.%s.%s', $categoriesCodeAndLocalesByChannel['channel_code'], $localeCode);
-                $aggregations['all_locales']['filter']['bool']['filter'][] = ['term' => [$completenessField => 100]];
+                $aggregations['--all_locales--']['filter']['bool']['filter'][] = ['term' => [$completenessField => 100]];
                 $aggregations[$localeCode] = [
                     'filter' => [
                         'bool' => [
@@ -202,7 +203,7 @@ SQL;
             $channelCode = $categoriesCodeAndLocalesByChannel['channel_code'];
             $result[$channelCode] = [];
             $result[$channelCode]['total'] = $rows['responses'][$index]['hits']['total']['value'] ?? 0;
-            $result[$channelCode]['all_locales'] = $rows['responses'][$index]['aggregations']['all_locales']['doc_count'] ?? 0;
+            $result[$channelCode]['all_locales'] = $rows['responses'][$index]['aggregations']['--all_locales--']['doc_count'] ?? 0;
             foreach ($categoriesCodeAndLocalesByChannel['locales'] as $locale) {
                 $result[$channelCode]['locales'][$locale] = $rows['responses'][$index]['aggregations'][$locale]['doc_count'] ?? 0;
             }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/helpers/convertBackendDashboardCompletenessData.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/src/helpers/convertBackendDashboardCompletenessData.ts
@@ -7,13 +7,12 @@ const convertBackendDashboardCompletenessData = (
 ): ChannelsLocalesCompletenessRatios => {
   let result: ChannelsLocalesCompletenessRatios = {};
   Object.entries(data).map(([channelCode, channelData]: [string, BackendChannelData]) => {
-    const divider: number = channelData.total * Object.keys(channelData.locales).length;
+    const divider: number = channelData.total;
     const channelRatio: number = divider === 0 ? 0 : Math.floor((channelData.complete / divider) * 100);
     const channelLabel = channelData.labels[catalogLocale] || `[${channelCode}]`;
 
     let localesRatios: {[localeTranslation: string]: number} = {};
     Object.entries(channelData.locales).map(([localeLabel, localeCompleteCount]: [string, number]) => {
-      const divider: number = channelData.total;
       localesRatios[localeLabel] = divider === 0 ? 0 : Math.floor((localeCompleteCount / divider) * 100);
     });
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/tests/front/unit/helpers/convertBackendDashboardCompletenessData.unit.ts
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/activity/tests/front/unit/helpers/convertBackendDashboardCompletenessData.unit.ts
@@ -10,7 +10,7 @@ const data: BackendCompletenessData = {
       fr_FR: 'Impression',
     },
     total: 1239,
-    complete: 569,
+    complete: 102,
     locales: {
       'German (Germany)': 110,
       'English (United States)': 343,
@@ -24,7 +24,7 @@ const data: BackendCompletenessData = {
       fr_FR: 'Mobile FR',
     },
     total: 1239,
-    complete: 415,
+    complete: 65,
     locales: {
       'German (Germany)': 71,
       'English (United States)': 256,
@@ -49,7 +49,7 @@ test('It calculate the completeness by channels and by locales', () => {
   const result: ChannelsLocalesCompletenessRatios = convertBackendDashboardCompletenessData(data, 'en_US');
   expect(result).toEqual({
     Print: {
-      channelRatio: 15,
+      channelRatio: 8,
       localesRatios: {
         'English (United States)': 27,
         'German (Germany)': 8,
@@ -57,7 +57,7 @@ test('It calculate the completeness by channels and by locales', () => {
       },
     },
     Mobile: {
-      channelRatio: 11,
+      channelRatio: 5,
       localesRatios: {
         'English (United States)': 20,
         'German (Germany)': 5,


### PR DESCRIPTION
The completeness ratio of a channel on the Activity dashboard is not well calculated. It should be the percent of products that have 100% completeness on all locales on that channel.

I reworked the ES query to do the calculation with aggregations.

Example for 4 products, with 2 products fully enriched on all locales
Before:
![PIM-10861-before](https://user-images.githubusercontent.com/26378046/221871075-329641b3-5dfa-4fb6-8382-e5f17aed5ef8.png)

After:
![PIM-10861-after](https://user-images.githubusercontent.com/26378046/221871132-6bf1b5c3-1a3a-4854-bd69-01bc2ac094cd.png)

