### PR TITLE
RAB-1287: Move delete attribute groups error into a dedicated subscriber 

### DIFF
--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -11,15 +11,16 @@ const DoubleCheckDeleteModal = ({
   children,
   doubleCheckInputLabel,
   textToCheck,
+  onConfirm,
   ...deleteModalProps
 }: DoubleCheckDeleteModalProps) => {
   const [value, setValue] = useState('');
   const canConfirmDelete = value === textToCheck;
 
   return (
-    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete}>
+    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete} onConfirm={onConfirm}>
       {children}
-      <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} />
+      <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} onSubmit={onConfirm} />
     </DeleteModal>
   );
 };

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeGroupOtherCannotBeRemovedSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeGroupOtherCannotBeRemovedSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupOtherCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
+use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CheckAttributeGroupOtherCannotBeRemovedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_REMOVE => 'preRemove',
+        ];
+    }
+
+    public function preRemove(RemoveEvent $event): void
+    {
+        $attributeGroup = $event->getSubject();
+        if (!$attributeGroup instanceof AttributeGroupInterface) {
+            return;
+        }
+
+        if ('other' === $attributeGroup->getCode()) {
+            throw AttributeGroupOtherCannotBeRemoved::create();
+        }
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeGroupWithAttributeCannotBeRemovedSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeGroupWithAttributeCannotBeRemovedSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupOtherCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupWithAttributeCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
+use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CheckAttributeGroupWithAttributeCannotBeRemovedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            StorageEvents::PRE_REMOVE => 'preRemove',
+        ];
+    }
+
+    public function preRemove(RemoveEvent $event): void
+    {
+        $attributeGroup = $event->getSubject();
+        if (!$attributeGroup instanceof AttributeGroupInterface) {
+            return;
+        }
+
+        if (0 < $attributeGroup->getAttributes()->count()) {
+            throw AttributeGroupWithAttributeCannotBeRemoved::createFromAttributeGroup($attributeGroup);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -145,6 +145,7 @@ services:
             - '@event_dispatcher'
             - '@pim_catalog.filter.chained'
             - '@akeneo.pim.structure.query.find_attribute_codes_for_attribute_groups'
+            - '@translator'
 
     pim_enrich.controller.rest.family:
         public: true

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -89,3 +89,11 @@ services:
             - '@doctrine.orm.entity_manager'
         tags:
             - { name: kernel.event_subscriber }
+
+    Akeneo\Pim\Structure\Bundle\EventSubscriber\CheckAttributeGroupOtherCannotBeRemovedSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }
+
+    Akeneo\Pim\Structure\Bundle\EventSubscriber\CheckAttributeGroupWithAttributeCannotBeRemovedSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -286,8 +286,8 @@ pim_enrich.entity.attribute_group:
         confirm: '{1}Are you sure you want to delete this attribute group?|]1, Inf[Are you sure you want to delete these {{ count }} attribute groups?'
         confirmation_phrase: 'Please type "{{ confirmation_word }}" to confirm:'
         confirmation_word: delete
-        attribute_warning: '{1}Deleting these attribute groups will impact {{ number_of_attribute }} child attribute. You will need to move this child attribute to a new attribute group.]1, Inf[Deleting these attribute groups will impact {{ number_of_attribute }} child attributes. You will need to move these child attributes to a new attribute group.'
-        select_attribute_group: '{1}Please select the attribute group to move the child attribute to:]1, Inf[Please select the attribute group to move the {{ number_of_attribute }} child attribute to:'
+        attribute_warning: '{1}Deleting these attribute groups will impact {{ number_of_attribute }} child attribute. You will need to move this child attribute to a new attribute group.|]1, Inf[Deleting these attribute groups will impact {{ number_of_attribute }} child attributes. You will need to move these child attributes to a new attribute group.'
+        select_attribute_group: '{1}Please select the attribute group to move the child attribute to:|]1, Inf[Please select the attribute group to move the {{ number_of_attribute }} child attributes to:'
         empty_result_label: 'No attribute group found'
         placeholder: 'Select attribute group'
         open_label: 'attribute group list'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -283,11 +283,11 @@ pim_enrich.entity.attribute_group:
     mass_delete:
         button: Delete
         title: Attribute Groups
-        confirm: '{1}Are you sure you want to delete this attribute group ?|]1, Inf[Are you sure you want to delete these {{ count }} attribute groups ?'
-        confirmation_phrase: 'Please type "{{ confirmation_word }}" to confirm.'
+        confirm: '{1}Are you sure you want to delete this attribute group?|]1, Inf[Are you sure you want to delete these {{ count }} attribute groups?'
+        confirmation_phrase: 'Please type "{{ confirmation_word }}" to confirm:'
         confirmation_word: delete
-        attribute_warning: 'Deleting these attribute groups will impact {{ number_of_attribute }} child attributes. You will need to move these child attributes to a new attribute group.'
-        select_attribute_group: 'Please select the attribute group to move the {{ number_of_attribute }} child attributes to:'
+        attribute_warning: '{1}Deleting these attribute groups will impact {{ number_of_attribute }} child attribute. You will need to move this child attribute to a new attribute group.]1, Inf[Deleting these attribute groups will impact {{ number_of_attribute }} child attributes. You will need to move these child attributes to a new attribute group.'
+        select_attribute_group: '{1}Please select the attribute group to move the child attribute to:]1, Inf[Please select the attribute group to move the {{ number_of_attribute }} child attribute to:'
         empty_result_label: 'No attribute group found'
         placeholder: 'Select attribute group'
         open_label: 'attribute group list'

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/messages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/messages.en_US.yml
@@ -9,6 +9,11 @@ pim_enrich:
     family:
         info:
             cant_remove_attribute_used_as_axis: Cannot remove this attribute used as a variant axis in a family variant
+    attribute_group:
+        remove:
+            attribute_group_with_attribute_cannot_be_removed: Attribute group containing attributes cannot be removed. Please remove its attributes prior to delete it.
+            attribute_group_other_cannot_be_removed: Attribute group "other" cannot be removed.
+
     # Group type
     group_type:
         tab:

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -69,14 +69,22 @@ const MassDeleteAttributeGroupsModal = ({
             {numberOfAttribute > 0 && (
               <>
                 <Helper level="error">
-                  {translate('pim_enrich.entity.attribute_group.mass_delete.attribute_warning', {
-                    number_of_attribute: numberOfAttribute,
-                  }, numberOfAttribute)}
+                  {translate(
+                    'pim_enrich.entity.attribute_group.mass_delete.attribute_warning',
+                    {
+                      number_of_attribute: numberOfAttribute,
+                    },
+                    numberOfAttribute
+                  )}
                 </Helper>
                 <Field
-                  label={translate('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group', {
-                    number_of_attribute: numberOfAttribute,
-                  }, numberOfAttribute)}
+                  label={translate(
+                    'pim_enrich.entity.attribute_group.mass_delete.select_attribute_group',
+                    {
+                      number_of_attribute: numberOfAttribute,
+                    },
+                    numberOfAttribute
+                  )}
                 >
                   <SelectInput
                     emptyResultLabel={translate('pim_enrich.entity.attribute_group.mass_delete.empty_result_label')}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -71,12 +71,12 @@ const MassDeleteAttributeGroupsModal = ({
                 <Helper level="error">
                   {translate('pim_enrich.entity.attribute_group.mass_delete.attribute_warning', {
                     number_of_attribute: numberOfAttribute,
-                  })}
+                  }, numberOfAttribute)}
                 </Helper>
                 <Field
                   label={translate('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group', {
                     number_of_attribute: numberOfAttribute,
-                  })}
+                  }, numberOfAttribute)}
                 >
                   <SelectInput
                     emptyResultLabel={translate('pim_enrich.entity.attribute_group.mass_delete.empty_result_label')}

--- a/src/Akeneo/Pim/Structure/Component/Exception/AttributeGroupOtherCannotBeRemoved.php
+++ b/src/Akeneo/Pim/Structure/Component/Exception/AttributeGroupOtherCannotBeRemoved.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Component\Exception;
+
+class AttributeGroupOtherCannotBeRemoved extends UserFacingError
+{
+    public static function create()
+    {
+        return new self('pim_enrich.attribute_group.remove.attribute_group_other_cannot_be_removed');
+    }
+}

--- a/src/Akeneo/Pim/Structure/Component/Exception/AttributeGroupWithAttributeCannotBeRemoved.php
+++ b/src/Akeneo/Pim/Structure/Component/Exception/AttributeGroupWithAttributeCannotBeRemoved.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Component\Exception;
+
+use Akeneo\Pim\Structure\Component\Model\AttributeGroupInterface;
+
+class AttributeGroupWithAttributeCannotBeRemoved extends UserFacingError
+{
+    public static function createFromAttributeGroup(AttributeGroupInterface $attributeGroup)
+    {
+        return new self('pim_enrich.attribute_group.remove.attribute_group_with_attribute_cannot_be_removed', [
+            'attributeGroup' => $attributeGroup
+        ]);
+    }
+}

--- a/src/Akeneo/Pim/Structure/Component/Exception/UserFacingError.php
+++ b/src/Akeneo/Pim/Structure/Component/Exception/UserFacingError.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace Akeneo\Pim\Structure\Component\Exception;
+
+class UserFacingError extends \Exception
+{
+    /**
+     * @param array<string,mixed> $translationParameters
+     */
+    public function __construct(
+        private string $translationKey,
+        private array $translationParameters = []
+    ) {
+        parent::__construct();
+    }
+
+    public function translationKey(): string
+    {
+        return $this->translationKey;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function translationParameters(): array
+    {
+        return $this->translationParameters;
+    }
+}

--- a/tests/back/Pim/Structure/Integration/AttributeGroup/EventSubscriber/CheckAttributeGroupOtherCannotBeRemovedSubscriberIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeGroup/EventSubscriber/CheckAttributeGroupOtherCannotBeRemovedSubscriberIntegration.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace AkeneoTest\Pim\Structure\Integration\AttributeGroup\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupOtherCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Repository\AttributeGroupRepositoryInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
+
+class CheckAttributeGroupOtherCannotBeRemovedSubscriberIntegration extends TestCase
+{
+    private AttributeGroupRepositoryInterface $attributeGroupRepository;
+    private RemoverInterface $attributeGroupRemover;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->attributeGroupRepository = $this->get('pim_catalog.repository.attribute_group');
+        $this->attributeGroupRemover = $this->get('pim_catalog.remover.attribute_group');
+    }
+
+    public function test_it_throws_an_exception_when_the_attribute_group_other_is_deleted(): void
+    {
+        $this->expectException(AttributeGroupOtherCannotBeRemoved::class);
+        $this->removeAttributeGroup('other');
+    }
+
+    private function removeAttributeGroup(string $attributeGroupCode): void
+    {
+        $attributeGroup = $this->attributeGroupRepository->findOneByIdentifier($attributeGroupCode);
+        $this->attributeGroupRemover->remove($attributeGroup);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}

--- a/tests/back/Pim/Structure/Integration/AttributeGroup/EventSubscriber/CheckAttributeGroupWithAttributeCannotBeRemovedSubscriberIntegration.php
+++ b/tests/back/Pim/Structure/Integration/AttributeGroup/EventSubscriber/CheckAttributeGroupWithAttributeCannotBeRemovedSubscriberIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace AkeneoTest\Pim\Structure\Integration\AttributeGroup\EventSubscriber;
+
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupOtherCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Exception\AttributeGroupWithAttributeCannotBeRemoved;
+use Akeneo\Pim\Structure\Component\Repository\AttributeGroupRepositoryInterface;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Component\StorageUtils\Remover\RemoverInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Webmozart\Assert\Assert;
+
+class CheckAttributeGroupWithAttributeCannotBeRemovedSubscriberIntegration extends TestCase
+{
+    private AttributeGroupRepositoryInterface $attributeGroupRepository;
+    private RemoverInterface $attributeGroupRemover;
+    private ValidatorInterface $validator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->validator = $this->get('validator');
+        $this->attributeGroupRepository = $this->get('pim_catalog.repository.attribute_group');
+        $this->attributeGroupRemover = $this->get('pim_catalog.remover.attribute_group');
+    }
+
+    public function test_it_throws_an_exception_when_the_attribute_group_have_attribute(): void
+    {
+        $this->givenAttributeGroup('an_attribute_group_with_attribute');
+        $this->givenAttribute('an_attribute', 'an_attribute_group_with_attribute');
+
+        $this->expectException(AttributeGroupWithAttributeCannotBeRemoved::class);
+        $this->removeAttributeGroup('an_attribute_group_with_attribute');
+    }
+
+    private function givenAttributeGroup(string $attributeGroupCode): void
+    {
+        $attributeGroup = $this->get('pim_catalog.factory.attribute_group')->create();
+        $this->get('pim_catalog.updater.attribute_group')->update($attributeGroup, [
+            'code' => $attributeGroupCode
+        ]);
+
+        $constraintViolations = $this->validator->validate($attributeGroup);
+        Assert::count($constraintViolations, 0);
+
+        $this->get('pim_catalog.saver.attribute_group')->save($attributeGroup);
+    }
+
+    private function givenAttribute(string $attributeCode, string $attributeGroupCode): void
+    {
+        $attribute = $this->get('pim_catalog.factory.attribute')->create();
+        $this->get('pim_catalog.updater.attribute')->update($attribute, [
+            'code' => $attributeCode,
+            'type' => 'pim_catalog_text',
+            'group' => $attributeGroupCode
+        ]);
+
+        $constraintViolations = $this->validator->validate($attribute);
+        Assert::count($constraintViolations, 0);
+
+        $this->get('pim_catalog.saver.attribute')->save($attribute);
+    }
+
+    private function removeAttributeGroup(string $attributeGroupCode): void
+    {
+        $this->get('pim_connector.doctrine.cache_clearer')->clear();
+
+        $attributeGroup = $this->attributeGroupRepository->findOneByIdentifier($attributeGroupCode);
+        $this->attributeGroupRemover->remove($attributeGroup);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, 

- I move all check before deletion into a dedicated subscriber, by this way we will have those check in mass delete 
- I also call on confirm on DoubleCheckModalDeletion when user hit Enter on confirmation input
- I fixed some translations that are not plurialized

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
