### PR TITLE
CXP-1415: Add IS NOT EMPTY to CategoryFilter to use it on the ProductQueryBuilder

### DIFF
--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/IsProductBelongingToCatalogQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/IsProductBelongingToCatalogQueryTest.php
@@ -8,6 +8,7 @@ use Akeneo\Catalogs\Application\Persistence\Catalog\GetCatalogQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Catalog\Product\IsProductBelongingToCatalogQueryInterface;
 use Akeneo\Catalogs\Domain\Operator;
 use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Ramsey\Uuid\Uuid;
@@ -94,6 +95,15 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
             'localizable' => true,
         ]);
 
+        $this->createCategory([
+            'parent' => 'master',
+            'code' => 'smartphone',
+            'labels' => [
+                'fr_FR' => 'Telephone intelligent',
+                'en_US' => 'Smartphone'
+            ]
+        ]);
+
         $this->createCatalog(
             id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
             name: 'Store US',
@@ -117,21 +127,30 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
                     'scope' => 'mobile',
                     'locale' => 'en_US',
                 ],
+                'category' => [
+                    'source' => 'categories',
+                    'scope' => null,
+                    'locale' => null,
+                ],
             ],
         );
 
         $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [
             new SetEnabled(true),
             new SetTextValue('name', 'mobile', 'en_US', 'Blue'),
+            new SetCategories(['smartphone']),
         ]);
 
         $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [
             new SetEnabled(true),
             new SetTextValue('name', 'mobile', 'en_US', ''),
+            new SetCategories(['smartphone']),
         ]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
+        $isProductBelongingToCatalog = $this->isProductBelongingToCatalogQuery->execute($catalog, '00380587-3893-46e6-a8c2-8fee6404cc9e');
+        $this->assertTrue($isProductBelongingToCatalog);
         $isProductBelongingToCatalog = $this->isProductBelongingToCatalogQuery->execute($catalog, '8985de43-08bc-484d-aee0-4489a56ba02d');
 
         $this->assertFalse($isProductBelongingToCatalog);
@@ -153,9 +172,12 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
             },
             "title": {
               "type": "string"
+            },
+            "category": {
+              "type": "string"
             }
           },
-          "required": ["title"]
+          "required": ["category"]
         }
         JSON_WRAP;
     }

--- a/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/IsProductBelongingToCatalogQueryTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Persistence/Catalog/Product/IsProductBelongingToCatalogQueryTest.php
@@ -8,7 +8,6 @@ use Akeneo\Catalogs\Application\Persistence\Catalog\GetCatalogQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Catalog\Product\IsProductBelongingToCatalogQueryInterface;
 use Akeneo\Catalogs\Domain\Operator;
 use Akeneo\Catalogs\Test\Integration\IntegrationTestCase;
-use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetEnabled;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetTextValue;
 use Ramsey\Uuid\Uuid;
@@ -95,15 +94,6 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
             'localizable' => true,
         ]);
 
-        $this->createCategory([
-            'parent' => 'master',
-            'code' => 'smartphone',
-            'labels' => [
-                'fr_FR' => 'Telephone intelligent',
-                'en_US' => 'Smartphone'
-            ]
-        ]);
-
         $this->createCatalog(
             id: 'db1079b6-f397-4a6a-bae4-8658e64ad47c',
             name: 'Store US',
@@ -127,30 +117,21 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
                     'scope' => 'mobile',
                     'locale' => 'en_US',
                 ],
-                'category' => [
-                    'source' => 'categories',
-                    'scope' => null,
-                    'locale' => null,
-                ],
             ],
         );
 
         $this->createProduct(Uuid::fromString('00380587-3893-46e6-a8c2-8fee6404cc9e'), [
             new SetEnabled(true),
             new SetTextValue('name', 'mobile', 'en_US', 'Blue'),
-            new SetCategories(['smartphone']),
         ]);
 
         $this->createProduct(Uuid::fromString('8985de43-08bc-484d-aee0-4489a56ba02d'), [
             new SetEnabled(true),
             new SetTextValue('name', 'mobile', 'en_US', ''),
-            new SetCategories(['smartphone']),
         ]);
 
         $catalog = $this->getCatalogQuery->execute('db1079b6-f397-4a6a-bae4-8658e64ad47c');
 
-        $isProductBelongingToCatalog = $this->isProductBelongingToCatalogQuery->execute($catalog, '00380587-3893-46e6-a8c2-8fee6404cc9e');
-        $this->assertTrue($isProductBelongingToCatalog);
         $isProductBelongingToCatalog = $this->isProductBelongingToCatalogQuery->execute($catalog, '8985de43-08bc-484d-aee0-4489a56ba02d');
 
         $this->assertFalse($isProductBelongingToCatalog);
@@ -172,12 +153,9 @@ class IsProductBelongingToCatalogQueryTest extends IntegrationTestCase
             },
             "title": {
               "type": "string"
-            },
-            "category": {
-              "type": "string"
             }
           },
-          "required": ["category"]
+          "required": ["title"]
         }
         JSON_WRAP;
     }

--- a/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/CategoryFilter.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Elasticsearch/Filter/Field/CategoryFilter.php
@@ -45,7 +45,7 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
             throw new \LogicException('The search query builder is not initialized in the filter.');
         }
 
-        if ($operator !== Operators::UNCLASSIFIED) {
+        if ($operator !== Operators::UNCLASSIFIED && $operator !== Operators::IS_NOT_EMPTY) {
             if (!isset($options['type_checking']) || $options['type_checking']) {
                 $this->checkValue($field, $value);
             }
@@ -99,6 +99,14 @@ class CategoryFilter extends AbstractFieldFilter implements FieldFilterInterface
                     'exists' => ['field' => 'categories']
                 ];
                 $this->searchQueryBuilder->addMustNot($clause);
+                break;
+
+            case Operators::IS_NOT_EMPTY:
+                $clause = [
+                    'exists' => ['field' => 'categories'],
+                ];
+
+                $this->searchQueryBuilder->addFilter($clause);
                 break;
 
             case Operators::IN_LIST_OR_UNCLASSIFIED:

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/query_builders.yml
@@ -355,7 +355,7 @@ services:
         arguments:
             - '@pim_catalog.repository.category'
             - ['categories']
-            - ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN']
+            - ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN', 'NOT EMPTY']
         tags:
             - { name: 'pim_catalog.elasticsearch.query.product_filter', priority: 30 }
             - { name: 'pim_catalog.elasticsearch.query.product_model_filter', priority: 30 }

--- a/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/PQB/Filter/Field/CategoryFilterIntegration.php
@@ -92,4 +92,10 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
 
         $this->executeFilter([['categories', Operators::GREATER_OR_EQUAL_THAN, ['categoryA1']]]);
     }
+
+    public function testOperatorNotEmpty()
+    {
+        $result = $this->executeFilter([['categories', Operators::IS_NOT_EMPTY, '']]);
+        $this->assert($result, ['foo']);
+    }
 }

--- a/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/ProductQueryBuilder/Filter/CategoryFilterIntegration.php
@@ -153,6 +153,17 @@ class CategoryFilterIntegration extends AbstractProductQueryBuilderTestCase
     }
 
     /**
+     * @test
+     *
+     * Select all not empty
+     */
+    public function showAllNotEmpty(): void
+    {
+        $result = $this->executeFilter([['categories', Operators::IS_NOT_EMPTY, []]]);
+        $this->assert($result, ['model-shoe', 'another-shoe']);
+    }
+
+    /**
      * Creates the category tree.
      *
      * See the class PhpDoc for more info.

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/CategoryFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/CategoryFilterSpec.php
@@ -2,23 +2,23 @@
 
 namespace Specification\Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field;
 
-use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Category\Infrastructure\Component\Classification\Model\CategoryInterface;
 use Akeneo\Category\Infrastructure\Component\Classification\Repository\CategoryRepositoryInterface;
-use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
-use PhpSpec\ObjectBehavior;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\AbstractFieldFilter;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\Filter\Field\CategoryFilter;
 use Akeneo\Pim\Enrichment\Bundle\Elasticsearch\SearchQueryBuilder;
 use Akeneo\Pim\Enrichment\Component\Product\Exception\InvalidOperatorException;
+use Akeneo\Pim\Enrichment\Component\Product\Exception\ObjectNotFoundException;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\FieldFilterInterface;
 use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
+use PhpSpec\ObjectBehavior;
 
 class CategoryFilterSpec extends ObjectBehavior
 {
     function let(CategoryRepositoryInterface $categoryRepository)
     {
-        $operators = ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN'];
+        $operators = ['IN', 'NOT IN', 'UNCLASSIFIED', 'IN OR UNCLASSIFIED', 'IN CHILDREN', 'NOT IN CHILDREN', 'NOT EMPTY'];
         $this->beConstructedWith($categoryRepository, ['categories'], $operators);
     }
 
@@ -48,6 +48,7 @@ class CategoryFilterSpec extends ObjectBehavior
             'IN OR UNCLASSIFIED',
             'IN CHILDREN',
             'NOT IN CHILDREN',
+            'NOT EMPTY',
         ]);
         $this->supportsOperator('UNCLASSIFIED')->shouldReturn(true);
         $this->supportsOperator('FAKE')->shouldReturn(false);

--- a/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/CategoryFilterSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Bundle/Elasticsearch/Filter/Field/CategoryFilterSpec.php
@@ -141,6 +141,17 @@ class CategoryFilterSpec extends ObjectBehavior
         $this->addFieldFilter('categories', Operators::UNCLASSIFIED, [], 'en_US', 'ecommerce', []);
     }
 
+    function it_adds_a_filter_with_operator_IS_NOT_EMPTY(SearchQueryBuilder $sqb) {
+        $sqb->addFilter(
+            [
+                'exists' => ['field' => 'categories'],
+            ]
+        )->shouldBeCalled();
+
+        $this->setQueryBuilder($sqb);
+        $this->addFieldFilter('categories', Operators::IS_NOT_EMPTY, [], 'en_US', 'ecommerce', []);
+    }
+
     function it_adds_a_filter_with_operator_IN_LIST_OR_UNCLASSIFIED(
         SearchQueryBuilder $sqb,
         CategoryRepositoryInterface $categoryRepository,


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add the "IS NOT EMPTY" filter for Category in order to use it with the ProductQueryBuilder