### PR TITLE
PIM-10874 : fix labels api type consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@
 - PIM-10832: Fix compute completeness job after removing an attribute from a family
 - PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on options import
 - PIM-10870: Fix display of permissions when empty
-- PIM-10860: [SLA] Announcements aren't shown 
+- PIM-10860: [SLA] Announcements aren't shown
+- PIM-10874: fix labels api type consistency
 
 ## Improvements
 

--- a/src/Akeneo/Category/back/ServiceApi/ExternalApiCategory.php
+++ b/src/Akeneo/Category/back/ServiceApi/ExternalApiCategory.php
@@ -108,7 +108,7 @@ class ExternalApiCategory
             'code' => $this->code,
             'parent' => $this->parentCode,
             'updated' => $this->updated,
-            'labels' => $this->labels,
+            'labels' => empty($this->labels) ? (object) [] : $this->labels,
         ];
 
         if ($withPosition) {

--- a/src/Akeneo/Category/back/tests/Integration/ServiceApi/ExternalApiCategoryIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/ServiceApi/ExternalApiCategoryIntegration.php
@@ -55,14 +55,15 @@ class ExternalApiCategoryIntegration extends CategoryTestCase
             'code' => 'my_category',
             'parent' => 'my_parent_category',
             'updated' => '2022-12-13T14:08:10+01:00',
-            'labels' => [],
+            'labels' => (object) [],
         ];
 
         $normalizedExternalApiCategory = ExternalApiCategory::fromDatabase($this->categoryDatabaseData)
             ->normalize(withPosition: false, withEnrichedAttributes: false);
 
         $this->assertIsArray($normalizedExternalApiCategory);
-        $this->assertSame($expectedNormalizedArray, $normalizedExternalApiCategory);
+        $this->assertEquals($expectedNormalizedArray, $normalizedExternalApiCategory);
+        $this->assertIsObject($normalizedExternalApiCategory['labels']);
     }
 
     public function testNormalizeExternalCategoryApiWithEmptyValues(): void
@@ -79,7 +80,7 @@ class ExternalApiCategoryIntegration extends CategoryTestCase
             'code' => 'my_category',
             'parent' => 'my_parent_category',
             'updated' => '2022-12-13T14:08:10+01:00',
-            'labels' => [],
+            'labels' => (object) [],
             'position' => 5,
         ];
 
@@ -87,7 +88,8 @@ class ExternalApiCategoryIntegration extends CategoryTestCase
             ->normalize(withPosition: true, withEnrichedAttributes: false);
 
         $this->assertIsArray($normalizedExternalApiCategory);
-        $this->assertSame($expectedNormalizedArray, $normalizedExternalApiCategory);
+        $this->assertEquals($expectedNormalizedArray, $normalizedExternalApiCategory);
+        $this->assertIsObject($normalizedExternalApiCategory['labels']);
 
     }
 
@@ -97,7 +99,7 @@ class ExternalApiCategoryIntegration extends CategoryTestCase
             'code' => 'my_category',
             'parent' => 'my_parent_category',
             'updated' => '2022-12-13T14:08:10+01:00',
-            'labels' => [],
+            'labels' => (object) [],
             'values' => (object) [],
         ];
 
@@ -106,5 +108,6 @@ class ExternalApiCategoryIntegration extends CategoryTestCase
 
         $this->assertIsArray($normalizedExternalApiCategory);
         $this->assertEquals($expectedNormalizedArray, $normalizedExternalApiCategory);
+        $this->assertIsObject($normalizedExternalApiCategory['labels']);
     }
 }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Empty labels for categories are given by the API as an array while the [documentation mentions an object](https://api.akeneo.com/api-reference.html#get_categories__code_):

![image](https://user-images.githubusercontent.com/114410848/222503914-f9b6f632-f9cb-406c-8bc2-efd6d15487ef.png)

After fix :
![image](https://user-images.githubusercontent.com/114410848/222504081-27f9c47d-64b5-4144-b09d-d08a39420d07.png)
![image](https://user-images.githubusercontent.com/114410848/222504160-612a841f-fce9-4620-8e74-8ba9b6bc6129.png)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
