### PR TITLE
GRF-771 : Update get categories SQL

### DIFF
--- a/src/Akeneo/Category/back/Infrastructure/Storage/Sql/GetCategoriesSql.php
+++ b/src/Akeneo/Category/back/Infrastructure/Storage/Sql/GetCategoriesSql.php
@@ -41,9 +41,11 @@ final class GetCategoriesSql implements GetCategoriesInterface
             enriched_values as (
                 SELECT category.id, category.value_collection
                 FROM pim_catalog_category category
-                JOIN pim_catalog_category_tree_template ctt ON ctt.category_tree_id = category.id
-                JOIN pim_catalog_category_template template ON template.uuid = ctt.category_template_uuid AND (template.is_deactivated IS NULL OR template.is_deactivated = 0)
-                WHERE $sqlWhere
+                LEFT JOIN pim_catalog_category_tree_template ctt ON ctt.category_tree_id = category.id
+                LEFT JOIN pim_catalog_category_template template ON template.uuid = ctt.category_template_uuid
+                WHERE $sqlWhere 
+                AND template.is_deactivated IS NULL 
+                    OR template.is_deactivated = 0
             ),
             position as (
                 SELECT code, position 

--- a/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
+++ b/src/Akeneo/Category/back/tests/Integration/Helper/CategoryTestCase.php
@@ -445,10 +445,10 @@ SQL;
         ]);
     }
 
-    protected function useTemplateFunctionalCatalog(string $templateUuid, string $productCode): void
+    protected function useTemplateFunctionalCatalog(string $templateUuid, string $categoryCode): Category
     {
         $category = $this->createOrUpdateCategory(
-            code: $productCode,
+            code: $categoryCode,
             labels: ['en_US' => 'socks'],
         );
 
@@ -459,6 +459,8 @@ SQL;
             $template->getUuid(),
             $template->getAttributeCollection(),
         );
+
+        return $category;
     }
 
     protected function deactivateTemplate(string $uuid): void

--- a/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Sql/GetCategoriesSqlIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/Infrastructure/Storage/Sql/GetCategoriesSqlIntegration.php
@@ -277,6 +277,110 @@ class GetCategoriesSqlIntegration extends CategoryTestCase
         }
     }
 
+    public function testGetAllCategoriesWithTheirValuesWhenTemplateActivatedAndEnrichedCategories(): void
+    {
+        // Given an enriched parent category and attached a template.
+        $parentCategory = $this->useTemplateFunctionalCatalog(
+            templateUuid: '02274dac-e99a-4e1d-8f9b-794d4c3ba330',
+            categoryCode: 'myParentCategory'
+        );
+        $this->updateCategoryWithValues((string) $parentCategory->getCode());
+
+        // Given an enriched child category
+        $childCategory = $this->createOrUpdateCategory(
+            code: "myChildCategory",
+            labels: [
+                'fr_FR' => 'Ma categorie enfant',
+                'en_US' => 'My child category'
+            ],
+            parentId: $parentCategory->getId()?->getValue()
+        );
+        $this->updateCategoryWithValues((string) $childCategory->getCode());
+
+        // When
+        $parameters = new ExternalApiSqlParameters(
+            sqlWhere: 'category.code IN (:category_codes)',
+            params: [
+                'category_codes' => ['myParentCategory', 'myChildCategory'],
+                'with_enriched_attributes' => true,
+                'with_position' => false,
+            ],
+            types : [
+                'category_codes' => Connection::PARAM_STR_ARRAY,
+                'with_enriched_attributes' => \PDO::PARAM_BOOL,
+                'with_position' => \PDO::PARAM_BOOL,
+            ],
+            limitAndOffset: 'LIMIT 10',
+        );
+
+        /** @var ExternalApiCategory[] $retrievedCategories */
+        $retrievedCategories = $this->get(GetCategoriesInterface::class)->execute($parameters);
+
+        // Then
+        $this->assertIsArray($retrievedCategories);
+        $this->assertCount(2, $retrievedCategories);
+        $this->assertContainsOnlyInstancesOf(ExternalApiCategory::class, $retrievedCategories);
+        $this->assertNotEmpty($retrievedCategories[0]->getValues());
+        $this->assertNotEmpty($retrievedCategories[1]->getValues());
+    }
+
+    public function testGetCategoriesWithTheirValuesIfAnyWhenTemplateActivatedAndEnrichedCategories(): void
+    {
+        // Given a non enriched parent category and attached a template.
+        $parentCategory = $this->useTemplateFunctionalCatalog(
+            templateUuid: '02274dac-e99a-4e1d-8f9b-794d4c3ba330',
+            categoryCode: 'myParentCategory'
+        );
+
+        // Given an enriched child category
+        $childCategory = $this->createOrUpdateCategory(
+            code: "myChildCategory",
+            labels: [
+                'fr_FR' => 'Ma categorie enfant',
+                'en_US' => 'My child category'
+            ],
+            parentId: $parentCategory->getId()?->getValue()
+        );
+        $this->updateCategoryWithValues((string) $childCategory->getCode());
+
+        // Given a non enriched child category
+        $this->createOrUpdateCategory(
+            code: "mySecondChildCategory",
+            labels: [
+                'fr_FR' => 'Ma seconde categorie enfant',
+                'en_US' => 'My second child category'
+            ],
+            parentId: $parentCategory->getId()?->getValue()
+        );
+
+        // When
+        $parameters = new ExternalApiSqlParameters(
+            sqlWhere: 'category.code IN (:category_codes)',
+            params: [
+                'category_codes' => ['myParentCategory', 'myChildCategory', 'mySecondChildCategory'],
+                'with_enriched_attributes' => true,
+                'with_position' => false,
+            ],
+            types : [
+                'category_codes' => Connection::PARAM_STR_ARRAY,
+                'with_enriched_attributes' => \PDO::PARAM_BOOL,
+                'with_position' => \PDO::PARAM_BOOL,
+            ],
+            limitAndOffset: 'LIMIT 10',
+        );
+
+        /** @var ExternalApiCategory[] $retrievedCategories */
+        $retrievedCategories = $this->get(GetCategoriesInterface::class)->execute($parameters);
+
+        // Then
+        $this->assertIsArray($retrievedCategories);
+        $this->assertCount(3, $retrievedCategories);
+        $this->assertContainsOnlyInstancesOf(ExternalApiCategory::class, $retrievedCategories);
+        $this->assertNull($retrievedCategories[0]->getValues());
+        $this->assertNotEmpty($retrievedCategories[1]->getValues());
+        $this->assertNull($retrievedCategories[2]->getValues());
+    }
+
     public function testGetCategoryByCodesWithIgnoredEnrichedAttributes(): void
     {
         $templateModel = $this->generateMockedCategoryTemplateModel(categoryTreeId: $this->categoryShoes->getId());


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Update the API REST end point to get enriched categories **category tree and their child with enriched values**  if the template is not deactivated.

## See Configuration :
![category tree print with no value](https://user-images.githubusercontent.com/6566364/222115082-547f26d4-ac9d-496b-b22f-6120f2acc37f.png)
![child category print_accessories with value](https://user-images.githubusercontent.com/6566364/222115363-54ea5518-81f7-4738-bf37-9e04a27b6a9d.png)

## See full API response for GET categories
(/api/rest/v1/categories?with_position=true&page=1&with_enriched_attributes=true&search={"code":[{"operator":"IN","value":["print", "print_accessories", "print_clothing", "print_shoes"]}]})
![api response from getCategories API REST](https://user-images.githubusercontent.com/6566364/222114957-cc738acc-aef9-4a7f-9591-2f50d0fe65dd.png)

## See Response for GET Categorie
(/api/rest/v1/categories/print_accessories?with_enriched_attributes=true)

![image](https://user-images.githubusercontent.com/6566364/222116843-fac48767-067f-41d5-8062-48f5c4de6e24.png)


**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
