### PR TITLE
CPM-951: Add sub entries to help menu

### DIFF
--- a/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
+++ b/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mockedDependencies, renderWithProviders} from '../../tests';
-import {fireEvent, screen} from '@testing-library/react';
+import {fireEvent, screen, waitFor} from '@testing-library/react';
 import {PimNavigation} from './PimNavigation';
 import {aMainNavigation} from './navigationTestHelper';
 
@@ -57,4 +57,38 @@ test('It show disabled entries as locked for the Free Trial', async () => {
 
   expect(screen.queryAllByTestId('pim-main-menu-item')).toHaveLength(3);
   expect(screen.queryAllByTestId('locked-entry')).toHaveLength(1);
+});
+
+test('It displays different url according to pim version', async () => {
+  // @ts-ignore
+  global.fetch = () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({pim_version: '6.7', pim_edition: 'ce'}),
+    });
+
+  renderWithProviders(
+    <PimNavigation
+      entries={aMainNavigation()}
+      activeEntryCode="entry10"
+      activeSubEntryCode="subentry2"
+      freeTrialEnabled={true}
+    />
+  );
+
+  expect(screen.getByText('pim_menu.tab.help.title')).toBeInTheDocument();
+  fireEvent.mouseOver(screen.getByText('pim_menu.tab.help.title'));
+
+  const helpCenterUrl = screen.getByText('pim_menu.tab.help.help_center');
+
+  await waitFor(() => !!helpCenterUrl);
+  expect(screen.getByText('pim_menu.tab.help.help_center')).toBeVisible();
+  expect(helpCenterUrl).toHaveAttribute(
+    'href',
+    'https://help.akeneo.com/pim/v6/index.html?utm_source=akeneo-app&utm_medium=interrogation-icon&utm_campaign=ce6.7'
+  );
+
+  fireEvent.mouseLeave(screen.getByText('pim_menu.tab.help.title'));
+  expect(screen.getByText('pim_menu.tab.help.help_center')).not.toBeVisible();
 });

--- a/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
+++ b/front-packages/shared/src/components/Navigation/PimNavigation.unit.tsx
@@ -6,6 +6,16 @@ import {aMainNavigation} from './navigationTestHelper';
 
 jest.mock('../PimView');
 
+beforeAll(() => {
+  // @ts-ignore
+  global.fetch = () =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({pim_version: 'serenity'}),
+    });
+});
+
 test('It displays the main navigation with an active entry and a sub menu', async () => {
   renderWithProviders(
     <PimNavigation entries={aMainNavigation()} activeEntryCode="entry1" activeSubEntryCode="subentry2" />

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -371,6 +371,10 @@ pim_menu:
         help:
             title: Help
             helper: Akeneo Help center
+            new: NEW
+            news: What’s new?
+            help_center: Help Center
+            akademy_training: Akademy training
     item:
         association_type: Association types
         attribute_group: Attribute groups


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Previous PR was reverted because a useless menu was added and broke Onboarder.
Then, a regression was detected on trial because there is a chatbot button on the bottom left of the screen.

The solution is to add the new menu entries next to the menu, and add a very high z-index to be higher than the one used for the tria chatbot.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
