### PR TITLE
RAB-1358: Fixes after breakit on bulk delete attribute groups

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/translations/jsmessages.en_US.yml
@@ -277,9 +277,7 @@ pim_enrich.entity.attribute_group:
             confirm: Are you sure you want to delete this attribute group?
     grid:
         columns:
-            name: Attribute groups name
-            attribute_count: Related Attributes
-        no_search_result: Sorry, there is no result for your search.
+            attribute_count: Related attributes count
     selected: '{0}0 attribute group selected|{1}1 attribute group selected|]1, Inf[{{ count }} attribute groups selected'
     mass_delete:
         button: Delete

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/AttributeGroupsDataGrid.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/AttributeGroupsDataGrid.tsx
@@ -1,21 +1,10 @@
 import React, {FC, useEffect, useRef, useState} from 'react';
+import styled from 'styled-components';
+import {Search, useAutoFocus, Table, Badge, CheckboxChecked} from 'akeneo-design-system';
+import {useTranslate, useFeatureFlags, useUserContext, getLabel} from '@akeneo-pim-community/shared';
 import {AttributeGroup} from '../../../models';
 import {NoResults} from '../../shared';
-import {Search, useAutoFocus, Table, Badge} from 'akeneo-design-system';
-import {getLabel} from 'pimui/js/i18n';
 import {useAttributeGroupPermissions, useAttributeGroupsIndexState, useFilteredAttributeGroups} from '../../../hooks';
-import {useDebounceCallback, useTranslate, useFeatureFlags, useUserContext} from '@akeneo-pim-community/shared';
-import styled from 'styled-components';
-
-type Props = {
-  attributeGroups: AttributeGroup[];
-  onGroupCountChange: (newGroupCount: number) => void;
-  isItemSelected: (attributeGroup: AttributeGroup) => boolean;
-  selectionState: boolean | 'mixed';
-  onSelectionChange: (attributeGroup: AttributeGroup, selected: boolean) => void;
-  selectedCount: number;
-  onSelectAllChange: (mode: boolean) => void;
-};
 
 const Wrapper = styled.div`
   display: flex;
@@ -26,6 +15,16 @@ const TableWrapper = styled.div`
   margin-left: -40px;
 `;
 
+type Props = {
+  attributeGroups: AttributeGroup[];
+  onGroupCountChange: (newGroupCount: number) => void;
+  isItemSelected: (attributeGroup: AttributeGroup) => boolean;
+  selectionState: CheckboxChecked;
+  onSelectionChange: (attributeGroup: AttributeGroup, selected: boolean) => void;
+  selectedCount: number;
+  onSelectAllChange: (mode: boolean) => void;
+};
+
 const AttributeGroupsDataGrid: FC<Props> = ({
   attributeGroups,
   onGroupCountChange,
@@ -33,27 +32,29 @@ const AttributeGroupsDataGrid: FC<Props> = ({
   selectionState,
   onSelectionChange,
 }) => {
-  const {refreshOrder} = useAttributeGroupsIndexState();
+  const {refreshOrder, redirect} = useAttributeGroupsIndexState();
   const {sortGranted} = useAttributeGroupPermissions();
-  const userContext = useUserContext();
+  const catalogLocale = useUserContext().get('catalogLocale');
   const {filteredGroups, search} = useFilteredAttributeGroups(attributeGroups);
   const translate = useTranslate();
   const [searchString, setSearchString] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
-  const featureFlags = useFeatureFlags();
+  const {isEnabled} = useFeatureFlags();
 
   useAutoFocus(inputRef);
 
-  const debouncedSearch = useDebounceCallback(search, 300);
-
   const onSearch = (searchValue: string) => {
     setSearchString(searchValue);
-    debouncedSearch(searchValue);
+    search(searchValue);
   };
 
   useEffect(() => {
     onGroupCountChange(filteredGroups.length);
   }, [filteredGroups.length, onGroupCountChange]);
+
+  const shouldDisplayPlaceholder = '' !== searchString && 0 === filteredGroups.length;
+  const shouldDisplayDQICell = isEnabled('data_quality_insights');
+  const canDragAndDrop = sortGranted && false === selectionState && '' === searchString;
 
   return (
     <Wrapper>
@@ -68,58 +69,57 @@ const AttributeGroupsDataGrid: FC<Props> = ({
           {translate('pim_common.result_count', {itemsCount: filteredGroups.length}, filteredGroups.length)}
         </Search.ResultCount>
       </Search>
-      {searchString !== '' && filteredGroups.length === 0 ? (
+      {shouldDisplayPlaceholder ? (
         <NoResults
-          title={translate('pim_enrich.entity.attribute_group.grid.no_search_result')}
+          title={translate('pim_common.no_search_result')}
           subtitle={translate('pim_datagrid.no_results_subtitle')}
         />
       ) : (
-        <>
-          <TableWrapper>
-            <Table
-              isDragAndDroppable={sortGranted && 'mixed' !== selectionState && !selectionState}
-              isSelectable={true}
-              onReorder={order => refreshOrder(order.map(index => attributeGroups[index]))}
-            >
-              <Table.Header>
-                <Table.HeaderCell>{translate('pim_enrich.entity.attribute_group.grid.columns.name')}</Table.HeaderCell>
+        <TableWrapper>
+          <Table
+            isDragAndDroppable={canDragAndDrop}
+            isSelectable={true}
+            onReorder={order => refreshOrder(order.map(index => attributeGroups[index]))}
+          >
+            <Table.Header>
+              <Table.HeaderCell>{translate('pim_common.label')}</Table.HeaderCell>
+              <Table.HeaderCell>
+                {translate('pim_enrich.entity.attribute_group.grid.columns.attribute_count')}
+              </Table.HeaderCell>
+              {shouldDisplayDQICell && (
                 <Table.HeaderCell>
-                  {translate('pim_enrich.entity.attribute_group.grid.columns.attribute_count')}
+                  {translate('akeneo_data_quality_insights.attribute_group.dqi_status')}
                 </Table.HeaderCell>
-                {featureFlags.isEnabled('data_quality_insights') && (
-                  <Table.HeaderCell>
-                    {translate('akeneo_data_quality_insights.attribute_group.dqi_status')}
-                  </Table.HeaderCell>
-                )}
-              </Table.Header>
-              <Table.Body>
-                {filteredGroups.map(attributeGroup => (
-                  <Table.Row
-                    key={attributeGroup.code}
-                    isSelected={isItemSelected(attributeGroup)}
-                    onSelectToggle={(selected: boolean) => onSelectionChange(attributeGroup, selected)}
-                  >
+              )}
+            </Table.Header>
+            <Table.Body>
+              {filteredGroups.map(attributeGroup => (
+                <Table.Row
+                  key={attributeGroup.code}
+                  isSelected={isItemSelected(attributeGroup)}
+                  onSelectToggle={selected => onSelectionChange(attributeGroup, selected)}
+                  onClick={() => redirect(attributeGroup)}
+                >
+                  <Table.Cell rowTitle={true}>
+                    {getLabel(attributeGroup.labels, catalogLocale, attributeGroup.code)}
+                  </Table.Cell>
+                  <Table.Cell>{attributeGroup.attribute_count}</Table.Cell>
+                  {shouldDisplayDQICell && (
                     <Table.Cell>
-                      {getLabel(attributeGroup.labels, userContext.get('catalogLocale'), attributeGroup.code)}
+                      <Badge level={attributeGroup.is_dqi_activated ? 'primary' : 'danger'}>
+                        {translate(
+                          `akeneo_data_quality_insights.attribute_group.${
+                            attributeGroup.is_dqi_activated ? 'activated' : 'disabled'
+                          }`
+                        )}
+                      </Badge>
                     </Table.Cell>
-                    <Table.Cell>{attributeGroup.attribute_count}</Table.Cell>
-                    {featureFlags.isEnabled('data_quality_insights') && (
-                      <Table.Cell>
-                        <Badge level={attributeGroup.is_dqi_activated ? 'primary' : 'danger'}>
-                          {translate(
-                            `akeneo_data_quality_insights.attribute_group.${
-                              attributeGroup.is_dqi_activated ? 'activated' : 'disabled'
-                            }`
-                          )}
-                        </Badge>
-                      </Table.Cell>
-                    )}
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table>
-          </TableWrapper>
-        </>
+                  )}
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </TableWrapper>
       )}
     </Wrapper>
   );

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -13,14 +13,14 @@ const ModalContent = styled.div`
 
 type MassDeleteAttributeGroupsModalProps = {
   selectedCount: number;
-  childrenAttributesCount: number;
-  targetAttributeGroups: AttributeGroup[];
+  impactedAttributesCount: number;
+  availableTargetAttributeGroups: AttributeGroup[];
 };
 
 const MassDeleteAttributeGroupsModal = ({
   selectedCount,
-  childrenAttributesCount,
-  targetAttributeGroups,
+  impactedAttributesCount,
+  availableTargetAttributeGroups,
 }: MassDeleteAttributeGroupsModalProps) => {
   const translate = useTranslate();
   const [isMassDeleteModalOpen, openMassDeleteModal, closeMassDeleteModal] = useBooleanState(false);
@@ -60,18 +60,18 @@ const MassDeleteAttributeGroupsModal = ({
                 selectedCount
               )}
             </p>
-            {0 < childrenAttributesCount && (
+            {0 < impactedAttributesCount && (
               <>
                 <Helper level="error">
                   {translate('pim_enrich.entity.attribute_group.mass_delete.attribute_warning', {
-                    number_of_attribute: childrenAttributesCount,
-                    childrenAttributesCount,
+                    number_of_attribute: impactedAttributesCount,
+                    impactedAttributesCount,
                   })}
                 </Helper>
                 <Field
                   label={translate('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group', {
-                    number_of_attribute: childrenAttributesCount,
-                    childrenAttributesCount,
+                    number_of_attribute: impactedAttributesCount,
+                    impactedAttributesCount,
                   })}
                 >
                   <SelectInput
@@ -81,7 +81,7 @@ const MassDeleteAttributeGroupsModal = ({
                     value={replacementAttributeGroup}
                     openLabel={translate('pim_enrich.entity.attribute_group.mass_delete.open_label')}
                   >
-                    {targetAttributeGroups.map(attributeGroup => (
+                    {availableTargetAttributeGroups.map(attributeGroup => (
                       <SelectInput.Option key={attributeGroup.code} value={attributeGroup.code}>
                         {getLabel(attributeGroup.labels, catalogLocale, attributeGroup.code)}
                       </SelectInput.Option>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -1,15 +1,8 @@
-import React, {useEffect, useRef, useState} from 'react';
-import {AttributeGroup} from '../../../models';
-import {Button, useBooleanState, useAutoFocus, Helper, SelectInput, Field} from 'akeneo-design-system';
-import {DoubleCheckDeleteModal, useTranslate, useUserContext} from '@akeneo-pim-community/shared';
+import React, {useRef, useState} from 'react';
 import styled from 'styled-components';
-import {getLabel} from 'pimui/js/i18n';
-
-type MassDeleteAttributeGroupsModalProps = {
-  selectedAttributeGroups: AttributeGroup[];
-  unselectAttributeGroups: AttributeGroup[];
-  onConfirm: () => void;
-};
+import {Button, useBooleanState, useAutoFocus, Helper, SelectInput, Field} from 'akeneo-design-system';
+import {DoubleCheckDeleteModal, getLabel, useTranslate, useUserContext} from '@akeneo-pim-community/shared';
+import {AttributeGroup} from '../../../models';
 
 const ModalContent = styled.div`
   margin-bottom: 20px;
@@ -18,28 +11,29 @@ const ModalContent = styled.div`
   gap: 20px;
 `;
 
+type MassDeleteAttributeGroupsModalProps = {
+  selectedCount: number;
+  childrenAttributesCount: number;
+  targetAttributeGroups: AttributeGroup[];
+};
+
 const MassDeleteAttributeGroupsModal = ({
-  selectedAttributeGroups,
-  unselectAttributeGroups,
-  onConfirm,
+  selectedCount,
+  childrenAttributesCount,
+  targetAttributeGroups,
 }: MassDeleteAttributeGroupsModalProps) => {
   const translate = useTranslate();
   const [isMassDeleteModalOpen, openMassDeleteModal, closeMassDeleteModal] = useBooleanState(false);
-  const [numberOfAttribute, setNumberOfAttribute] = useState<number>(0);
   const [replacementAttributeGroup, setReplacementAttributeGroup] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const userContext = useUserContext();
+  const catalogLocale = useUserContext().get('catalogLocale');
+
+  const handleConfirm = () => {
+    closeMassDeleteModal();
+    // TODO launch job, will be implemented in RAB-1278
+  };
 
   useAutoFocus(inputRef);
-
-  useEffect(() => {
-    setNumberOfAttribute(
-      selectedAttributeGroups.reduce(
-        (accumulator: number, attributeGroup: AttributeGroup) => accumulator + attributeGroup.attribute_count,
-        0
-      )
-    );
-  }, [selectedAttributeGroups]);
 
   return (
     <>
@@ -53,7 +47,7 @@ const MassDeleteAttributeGroupsModal = ({
             confirmation_word: translate('pim_enrich.entity.attribute_group.mass_delete.confirmation_word'),
           })}
           textToCheck={translate('pim_enrich.entity.attribute_group.mass_delete.confirmation_word')}
-          onConfirm={() => onConfirm()}
+          onConfirm={handleConfirm}
           onCancel={closeMassDeleteModal}
         >
           <ModalContent>
@@ -61,30 +55,24 @@ const MassDeleteAttributeGroupsModal = ({
               {translate(
                 'pim_enrich.entity.attribute_group.mass_delete.confirm',
                 {
-                  count: selectedAttributeGroups.length,
+                  count: selectedCount,
                 },
-                selectedAttributeGroups.length
+                selectedCount
               )}
             </p>
-            {numberOfAttribute > 0 && (
+            {0 < childrenAttributesCount && (
               <>
                 <Helper level="error">
-                  {translate(
-                    'pim_enrich.entity.attribute_group.mass_delete.attribute_warning',
-                    {
-                      number_of_attribute: numberOfAttribute,
-                    },
-                    numberOfAttribute
-                  )}
+                  {translate('pim_enrich.entity.attribute_group.mass_delete.attribute_warning', {
+                    number_of_attribute: childrenAttributesCount,
+                    childrenAttributesCount,
+                  })}
                 </Helper>
                 <Field
-                  label={translate(
-                    'pim_enrich.entity.attribute_group.mass_delete.select_attribute_group',
-                    {
-                      number_of_attribute: numberOfAttribute,
-                    },
-                    numberOfAttribute
-                  )}
+                  label={translate('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group', {
+                    number_of_attribute: childrenAttributesCount,
+                    childrenAttributesCount,
+                  })}
                 >
                   <SelectInput
                     emptyResultLabel={translate('pim_enrich.entity.attribute_group.mass_delete.empty_result_label')}
@@ -93,9 +81,9 @@ const MassDeleteAttributeGroupsModal = ({
                     value={replacementAttributeGroup}
                     openLabel={translate('pim_enrich.entity.attribute_group.mass_delete.open_label')}
                   >
-                    {unselectAttributeGroups.map(attributeGroup => (
+                    {targetAttributeGroups.map(attributeGroup => (
                       <SelectInput.Option key={attributeGroup.code} value={attributeGroup.code}>
-                        {getLabel(attributeGroup.labels, userContext.get('catalogLocale'), attributeGroup.code)}
+                        {getLabel(attributeGroup.labels, catalogLocale, attributeGroup.code)}
                       </SelectInput.Option>
                     ))}
                   </SelectInput>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/attribute-groups/index.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/hooks/attribute-groups/index.ts
@@ -1,4 +1,4 @@
 export * from './useAttributeGroupsIndexState';
 export * from './useAttributeGroupPermissions';
-export * from './useRedirectToAttributeGroup';
 export * from './useFilteredAttributeGroups';
+export * from './useRedirectToAttributeGroup';

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/models/AttributeGroup.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/models/AttributeGroup.ts
@@ -1,3 +1,5 @@
+import {Selection} from 'akeneo-design-system';
+
 type AttributeGroupLabels = {
   [locale: string]: string;
 };
@@ -20,4 +22,29 @@ const toSortedAttributeGroupsArray = (collection: AttributeGroupCollection): Att
   });
 };
 
-export {AttributeGroup, AttributeGroupCollection, AttributeGroupLabels, toSortedAttributeGroupsArray};
+const getImpactedAndTargetAttributeGroups = (
+  attributeGroups: AttributeGroup[],
+  selection: Selection<AttributeGroup>
+): [number, AttributeGroup[]] => {
+  const excludedAttributeGroups = attributeGroups.filter(
+    attributeGroup => !selection.collection.includes(attributeGroup)
+  );
+
+  const [impactedAttributeGroups, targetAttributeGroups] =
+    'in' === selection.mode
+      ? [selection.collection, excludedAttributeGroups]
+      : [excludedAttributeGroups, selection.collection];
+
+  return [
+    impactedAttributeGroups.reduce((totalCount, {attribute_count}) => totalCount + attribute_count, 0),
+    targetAttributeGroups,
+  ];
+};
+
+export {
+  AttributeGroup,
+  AttributeGroupCollection,
+  AttributeGroupLabels,
+  getImpactedAndTargetAttributeGroups,
+  toSortedAttributeGroupsArray,
+};

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AttributeGroupsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AttributeGroupsIndex.tsx
@@ -1,7 +1,5 @@
 import React, {FC, useEffect, useState} from 'react';
-import {PageHeader, useRoute, useTranslate, PimView} from '@akeneo-pim-community/shared';
-import {AttributeGroupsCreateButton, AttributeGroupsDataGrid, MassDeleteAttributeGroupsModal} from '../components';
-import {useAttributeGroupsIndexState} from '../hooks';
+import styled from 'styled-components';
 import {
   Breadcrumb,
   Checkbox,
@@ -11,16 +9,18 @@ import {
   Dropdown,
   ArrowDownIcon,
 } from 'akeneo-design-system';
-import {AttributeGroup} from '../models';
-import styled from 'styled-components';
+import {PageHeader, useRoute, useTranslate, PimView} from '@akeneo-pim-community/shared';
+import {AttributeGroupsCreateButton, AttributeGroupsDataGrid, MassDeleteAttributeGroupsModal} from '../components';
+import {useAttributeGroupsIndexState} from '../hooks';
+import {AttributeGroup, getImpactedAndTargetAttributeGroups} from '../models';
 
-const Content = styled('div')`
+const Content = styled.div`
   flex: 1;
   overflow-y: auto;
   padding: 0 40px;
 `;
 
-const Page = styled('div')`
+const Page = styled.div`
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -33,8 +33,12 @@ const AttributeGroupsIndex: FC = () => {
     useSelection<AttributeGroup>(attributeGroups.length);
   const translate = useTranslate();
   const settingsHomePageRoute = `#${useRoute('pim_settings_index')}`;
-
   const [groupCount, setGroupCount] = useState<number>(attributeGroups.length);
+
+  const [childrenAttributesCount, targetAttributeGroups] = getImpactedAndTargetAttributeGroups(
+    attributeGroups,
+    selection
+  );
 
   useEffect(() => {
     (async () => {
@@ -47,7 +51,7 @@ const AttributeGroupsIndex: FC = () => {
       <PageHeader showPlaceholder={isPending}>
         <PageHeader.Breadcrumb>
           <Breadcrumb>
-            <Breadcrumb.Step href={`#${settingsHomePageRoute}`}>{translate('pim_menu.tab.settings')}</Breadcrumb.Step>
+            <Breadcrumb.Step href={settingsHomePageRoute}>{translate('pim_menu.tab.settings')}</Breadcrumb.Step>
             <Breadcrumb.Step>{translate('pim_enrich.entity.attribute_group.plural_label')}</Breadcrumb.Step>
           </Breadcrumb>
         </PageHeader.Breadcrumb>
@@ -61,7 +65,7 @@ const AttributeGroupsIndex: FC = () => {
           <AttributeGroupsCreateButton />
         </PageHeader.Actions>
         <PageHeader.Title>
-          {translate('pim_enrich.entity.attribute_group.result_count', {count: groupCount.toString()}, groupCount)}
+          {translate('pim_enrich.entity.attribute_group.result_count', {count: groupCount}, groupCount)}
         </PageHeader.Title>
       </PageHeader>
       <Content>
@@ -112,13 +116,11 @@ const AttributeGroupsIndex: FC = () => {
             {translate('pim_enrich.entity.attribute_group.selected', {count: selectedCount}, selectedCount)}
           </Toolbar.LabelContainer>
           <Toolbar.ActionsContainer>
-            {selection.collection.length > 0 && (
+            {0 < selectedCount && (
               <MassDeleteAttributeGroupsModal
-                selectedAttributeGroups={selection.collection}
-                unselectAttributeGroups={attributeGroups.filter(
-                  (attributeGroup: AttributeGroup) => !selection.collection.includes(attributeGroup)
-                )}
-                onConfirm={() => {}}
+                selectedCount={selectedCount}
+                childrenAttributesCount={childrenAttributesCount}
+                targetAttributeGroups={targetAttributeGroups}
               />
             )}
           </Toolbar.ActionsContainer>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AttributeGroupsIndex.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/pages/AttributeGroupsIndex.tsx
@@ -35,7 +35,7 @@ const AttributeGroupsIndex: FC = () => {
   const settingsHomePageRoute = `#${useRoute('pim_settings_index')}`;
   const [groupCount, setGroupCount] = useState<number>(attributeGroups.length);
 
-  const [childrenAttributesCount, targetAttributeGroups] = getImpactedAndTargetAttributeGroups(
+  const [impactedAttributesCount, availableTargetAttributeGroups] = getImpactedAndTargetAttributeGroups(
     attributeGroups,
     selection
   );
@@ -119,8 +119,8 @@ const AttributeGroupsIndex: FC = () => {
             {0 < selectedCount && (
               <MassDeleteAttributeGroupsModal
                 selectedCount={selectedCount}
-                childrenAttributesCount={childrenAttributesCount}
-                targetAttributeGroups={targetAttributeGroups}
+                impactedAttributesCount={impactedAttributesCount}
+                availableTargetAttributeGroups={availableTargetAttributeGroups}
               />
             )}
           </Toolbar.ActionsContainer>

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 test('it renders a confirm modal delete button', () => {
   renderWithProviders(
-    <MassDeleteAttributeGroupsModal selectedCount={0} childrenAttributesCount={0} targetAttributeGroups={[]} />
+    <MassDeleteAttributeGroupsModal selectedCount={0} impactedAttributesCount={0} availableTargetAttributeGroups={[]} />
   );
 
   expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button')).toBeInTheDocument();
@@ -17,8 +17,8 @@ test('it opens a modal with a confirmation input & helper if there are child att
   renderWithProviders(
     <MassDeleteAttributeGroupsModal
       selectedCount={1}
-      childrenAttributesCount={3}
-      targetAttributeGroups={[
+      impactedAttributesCount={3}
+      availableTargetAttributeGroups={[
         {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 2},
       ]}
     />
@@ -37,8 +37,8 @@ test('it can select an attribute group to assign affected attributes', () => {
   renderWithProviders(
     <MassDeleteAttributeGroupsModal
       selectedCount={1}
-      childrenAttributesCount={3}
-      targetAttributeGroups={[
+      impactedAttributesCount={3}
+      availableTargetAttributeGroups={[
         {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
         {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
       ]}
@@ -62,8 +62,8 @@ test('it can close the modal when confirming with the correct word', () => {
   renderWithProviders(
     <MassDeleteAttributeGroupsModal
       selectedCount={1}
-      childrenAttributesCount={3}
-      targetAttributeGroups={[
+      impactedAttributesCount={3}
+      availableTargetAttributeGroups={[
         {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
         {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
       ]}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
@@ -1,105 +1,83 @@
-import '@testing-library/jest-dom';
 import React from 'react';
 import {renderWithProviders} from '@akeneo-pim-community/shared';
 import {MassDeleteAttributeGroupsModal} from '../../../../../../../src';
-import {fireEvent, screen, act} from '@testing-library/react';
+import {screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-test('it renders a confirm modal delete', () => {
+test('it renders a confirm modal delete button', () => {
   renderWithProviders(
-    <MassDeleteAttributeGroupsModal selectedAttributeGroups={[]} unselectAttributeGroups={[]} onConfirm={() => {}} />
+    <MassDeleteAttributeGroupsModal selectedCount={0} childrenAttributesCount={0} targetAttributeGroups={[]} />
   );
 
   expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button')).toBeInTheDocument();
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });
 
-test('it display number of attribute groups to delete', async () => {
+test('it opens a modal with a confirmation input & helper if there are child attributes', () => {
   renderWithProviders(
     <MassDeleteAttributeGroupsModal
-      selectedAttributeGroups={[
-        {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 0},
+      selectedCount={1}
+      childrenAttributesCount={3}
+      targetAttributeGroups={[
+        {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 2},
       ]}
-      unselectAttributeGroups={[]}
-      onConfirm={() => {}}
-      onConfirm={() => {}}
     />
   );
 
-  await act(async () => {
-    fireEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
-  });
+  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
 
+  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
+  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.attribute_warning')).toBeInTheDocument();
   expect(
-    screen.queryByText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group')
-  ).not.toBeInTheDocument();
-  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
+    screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.confirmation_phrase')
+  ).toBeInTheDocument();
 });
 
-test('it display number of attribute affected', async () => {
+test('it can select an attribute group to assign affected attributes', () => {
   renderWithProviders(
     <MassDeleteAttributeGroupsModal
-      selectedAttributeGroups={[
+      selectedCount={1}
+      childrenAttributesCount={3}
+      targetAttributeGroups={[
         {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
         {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
       ]}
-      unselectAttributeGroups={[]}
-      onConfirm={() => {}}
     />
   );
 
-  await act(async () => {
-    fireEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
-  });
-
-  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group')).toBeInTheDocument();
-  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
-});
-
-test('I can select an attribute group to assign affected attributes', async () => {
-  renderWithProviders(
-    <MassDeleteAttributeGroupsModal
-      selectedAttributeGroups={[
-        {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
-        {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
-      ]}
-      unselectAttributeGroups={[
-        {
-          code: 'attribute_group_3',
-          labels: {en_US: 'attribute group 3'},
-          sort_order: 3,
-          is_dqi_activated: false,
-          attribute_count: 4,
-        },
-        {
-          code: 'attribute_group_4',
-          labels: {en_US: 'attribute group 4'},
-          sort_order: 4,
-          is_dqi_activated: false,
-          attribute_count: 4,
-        },
-        {
-          code: 'attribute_group_5',
-          labels: {en_US: 'attribute group 5'},
-          sort_order: 5,
-          is_dqi_activated: false,
-          attribute_count: 4,
-        },
-      ]}
-      onConfirm={() => {}}
-    />
-  );
-
-  await act(async () => {
-    fireEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
-  });
+  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
 
   expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group')).toBeInTheDocument();
   expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
 
-  await act(async () => {
-    fireEvent.click(screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group'));
-  });
+  userEvent.click(screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group'));
 
-  expect(screen.getByText('attribute group 3')).toBeInTheDocument();
-  expect(screen.getByText('attribute group 4')).toBeInTheDocument();
-  expect(screen.getByText('attribute group 5')).toBeInTheDocument();
+  expect(screen.getByText('[attribute_group_1]')).toBeInTheDocument();
+  expect(screen.getByText('[attribute_group_2]')).toBeInTheDocument();
+
+  userEvent.click(screen.getByText('[attribute_group_1]'));
+});
+
+test('it can close the modal when confirming with the correct word', () => {
+  renderWithProviders(
+    <MassDeleteAttributeGroupsModal
+      selectedCount={1}
+      childrenAttributesCount={3}
+      targetAttributeGroups={[
+        {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
+        {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
+      ]}
+    />
+  );
+
+  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+  userEvent.type(
+    screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.confirmation_phrase'),
+    'pim_enrich.entity.attribute_group.mass_delete.confirmation_word'
+  );
+  userEvent.click(screen.getByText('pim_common.delete'));
+
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 });

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/models/AttributeGroup.unit.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/models/AttributeGroup.unit.ts
@@ -1,19 +1,42 @@
-import {toSortedAttributeGroupsArray} from '@akeneo-pim-community/settings-ui/src/models';
+import {
+  AttributeGroup,
+  getImpactedAndTargetAttributeGroups,
+  toSortedAttributeGroupsArray,
+} from '@akeneo-pim-community/settings-ui/src/models';
+import {Selection} from 'akeneo-design-system';
 import {aCollectionOfAttributeGroups} from '../../utils/provideAttributeGroupHelper';
 
-describe('toSortedAttributeGroupsArray', () => {
-  test('it builds an array of attribute groups, sorted by the sort_order property', () => {
-    const collection = aCollectionOfAttributeGroups([
-      {code: 'groupA', order: 2},
-      {code: 'groupB', order: 3},
-      {code: 'groupC', order: 1},
-    ]);
+test('it builds an array of attribute groups, sorted by the sort_order property', () => {
+  const collection = aCollectionOfAttributeGroups([
+    {code: 'groupA', order: 2},
+    {code: 'groupB', order: 3},
+    {code: 'groupC', order: 1},
+  ]);
 
-    const result = toSortedAttributeGroupsArray(collection);
+  const result = toSortedAttributeGroupsArray(collection);
 
-    expect(result.length).toBe(3);
-    expect(result[0].code).toBe('groupC');
-    expect(result[1].code).toBe('groupA');
-    expect(result[2].code).toBe('groupB');
-  });
+  expect(result.length).toBe(3);
+  expect(result[0].code).toBe('groupC');
+  expect(result[1].code).toBe('groupA');
+  expect(result[2].code).toBe('groupB');
+});
+
+test('it can get the total number of impacted attribute groups children & target attribute groups', () => {
+  const attributeGroups: AttributeGroup[] = [
+    {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
+    {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
+    {code: 'attribute_group_3', labels: {}, sort_order: 3, is_dqi_activated: false, attribute_count: 2},
+  ];
+
+  const selection: Selection<AttributeGroup> = {
+    collection: [attributeGroups[0], attributeGroups[2]],
+    mode: 'in',
+  };
+
+  expect(getImpactedAndTargetAttributeGroups(attributeGroups, selection)).toEqual([6, [attributeGroups[1]]]);
+
+  expect(getImpactedAndTargetAttributeGroups(attributeGroups, {...selection, mode: 'not_in'})).toEqual([
+    5,
+    selection.collection,
+  ]);
 });

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/models/AttributeGroup.unit.ts
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/models/AttributeGroup.unit.ts
@@ -37,6 +37,6 @@ test('it can get the total number of impacted attribute groups children & target
 
   expect(getImpactedAndTargetAttributeGroups(attributeGroups, {...selection, mode: 'not_in'})).toEqual([
     5,
-    selection.collection,
+    [attributeGroups[0], attributeGroups[2]],
   ]);
 });


### PR DESCRIPTION

- Disable Drag n Drop when search value is not empty
- Add link to edit attribute group page on row click
- Change Attribute group name header to Label
- Set Attribute group label to brand100 (row title to true)
- Fix attribute children count when select all then unselect one attribute group & Fix target attribute group list when select all then unselect one attribute group with custom utility hook