### PR TITLE
Fix box-sizing reset issue with the svg icons

### DIFF
--- a/front-packages/akeneo-design-system/src/components/Input/DateInput/DateInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/DateInput/DateInput.tsx
@@ -11,10 +11,6 @@ const InputContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-
-  svg {
-    box-sizing: content-box;
-  }
 `;
 
 const Input = styled.input<{readOnly: boolean; invalid: boolean} & AkeneoThemedProps>`
@@ -66,7 +62,7 @@ const Input = styled.input<{readOnly: boolean; invalid: boolean} & AkeneoThemedP
   }
 `;
 
-const commonIconStyles = css<{readOnly: boolean; invalid: boolean} & AkeneoThemedProps>`
+const IconContainer = styled.div<{readOnly: boolean} & AkeneoThemedProps>`
   position: absolute;
   right: 0;
   top: 0;
@@ -74,17 +70,12 @@ const commonIconStyles = css<{readOnly: boolean; invalid: boolean} & AkeneoTheme
   padding-left: 12px;
   pointer-events: none;
   z-index: 1;
-`;
 
-const DatePickerIcon = styled(DateIcon)`
-  background: ${getColor('white')};
-  ${commonIconStyles}
+  background: ${({readOnly}) => (readOnly ? getColor('grey', 20) : getColor('white'))};
 `;
 
 const ReadOnlyIcon = styled(LockIcon)`
   color: ${getColor('grey', 100)};
-  background: ${getColor('grey', 20)};
-  ${commonIconStyles}
 `;
 
 type DateInputProps = Override<
@@ -152,8 +143,10 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
           onClick={handleClick}
           {...rest}
         />
-        {readOnly && <ReadOnlyIcon size={16} />}
-        {!readOnly && <DatePickerIcon size={16} />}
+        <IconContainer readOnly={readOnly}>
+          {readOnly && <ReadOnlyIcon size={16} />}
+          {!readOnly && <DateIcon size={16} />}
+        </IconContainer>
       </InputContainer>
     );
   }

--- a/front-packages/akeneo-design-system/src/components/Input/DateInput/DateInput.tsx
+++ b/front-packages/akeneo-design-system/src/components/Input/DateInput/DateInput.tsx
@@ -11,6 +11,10 @@ const InputContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+
+  svg {
+    box-sizing: content-box;
+  }
 `;
 
 const Input = styled.input<{readOnly: boolean; invalid: boolean} & AkeneoThemedProps>`


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->
Fix the style conflicts when the InputDate is used in the PIM. The icon size is collapsed and the icon is not visible. The fix sets the a wrapper container around the icon to apply the background and hide the native datepicker icon for Firefox.
Expected in the storybook
![Screenshot from 2023-03-06 17-53-09](https://user-images.githubusercontent.com/50582517/223177494-346afe63-0318-41f5-b4cc-e50be5736459.png)

Integration in the PIM
![Screenshot from 2023-03-06 17-20-43](https://user-images.githubusercontent.com/50582517/223177272-e4c63979-23b4-4742-a36f-13b06844185c.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
