### PR TITLE
RAB-1365: Bug fix on mass delete attribute group

### DIFF
--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -29,7 +29,7 @@ const DoubleCheckDeleteModal = ({
   return (
     <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete && textIsConfirmed} onConfirm={handleConfirm}>
       {children}
-      <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} onSubmit={onConfirm} />
+      <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} onSubmit={handleConfirm} />
     </DeleteModal>
   );
 };

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -16,10 +16,10 @@ const DoubleCheckDeleteModal = ({
   ...deleteModalProps
 }: DoubleCheckDeleteModalProps) => {
   const [value, setValue] = useState('');
-  const textIsConfirmed = value === textToCheck;
+  const canConfirm = canConfirmDelete && value === textToCheck;
 
   const handleConfirm = () => {
-    if (!canConfirmDelete || !textIsConfirmed) {
+    if (!canConfirm) {
       return;
     }
 
@@ -27,7 +27,7 @@ const DoubleCheckDeleteModal = ({
   };
 
   return (
-    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete && textIsConfirmed} onConfirm={handleConfirm}>
+    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirm} onConfirm={handleConfirm}>
       {children}
       <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} onSubmit={handleConfirm} />
     </DeleteModal>

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -18,8 +18,16 @@ const DoubleCheckDeleteModal = ({
   const [value, setValue] = useState('');
   const textIsConfirmed = value === textToCheck;
 
+  const handleConfirm = () => {
+    if (!textIsConfirmed) {
+      return;
+    }
+
+    onConfirm();
+  }
+
   return (
-    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete && textIsConfirmed} onConfirm={onConfirm}>
+    <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete && textIsConfirmed} onConfirm={handleConfirm}>
       {children}
       <TextField value={value} label={doubleCheckInputLabel} onChange={setValue} onSubmit={onConfirm} />
     </DeleteModal>

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -24,7 +24,7 @@ const DoubleCheckDeleteModal = ({
     }
 
     onConfirm();
-  }
+  };
 
   return (
     <DeleteModal {...deleteModalProps} canConfirmDelete={canConfirmDelete && textIsConfirmed} onConfirm={handleConfirm}>

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.tsx
@@ -19,7 +19,7 @@ const DoubleCheckDeleteModal = ({
   const textIsConfirmed = value === textToCheck;
 
   const handleConfirm = () => {
-    if (!textIsConfirmed) {
+    if (!canConfirmDelete || !textIsConfirmed) {
       return;
     }
 

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
@@ -63,4 +63,4 @@ test('It does not call onConfirm when user press enter and the text is not confi
   fireEvent.keyDown(document, '{enter}');
 
   expect(handleConfirm).not.toBeCalled();
-})
+});

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {screen} from '@testing-library/react';
+import {screen, fireEvent} from '@testing-library/react';
 import {renderWithProviders} from '../tests';
 import {DoubleCheckDeleteModal} from './DoubleCheckDeleteModal';
 import userEvent from '@testing-library/user-event';
@@ -43,3 +43,24 @@ test('It allows deletion when user type the text to check', () => {
   userEvent.click(screen.getByText('pim_common.delete'));
   expect(handleConfirm).toBeCalled();
 });
+
+test('It does not call onConfirm when user press enter and the text is not confirmed', () => {
+  const handleConfirm = jest.fn();
+
+  renderWithProviders(
+    <DoubleCheckDeleteModal
+      title="Entity"
+      onCancel={jest.fn()}
+      onConfirm={handleConfirm}
+      doubleCheckInputLabel="a_double_check_input_label"
+      textToCheck="delete"
+    >
+      Are you sure you want to remove this entity ?
+    </DoubleCheckDeleteModal>
+  );
+
+  userEvent.type(screen.getByLabelText('a_double_check_input_label'), 'eteled');
+  fireEvent.keyDown(document, '{enter}');
+
+  expect(handleConfirm).not.toBeCalled();
+})

--- a/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
+++ b/front-packages/shared/src/components/DoubleCheckDeleteModal.unit.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {screen, fireEvent} from '@testing-library/react';
+import {screen} from '@testing-library/react';
 import {renderWithProviders} from '../tests';
 import {DoubleCheckDeleteModal} from './DoubleCheckDeleteModal';
 import userEvent from '@testing-library/user-event';
@@ -59,8 +59,8 @@ test('It does not call onConfirm when user press enter and the text is not confi
     </DoubleCheckDeleteModal>
   );
 
-  userEvent.type(screen.getByLabelText('a_double_check_input_label'), 'eteled');
-  fireEvent.keyDown(document, '{enter}');
+  const input = screen.getByLabelText('a_double_check_input_label');
+  userEvent.type(input, 'eteled{enter}');
 
   expect(handleConfirm).not.toBeCalled();
 });

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -46,7 +46,7 @@ const MassDeleteAttributeGroupsModal = ({
 
   useEffect(() => {
     setReplacementAttributeGroup(null);
-  }, [isMassDeleteModalOpen]);
+  }, [setReplacementAttributeGroup, isMassDeleteModalOpen]);
 
   const handleLaunchMassDelete = async () => {
     if (isLoading) return;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState, useEffect} from 'react';
+import React, {useRef, useState} from 'react';
 import styled from 'styled-components';
 import {Button, useBooleanState, useAutoFocus, Helper, SelectInput, Field} from 'akeneo-design-system';
 import {
@@ -44,9 +44,10 @@ const MassDeleteAttributeGroupsModal = ({
 
   useAutoFocus(inputRef);
 
-  useEffect(() => {
+  const handleOpenMassDeleteModal = () => {
     setReplacementAttributeGroup(null);
-  }, [setReplacementAttributeGroup, isMassDeleteModalOpen]);
+    openMassDeleteModal();
+  };
 
   const handleLaunchMassDelete = async () => {
     if (isLoading) return;
@@ -62,7 +63,7 @@ const MassDeleteAttributeGroupsModal = ({
 
   return (
     <>
-      <Button level="danger" onClick={openMassDeleteModal}>
+      <Button level="danger" onClick={handleOpenMassDeleteModal}>
         {translate('pim_common.delete')}
       </Button>
       {isMassDeleteModalOpen && (

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/src/components/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.tsx
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react';
+import React, {useRef, useState, useEffect} from 'react';
 import styled from 'styled-components';
 import {Button, useBooleanState, useAutoFocus, Helper, SelectInput, Field} from 'akeneo-design-system';
 import {
@@ -43,6 +43,10 @@ const MassDeleteAttributeGroupsModal = ({
   );
 
   useAutoFocus(inputRef);
+
+  useEffect(() => {
+    setReplacementAttributeGroup(null);
+  }, [isMassDeleteModalOpen]);
 
   const handleLaunchMassDelete = async () => {
     if (isLoading) return;

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
@@ -165,22 +165,13 @@ test('it resets assigned attribute group when modal is closed', () => {
     />
   );
 
-  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
-
-  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group')).toBeInTheDocument();
-  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
-
+  userEvent.click(screen.getByText('pim_common.delete'));
   userEvent.click(screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group'));
-
-  expect(screen.getByText('[attribute_group_1]')).toBeInTheDocument();
-  expect(screen.getByText('[attribute_group_2]')).toBeInTheDocument();
-
   userEvent.click(screen.getByText('[attribute_group_1]'));
-
   expect(screen.getByText('[attribute_group_1]')).toBeInTheDocument();
 
   userEvent.click(screen.getByText('pim_common.cancel'));
-  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
+  userEvent.click(screen.getByText('pim_common.delete'));
 
   expect(screen.queryByText('[attribute_group_1]')).not.toBeInTheDocument();
 });

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/workspaces/settings-ui/tests/front/unit/components/shared/datagrids/attribute-groups/MassDeleteAttributeGroupsModal.unit.tsx
@@ -151,3 +151,36 @@ test('it launch mass delete', async () => {
   });
   expect(launchMassDelete).toBeCalled();
 });
+
+test('it resets assigned attribute group when modal is closed', () => {
+  renderWithProviders(
+    <MassDeleteAttributeGroupsModal
+      impactedAttributeGroups={[
+        {code: 'attribute_group_3', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 3},
+      ]}
+      availableTargetAttributeGroups={[
+        {code: 'attribute_group_1', labels: {}, sort_order: 1, is_dqi_activated: false, attribute_count: 4},
+        {code: 'attribute_group_2', labels: {}, sort_order: 2, is_dqi_activated: false, attribute_count: 5},
+      ]}
+    />
+  );
+
+  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
+
+  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group')).toBeInTheDocument();
+  expect(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.confirm')).toBeInTheDocument();
+
+  userEvent.click(screen.getByLabelText('pim_enrich.entity.attribute_group.mass_delete.select_attribute_group'));
+
+  expect(screen.getByText('[attribute_group_1]')).toBeInTheDocument();
+  expect(screen.getByText('[attribute_group_2]')).toBeInTheDocument();
+
+  userEvent.click(screen.getByText('[attribute_group_1]'));
+
+  expect(screen.getByText('[attribute_group_1]')).toBeInTheDocument();
+
+  userEvent.click(screen.getByText('pim_common.cancel'));
+  userEvent.click(screen.getByText('pim_enrich.entity.attribute_group.mass_delete.button'));
+
+  expect(screen.queryByText('[attribute_group_1]')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I tried to fix 2 UI glitchs : 
- We need to reset `MassDeleteAttributeGroupsModal` state to avoid having the replacement attribute group kept between different selection
- We need to override the `onChange` props of `DeleteModal` to avoid user bypassing double check (the modal still closes when user hints `Enter` : I don't know if I can disallow that and if there is a real interest as the job is not launched anymore)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
