### PR TITLE
CPM-1002: Fix SimpleSelectProperty normalize to not retrieve scope and locale if not needed

### DIFF
--- a/components/identifier-generator/back/src/Domain/Model/Property/SimpleSelectProperty.php
+++ b/components/identifier-generator/back/src/Domain/Model/Property/SimpleSelectProperty.php
@@ -18,8 +18,8 @@ use Webmozart\Assert\Assert;
  *  type: 'simple_select',
  *  attributeCode: string,
  *  process: ProcessNormalized,
- *  scope: string|null,
- *  locale: string|null
+ *  scope?: string|null,
+ *  locale?: string|null
  * }
  */
 final class SimpleSelectProperty implements PropertyInterface
@@ -49,13 +49,20 @@ final class SimpleSelectProperty implements PropertyInterface
      */
     public function normalize(): array
     {
-        return [
+        $simpleSelectProperty = [
             'type' => self::TYPE,
             'attributeCode' => $this->attributeCode,
             'process' => $this->process->normalize(),
-            'scope' => $this->scope,
-            'locale' => $this->locale,
         ];
+
+        if (null !== $this->scope) {
+            $simpleSelectProperty['scope'] = $this->scope;
+        }
+        if (null !== $this->locale) {
+            $simpleSelectProperty['locale'] = $this->locale;
+        }
+
+        return $simpleSelectProperty;
     }
 
     public static function fromNormalized(array $normalizedProperty): PropertyInterface

--- a/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Controller/CreateIdentifierGeneratorWithSimpleSelectEndToEnd.php
+++ b/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Controller/CreateIdentifierGeneratorWithSimpleSelectEndToEnd.php
@@ -53,8 +53,8 @@ final class CreateIdentifierGeneratorWithSimpleSelectEndToEnd extends Controller
         Assert::assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $uuid = $this->getUuidFromCode('my_new_generator');
         Assert::assertSame(
-            sprintf(
-                '{"uuid":"%s","code":"my_new_generator","conditions":[],"structure":[{"type":"free_text","string":"AKN"},{"type":"simple_select","attributeCode":"a_simple_select_color","process":{"type":"no"},"scope":null,"locale":null}],"labels":{"en_US":"My new generator","fr_FR":"Mon nouveau g\u00e9n\u00e9rateur"},"target":"sku","delimiter":"-","text_transformation":"no"}',
+            \sprintf(
+                '{"uuid":"%s","code":"my_new_generator","conditions":[],"structure":[{"type":"free_text","string":"AKN"},{"type":"simple_select","attributeCode":"a_simple_select_color","process":{"type":"no"}}],"labels":{"en_US":"My new generator","fr_FR":"Mon nouveau g\u00e9n\u00e9rateur"},"target":"sku","delimiter":"-","text_transformation":"no"}',
                 $uuid
             ),
             $response->getContent()
@@ -88,7 +88,7 @@ final class CreateIdentifierGeneratorWithSimpleSelectEndToEnd extends Controller
         Assert::assertSame(Response::HTTP_CREATED, $response->getStatusCode());
         $uuid = $this->getUuidFromCode('my_new_generator');
         Assert::assertSame(
-            sprintf(
+            \sprintf(
                 '{"uuid":"%s","code":"my_new_generator","conditions":[],"structure":[{"type":"free_text","string":"AKN"},{"type":"simple_select","attributeCode":"a_simple_select_color_scopable_and_localizable","process":{"type":"no"},"scope":"ecommerce","locale":"en_US"}],"labels":{"en_US":"My new generator","fr_FR":"Mon nouveau g\u00e9n\u00e9rateur"},"target":"sku","delimiter":"-","text_transformation":"no"}',
                 $uuid
             ),

--- a/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Controller/GetIdentifierGeneratorControllerEndToEnd.php
+++ b/components/identifier-generator/back/tests/EndToEnd/Infrastructure/Controller/GetIdentifierGeneratorControllerEndToEnd.php
@@ -4,7 +4,13 @@ declare(strict_types=1);
 
 namespace Akeneo\Test\Pim\Automation\IdentifierGenerator\EndToEnd\Infrastructure\Controller;
 
+use Akeneo\Pim\Structure\Bundle\Doctrine\ORM\Saver\AttributeSaver;
+use Akeneo\Pim\Structure\Component\AttributeTypes;
+use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
+use Akeneo\Test\Common\EntityBuilder;
 use Akeneo\Test\Pim\Automation\IdentifierGenerator\EndToEnd\ControllerEndToEndTestCase;
+use Akeneo\Tool\Bundle\StorageUtilsBundle\Doctrine\Common\Saver\BaseSaver;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -48,6 +54,7 @@ final class GetIdentifierGeneratorControllerEndToEnd extends ControllerEndToEndT
     /** @test */
     public function it_returns_an_identifier_generator(): void
     {
+        $this->createSimpleSelectAttributeWithOptions('simple_select_localizable_scopable', ['optionA', 'optionB'], true, true);
         $identifierGeneratorData = [
             'code' => 'my_new_generator',
             'labels' => [
@@ -56,10 +63,24 @@ final class GetIdentifierGeneratorControllerEndToEnd extends ControllerEndToEndT
             ],
             'target' => 'sku',
             'conditions' => [],
-            'structure' => [[
-                'type' => 'free_text',
-                'string' => 'AKN',
-            ]],
+            'structure' => [
+                [
+                    'type' => 'free_text',
+                    'string' => 'AKN',
+                ],
+                [
+                    'type' => 'simple_select',
+                    'attributeCode' => 'a_simple_select',
+                    'process' => ['type' => 'no'],
+                ],
+                [
+                    'type' => 'simple_select',
+                    'attributeCode' => 'simple_select_localizable_scopable',
+                    'process' => ['type' => 'no'],
+                    'locale' => 'en_US',
+                    'scope' => 'ecommerce',
+                ],
+            ],
             'delimiter' => null,
             'text_transformation' => 'no',
         ];
@@ -79,7 +100,7 @@ final class GetIdentifierGeneratorControllerEndToEnd extends ControllerEndToEndT
         $uuid = $this->getUuidFromCode('my_new_generator');
         Assert::assertSame(
             \sprintf(
-                '{"uuid":"%s","code":"my_new_generator","conditions":[],"structure":[{"type":"free_text","string":"AKN"}],"labels":{"en_US":"My new generator","fr_FR":"Mon nouveau g\u00e9n\u00e9rateur"},"target":"sku","delimiter":null,"text_transformation":"no"}',
+                '{"uuid":"%s","code":"my_new_generator","conditions":[],"structure":[{"type":"free_text","string":"AKN"},{"type":"simple_select","attributeCode":"a_simple_select","process":{"type":"no"}},{"type":"simple_select","attributeCode":"simple_select_localizable_scopable","process":{"type":"no"},"scope":"ecommerce","locale":"en_US"}],"labels":{"en_US":"My new generator","fr_FR":"Mon nouveau g\u00e9n\u00e9rateur"},"target":"sku","delimiter":null,"text_transformation":"no"}',
                 $uuid
             ),
             $response->getContent()
@@ -91,5 +112,57 @@ final class GetIdentifierGeneratorControllerEndToEnd extends ControllerEndToEndT
         return $this->get('database_connection')->executeQuery(<<<SQL
 SELECT BIN_TO_UUID(uuid) AS uuid FROM pim_catalog_identifier_generator WHERE code=:code
 SQL, ['code' => $code])->fetchOne();
+    }
+
+    private function createSimpleSelectAttributeWithOptions(string $code, array $optionCodes, bool $localizable, bool $scopable): AttributeInterface
+    {
+        $attribute = $this->createAttribute($code, ['type' => AttributeTypes::OPTION_SIMPLE_SELECT], $localizable, $scopable);
+
+        foreach ($optionCodes as $sortOrder => $optionCode) {
+            $option = $this->getAttributeOptionFactory()->create();
+            $option->setCode($optionCode);
+            $option->setAttribute($attribute);
+            $option->setSortOrder($sortOrder);
+            $this->getAttributeOptionSaver()->save($option);
+        }
+
+        return $attribute;
+    }
+
+    private function createAttribute(string $code, array $data, bool $localizable, bool $scopable): AttributeInterface
+    {
+        $defaultData = [
+            'code' => $code,
+            'type' => AttributeTypes::TEXT,
+            'group' => 'other',
+            'localizable' => $localizable,
+            'scopable' => $scopable,
+        ];
+        $data = \array_merge($defaultData, $data);
+
+        $attribute = $this->getAttributeBuilder()->build($data, true);
+        $this->getAttributeSaver()->save($attribute);
+
+        return $attribute;
+    }
+
+    private function getAttributeBuilder(): EntityBuilder
+    {
+        return $this->get('akeneo_integration_tests.base.attribute.builder');
+    }
+
+    private function getAttributeSaver(): AttributeSaver
+    {
+        return $this->get('pim_catalog.saver.attribute');
+    }
+
+    private function getAttributeOptionFactory(): SimpleFactoryInterface
+    {
+        return $this->get('pim_catalog.factory.attribute_option');
+    }
+
+    private function getAttributeOptionSaver(): BaseSaver
+    {
+        return $this->get('pim_catalog.saver.attribute_option');
     }
 }

--- a/components/identifier-generator/back/tests/Specification/Domain/Model/Property/SimpleSelectPropertySpec.php
+++ b/components/identifier-generator/back/tests/Specification/Domain/Model/Property/SimpleSelectPropertySpec.php
@@ -55,8 +55,31 @@ class SimpleSelectPropertySpec extends ObjectBehavior
                 'operator' => '=',
                 'value' => 3
             ],
-            'scope' => null,
-            'locale' => null,
+        ]);
+    }
+
+    public function it_normalizes_itself_with_scope_and_locale(): void
+    {
+        $this->beConstructedThrough('fromNormalized', [
+            [
+                'type' => 'simple_select',
+                'attributeCode' => 'color',
+                'process' => ['type' => 'truncate', 'operator' => '=', 'value' => 3],
+                'scope' => 'ecommerce',
+                'locale' => 'en_US'
+            ]
+        ]);
+
+        $this->normalize()->shouldReturn([
+            'type' => 'simple_select',
+            'attributeCode' => 'color',
+            'process' => [
+                'type' => 'truncate',
+                'operator' => '=',
+                'value' => 3
+            ],
+            'scope' => 'ecommerce',
+            'locale' => 'en_US'
         ]);
     }
 

--- a/components/identifier-generator/front/src/feature/hooks/useGetAttributeByCode.ts
+++ b/components/identifier-generator/front/src/feature/hooks/useGetAttributeByCode.ts
@@ -11,11 +11,11 @@ const getAttributeByCode = async (identifier: string, router: Router): Promise<A
     headers: [['X-Requested-With', 'XMLHttpRequest']],
   });
 
-      if (!response.ok) {
-        if (response.status === 401) throw new Unauthorized();
-        if (response.status === 404) throw new AttributeNotFound();
-        throw new ServerError();
-      }
+  if (!response.ok) {
+    if (response.status === 401) throw new Unauthorized();
+    if (response.status === 404) throw new AttributeNotFound();
+    throw new ServerError();
+  }
 
   return await response.json();
 };


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

SimpleSelectProperty 's `normalize` function used to retrieve scope and locale even if value is null.
But in the UpdateIdentifierGenerator validators, we require scope and locale not to be passed if not needed
**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
