### PR TITLE
CPM-998: Expose GetCategoryCodes query in Enrichment service API

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Query/GetProductCategoryCodesQuery.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Query/GetProductCategoryCodesQuery.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\Query;
+
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductCategoryCodesQuery
+{
+    /**
+     * @param UuidInterface[] $productUuids
+     */
+    public function __construct(public readonly array $productUuids)
+    {
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/AddCategoriesApplier.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/AddCategoriesApplier.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Product\Application\Applier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\AddCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Webmozart\Assert\Assert;
@@ -30,10 +29,9 @@ class AddCategoriesApplier implements UserIntentApplier
     public function apply(UserIntent $addCategories, ProductInterface $product, int $userId): void
     {
         Assert::isInstanceOf($addCategories, AddCategories::class);
-        $productIdentifier = ProductIdentifier::fromString($product->getIdentifier());
 
-        $categoryCodes = $this->getCategoryCodes->fromProductIdentifiers([$productIdentifier]);
-        $categoryCodes = $categoryCodes[$product->getIdentifier()] ?? [];
+        $categoryCodes = $this->getCategoryCodes->fromProductUuids([$product->getUuid()]);
+        $categoryCodes = $categoryCodes[$product->getUuid()->toString()] ?? [];
 
         $this->productUpdater->update($product, [
             'categories' => \array_values(\array_unique(\array_merge($categoryCodes, $addCategories->categoryCodes()))),

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/RemoveCategoriesApplier.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/Applier/RemoveCategoriesApplier.php
@@ -7,7 +7,6 @@ namespace Akeneo\Pim\Enrichment\Product\Application\Applier;
 use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\RemoveCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use Webmozart\Assert\Assert;
@@ -30,10 +29,9 @@ class RemoveCategoriesApplier implements UserIntentApplier
     public function apply(UserIntent $removeCategories, ProductInterface $product, int $userId): void
     {
         Assert::isInstanceOf($removeCategories, RemoveCategories::class);
-        $productIdentifier = ProductIdentifier::fromString($product->getIdentifier());
 
-        $categoryCodes = $this->getCategoryCodes->fromProductIdentifiers([$productIdentifier]);
-        $categoryCodes = $categoryCodes[$product->getIdentifier()] ?? [];
+        $categoryCodes = $this->getCategoryCodes->fromProductUuids([$product->getUuid()]);
+        $categoryCodes = $categoryCodes[$product->getUuid()->toString()] ?? [];
 
         $this->productUpdater->update($product, [
             'categories' => \array_values(\array_diff($categoryCodes, $removeCategories->categoryCodes())),

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/Category/GetProductCategoryCodesHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/Category/GetProductCategoryCodesHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Application\Category;
+
+use Akeneo\Pim\Enrichment\Product\API\Query\GetProductCategoryCodesQuery;
+use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductCategoryCodesHandler
+{
+    public function __construct(private readonly GetCategoryCodes $getCategoryCodes)
+    {
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function __invoke(GetProductCategoryCodesQuery $query): array
+    {
+        return $this->getCategoryCodes->fromProductUuids($query->productUuids);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Domain/Query/GetCategoryCodes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Product\Domain\Query;
 
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Ramsey\Uuid\UuidInterface;
 
 /**
@@ -13,19 +12,6 @@ use Ramsey\Uuid\UuidInterface;
  */
 interface GetCategoryCodes
 {
-    /**
-     * @deprecated
-     *
-     * @param ProductIdentifier[] $productIdentifiers
-     * @return array<string, string[]> example:
-     *  {
-     *      "product1": ["categoryA", "categoryB"],
-     *      "product2": ["categoryA"],
-     *      ...
-     *  }
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): array;
-
     /**
      * @param UuidInterface[] $uuids
      * @return array<string, string[]> example:

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/SqlGetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Query/SqlGetCategoryCodes.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Enrichment\Product\Infrastructure\Query;
 
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Doctrine\DBAL\Connection;
 use Ramsey\Uuid\UuidInterface;
@@ -16,72 +15,8 @@ use Webmozart\Assert\Assert;
  */
 final class SqlGetCategoryCodes implements GetCategoryCodes
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): array
-    {
-        if ([] === $productIdentifiers) {
-            return [];
-        }
-
-        Assert::allIsInstanceOf($productIdentifiers, ProductIdentifier::class);
-        $stringProductIdentifiers = \array_map(
-            static fn (ProductIdentifier $productIdentifier): string => $productIdentifier->asString(),
-            $productIdentifiers
-        );
-
-        $sql = <<<SQL
-        WITH
-        existing_product AS (
-            SELECT uuid, product_model_id, identifier FROM pim_catalog_product WHERE identifier IN (:product_identifiers)
-        )
-        SELECT p.identifier, IF(COUNT(mc.category_code) = 0, JSON_ARRAY(), JSON_ARRAYAGG(mc.category_code)) as category_codes
-        FROM 
-            existing_product p
-            LEFT JOIN (
-                SELECT
-                    p.identifier, c.code AS category_code
-                FROM existing_product p
-                    INNER JOIN pim_catalog_category_product cp ON cp.product_uuid = p.uuid
-                    INNER JOIN pim_catalog_category c ON c.id = cp.category_id
-                UNION ALL
-                SELECT
-                    p.identifier, c.code AS category_code
-                FROM existing_product p
-                    INNER JOIN pim_catalog_product_model sub ON sub.id = p.product_model_id
-                    INNER JOIN pim_catalog_category_product_model cpm ON cpm.product_model_id = sub.id
-                    INNER JOIN pim_catalog_category c ON c.id = cpm.category_id
-                UNION ALL
-                SELECT
-                    p.identifier, c.code AS category_code
-                FROM existing_product p
-                    INNER JOIN pim_catalog_product_model sub ON sub.id = p.product_model_id
-                    INNER JOIN pim_catalog_product_model root ON root.id = sub.parent_id
-                    INNER JOIN pim_catalog_category_product_model cpm ON cpm.product_model_id = root.id
-                    INNER JOIN pim_catalog_category c ON c.id = cpm.category_id
-            ) AS mc ON mc.identifier = p.identifier
-        GROUP BY p.identifier
-        SQL;
-
-        $results = $this->connection->executeQuery(
-            $sql,
-            ['product_identifiers' => $stringProductIdentifiers],
-            ['product_identifiers' => Connection::PARAM_STR_ARRAY]
-        )->fetchAllAssociative();
-
-        $indexedResults = [];
-        foreach ($results as $result) {
-            /** @var string[] $decoded */
-            $decoded = \json_decode($result['category_codes'], true);
-            $indexedResults[(string) $result['identifier']] = $decoded;
-        }
-
-        return $indexedResults;
     }
 
     /**

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/handlers.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/handlers.yml
@@ -26,3 +26,9 @@ services:
             - '@validator'
         tags:
             - { name: 'akeneo.pim.enrichment.product.query_handler', query: 'Akeneo\Pim\Enrichment\Product\API\Query\GetProductUuidsQuery' }
+
+    Akeneo\Pim\Enrichment\Product\Application\Category\GetProductCategoryCodesHandler:
+        arguments:
+            - '@Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes'
+        tags:
+            - { name: 'akeneo.pim.enrichment.product.query_handler', query: 'Akeneo\Pim\Enrichment\Product\API\Query\GetProductCategoryCodesQuery' }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetCategoryCodes.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/InMemory/InMemoryGetCategoryCodes.php
@@ -21,27 +21,6 @@ final class InMemoryGetCategoryCodes implements GetCategoryCodes
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function fromProductIdentifiers(array $productIdentifiers): array
-    {
-        $productIdentifiers = \array_map(
-            static fn (ProductIdentifier $identifier): string => \strtolower($identifier->asString()),
-            $productIdentifiers
-        );
-
-        $results = [];
-        /** @var ProductInterface $product */
-        foreach ($this->productRepository->findAll() as $product) {
-            if (\in_array(\strtolower($product->getIdentifier()), $productIdentifiers)) {
-                $results[$product->getIdentifier()] = $product->getCategoryCodes();
-            }
-        }
-
-        return $results;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function fromProductUuids(array $productUuids): array

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetCategoryCodesSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Acceptance/Specification/InMemory/InMemoryGetCategoryCodesSpec.php
@@ -7,7 +7,6 @@ namespace Specification\Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory;
 use Akeneo\Category\Infrastructure\Component\Model\Category;
 use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Component\Product\Repository\ProductRepositoryInterface;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Pim\Enrichment\Product\Test\Acceptance\InMemory\InMemoryGetCategoryCodes;
 use PhpSpec\ObjectBehavior;
@@ -24,40 +23,6 @@ class InMemoryGetCategoryCodesSpec extends ObjectBehavior
     {
         $this->shouldHaveType(InMemoryGetCategoryCodes::class);
         $this->shouldImplement(GetCategoryCodes::class);
-    }
-
-    function it_returns_the_category_codes(ProductRepositoryInterface $productRepository)
-    {
-        $master = new Category();
-        $master->setCode('master');
-        $print = new Category();
-        $print->setCode('print');
-
-        $product1 = new Product();
-        $product1->setIdentifier('id1');
-        $product1->addCategory($master);
-        $product1->addCategory($print);
-
-        $product2 = new Product();
-        $product2->setIdentifier('id2');
-        $product2->addCategory($master);
-
-        $product3 = new Product();
-        $product3->setIdentifier('id3');
-
-        $productRepository->findAll()->willReturn([$product1, $product2, $product3]);
-
-        $this->fromProductIdentifiers([])->shouldReturn([]);
-        $this->fromProductIdentifiers([
-            ProductIdentifier::fromString('id1'),
-            ProductIdentifier::fromString('ID2'),
-            ProductIdentifier::fromString('id3'),
-            ProductIdentifier::fromString('unknown'),
-        ])->shouldReturn([
-            'id1' => ['master', 'print'],
-            'id2' => ['master'],
-            'id3' => [],
-        ]);
     }
 
     function it_returns_the_category_codes_by_uuid(ProductRepositoryInterface $productRepository)

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/EnrichmentProductTestCase.php
@@ -9,6 +9,7 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\ProductModelInterface;
 use Akeneo\Pim\Enrichment\Product\API\Command\UpsertProductCommand;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\QuantifiedAssociation\QuantifiedEntity;
 use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductIdentifier;
+use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
 use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Pim\Structure\Component\Model\FamilyInterface;
@@ -100,6 +101,20 @@ abstract class EnrichmentProductTestCase extends TestCase
         $command = UpsertProductCommand::createWithIdentifier(
             userId: $this->getUserId('peter'),
             productIdentifier: ProductIdentifier::fromIdentifier($identifier),
+            userIntents: $userIntents
+        );
+        $this->commandMessageBus->dispatch($command);
+        $this->getContainer()->get('pim_catalog.validator.unique_value_set')->reset();
+        $this->get('akeneo.pim.storage_utils.cache.cached_queries_clearer')->clear();
+        $this->clearDoctrineUoW();
+    }
+
+    protected function createProductWithUuid(string $uuid, array $userIntents): void
+    {
+        $this->get('akeneo_integration_tests.helper.authenticator')->logIn('peter');
+        $command = UpsertProductCommand::createWithUuid(
+            userId: $this->getUserId('peter'),
+            productUuid: ProductUuid::fromString($uuid),
             userIntents: $userIntents
         );
         $this->commandMessageBus->dispatch($command);

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/Category/GetProductCategoryCodesHandlerIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Handler/Category/GetProductCategoryCodesHandlerIntegration.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Test\Integration\Handler\Category;
+
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
+use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
+use Akeneo\Pim\Enrichment\Product\API\Query\GetProductCategoryCodesQuery;
+use Akeneo\Test\Pim\Enrichment\Product\Integration\EnrichmentProductTestCase;
+use PHPUnit\Framework\Assert;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class GetProductCategoryCodesHandlerIntegration extends EnrichmentProductTestCase
+{
+    private const UUID_FOO = 'eac5393e-8de8-4d3a-90db-93bbba8b4ffb';
+    private const UUID_BAR = '49aa038f-b7d9-465c-b12d-88f048d60dd4';
+    private const UUID_BAZ = 'a76cbde9-929b-4d2c-8ff1-a69e48cf063d';
+
+    /** @test */
+    public function it_gets_category_codes_from_product_uuids()
+    {
+        $uuids = [
+            Uuid::fromString(self::UUID_FOO),
+            Uuid::fromString(self::UUID_BAR),
+            Uuid::fromString(self::UUID_BAZ),
+            Uuid::uuid4(),
+        ];
+
+        $envelope = $this->queryMessageBus->dispatch(new GetProductCategoryCodesQuery($uuids));
+        $handledStamp = $envelope->last(HandledStamp::class);
+
+        Assert::assertInstanceOf(HandledStamp::class, $handledStamp);
+        Assert::assertEqualsCanonicalizing(
+            [
+                self::UUID_FOO => ['print', 'sales'],
+                self::UUID_BAR => ['sales', 'suppliers'],
+                self::UUID_BAZ => [],
+            ],
+            $handledStamp->getResult()
+        );
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loadEnrichmentProductFunctionalFixtures();
+        $this->createProductModel('root_pm', 'color_variant_accessories', ['categories' => ['print']]);
+        $this->createProductWithUuid(self::UUID_FOO, [
+            new ChangeParent('root_pm'),
+            new SetIdentifierValue('sku', 'foo'),
+            new SetCategories(['sales']),
+            new SetSimpleSelectValue('main_color', null, null, 'red')
+        ]);
+        $this->createProductWithUuid(self::UUID_BAR, [
+            new SetIdentifierValue('sku', 'bar'),
+            new SetCategories(['sales', 'suppliers']),
+        ]);
+        $this->createProductWithUuid(self::UUID_BAZ, [
+            new SetIdentifierValue('sku', 'baz'),
+        ]);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/SqlGetCategoryCodesIntegration.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Integration/Query/SqlGetCategoryCodesIntegration.php
@@ -12,7 +12,6 @@ use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetIdentifierValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\UserIntent;
 use Akeneo\Pim\Enrichment\Product\API\ValueObject\ProductUuid;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
@@ -81,28 +80,6 @@ final class SqlGetCategoryCodesIntegration extends TestCase
                 new SetSimpleSelectValue('a_simple_select', null, null, 'optionB'),
                 new SetCategories(['categoryA', 'categoryA1']),
             ]
-        );
-    }
-
-    /** @test */
-    public function it_gets_product_categories_by_identifier(): void
-    {
-        Assert::assertSame([], $this->getCategoryCodes->fromProductIdentifiers([]));
-        $this->assertEqualArrays(
-            [
-                'foo' => ['categoryA', 'categoryB'],
-                'bar' => ['categoryA', 'categoryA1'],
-                'baz' => ['categoryA', 'categoryA1', 'categoryC'],
-            ],
-            $this->getCategoryCodes->fromProductIdentifiers(
-                [
-                    ProductIdentifier::fromString('foo'),
-                    ProductIdentifier::fromString('unknown_sku'),
-                    ProductIdentifier::fromString('baz'),
-                    ProductIdentifier::fromString('bar'),
-                    ProductIdentifier::fromString('foo'),
-                ]
-            )
         );
     }
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/AddCategoriesApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/AddCategoriesApplierSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\AddCategories;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\AddCategoriesApplier;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\UserIntentApplier;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -36,9 +35,8 @@ class AddCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
-            ->willReturn(['id' => []]);
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
+            ->willReturn([$product->getUuid()->toString() => []]);
 
         $productUpdater->update($product, ['categories' => ['supplier', 'print']])->shouldBeCalledOnce();
 
@@ -50,9 +48,8 @@ class AddCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
-            ->willReturn(['id' => ['print', 'master']]);
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
+            ->willReturn([$product->getUuid()->toString() => ['print', 'master']]);
 
         $productUpdater->update($product, ['categories' => ['print', 'master', 'supplier']])->shouldBeCalledOnce();
 
@@ -64,8 +61,7 @@ class AddCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
             ->willReturn([]);
 
         $productUpdater->update($product, ['categories' => ['supplier', 'print']])->shouldBeCalledOnce();

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/RemoveCategoriesApplierSpec.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/Specification/Application/Applier/RemoveCategoriesApplierSpec.php
@@ -8,7 +8,6 @@ use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\RemoveCategories;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\RemoveCategoriesApplier;
 use Akeneo\Pim\Enrichment\Product\Application\Applier\UserIntentApplier;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
 use PhpSpec\ObjectBehavior;
@@ -36,9 +35,8 @@ class RemoveCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
-            ->willReturn(['id' => []]);
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
+            ->willReturn([$product->getUuid()->toString() => []]);
 
         $productUpdater->update($product, ['categories' => []])->shouldBeCalledOnce();
 
@@ -50,9 +48,8 @@ class RemoveCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
-            ->willReturn(['id' => ['print', 'master', 'sales']]);
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
+            ->willReturn([$product->getUuid()->toString() => ['print', 'master', 'sales']]);
 
         $productUpdater->update($product, ['categories' => ['master', 'sales']])->shouldBeCalledOnce();
 
@@ -64,8 +61,7 @@ class RemoveCategoriesApplierSpec extends ObjectBehavior
         GetCategoryCodes $getCategoryCodes
     ) {
         $product = new Product();
-        $product->setIdentifier('id');
-        $getCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('id')])
+        $getCategoryCodes->fromProductUuids([$product->getUuid()])
             ->willReturn([]);
 
         $productUpdater->update($product, ['categories' => []])->shouldBeCalledOnce();

--- a/tests/back/Category/Integration/Query/SqlGetCategoryCodesIntegration.php
+++ b/tests/back/Category/Integration/Query/SqlGetCategoryCodesIntegration.php
@@ -7,7 +7,6 @@ namespace Akeneo\Test\Category\Integration\Query;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ChangeParent;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetCategories;
 use Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\SetSimpleSelectValue;
-use Akeneo\Pim\Enrichment\Product\Domain\Model\ProductIdentifier;
 use Akeneo\Pim\Enrichment\Product\Domain\Query\GetCategoryCodes;
 use Akeneo\Pim\Enrichment\Product\Infrastructure\Query\SqlGetCategoryCodes;
 use Akeneo\Test\Pim\Enrichment\Product\Integration\EnrichmentProductTestCase;
@@ -24,34 +23,6 @@ final class SqlGetCategoryCodesIntegration extends EnrichmentProductTestCase
         $this->sqlGetCategoryCodes = $this->get(GetCategoryCodes::class);
 
         $this->loadEnrichmentProductFunctionalFixtures();
-    }
-
-    /** @test */
-    public function it_returns_category_codes_for_products()
-    {
-        $this->createProduct('product_without_category', []);
-        $this->createProduct('product_with_categories', [new SetCategories(['suppliers', 'print'])]);
-
-        Assert::assertSame([], $this->sqlGetCategoryCodes->fromProductIdentifiers([]));
-        Assert::assertSame(
-            ['product_without_category' => []],
-            $this->sqlGetCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('product_without_category')])
-        );
-        Assert::assertEqualsCanonicalizing(
-            ['product_with_categories' => ['suppliers', 'print']],
-            $this->sqlGetCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('product_with_categories')])
-        );
-        Assert::assertEqualsCanonicalizing(
-            [
-                'product_without_category' => [],
-                'product_with_categories' => ['suppliers', 'print'],
-            ],
-            $this->sqlGetCategoryCodes->fromProductIdentifiers([
-                ProductIdentifier::fromString('product_without_category'),
-                ProductIdentifier::fromString('product_with_categories'),
-                ProductIdentifier::fromString('unknown'),
-            ])
-        );
     }
 
     /** @test */
@@ -81,33 +52,6 @@ final class SqlGetCategoryCodesIntegration extends EnrichmentProductTestCase
                 $productWithCategoriesUuid,
                 Uuid::uuid4(),
             ])
-        );
-    }
-
-    /** @test */
-    public function it_returns_category_codes_for_variant_products()
-    {
-        $this->createProductModel('root', 'color_variant_accessories', [
-            'categories' => ['print'],
-        ]);
-        $this->createProduct('variant_product1', [
-            new ChangeParent('root'),
-            new SetCategories(['suppliers']),
-            new SetSimpleSelectValue('main_color', null, null, 'red')
-        ]);
-        $this->createProduct('variant_product2', [
-            new ChangeParent('root'),
-            new SetCategories(['suppliers', 'print']),
-            new SetSimpleSelectValue('main_color', null, null, 'green')
-        ]);
-
-        Assert::assertEqualsCanonicalizing(
-            ['variant_product1' => ['print', 'suppliers']],
-            $this->sqlGetCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('variant_product1')])
-        );
-        Assert::assertEqualsCanonicalizing(
-            ['variant_product2' => ['print', 'suppliers']],
-            $this->sqlGetCategoryCodes->fromProductIdentifiers([ProductIdentifier::fromString('variant_product2')])
         );
     }
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

Expose the GetCategoryCodes query in Enrichment service API, so it can be used by external contexts. I also removed the deprecated `fromProductIdentifiers()` method.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
