### PR TITLE
RAB-1357: Update and use cached channels query in attribute deletion check

### DIFF
--- a/src/Akeneo/Channel/back/API/Query/Channel.php
+++ b/src/Akeneo/Channel/back/API/Query/Channel.php
@@ -16,7 +16,8 @@ final class Channel
         private string $code,
         private array $localeCodes,
         private LabelCollection $labels,
-        private array $activeCurrencies
+        private array $activeCurrencies,
+        private ConversionUnitCollection $conversionUnits,
     ) {
     }
 
@@ -54,5 +55,10 @@ final class Channel
     public function isCurrencyActive(string $currencyCode): bool
     {
         return in_array($currencyCode, $this->activeCurrencies);
+    }
+
+    public function getConversionUnits(): ConversionUnitCollection
+    {
+        return $this->conversionUnits;
     }
 }

--- a/src/Akeneo/Channel/back/API/Query/ConversionUnitCollection.php
+++ b/src/Akeneo/Channel/back/API/Query/ConversionUnitCollection.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\API\Query;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license https://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+final class ConversionUnitCollection
+{
+    private function __construct(
+        /** @var array<string, string> $conversionUnits */
+        private array $conversionUnits,
+    ) {
+        Assert::allString($conversionUnits);
+    }
+
+    /**
+     * @param array<string, string> $conversionUnits
+     */
+    public static function fromArray(array $conversionUnits): self
+    {
+        return new self($conversionUnits);
+    }
+
+    public function hasConversionUnit(string $attributeCode): bool
+    {
+        return array_key_exists($attributeCode, $this->conversionUnits);
+    }
+
+    public function getConversionUnit(string $attributeCode): ?string
+    {
+        return $this->conversionUnits[$attributeCode] ?? null;
+    }
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindChannels.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Query/Sql/SqlFindChannels.php
@@ -4,6 +4,7 @@
 namespace Akeneo\Channel\Infrastructure\Query\Sql;
 
 use Akeneo\Channel\API\Query\Channel;
+use Akeneo\Channel\API\Query\ConversionUnitCollection;
 use Akeneo\Channel\API\Query\FindChannels;
 use Akeneo\Channel\API\Query\LabelCollection;
 use Doctrine\DBAL\Connection;
@@ -29,7 +30,8 @@ final class SqlFindChannels implements FindChannels
                 c.code AS channelCode, 
                 JSON_REMOVE(JSON_OBJECTAGG(IFNULL(l.id, 'NO_LOCALE'), l.code), '$.NO_LOCALE') AS localeCodes,
                 JSON_REMOVE(JSON_OBJECTAGG(IFNULL(ct.locale, 'NO_LABEL'), ct.label), '$.NO_LABEL') AS labels,
-                JSON_REMOVE(JSON_OBJECTAGG(IFNULL(cur.id, 'NO_CURRENCY'), cur.code), '$.NO_CURRENCY') AS activatedCurrencies
+                JSON_REMOVE(JSON_OBJECTAGG(IFNULL(cur.id, 'NO_CURRENCY'), cur.code), '$.NO_CURRENCY') AS activatedCurrencies,
+                c.conversionUnits
             FROM pim_catalog_channel c
             LEFT JOIN pim_catalog_channel_locale cl 
                 ON c.id = cl.channel_id
@@ -52,7 +54,8 @@ final class SqlFindChannels implements FindChannels
                 $result['channelCode'],
                 array_values(json_decode($result['localeCodes'], true)),
                 LabelCollection::fromArray(json_decode($result['labels'], true)),
-                array_values(json_decode($result['activatedCurrencies'], true))
+                array_values(json_decode($result['activatedCurrencies'], true)),
+                ConversionUnitCollection::fromArray(unserialize($result['conversionUnits'])),
             );
         }
 

--- a/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindChannelsIntegration.php
+++ b/src/Akeneo/Channel/back/tests/Integration/Query/Sql/SqlFindChannelsIntegration.php
@@ -6,15 +6,18 @@ use Akeneo\Channel\API\Query\Channel;
 use Akeneo\Channel\API\Query\FindChannels;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
 
 final class SqlFindChannelsIntegration extends TestCase
 {
+    private Connection $connection;
     private FindChannels $sqlFindChannels;
 
     public function setUp(): void
     {
         parent::setUp();
 
+        $this->connection = $this->get('database_connection');
         $this->sqlFindChannels = $this->get(
             'Akeneo\Channel\Infrastructure\Query\Sql\SqlFindChannels'
         );
@@ -22,6 +25,9 @@ final class SqlFindChannelsIntegration extends TestCase
 
     public function test_it_finds_all_channels(): void
     {
+        $conversionUnits = ['an_measurement_attribute' => 'KILOGRAM'];
+        $this->saveConversionUnitsForChannel($conversionUnits, 'print');
+
         $results = $this->sqlFindChannels->findAll();
 
         $this->assertIsArray($results);
@@ -41,10 +47,23 @@ final class SqlFindChannelsIntegration extends TestCase
         $this->assertEquals('Print', $printChannel->getLabels()->getLabel('fr_FR'));
         $this->assertEquals('Print', $printChannel->getLabels()->getLabel('de_DE'));
         $this->assertEquals(null, $printChannel->getLabels()->getLabel('jp_JP'));
+
+        $this->assertEquals('KILOGRAM', $printChannel->getConversionUnits()->getConversionUnit('an_measurement_attribute'));
     }
 
     protected function getConfiguration(): Configuration
     {
         return $this->catalog->useFunctionalCatalog('catalog_modeling');
+    }
+
+    /**
+     * @param array<string, string> $conversionUnits
+     */
+    private function saveConversionUnitsForChannel(array $conversionUnits, string $channelCode): void
+    {
+        $sql = <<<SQL
+UPDATE pim_catalog_channel SET conversionUnits = :conversion_units WHERE code = :code
+SQL;
+        $this->connection->executeQuery($sql, ['conversion_units' => serialize($conversionUnits), 'code' => $channelCode]);
     }
 }

--- a/src/Akeneo/Channel/back/tests/Specification/API/Query/ChannelSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/API/Query/ChannelSpec.php
@@ -2,6 +2,7 @@
 
 namespace Specification\Akeneo\Channel\API\Query;
 
+use Akeneo\Channel\API\Query\ConversionUnitCollection;
 use Akeneo\Channel\API\Query\LabelCollection;
 use PhpSpec\ObjectBehavior;
 
@@ -13,7 +14,8 @@ class ChannelSpec extends ObjectBehavior
             'mobile',
             ['fr_FR', 'uk_UA'],
             LabelCollection::fromArray(['fr_FR' => 'Mobile', 'uk_UA' => 'смартфон']),
-            ['EUR', 'USD']
+            ['EUR', 'USD'],
+            ConversionUnitCollection::fromArray(['an_measurement_attribute' => 'GRAM', 'another_measurement_attribute' => 'POUND'])
         );
     }
 
@@ -23,6 +25,7 @@ class ChannelSpec extends ObjectBehavior
         $this->getLocaleCodes()->shouldReturn(['fr_FR', 'uk_UA']);
         $this->getLabels()->shouldBeLike(LabelCollection::fromArray(['fr_FR' => 'Mobile', 'uk_UA' => 'смартфон']));
         $this->getActiveCurrencies()->shouldReturn(['EUR', 'USD']);
+        $this->getConversionUnits()->shouldBeLike(ConversionUnitCollection::fromArray(['an_measurement_attribute' => 'GRAM', 'another_measurement_attribute' => 'POUND']));
     }
 
     public function it_tells_if_a_given_locale_is_active()

--- a/src/Akeneo/Channel/back/tests/Specification/API/Query/ConversionUnitCollectionSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/API/Query/ConversionUnitCollectionSpec.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Channel\API\Query;
+
+use Akeneo\Channel\API\Query\ConversionUnitCollection;
+use PhpSpec\ObjectBehavior;
+use Webmozart\Assert\InvalidArgumentException;
+
+class ConversionUnitCollectionSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedThrough('fromArray', [['an_measurement_attribute' => 'GRAM', 'another_measurement_attribute' => 'POUND']]);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ConversionUnitCollection::class);
+    }
+
+    public function it_throws_exception_when_trying_to_create_it_with_non_string_array(): void
+    {
+        $this->shouldThrow(InvalidArgumentException::class)->during('fromArray', [['an_attribute' => 1]]);
+    }
+
+    public function it_says_if_it_has_a_conversion_unit_or_not(): void
+    {
+        $this->hasConversionUnit('an_measurement_attribute')->shouldReturn(true);
+        $this->hasConversionUnit('another_measurement_attribute')->shouldReturn(true);
+        $this->hasConversionUnit('an_unknown_measurement_attribute')->shouldReturn(false);
+    }
+
+    public function it_returns_a_conversion_unit(): void
+    {
+        $this->getConversionUnit('an_measurement_attribute')->shouldReturn('GRAM');
+        $this->getConversionUnit('another_measurement_attribute')->shouldReturn('POUND');
+        $this->getConversionUnit('an_unknown_measurement_attribute')->shouldReturn(null);
+    }
+}

--- a/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Query/Cache/CachedFindChannelsSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Query/Cache/CachedFindChannelsSpec.php
@@ -3,6 +3,7 @@
 namespace Specification\Akeneo\Channel\Infrastructure\Query\Cache;
 
 use Akeneo\Channel\API\Query\Channel;
+use Akeneo\Channel\API\Query\ConversionUnitCollection;
 use Akeneo\Channel\API\Query\FindChannels;
 use Akeneo\Channel\API\Query\LabelCollection;
 use PhpSpec\ObjectBehavior;
@@ -26,7 +27,11 @@ class CachedFindChannelsSpec extends ObjectBehavior
                     LabelCollection::fromArray([
                         'en_US' => 'Ecommerce',
                     ]),
-                    ['USD']
+                    ['USD'],
+                    ConversionUnitCollection::fromArray([
+                        'an_measurement_attribute' => 'GRAM',
+                        'another_measurement_attribute' => 'POUND'
+                    ]),
                 ),
                 new Channel(
                     'mobile',
@@ -34,7 +39,11 @@ class CachedFindChannelsSpec extends ObjectBehavior
                     LabelCollection::fromArray([
                         'en_US' => 'Mobile',
                     ]),
-                    ['EUR']
+                    ['EUR'],
+                    ConversionUnitCollection::fromArray([
+                        'an_measurement_attribute' => 'GRAM',
+                        'another_measurement_attribute' => 'POUND'
+                    ]),
                 ),
             ])
             ->shouldBeCalledOnce();

--- a/src/Akeneo/Pim/Structure/.php_cd.php
+++ b/src/Akeneo/Pim/Structure/.php_cd.php
@@ -25,6 +25,7 @@ $rules = [
         'Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface',
         'Psr\Log\LoggerInterface',
         'Akeneo\Platform\Bundle\FrameworkBundle\Security\SecurityFacadeInterface',
+        'Akeneo\Channel\API',
 
         // TIP-906: Functional problem to query products before removing AttributeOption
         'Akeneo\Pim\Enrichment\Bundle\Elasticsearch\ProductAndProductModelQueryBuilderFactory',
@@ -40,9 +41,6 @@ $rules = [
 
         // TIP-910: PIM/Structure should not be linked to Channel
         'Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface',
-
-        // RAB-1357
-        'Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface',
 
         // TIP-939: Remove filter system for permissions
         'Akeneo\Platform\Bundle\UIBundle\Provider\TranslatedLabelsProviderInterface',

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
@@ -54,7 +54,7 @@ class CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber impleme
         );
 
         return array_map(
-            static fn (Channel $channel) => $channel->getCode(),
+            static fn (Channel $channel): string => $channel->getCode(),
             $channelsUsedAsConversionUnit,
         );
     }

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
@@ -50,7 +50,7 @@ class CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber impleme
 
         $channelsUsedAsConversionUnit = array_filter(
             $channels,
-            static fn (Channel $channel) => $channel->getConversionUnits()->hasConversionUnit($attributeCode)
+            static fn (Channel $channel): bool => $channel->getConversionUnits()->hasConversionUnit($attributeCode)
         );
 
         return array_map(

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Structure\Bundle\EventSubscriber;
 
-use Akeneo\Channel\Infrastructure\Component\Repository\ChannelRepositoryInterface;
+use Akeneo\Channel\API\Query\Channel;
+use Akeneo\Channel\API\Query\FindChannels;
 use Akeneo\Pim\Structure\Component\Exception\CannotRemoveAttributeException;
 use Akeneo\Pim\Structure\Component\Model\AttributeInterface;
 use Akeneo\Tool\Component\StorageUtils\Event\RemoveEvent;
@@ -18,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber implements EventSubscriberInterface
 {
     public function __construct(
-        private readonly ChannelRepositoryInterface $channelRepository,
+        private readonly FindChannels $findChannels,
     ) {
     }
 
@@ -45,14 +46,16 @@ class CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber impleme
 
     private function channelCodesUsedAsConversionUnit(string $attributeCode): array
     {
-        $channelCodes = [];
-        /** @TODO RAB-1357: use cached repository */
-        foreach ($this->channelRepository->findAll() as $channel) {
-            if (array_key_exists($attributeCode, $channel->getConversionUnits())) {
-                $channelCodes[] = $channel->getCode();
-            }
-        }
+        $channels = $this->findChannels->findAll();
 
-        return $channelCodes;
+        $channelsUsedAsConversionUnit = array_filter(
+            $channels,
+            static fn (Channel $channel) => $channel->getConversionUnits()->hasConversionUnit($attributeCode)
+        );
+
+        return array_map(
+            static fn (Channel $channel) => $channel->getCode(),
+            $channelsUsedAsConversionUnit,
+        );
     }
 }

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -96,7 +96,7 @@ services:
 
     Akeneo\Pim\Structure\Bundle\EventSubscriber\CheckAttributeIsNotUsedAsChannelConversionUnitOnDeletionSubscriber:
         arguments:
-            - '@pim_catalog.repository.channel'
+            - '@Akeneo\Channel\Infrastructure\Query\Cache\CachedFindChannels'
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I extended the Channel read model exposed by the Channel Service API to add it the conversion units. That's allow us to use it inside Structure domain for checking attribute deletion.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
