### PR TITLE
PIM-10780: Fix PEF display for localizable and scopable values with wrong case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - PIM-10868: Fix checkboxes on category trees
 - PIM-10832: Fix compute completeness job after removing an attribute from a family
 - PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on options import
+- PIM-10780: Fix PEF display for localizable values with locale codes with wrong case
 
 ## Improvements
 

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi\Cache;
 
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
@@ -15,12 +16,12 @@ use Webmozart\Assert\Assert;
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface, GetCaseSensitiveLocaleCodeInterface
+final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface, GetCaseSensitiveLocaleCodeInterface, GetCaseSensitiveChannelCodeInterface
 {
     /**
      * // TODO Should we check the case where channel codes are integers ?
      *
-     * Contains the list of lowercase activated locale codes for each existing channel
+     * Contains the list of lowercase activated locale codes for each existing lowercase channel
      * Example: [
      *   'ecommerce' => ['en_us', 'fr_fr'],
      *   'mobile' => ['de_de', 'fr_fr'],
@@ -42,6 +43,17 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
      */
     private ?array $indexedLocales = null;
 
+    /**
+     * Contains the mapping of the lowercase version of each channel code to the original one
+     * Example: [
+     *   'ecommerce' => 'eCommerce',
+     *   'mobile' => 'mobile',
+     * ]
+     *
+     * @var null|array<string, string>
+     */
+    private ?array $indexedChannels = null;
+
     public function __construct(
         private readonly GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes
     ) {
@@ -54,7 +66,7 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
     {
         $this->initializeCache();
 
-        return array_key_exists($channelCode, $this->indexedChannelsWithLocales);
+        return array_key_exists(\mb_strtolower($channelCode), $this->indexedChannels);
     }
 
     /**
@@ -76,8 +88,8 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
         $this->initializeCache();
         Assert::isArray($this->indexedChannelsWithLocales);
 
-        return \array_key_exists($channelCode, $this->indexedChannelsWithLocales) &&
-            \in_array(\mb_strtolower($localeCode), $this->indexedChannelsWithLocales[$channelCode]);
+        return \array_key_exists(\mb_strtolower($channelCode), $this->indexedChannelsWithLocales) &&
+            \in_array(\mb_strtolower($localeCode), $this->indexedChannelsWithLocales[\mb_strtolower($channelCode)]);
     }
 
     public function forLocaleCode(string $localeCode): string
@@ -91,6 +103,19 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
         }
 
         return $this->indexedLocales[$lowercaseLocaleCode];
+    }
+
+    public function forChannelCode(string $channelCode): string
+    {
+        $this->initializeCache();;
+        Assert::isArray($this->indexedChannels);
+        $lowercaseChannelCode = \mb_strtolower($channelCode);
+
+        if (!\array_key_exists($lowercaseChannelCode, $this->indexedChannels)) {
+            throw new \LogicException(sprintf('Channel "%s" does not exist.', $channelCode));
+        }
+
+        return $this->indexedChannels[$lowercaseChannelCode];
     }
 
     /**
@@ -108,6 +133,7 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
     {
         $this->indexedChannelsWithLocales = null;
         $this->indexedLocales = null;
+        $this->indexedChannels = null;
     }
 
     private function initializeCache(): void
@@ -116,12 +142,14 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
             $channelsWithLocales = $this->getChannelCodeWithLocaleCodes->findAll();
             foreach ($channelsWithLocales as $channelWithLocales) {
                 $channelCode = $channelWithLocales['channelCode'];
+                $lowercaseChannelCode = \mb_strtolower($channelCode);
+                $this->indexedChannels[$lowercaseChannelCode] = $channelCode;
                 $localeCodes = $channelWithLocales['localeCodes'];
                 foreach ($localeCodes as $localeCode) {
                     $this->indexedLocales[\mb_strtolower($localeCode)] = $localeCode;
                 }
                 $lowercaseLocaleCodes = \array_map(static fn (string $localeCode): string => \mb_strtolower($localeCode), $localeCodes);
-                $this->indexedChannelsWithLocales[$channelCode] = $lowercaseLocaleCodes;
+                $this->indexedChannelsWithLocales[$lowercaseChannelCode] = $lowercaseLocaleCodes;
             }
         }
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -5,24 +5,46 @@ declare(strict_types=1);
 namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi\Cache;
 
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
+use Webmozart\Assert\Assert;
 
 /**
  * @author    Nicolas Marniesse <nicolas.marniesse@akeneo.com>
  * @copyright 2020 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface
+final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface, GetCaseSensitiveLocaleCodeInterface
 {
-    private GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes;
+    /**
+     * // TODO Should we check the case where channel codes are integers ?
+     *
+     * Contains the list of lowercase activated locale codes for each existing channel
+     * Example: [
+     *   'ecommerce' => ['en_us', 'fr_fr'],
+     *   'mobile' => ['de_de', 'fr_fr'],
+     * ]
+     *
+     * @var null|array<string, string[]>
+     */
+    private ?array $indexedChannelsWithLocales = null;
 
-    /** @var null|array */
-    private $indexedChannelsWithLocales = null;
+    /**
+     * Contains the mapping of the lowercase version of each activated locale code to the original one
+     * Example: [
+     *   'fr_fr' => 'fr_FR',
+     *   'de_de' => 'de_DE',
+     *   'en_us' => 'en_US',
+     * ]
+     *
+     * @var null|array<string, string>
+     */
+    private ?array $indexedLocales = null;
 
-    public function __construct(GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes)
-    {
-        $this->getChannelCodeWithLocaleCodes = $getChannelCodeWithLocaleCodes;
+    public function __construct(
+        private readonly GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes
+    ) {
     }
 
     /**
@@ -41,14 +63,9 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
     public function isLocaleActive(string $localeCode): bool
     {
         $this->initializeCache();
+        Assert::isArray($this->indexedLocales);
 
-        foreach ($this->indexedChannelsWithLocales as $channelWithLocales) {
-            if (in_array($localeCode, $channelWithLocales['localeCodes'])) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_key_exists(\mb_strtolower($localeCode), $this->indexedLocales);
     }
 
     /**
@@ -57,11 +74,23 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
     public function isLocaleBoundToChannel(string $localeCode, string $channelCode): bool
     {
         $this->initializeCache();
+        Assert::isArray($this->indexedChannelsWithLocales);
 
-        return isset($this->indexedChannelsWithLocales[$channelCode])
-            ? in_array($localeCode, $this->indexedChannelsWithLocales[$channelCode]['localeCodes'])
-            : false
-        ;
+        return \array_key_exists($channelCode, $this->indexedChannelsWithLocales) &&
+            \in_array(\mb_strtolower($localeCode), $this->indexedChannelsWithLocales[$channelCode]);
+    }
+
+    public function forLocaleCode(string $localeCode): string
+    {
+        $this->initializeCache();;
+        Assert::isArray($this->indexedLocales);
+        $lowercaseLocaleCode = \mb_strtolower($localeCode);
+
+        if (!\array_key_exists($lowercaseLocaleCode, $this->indexedLocales)) {
+            throw new \LogicException(sprintf('Locale "%s" does not exist or is not activated.', $localeCode));
+        }
+
+        return $this->indexedLocales[$lowercaseLocaleCode];
     }
 
     /**
@@ -73,19 +102,26 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
      * - if this cache is not cleared, then en_US is not considered activated when querying with this service
      *
      * The correct way to handle that is to clear the cache after saving a channel.
-     * As it never occur in real use case (except tests), it will not impact performance
+     * As it never occurs in real use case (except tests), it will not impact performance
      */
     public function clearCache(): void
     {
         $this->indexedChannelsWithLocales = null;
+        $this->indexedLocales = null;
     }
 
     private function initializeCache(): void
     {
-        if (null == $this->indexedChannelsWithLocales) {
+        if (null === $this->indexedChannelsWithLocales) {
             $channelsWithLocales = $this->getChannelCodeWithLocaleCodes->findAll();
             foreach ($channelsWithLocales as $channelWithLocales) {
-                $this->indexedChannelsWithLocales[$channelWithLocales['channelCode']] = $channelWithLocales;
+                $channelCode = $channelWithLocales['channelCode'];
+                $localeCodes = $channelWithLocales['localeCodes'];
+                foreach ($localeCodes as $localeCode) {
+                    $this->indexedLocales[\mb_strtolower($localeCode)] = $localeCode;
+                }
+                $lowercaseLocaleCodes = \array_map(static fn (string $localeCode): string => \mb_strtolower($localeCode), $localeCodes);
+                $this->indexedChannelsWithLocales[$channelCode] = $lowercaseLocaleCodes;
             }
         }
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetCaseSensitiveChannelCodeInterface
+{
+
+    public function forChannelCode(string $channelCode): string;
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetCaseSensitiveLocaleCodeInterface
+{
+
+    public function forLocaleCode(string $localeCode): string;
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -117,6 +117,7 @@ services:
         arguments:
             - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@pim_channel.query.cache.channel_exists_with_locale'
+            - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@akeneo.pim.structure.query.get_attributes'
 
     akeneo.pim.enrichment.factory.empty_values_cleaner:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -116,6 +116,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentChannelLocaleValuesFilter'
         arguments:
             - '@pim_channel.query.cache.channel_exists_with_locale'
+            - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@akeneo.pim.structure.query.get_attributes'
 
     akeneo.pim.enrichment.factory.empty_values_cleaner:

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 
 /**
@@ -14,8 +15,9 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
 {
     public function __construct(
-        private ChannelExistsWithLocaleInterface $channelsLocales,
-        private GetAttributes $getAttributes
+        private readonly ChannelExistsWithLocaleInterface $channelsLocales,
+        private readonly GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        private readonly GetAttributes $getAttributes
     ) {
     }
 
@@ -41,9 +43,10 @@ class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
         $filteredProductValues = [];
         foreach ($productValues as $channel => $localeValues) {
             if ($this->doesChannelExist($channel)) {
-                foreach ($localeValues as $locale => $value) {
-                    if ($this->isLocaleActivatedForChannel($locale, $channel)) {
-                        $filteredProductValues[$channel][$locale] = $value;
+                foreach ($localeValues as $localeCode => $value) {
+                    if ($this->isLocaleActivatedForChannel($localeCode, $channel)) {
+                        $originalLocaleCode = $localeCode === '<all_locales>' ? '<all_locales>' : $this->getCaseSensitiveLocaleCode->forLocaleCode($localeCode);
+                        $filteredProductValues[$channel][$originalLocaleCode] = $value;
                     }
                 }
             }

--- a/tests/back/Channel/Specification/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -50,12 +50,14 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
         $this->isLocaleActive('en_US')->shouldReturn(true);
         $this->isLocaleActive('de_DE')->shouldReturn(true);
         $this->isLocaleActive('es_ES')->shouldReturn(false);
+        $this->isLocaleActive('fr_fr')->shouldReturn(true); // Works with lowercase
     }
 
     function it_tests_the_locale_is_bound_to_locale()
     {
         $this->isLocaleBoundToChannel('fr_FR', 'ecommerce')->shouldReturn(true);
         $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_us', 'ecommerce')->shouldReturn(true); // Works with lowercase
         $this->isLocaleBoundToChannel('de_DE', 'ecommerce')->shouldReturn(false);
 
         $this->isLocaleBoundToChannel('de_DE', 'mobile')->shouldReturn(true);
@@ -65,5 +67,12 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
         $this->isLocaleBoundToChannel('en_US', 'unknown')->shouldReturn(false);
         $this->isLocaleBoundToChannel('unknown', 'unknown')->shouldReturn(false);
+    }
+
+    function it_returns_original_locale_code()
+    {
+        $this->forLocaleCode('en_US')->shouldReturn('en_US');
+        $this->forLocaleCode('EN_us')->shouldReturn('en_US');
+        $this->shouldThrow(\LogicException::class)->during('forLocaleCode', ['unknown']);
     }
 }

--- a/tests/back/Channel/Specification/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -15,7 +15,7 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
     {
         $getChannelCodeWithLocaleCodes->findAll()->willReturn([
             [
-                'channelCode' => 'ecommerce',
+                'channelCode' => 'eCommerce',
                 'localeCodes' => ['en_US', 'fr_FR'],
             ],
             [
@@ -38,7 +38,8 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
     function it_tests_the_channel_exist()
     {
-        $this->doesChannelExist('ecommerce')->shouldReturn(true);
+        $this->doesChannelExist('eCommerce')->shouldReturn(true);
+        $this->doesChannelExist('ecommerce')->shouldReturn(true); // Works with lowercase
         $this->doesChannelExist('mobile')->shouldReturn(true);
         $this->doesChannelExist('print')->shouldReturn(true);
         $this->doesChannelExist('other')->shouldReturn(false);
@@ -55,10 +56,11 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
     function it_tests_the_locale_is_bound_to_locale()
     {
-        $this->isLocaleBoundToChannel('fr_FR', 'ecommerce')->shouldReturn(true);
-        $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true);
-        $this->isLocaleBoundToChannel('en_us', 'ecommerce')->shouldReturn(true); // Works with lowercase
-        $this->isLocaleBoundToChannel('de_DE', 'ecommerce')->shouldReturn(false);
+        $this->isLocaleBoundToChannel('fr_FR', 'eCommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_US', 'eCommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_us', 'eCommerce')->shouldReturn(true); // Works with lowercase locale
+        $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true); // Works with lowercase channel
+        $this->isLocaleBoundToChannel('de_DE', 'eCommerce')->shouldReturn(false);
 
         $this->isLocaleBoundToChannel('de_DE', 'mobile')->shouldReturn(true);
         $this->isLocaleBoundToChannel('en_US', 'mobile')->shouldReturn(false);
@@ -74,5 +76,12 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
         $this->forLocaleCode('en_US')->shouldReturn('en_US');
         $this->forLocaleCode('EN_us')->shouldReturn('en_US');
         $this->shouldThrow(\LogicException::class)->during('forLocaleCode', ['unknown']);
+    }
+
+    function it_returns_original_channel_code()
+    {
+        $this->forChannelCode('eCommerce')->shouldReturn('eCommerce');
+        $this->forChannelCode('ecommerCE')->shouldReturn('eCommerce');
+        $this->shouldThrow(\LogicException::class)->during('forChannelCode', ['unknown']);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
@@ -19,15 +21,23 @@ class NonExistentChannelLocaleValuesFilterSpec extends ObjectBehavior
 {
     public function let(
         ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
         GetAttributes $getAttributes
     )
     {
-        $this->beConstructedWith($channelsLocales, $getAttributes);
+        $this->beConstructedWith($channelsLocales, $getCaseSensitiveLocaleCode, $getCaseSensitiveChannelCode, $getAttributes);
+
+        $getCaseSensitiveLocaleCode->forLocaleCode('en_US')->willReturn('en_US');
+        $getCaseSensitiveLocaleCode->forLocaleCode('fr_FR')->willReturn('fr_FR');
+        $getCaseSensitiveChannelCode->forChannelCode('ecommerce')->willReturn('ecommerce');
     }
 
     public function it_filters_values_of_non_existing_channels(
-        $channelsLocales,
-        $getAttributes
+        ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
+        GetAttributes $getAttributes
     ) {
         $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
             AttributeTypes::OPTION_SIMPLE_SELECT => [
@@ -125,8 +135,12 @@ class NonExistentChannelLocaleValuesFilterSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_filters_values_of_not_activated_locales($channelsLocales, GetAttributes $getAttributes)
-    {
+    public function it_filters_values_of_not_activated_locales(
+        ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
+        GetAttributes $getAttributes
+    ) {
         $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
             AttributeTypes::OPTION_SIMPLE_SELECT => [
                 'a_select' => [


### PR DESCRIPTION
How to reproduce this bug ?
Simple put this kind of values in a product:

```
"localizablescopableprice": {"ecommerCe": {"en_us": [{"amount": "12.00", "currency": "EUR"}, {"amount": "37.00", "currency": "USD"}]}}}
```

The case of ecommerce and en_US is not the right one and values are filtered before normalization, so do not appear on PEF. This PR fixes it