### PR TITLE
fix-performance-tests

### DIFF
--- a/components/identifier-generator/back/src/Infrastructure/Query/SqlGetSequencedNextIdentifierQuery.php
+++ b/components/identifier-generator/back/src/Infrastructure/Query/SqlGetSequencedNextIdentifierQuery.php
@@ -26,10 +26,6 @@ final class SqlGetSequencedNextIdentifierQuery implements GetNextIdentifierQuery
         string $prefix,
         int $numberMin,
     ): int {
-        if ($this->isPreviousDatabaseVersion()) {
-            return $this->getNextIdentifierQuery->fromPrefix($identifierGenerator, $prefix, $numberMin);
-        };
-
         $lastAllocatedNumber = $this->getLastAllocatedNumber($identifierGenerator, $prefix);
         if (null === $lastAllocatedNumber) {
             $nextIdentifier = $this->getNextIdentifierQuery->fromPrefix($identifierGenerator, $prefix, $numberMin);
@@ -117,20 +113,5 @@ SQL;
             'number' => $newAllocatedNumber,
             'last_allocated_number' => $newAllocatedNumber - 1,
         ]));
-    }
-
-    private function isPreviousDatabaseVersion(): bool
-    {
-        return !$this->tableExists();
-    }
-
-    private function tableExists(): bool
-    {
-        return $this->connection->executeQuery(
-            'SHOW TABLES LIKE :tableName',
-            [
-                'tableName' => 'pim_catalog_identifier_generator_sequence',
-            ]
-        )->rowCount() >= 1;
     }
 }

--- a/components/identifier-generator/back/src/Infrastructure/Query/SqlUpdateIdentifierPrefixesQuery.php
+++ b/components/identifier-generator/back/src/Infrastructure/Query/SqlUpdateIdentifierPrefixesQuery.php
@@ -34,10 +34,6 @@ final class SqlUpdateIdentifierPrefixesQuery implements UpdateIdentifierPrefixes
      */
     public function updateFromProducts(array $products): bool
     {
-        if ($this->isPreviousDatabaseVersion()) {
-            return false;
-        }
-
         $onlyProducts = \array_filter(
             $products,
             // TODO TIP-987 Remove this when decoupling PublishedProduct from Enrichment
@@ -131,20 +127,5 @@ SQL;
         }
 
         return $this->identifierAttributesCache;
-    }
-
-    private function isPreviousDatabaseVersion(): bool
-    {
-        $sql = <<<SQL
-SELECT COLUMN_TYPE from information_schema.COLUMNS
-WHERE TABLE_SCHEMA='%s'
-  AND TABLE_NAME='pim_catalog_identifier_generator_prefixes'
-  AND COLUMN_NAME='number';
-SQL;
-
-        $type = $this->connection->fetchOne(\sprintf($sql, $this->connection->getDatabase()));
-        Assert::string($type);
-
-        return \strtolower($type) === 'int';
     }
 }


### PR DESCRIPTION
We had to be sure that queries can be executed with or without migrations.
As every migration is done on prod, we can remove them.