### PR TITLE
PIM-10745: Fix history display for product's quantified association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
 - PIM-10832: Fix compute completeness job after removing an attribute from a family
 - PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on options import
 - PIM-10870: Fix display of permissions when empty
-- PIM-10860: [SLA] Announcements aren't shown 
+- PIM-10860: [SLA] Announcements aren't shown
+- PIM-10745: Fix history display for product's quantified association
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/VersioningController.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Controller/InternalApi/VersioningController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Bundle\Controller\InternalApi;
 
 use Akeneo\Pim\Enrichment\Bundle\Resolver\FQCNResolver;
@@ -18,34 +20,12 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
  */
 class VersioningController
 {
-    /** @var VersionRepositoryInterface */
-    protected $versionRepository;
-
-    /** @var FQCNResolver */
-    protected $FQCNResolver;
-
-    /** @var NormalizerInterface */
-    protected $normalizer;
-
-    /** @var UserContext */
-    protected $userContext;
-
-    /**
-     * @param VersionRepositoryInterface $versionRepository
-     * @param FQCNResolver               $FQCNResolver
-     * @param NormalizerInterface        $normalizer
-     * @param UserContext                $userContext
-     */
     public function __construct(
-        VersionRepositoryInterface $versionRepository,
-        FQCNResolver $FQCNResolver,
-        NormalizerInterface $normalizer,
-        UserContext $userContext
+        private readonly VersionRepositoryInterface $versionRepository,
+        private readonly FQCNResolver $FQCNResolver,
+        private readonly NormalizerInterface $normalizer,
+        private readonly UserContext $userContext
     ) {
-        $this->versionRepository = $versionRepository;
-        $this->FQCNResolver = $FQCNResolver;
-        $this->normalizer = $normalizer;
-        $this->userContext = $userContext;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
@@ -5,6 +5,7 @@ parameters:
     pim_catalog.localization.presenter.number.class:   Akeneo\Tool\Component\Localization\Presenter\NumberPresenter
     pim_catalog.localization.presenter.date.class:     Akeneo\Tool\Component\Localization\Presenter\DatePresenter
     pim_catalog.localization.presenter.boolean.class:  Akeneo\Tool\Component\Localization\Presenter\BooleanPresenter
+    pim_catalog.localization.presenter.product_quantified_association.class: Akeneo\Tool\Component\Localization\Presenter\ProductQuantifiedAssociationPresenter
 
 services:
     pim_catalog.localization.presenter.registry:
@@ -87,3 +88,11 @@ services:
             - ['date_min', 'date_max']
         tags:
             - { name: pim_catalog.localization.presenter, type: 'attribute_option' }
+
+    # Association
+    pim_catalog.localization.presenter.product_quantified_association:
+        class: '%pim_catalog.localization.presenter.product_quantified_association.class%'
+        arguments:
+            - '@Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier'
+        tags:
+            - { name: pim_catalog.localization.presenter, type: 'product_field' }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/localization/presenters.yml
@@ -94,5 +94,6 @@ services:
         class: '%pim_catalog.localization.presenter.product_quantified_association.class%'
         arguments:
             - '@Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier'
+            - '@pim_connector.array_converter.flat_to_standard.product.association_columns_resolver'
         tags:
             - { name: pim_catalog.localization.presenter, type: 'product_field' }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
 use Akeneo\Pim\Enrichment\Component\Product\Localization\Presenter\PresenterRegistryInterface;
@@ -37,7 +39,7 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     protected AttributeRepositoryInterface $attributeRepository;
     protected UserContext $userContext;
 
-    const ATTRIBUTE_HEADER_SEPARATOR = "-";
+    public const ATTRIBUTE_HEADER_SEPARATOR = "-";
 
     public function __construct(
         UserManager $userManager,
@@ -144,11 +146,11 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
             $attributeCode = $this->extractAttributeCode($valueHeader);
             $context['attribute'] = $attributeCode;
 
-            if (!isset($attributeTypes[$attributeCode])) {
-                continue;
+            if (isset($attributeTypes[$attributeCode])) {
+                $presenter = $this->presenterRegistry->getPresenterByAttributeType($attributeTypes[$attributeCode]);
+            } else {
+                $presenter = $this->presenterRegistry->getPresenterByFieldCode($valueHeader);
             }
-
-            $presenter = $this->presenterRegistry->getPresenterByAttributeType($attributeTypes[$attributeCode]);
             if (null === $presenter) {
                 continue;
             }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
@@ -39,7 +39,7 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     protected AttributeRepositoryInterface $attributeRepository;
     protected UserContext $userContext;
 
-    public const ATTRIBUTE_HEADER_SEPARATOR = "-";
+    private const ATTRIBUTE_HEADER_SEPARATOR = '-';
 
     public function __construct(
         UserManager $userManager,

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/FindIdentifier.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/FindIdentifier.php
@@ -11,4 +11,10 @@ namespace Akeneo\Pim\Enrichment\Component\Product\Query;
 interface FindIdentifier
 {
     public function fromUuid(string $uuid): null|string;
+
+    /**
+     * @param string[] $uuids
+     * @return array<string, string>
+     */
+    public function fromUuids(array $uuids): array;
 }

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Query/FindIdentifier.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Query/FindIdentifier.php
@@ -15,6 +15,7 @@ interface FindIdentifier
     /**
      * @param string[] $uuids
      * @return array<string, string>
+     * @throws \InvalidArgumentException if any of the $uuids is not a valid Uuid string
      */
     public function fromUuids(array $uuids): array;
 }

--- a/src/Akeneo/Tool/Component/Localization/Presenter/ProductQuantifiedAssociationPresenter.php
+++ b/src/Akeneo/Tool/Component/Localization/Presenter/ProductQuantifiedAssociationPresenter.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Akeneo\Tool\Component\Localization\Presenter;
 
+use Akeneo\Pim\Enrichment\Component\Product\Connector\ArrayConverter\FlatToStandard\AssociationColumnsResolver;
 use Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier;
 use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
 
 /**
  * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
@@ -13,37 +15,44 @@ use Ramsey\Uuid\Uuid;
  */
 class ProductQuantifiedAssociationPresenter implements PresenterInterface
 {
-    public function __construct(private readonly FindIdentifier $findIdentifier)
-    {
+    public function __construct(
+        private readonly FindIdentifier $findIdentifier,
+        private readonly AssociationColumnsResolver $associationColumnsResolver
+    ) {
     }
 
     /**
-     * @param $value
+     * @param string $value
      * @param array $options
      * @return string
      */
     public function present($value, array $options = []): string
     {
+        Assert::string($value);
         if (empty($value)) {
             return $value;
         }
         $values = explode(',', $value);
         $formattedValues = [];
-        $validUuids = \array_filter(\array_map(fn (string $uuid) => Uuid::isValid($uuid) ? $uuid : null, $values));
+        $validUuids = \array_filter($values, static fn (string $uuid): bool => Uuid::isValid($uuid));
         $identifiersFromUuids = $this->findIdentifier->fromUuids($validUuids);
-        foreach ($values as $uuid) {
-            if (isset($identifiersFromUuids[$uuid])) {
-                $formattedValues[] = $identifiersFromUuids[$uuid];
-            } else {
-                $formattedValues[] = sprintf('[%s]', $uuid);
-            }
+        foreach ($values as $key) {
+            $formattedValues[] = $identifiersFromUuids[$key]
+                ?? (\in_array($key, $validUuids) ? sprintf('[%s]', $key) : $key);
         }
 
         return implode(',', $formattedValues);
     }
 
-    public function supports($attributeType): bool
+    /**
+     * @param string $propertyName
+     * @return bool
+     */
+    public function supports($propertyName): bool
     {
-        return 1 === \preg_match('/(.*)-products$/', $attributeType);
+        $quantifiedAssociationNames = $this->associationColumnsResolver->resolveQuantifiedIdentifierAssociationColumns();
+        $pattern = \sprintf('/%s$/', AssociationColumnsResolver::PRODUCT_ASSOCIATION_SUFFIX);
+
+        return \in_array($propertyName, $quantifiedAssociationNames) && 1 === \preg_match($pattern, $propertyName);
     }
 }

--- a/src/Akeneo/Tool/Component/Localization/Presenter/ProductQuantifiedAssociationPresenter.php
+++ b/src/Akeneo/Tool/Component/Localization/Presenter/ProductQuantifiedAssociationPresenter.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Localization\Presenter;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductQuantifiedAssociationPresenter implements PresenterInterface
+{
+    public function __construct(private readonly FindIdentifier $findIdentifier)
+    {
+    }
+
+    /**
+     * @param $value
+     * @param array $options
+     * @return string
+     */
+    public function present($value, array $options = []): string
+    {
+        if (empty($value)) {
+            return $value;
+        }
+        $values = explode(',', $value);
+        $formattedValues = [];
+        $validUuids = \array_filter(\array_map(fn (string $uuid) => Uuid::isValid($uuid) ? $uuid : null, $values));
+        $identifiersFromUuids = $this->findIdentifier->fromUuids($validUuids);
+        foreach ($values as $uuid) {
+            if (isset($identifiersFromUuids[$uuid])) {
+                $formattedValues[] = $identifiersFromUuids[$uuid];
+            } else {
+                $formattedValues[] = sprintf('[%s]', $uuid);
+            }
+        }
+
+        return implode(',', $formattedValues);
+    }
+
+    public function supports($attributeType): bool
+    {
+        return 1 === \preg_match('/(.*)-products$/', $attributeType);
+    }
+}

--- a/src/Akeneo/Tool/Component/Localization/spec/Presenter/ProductQuantifiedAssociationPresenterSpec.php
+++ b/src/Akeneo/Tool/Component/Localization/spec/Presenter/ProductQuantifiedAssociationPresenterSpec.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Akeneo\Tool\Component\Localization\Presenter;
+
+use Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier;
+use Akeneo\Tool\Component\Localization\Presenter\ProductQuantifiedAssociationPresenter;
+use PhpSpec\ObjectBehavior;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ProductQuantifiedAssociationPresenterSpec extends ObjectBehavior
+{
+    public function let(FindIdentifier $findIdentifier): void
+    {
+        $this->beConstructedWith($findIdentifier);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ProductQuantifiedAssociationPresenter::class);
+    }
+
+    public function it_only_supports_product_association(): void
+    {
+        $this->supports('association-products-quantity')->shouldReturn(false);
+        $this->supports('products')->shouldReturn(false);
+        $this->supports('association-products')->shouldReturn(true);
+        $this->supports('asso-products')->shouldReturn(true);
+    }
+
+    public function it_presents_identifier_when_product_uuid_is_passed(
+        FindIdentifier $findIdentifier
+    ): void {
+        $uuid = Uuid::uuid4()->toString();
+        $findIdentifier
+            ->fromUuids([$uuid])
+            ->shouldBeCalledOnce()
+            ->willReturn([$uuid => 'my-identifier']);
+
+        $value = implode(',', [$uuid]);
+        $this->present($value)->shouldReturn('my-identifier');
+    }
+
+    public function it_presents_uuid_when_product_uuid_is_passed_and_product_has_no_identifier(
+        FindIdentifier $findIdentifier
+    ): void {
+        $uuid = Uuid::uuid4()->toString();
+        $findIdentifier
+            ->fromUuids([$uuid])
+            ->shouldBeCalledOnce()
+            ->willReturn([$uuid => null]);
+
+        $value = implode(',', [$uuid]);
+        $this->present($value)->shouldReturn(sprintf('[%s]', $uuid));
+    }
+
+    public function it_presents_identifiers_when_products_uuids_are_passed(
+        FindIdentifier $findIdentifier
+    ): void {
+        $uuid = Uuid::uuid4()->toString();
+        $uuid2 = Uuid::uuid4()->toString();
+        $findIdentifier
+            ->fromUuids([$uuid, $uuid2])
+            ->shouldBeCalledOnce()
+            ->willReturn([$uuid => 'my-identifier', $uuid2 => 'my-identifier-2']);
+
+        $value = implode(',', [$uuid, $uuid2]);
+        $this->present($value)->shouldReturn('my-identifier,my-identifier-2');
+    }
+
+    public function it_presents_input_string_when_is_invalid(
+        FindIdentifier $findIdentifier
+    ): void {
+        $findIdentifier
+            ->fromUuids([])
+            ->shouldBeCalledOnce()
+            ->willReturn([]);
+
+        $value = 'invalid_uuid';
+        $this->present($value)->shouldReturn('[invalid_uuid]');
+    }
+
+    public function it_presents_uuid_when_product_is_not_found(
+        FindIdentifier $findIdentifier
+    ): void {
+        $uuid = Uuid::uuid4()->toString();
+        $findIdentifier
+            ->fromUuids([$uuid])
+            ->shouldBeCalledOnce()
+            ->willReturn([]);
+
+        $this->present($uuid)->shouldReturn(sprintf('[%s]', $uuid));
+    }
+
+    public function it_presents_mixed_result_when_several_products_are_finded(
+        FindIdentifier $findIdentifier
+    ): void {
+        $uuid = Uuid::uuid4()->toString();
+        $uuid2 = Uuid::uuid4()->toString();
+        $uuid3 = Uuid::uuid4()->toString();
+        $uuid4 = 'invalid_uuid';
+        $findIdentifier
+            ->fromUuids([$uuid, $uuid2, $uuid3])
+            ->shouldBeCalledOnce()
+            ->willReturn([$uuid => 'my-identifier', $uuid2 => null]);
+
+        $value = implode(',', [$uuid, $uuid2, $uuid3, $uuid4]);
+        $this->present($value)->shouldReturn(sprintf('%s,[%s],[%s],[%s]', 'my-identifier', $uuid2, $uuid3, $uuid4));
+    }
+}

--- a/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlFindProductIdentifierIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Storage/Sql/Product/SqlFindProductIdentifierIntegration.php
@@ -35,12 +35,28 @@ class SqlFindProductIdentifierIntegration extends TestCase
     public function it_gets_the_identifiers_of_products_from_its_uuids(): void
     {
         $findIdentifier = $this->get('Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier');
+        $unknownId = Uuid::uuid4();
+
         Assert::assertSame(
             [$this->fooUuid => 'foo'],
             $findIdentifier->fromUuids([$this->fooUuid])
         );
-        $unknownId = Uuid::uuid4();
+
         Assert::assertEmpty($findIdentifier->fromUuids([$unknownId->toString()]));
+
+        Assert::assertSame(
+            [$this->fooUuid => 'foo'],
+            $findIdentifier->fromUuids([$this->fooUuid, $unknownId->toString()])
+        );
+    }
+
+    /** @test */
+    public function it_throws_exception_when_uuid_is_bad()
+    {
+        $findIdentifier = $this->get('Akeneo\Pim\Enrichment\Component\Product\Query\FindIdentifier');
+        $this->expectException(\InvalidArgumentException::class);
+
+        $findIdentifier->fromUuids(['invalid_uuid']);
     }
 
     protected function setUp(): void

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
@@ -11,12 +13,13 @@ use Akeneo\UserManagement\Bundle\Manager\UserManager;
 use Akeneo\Pim\Enrichment\Component\Product\Localization\Presenter\PresenterRegistryInterface;
 use Akeneo\UserManagement\Component\Model\User;
 use Prophecy\Argument;
+use Ramsey\Uuid\Uuid;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class VersionNormalizerSpec extends ObjectBehavior
 {
-    function let(
+    public function let(
         UserManager $userManager,
         TranslatorInterface $translator,
         LocaleAwareInterface $localeAware,
@@ -24,7 +27,7 @@ class VersionNormalizerSpec extends ObjectBehavior
         PresenterRegistryInterface $presenterRegistry,
         AttributeRepositoryInterface $attributeRepository,
         UserContext $userContext
-    ) {
+    ): void {
         $this->beConstructedWith(
             $userManager,
             $translator,
@@ -36,14 +39,13 @@ class VersionNormalizerSpec extends ObjectBehavior
         );
     }
 
-    function it_supports_versions(Version $version)
+    public function it_supports_versions(Version $version): void
     {
         $this->supportsNormalization($version, 'internal_api')->shouldReturn(true);
     }
 
-    function it_normalize_versions(
+    public function it_normalize_versions(
         $userManager,
-        $translator,
         $datetimePresenter,
         $presenterRegistry,
         $userContext,
@@ -53,14 +55,17 @@ class VersionNormalizerSpec extends ObjectBehavior
         PresenterInterface $numberPresenter,
         PresenterInterface $pricesPresenter,
         PresenterInterface $metricPresenter,
+        PresenterInterface $productAssociationPresenter,
         AttributeRepositoryInterface $attributeRepository
-    ) {
+    ): void {
         $versionTime = new \DateTime();
+        $uuid = Uuid::uuid4()->toString();
 
         $changeset = [
             'maximum_frame_rate' => ['old' => '', 'new' => '200.7890'],
             'price-EUR'          => ['old' => '5.00', 'new' => '5.15'],
             'weight'             => ['old' => '', 'new' => '10.1234'],
+            'asso-products'      => ['old' => '', 'new' => $uuid],
         ];
 
         $version->getId()->willReturn(12);
@@ -78,10 +83,11 @@ class VersionNormalizerSpec extends ObjectBehavior
         $steve->getFirstName()->willReturn('Steve');
         $steve->getLastName()->willReturn('Jobs');
 
-        $changeset = [
+        $normalizedChangeset = [
             'maximum_frame_rate' => ['old' => '', 'new' => '200,7890'],
             'price-EUR'          => ['old' => '5,00 €', 'new' => '5,15 €'],
             'weight'             => ['old' => '', 'new' => '10,1234'],
+            'asso-products'      => ['old' => '', 'new' => 'my-identifier'],
         ];
 
         $options = [
@@ -95,50 +101,71 @@ class VersionNormalizerSpec extends ObjectBehavior
         $userContext->getUserTimezone()->willReturn('Europe/Paris');
 
         $attributeRepository
-            ->getAttributeTypeByCodes(['maximum_frame_rate', 'price', 'weight'])
+            ->getAttributeTypeByCodes(['maximum_frame_rate', 'price', 'weight', 'asso'])
             ->willReturn([
                 'maximum_frame_rate' => 'pim_catalog_number',
                 'price' => 'pim_catalog_price_collection',
-                'weight' => 'pim_catalog_metric'
+                'weight' => 'pim_catalog_metric',
             ]);
 
         $presenterRegistry->getPresenterByAttributeType('pim_catalog_number')->willReturn($numberPresenter);
         $presenterRegistry->getPresenterByAttributeType('pim_catalog_price_collection')->willReturn($pricesPresenter);
         $presenterRegistry->getPresenterByAttributeType('pim_catalog_metric')->willReturn($metricPresenter);
+        $presenterRegistry->getPresenterByFieldCode('asso-products')->willReturn($productAssociationPresenter);
 
         $numberPresenter
             ->present('200.7890', $options + ['versioned_attribute' => 'maximum_frame_rate', 'attribute' => 'maximum_frame_rate'])
             ->willReturn('200,7890');
-        $pricesPresenter->present('5.00', $options + ['versioned_attribute' => 'price-EUR', 'attribute' => 'price'])->willReturn('5,00 €');
-        $pricesPresenter->present('5.15', $options + ['versioned_attribute' => 'price-EUR', 'attribute' => 'price'])->willReturn('5,15 €');
-        $metricPresenter->present('10.1234', $options + ['versioned_attribute' => 'weight', 'attribute' => 'weight'])->willReturn('10,1234');
+        $pricesPresenter
+            ->present('5.00', $options + ['versioned_attribute' => 'price-EUR', 'attribute' => 'price'])
+            ->willReturn('5,00 €');
+        $pricesPresenter
+            ->present('5.15', $options + ['versioned_attribute' => 'price-EUR', 'attribute' => 'price'])
+            ->willReturn('5,15 €');
+        $metricPresenter
+            ->present('10.1234', $options + ['versioned_attribute' => 'weight', 'attribute' => 'weight'])
+            ->willReturn('10,1234');
+        $productAssociationPresenter
+            ->present($uuid, $options + ['versioned_attribute' => 'asso-products', 'attribute' => 'asso'])
+            ->willReturn('my-identifier');
 
-        $numberPresenter->present('', $options + ['versioned_attribute' => 'maximum_frame_rate', 'attribute' => 'maximum_frame_rate'])->willReturn('');
-        $pricesPresenter->present('', $options)->willReturn('');
-        $metricPresenter->present('', $options + ['versioned_attribute' => 'weight', 'attribute' => 'weight'])->willReturn('');
-        $datetimePresenter->present($versionTime, $datetimePresenterOtions)->willReturn('01/01/1985 09:41 AM');
+        $numberPresenter
+            ->present('', $options + ['versioned_attribute' => 'maximum_frame_rate', 'attribute' => 'maximum_frame_rate'])
+            ->willReturn('');
+        $pricesPresenter
+            ->present('', $options)
+            ->willReturn('');
+        $metricPresenter
+            ->present('', $options + ['versioned_attribute' => 'weight', 'attribute' => 'weight'])
+            ->willReturn('');
+        $datetimePresenter
+            ->present($versionTime, $datetimePresenterOtions)
+            ->willReturn('01/01/1985 09:41 AM');
+        $productAssociationPresenter
+            ->present('', $options + ['versioned_attribute' => 'asso-products', 'attribute' => 'asso'])
+            ->willReturn('');
 
         $this->normalize($version, 'internal_api')->shouldReturn([
             'id'          => 12,
             'author'      => 'Steve Jobs',
             'resource_id' => '112',
             'snapshot'    => 'a nice snapshot',
-            'changeset'   => $changeset,
+            'changeset'   => $normalizedChangeset,
             'context'     => ['locale' => 'en_US', 'channel' => 'mobile'],
             'version'     => 12,
             'logged_at'   => '01/01/1985 09:41 AM',
-            'pending'     => false
+            'pending'     => false,
         ]);
     }
 
-    function it_normalize_versions_with_deleted_user(
+    public function it_normalize_versions_with_deleted_user(
         $userManager,
         $translator,
         $datetimePresenter,
         $userContext,
         LocaleAwareInterface $localeAware,
         Version $version
-    ) {
+    ): void {
         $versionTime = new \DateTime();
 
         $version->getId()->willReturn(12);
@@ -168,7 +195,7 @@ class VersionNormalizerSpec extends ObjectBehavior
             'context'     => ['locale' => 'en_US', 'channel' => 'mobile'],
             'version'     => 12,
             'logged_at'   => '01/01/1985 09:41 AM',
-            'pending'     => false
+            'pending'     => false,
         ]);
     }
 }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/VersionNormalizerSpec.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Enrichment\Component\Product\Normalizer\InternalApi;
 
+use Akeneo\Pim\Enrichment\Component\Product\Localization\Presenter\PresenterRegistryInterface;
 use Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface;
 use Akeneo\Tool\Component\Localization\Presenter\PresenterInterface;
 use Akeneo\Tool\Component\Versioning\Model\Version;
 use Akeneo\UserManagement\Bundle\Context\UserContext;
-use PhpSpec\ObjectBehavior;
 use Akeneo\UserManagement\Bundle\Manager\UserManager;
-use Akeneo\Pim\Enrichment\Component\Product\Localization\Presenter\PresenterRegistryInterface;
 use Akeneo\UserManagement\Component\Model\User;
+use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Ramsey\Uuid\Uuid;
 use Symfony\Contracts\Translation\LocaleAwareInterface;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

### Issue

If associations with quantities are used with products that all have SKUs, UUID are displayed in the history.

### Expected behavior

Identifiers shall be displayed in product history.

  
   
**Example with associated products** (one with identifier, one without identifier)

![Screenshot from 2023-03-01 14-54-00](https://user-images.githubusercontent.com/1288342/222161139-15f097f1-d4c4-4615-a021-8e88b0fa1682.png)
![Screenshot from 2023-03-01 14-54-42](https://user-images.githubusercontent.com/1288342/222161220-bdc5814c-48a0-4a63-a0c2-d775d95b1eaa.png)


**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
