### PR TITLE
RAB-1263: Create a dedicated controller for mass delete attributes instead of using enrichment one

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/MassDeleteAttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/MassDeleteAttributeController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Bundle\Controller\InternalApi;
+
+use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class MassDeleteAttributeController
+{
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private JobLauncherInterface $jobLauncher,
+        private IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+    ) {
+    }
+
+    public function launchAction(Request $request): Response
+    {
+        $jobInstance = $this->jobInstanceRepository->findOneByIdentifier('delete_attributes');
+        $user = $this->tokenStorage->getToken()->getUser();
+        if (!$user instanceof UserInterface) {
+            return new JsonResponse(status: Response::HTTP_UNAUTHORIZED);
+        }
+
+        $configuration = json_decode($request->getContent(), true);
+        $configuration['users_to_notify'] = [$user->getUserIdentifier()];
+
+        $this->jobLauncher->launch($jobInstance, $user, $configuration);
+
+        return new JsonResponse();
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -231,3 +231,10 @@ services:
         arguments:
             - '@pim_reference_data.registry'
             - '@pim_internal_api_serializer'
+
+    Akeneo\Pim\Structure\Bundle\Controller\InternalApi\MassDeleteAttributeController:
+        arguments:
+            - '@security.token_storage'
+            - '@akeneo_batch_queue.launcher.queue_job_launcher'
+            - '@akeneo_batch.job.job_instance_repository'
+        tags: ['controller.service_arguments']

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/routing/internal_api/attribute.yml
@@ -8,6 +8,11 @@ pim_enrich_attribute_rest_create:
     defaults: { _controller: pim_enrich.controller.rest.attribute:createAction }
     methods: [PUT]
 
+pim_structure_launch_mass_delete_attribute:
+    path: /mass-delete
+    defaults: { _controller: Akeneo\Pim\Structure\Bundle\Controller\InternalApi\MassDeleteAttributeController:launchAction }
+    methods: [POST]
+
 pim_enrich_attribute_rest_get:
     path: /{identifier}
     defaults: { _controller: pim_enrich.controller.rest.attribute:getAction }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/attribute-mass-delete-action.ts
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/public/js/datagrid/action/attribute-mass-delete-action.ts
@@ -25,7 +25,7 @@ type MassActionData = {
 };
 
 const GET_FILTERS_ROUTE = 'pim_enrich_mass_edit_rest_get_filter';
-const LAUNCH_JOB_ROUTE = 'pim_enrich_mass_edit_rest_launch';
+const LAUNCH_JOB_ROUTE = 'pim_structure_launch_mass_delete_attribute';
 const DELETE_ATTRIBUTES_JOB = 'delete_attributes';
 
 class AttributeMassDeleteAction extends MassAction {
@@ -83,7 +83,9 @@ class AttributeMassDeleteAction extends MassAction {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(data),
+        body: JSON.stringify({
+          filters: data.filters,
+        }),
       });
 
       if (response.ok) {


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, 

I just a factorization, now we used a dedicated controller to launch a attribute mass delete job instead of using the MassEdit controller of Enrichment. By this way we decouple your self to enrichment when we are going to work on ACL we can do the necessary checks.
![Screenshot from 2023-03-01 15-43-13](https://user-images.githubusercontent.com/7239572/222188370-33fa1ac5-0a0c-4a91-a3f5-bf77f53eb69c.png)


Email and notification already work perfectly

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
