### PR TITLE
Fix integration test on Category BC

### DIFF
--- a/src/Akeneo/Category/back/tests/Integration/ServiceApi/CategoryQueryIntegration.php
+++ b/src/Akeneo/Category/back/tests/Integration/ServiceApi/CategoryQueryIntegration.php
@@ -153,7 +153,7 @@ SQL;
         $searchCategoriesByCode = ['bike','paddle'];
         $categories = $this->getHandler()->byCodes($searchCategoriesByCode);
 
-        Assert::assertCount(0, $categories);
+        Assert::assertCount(0, iterator_to_array($categories, false));
     }
 
     public function testItDoNotGetCategoriesByIds(): void
@@ -161,7 +161,7 @@ SQL;
         $searchCategoriesByIds = [999,1000];
         $categories = $this->getHandler()->byIds($searchCategoriesByIds);
 
-        Assert::assertCount(0, $categories);
+        Assert::assertCount(0, iterator_to_array($categories, false));
     }
 
     protected function getConfiguration(): Configuration


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Passing a Generator for the parameter corresponding to the haystack in the `assertCount` method is deprecated and will be removed in PHPUnit 10, we have to convert it to array.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
