### PR TITLE
CPM-985: Fix maximum width for IconCardGrid

### DIFF
--- a/front-packages/akeneo-design-system/src/components/IconCard/IconCard.tsx
+++ b/front-packages/akeneo-design-system/src/components/IconCard/IconCard.tsx
@@ -78,7 +78,7 @@ const Content = styled.div`
 
 const IconCardGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 20px;
 `;
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When an IconCardGrid has only one child IconCard, it takes up the whole grid width, which feels a little weird. This PR makes sure IconCards have a maximum width

Before:
![settings-before](https://user-images.githubusercontent.com/5301298/223477303-a59a227e-c3d2-4ab2-9b9d-7f9ef6f538dd.png)

After:
![settings-after](https://user-images.githubusercontent.com/5301298/223477323-5fbe1ded-b2c1-4787-a88d-59bf60b1d208.png)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
