### PR TITLE
CPM-986: Fix cache on get families

### DIFF
--- a/components/identifier-generator/front/src/feature/hooks/useGetFamilies.ts
+++ b/components/identifier-generator/front/src/feature/hooks/useGetFamilies.ts
@@ -12,7 +12,13 @@ const useGetFamilies = (params: {page?: number; search?: string; codes?: FamilyC
   const router = useRouter();
 
   return useQuery<Family[], Error, Family[], QueryKey>({
-    queryKey: ['getFamilies', params.page ?? 1, params.search ?? '', params.codes],
+    queryKey: [
+      'getFamilies',
+      params.page ?? 1,
+      params.search ?? '',
+      params.codes,
+      params.limit || DEFAULT_LIMIT_PAGINATION,
+    ],
     queryFn: async (parameters: {queryKey: QueryKey}) => {
       const queryParameters: {[key: string]: string | number | FamilyCode[] | undefined} = {
         limit: params.limit || DEFAULT_LIMIT_PAGINATION,


### PR DESCRIPTION
There is a cache on queries with react-query
When we did a call for having the families from another component, then wanted to have the same call but updating the "limit", the cache was telling is that we already having this result, which is not the case.
We added the limit to the parameters able to change and calling a new call.