### PR TITLE
Fix PEF display for localizable and scopable values with wrong case

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+- PIM-10780: Fix PEF display for localizable values with locale codes with wrong case
+
 # 6.0.73 (2023-02-28)
 
 ## Bug fixes

--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,7 @@
 # 6.0.x
 
+## Bug fixes
+
 - PIM-10780: Fix PEF display for localizable values with locale codes with wrong case
 
 # 6.0.73 (2023-02-28)

--- a/src/Akeneo/Channel/.php_cd.php
+++ b/src/Akeneo/Channel/.php_cd.php
@@ -25,11 +25,13 @@ $rules = [
         'Akeneo\UserManagement\Bundle\Context\UserContext',
     ])->in('Akeneo\Channel\Bundle'),
     $builder->only([
+        'Webmozart\Assert\Assert',
         'Symfony\Component',
         'Symfony\Contracts',
         'Doctrine\Common',
         'Doctrine\Persistence',
         'Akeneo\Tool\Component',
+
         // TIP-942: Channel should not be linked to Category
         'Akeneo\Pim\Enrichment\Component\Category\Model\CategoryInterface',
 

--- a/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Channel\Component\Query\PublicApi\Cache;
 
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Component\Query\PublicApi\GetChannelCodeWithLocaleCodesInterface;
 use Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface;
 use Webmozart\Assert\Assert;
@@ -21,8 +19,6 @@ use Webmozart\Assert\Assert;
 final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInterface, CachedQueryInterface, GetCaseSensitiveLocaleCodeInterface, GetCaseSensitiveChannelCodeInterface
 {
     /**
-     * // TODO Should we check the case where channel codes are integers ?
-     *
      * Contains the list of lowercase activated locale codes for each existing lowercase channel
      * Example: [
      *   'ecommerce' => ['en_us', 'fr_fr'],
@@ -57,7 +53,7 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
     private ?array $indexedChannels = null;
 
     public function __construct(
-        private readonly GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes
+        private GetChannelCodeWithLocaleCodesInterface $getChannelCodeWithLocaleCodes
     ) {
     }
 

--- a/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocale.php
@@ -92,7 +92,7 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
 
     public function forLocaleCode(string $localeCode): string
     {
-        $this->initializeCache();;
+        $this->initializeCache();
         Assert::isArray($this->indexedLocales);
         $lowercaseLocaleCode = \mb_strtolower($localeCode);
 
@@ -105,7 +105,7 @@ final class CachedChannelExistsWithLocale implements ChannelExistsWithLocaleInte
 
     public function forChannelCode(string $channelCode): string
     {
-        $this->initializeCache();;
+        $this->initializeCache();
         Assert::isArray($this->indexedChannels);
         $lowercaseChannelCode = \mb_strtolower($channelCode);
 

--- a/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetCaseSensitiveChannelCodeInterface
+{
+
+    public function forChannelCode(string $channelCode): string;
+}

--- a/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveChannelCodeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+namespace Akeneo\Channel\Component\Query\PublicApi;
 
 /**
  * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
@@ -8,6 +8,9 @@ namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
  */
 interface GetCaseSensitiveChannelCodeInterface
 {
-
+    /**
+     * Returns the case sensitive channel code from any channel code
+     * Example: forChannelCode('ECommeRce') => 'ecommerce'
+     */
     public function forChannelCode(string $channelCode): string;
 }

--- a/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+namespace Akeneo\Channel\Component\Query\PublicApi;
 
 /**
  * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
@@ -8,6 +8,9 @@ namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
  */
 interface GetCaseSensitiveLocaleCodeInterface
 {
-
+    /**
+     * Returns the case sensitive locale code from any locale code
+     * Example: forLocaleCode('EN_us') => 'en_US'
+     */
     public function forLocaleCode(string $localeCode): string;
 }

--- a/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
+++ b/src/Akeneo/Channel/Component/Query/PublicApi/GetCaseSensitiveLocaleCodeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Akeneo\Channel\Infrastructure\Component\Query\PublicApi;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface GetCaseSensitiveLocaleCodeInterface
+{
+
+    public function forLocaleCode(string $localeCode): string;
+}

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -116,6 +116,7 @@ services:
         class: 'Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\NonExistentChannelLocaleValuesFilter'
         arguments:
             - '@pim_channel.query.cache.channel_exists_with_locale'
+            - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@akeneo.pim.structure.query.get_attributes'
         tags:
             - { name: akeneo.pim.enrichment.factory.non_existent_values_filter, priority: -1 }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/factories.yml
@@ -117,6 +117,7 @@ services:
         arguments:
             - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@pim_channel.query.cache.channel_exists_with_locale'
+            - '@pim_channel.query.cache.channel_exists_with_locale'
             - '@akeneo.pim.structure.query.get_attributes'
         tags:
             - { name: akeneo.pim.enrichment.factory.non_existent_values_filter, priority: -1 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 
@@ -14,8 +16,9 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
 {
     public function __construct(
-        private ChannelExistsWithLocaleInterface $channelsLocales,
-        private GetAttributes $getAttributes
+        private readonly ChannelExistsWithLocaleInterface $channelsLocales,
+        private readonly GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        private readonly GetAttributes $getAttributes
     ) {
     }
 
@@ -41,9 +44,10 @@ class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
         $filteredProductValues = [];
         foreach ($productValues as $channel => $localeValues) {
             if ($this->doesChannelExist($channel)) {
-                foreach ($localeValues as $locale => $value) {
-                    if ($this->isLocaleActivatedForChannel($locale, $channel)) {
-                        $filteredProductValues[$channel][$locale] = $value;
+                foreach ($localeValues as $localeCode => $value) {
+                    if ($this->isLocaleActivatedForChannel($localeCode, $channel)) {
+                        $originalLocaleCode = $localeCode === '<all_locales>' ? '<all_locales>' : $this->getCaseSensitiveLocaleCode->forLocaleCode($localeCode);
+                        $filteredProductValues[$channel][$originalLocaleCode] = $value;
                     }
                 }
             }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
 use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
@@ -18,6 +19,7 @@ class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
     public function __construct(
         private readonly ChannelExistsWithLocaleInterface $channelsLocales,
         private readonly GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        private readonly GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
         private readonly GetAttributes $getAttributes
     ) {
     }
@@ -42,12 +44,13 @@ class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
     private function filterProductValues(array $productValues): array
     {
         $filteredProductValues = [];
-        foreach ($productValues as $channel => $localeValues) {
-            if ($this->doesChannelExist($channel)) {
+        foreach ($productValues as $channelCode => $localeValues) {
+            if ($this->doesChannelExist($channelCode)) {
                 foreach ($localeValues as $localeCode => $value) {
-                    if ($this->isLocaleActivatedForChannel($localeCode, $channel)) {
+                    if ($this->isLocaleActivatedForChannel($localeCode, $channelCode)) {
                         $originalLocaleCode = $localeCode === '<all_locales>' ? '<all_locales>' : $this->getCaseSensitiveLocaleCode->forLocaleCode($localeCode);
-                        $filteredProductValues[$channel][$originalLocaleCode] = $value;
+                        $originalChannelCode = $channelCode === '<all_channels>' ? '<all_channels>' : $this->getCaseSensitiveChannelCode->forChannelCode($channelCode);
+                        $filteredProductValues[$originalChannelCode][$originalLocaleCode] = $value;
                     }
                 }
             }
@@ -61,10 +64,10 @@ class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
         $filteredProductValues = [];
         $attribute = $this->getAttributes->forCode($attributeCode);
 
-        foreach ($productValues as $channel => $localeValues) {
+        foreach ($productValues as $channelCode => $localeValues) {
             foreach ($localeValues as $localeCode => $value) {
                 if (!$attribute->isLocaleSpecific() || $localeCode === '<all_locales>' || in_array($localeCode, $attribute->availableLocaleCodes())) {
-                    $filteredProductValues[$channel][$localeCode] = $value;
+                    $filteredProductValues[$channelCode][$localeCode] = $value;
                 }
             }
         }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilter.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 
 /**
@@ -17,10 +16,10 @@ use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
 class NonExistentChannelLocaleValuesFilter implements NonExistentValuesFilter
 {
     public function __construct(
-        private readonly ChannelExistsWithLocaleInterface $channelsLocales,
-        private readonly GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
-        private readonly GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
-        private readonly GetAttributes $getAttributes
+        private ChannelExistsWithLocaleInterface $channelsLocales,
+        private GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        private GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
+        private GetAttributes $getAttributes
     ) {
     }
 

--- a/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -50,12 +50,14 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
         $this->isLocaleActive('en_US')->shouldReturn(true);
         $this->isLocaleActive('de_DE')->shouldReturn(true);
         $this->isLocaleActive('es_ES')->shouldReturn(false);
+        $this->isLocaleActive('fr_fr')->shouldReturn(true); // Works with lowercase
     }
 
     function it_tests_the_locale_is_bound_to_locale()
     {
         $this->isLocaleBoundToChannel('fr_FR', 'ecommerce')->shouldReturn(true);
         $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_us', 'ecommerce')->shouldReturn(true); // Works with lowercase
         $this->isLocaleBoundToChannel('de_DE', 'ecommerce')->shouldReturn(false);
 
         $this->isLocaleBoundToChannel('de_DE', 'mobile')->shouldReturn(true);
@@ -65,5 +67,12 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
         $this->isLocaleBoundToChannel('en_US', 'unknown')->shouldReturn(false);
         $this->isLocaleBoundToChannel('unknown', 'unknown')->shouldReturn(false);
+    }
+
+    function it_returns_original_locale_code()
+    {
+        $this->forLocaleCode('en_US')->shouldReturn('en_US');
+        $this->forLocaleCode('EN_us')->shouldReturn('en_US');
+        $this->shouldThrow(\LogicException::class)->during('forLocaleCode', ['unknown']);
     }
 }

--- a/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
+++ b/tests/back/Channel/Specification/Component/Query/PublicApi/Cache/CachedChannelExistsWithLocaleSpec.php
@@ -15,7 +15,7 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
     {
         $getChannelCodeWithLocaleCodes->findAll()->willReturn([
             [
-                'channelCode' => 'ecommerce',
+                'channelCode' => 'eCommerce',
                 'localeCodes' => ['en_US', 'fr_FR'],
             ],
             [
@@ -38,7 +38,8 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
     function it_tests_the_channel_exist()
     {
-        $this->doesChannelExist('ecommerce')->shouldReturn(true);
+        $this->doesChannelExist('eCommerce')->shouldReturn(true);
+        $this->doesChannelExist('ecommerce')->shouldReturn(true); // Works with lowercase
         $this->doesChannelExist('mobile')->shouldReturn(true);
         $this->doesChannelExist('print')->shouldReturn(true);
         $this->doesChannelExist('other')->shouldReturn(false);
@@ -55,10 +56,11 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
 
     function it_tests_the_locale_is_bound_to_locale()
     {
-        $this->isLocaleBoundToChannel('fr_FR', 'ecommerce')->shouldReturn(true);
-        $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true);
-        $this->isLocaleBoundToChannel('en_us', 'ecommerce')->shouldReturn(true); // Works with lowercase
-        $this->isLocaleBoundToChannel('de_DE', 'ecommerce')->shouldReturn(false);
+        $this->isLocaleBoundToChannel('fr_FR', 'eCommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_US', 'eCommerce')->shouldReturn(true);
+        $this->isLocaleBoundToChannel('en_us', 'eCommerce')->shouldReturn(true); // Works with lowercase locale
+        $this->isLocaleBoundToChannel('en_US', 'ecommerce')->shouldReturn(true); // Works with lowercase channel
+        $this->isLocaleBoundToChannel('de_DE', 'eCommerce')->shouldReturn(false);
 
         $this->isLocaleBoundToChannel('de_DE', 'mobile')->shouldReturn(true);
         $this->isLocaleBoundToChannel('en_US', 'mobile')->shouldReturn(false);
@@ -74,5 +76,12 @@ class CachedChannelExistsWithLocaleSpec extends ObjectBehavior
         $this->forLocaleCode('en_US')->shouldReturn('en_US');
         $this->forLocaleCode('EN_us')->shouldReturn('en_US');
         $this->shouldThrow(\LogicException::class)->during('forLocaleCode', ['unknown']);
+    }
+
+    function it_returns_original_channel_code()
+    {
+        $this->forChannelCode('eCommerce')->shouldReturn('eCommerce');
+        $this->forChannelCode('ecommerCE')->shouldReturn('eCommerce');
+        $this->shouldThrow(\LogicException::class)->during('forChannelCode', ['unknown']);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
-use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
+use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
+use Akeneo\Channel\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/NonExistentValuesFilter/NonExistentChannelLocaleValuesFilterSpec.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter;
 
-use Akeneo\Channel\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\ChannelExistsWithLocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveChannelCodeInterface;
+use Akeneo\Channel\Infrastructure\Component\Query\PublicApi\GetCaseSensitiveLocaleCodeInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Factory\NonExistentValuesFilter\OnGoingFilteredRawValues;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\AttributeType\GetAttributes;
@@ -19,15 +21,23 @@ class NonExistentChannelLocaleValuesFilterSpec extends ObjectBehavior
 {
     public function let(
         ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
         GetAttributes $getAttributes
     )
     {
-        $this->beConstructedWith($channelsLocales, $getAttributes);
+        $this->beConstructedWith($channelsLocales, $getCaseSensitiveLocaleCode, $getCaseSensitiveChannelCode, $getAttributes);
+
+        $getCaseSensitiveLocaleCode->forLocaleCode('en_US')->willReturn('en_US');
+        $getCaseSensitiveLocaleCode->forLocaleCode('fr_FR')->willReturn('fr_FR');
+        $getCaseSensitiveChannelCode->forChannelCode('ecommerce')->willReturn('ecommerce');
     }
 
     public function it_filters_values_of_non_existing_channels(
-        $channelsLocales,
-        $getAttributes
+        ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
+        GetAttributes $getAttributes
     ) {
         $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
             AttributeTypes::OPTION_SIMPLE_SELECT => [
@@ -125,8 +135,12 @@ class NonExistentChannelLocaleValuesFilterSpec extends ObjectBehavior
         ]);
     }
 
-    public function it_filters_values_of_not_activated_locales($channelsLocales, GetAttributes $getAttributes)
-    {
+    public function it_filters_values_of_not_activated_locales(
+        ChannelExistsWithLocaleInterface $channelsLocales,
+        GetCaseSensitiveLocaleCodeInterface $getCaseSensitiveLocaleCode,
+        GetCaseSensitiveChannelCodeInterface $getCaseSensitiveChannelCode,
+        GetAttributes $getAttributes
+    ) {
         $ongoingFilteredRawValues = OnGoingFilteredRawValues::fromNonFilteredValuesCollectionIndexedByType([
             AttributeTypes::OPTION_SIMPLE_SELECT => [
                 'a_select' => [


### PR DESCRIPTION
How to reproduce this bug ?
Simple put this kind of values in a product:

```
"localizablescopableprice": {"ecommerCe": {"en_us": [{"amount": "12.00", "currency": "EUR"}, {"amount": "37.00", "currency": "USD"}]}}}
```

The case of ecommerce and en_US is not the right one and values are filtered before normalization, so do not appear on PEF. This PR fixes it