### PR TITLE
SP-490: add a service API to retrieve a list of families or a single Family

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetFamilies.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetFamilies.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Bundle\Query\PublicApi\Family\Sql;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\Family;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetFamilies;
+use Doctrine\DBAL\Connection;
+
+class SqlGetFamilies implements GetFamilies
+{
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function byCodes(array $familyCodes): array
+    {
+        if (empty($familyCodes)) {
+            return [];
+        }
+
+        $sql = <<<SQL
+SELECT
+   family.code AS code,
+   COALESCE(JSON_OBJECTAGG(trans.locale, trans.label), JSON_ARRAY()) AS labels
+FROM pim_catalog_family family
+INNER JOIN pim_catalog_family_translation trans ON family.id = trans.foreign_key
+WHERE family.code IN (:familyCodes)
+GROUP BY family.code
+SQL;
+        $rows = $this->connection->executeQuery(
+            $sql,
+            [
+                'familyCodes' => $familyCodes,
+            ],
+            ['familyCodes' => Connection::PARAM_STR_ARRAY]
+        )->fetchAllAssociative();
+
+        $families = [];
+        foreach ($rows as $row) {
+            $families[$row['code']] = new Family($row['code'], json_decode($row['labels'], true));
+        }
+
+        return $families;
+    }
+
+    public function byCode(string $familyCode): ?Family
+    {
+        $byCodes = $this->byCodes([$familyCode]);
+
+        return $byCodes[$familyCode] ?? null;
+    }
+}

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/queries.yml
@@ -217,3 +217,8 @@ services:
             - '@database_connection'
             - '@feature_flags'
             - '@Akeneo\Pim\Automation\DataQualityInsights\PublicApi\Query\AttributeGroup\GetAttributeGroupsActivationQuery'
+
+    Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetFamilies:
+        class: Akeneo\Pim\Structure\Bundle\Query\PublicApi\Family\Sql\SqlGetFamilies
+        arguments:
+            - '@database_connection'

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Family;
+
+final class Family
+{
+    public function __construct(
+        public readonly string $code,
+        public readonly array $labels,
+    ) {
+    }
+}

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/GetFamilies.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/GetFamilies.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Family;
+
+interface GetFamilies
+{
+    public function byCode(string $familyCode): ?Family;
+
+    /** @return array<string, Family> */
+    public function byCodes(array $familyCodes): array;
+}

--- a/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AkeneoTest\Pim\Structure\Integration\Family;
+
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\Family;
+use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetFamilies;
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Webmozart\Assert\Assert;
+
+final class SqlGetFamilyIntegration extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->givenFamilies([
+            [
+                'code' => 'shoes',
+                'labels' => [
+                    'en_US' => 'Shoes',
+                    'fr_FR' => 'Chaussures'
+                ]
+            ],
+            [
+                'code' => 'accessories',
+                'labels' => [
+                    'en_US' => 'Accessories',
+                    'fr_FR' => 'Accessoires'
+                ]
+            ],
+            [
+                'code' => 'hats',
+                'labels' => [
+                    'en_US' => 'Hats',
+                    'fr_FR' => 'Chapeaux'
+                ]
+            ],
+        ]);
+    }
+
+    public function test_it_gets_families_by_codes(): void
+    {
+        $query = $this->get(GetFamilies::class);
+
+        $expected = [
+            'accessories' => new Family(
+                'accessories',
+                [
+                    'en_US' => 'Accessories',
+                    'fr_FR' => 'Accessoires'
+                ]
+            ),
+            'shoes' =>new Family(
+                'shoes',
+                [
+                    'en_US' => 'Shoes',
+                    'fr_FR' => 'Chaussures'
+                ],
+            ),
+        ];
+        $actual = $query->byCodes(['shoes', 'accessories']);
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function test_it_gets_an_empty_list_if_all_the_families_do_not_exist(): void
+    {
+        $query = $this->get(GetFamilies::class);
+
+        $actual = $query->byCodes(['unknown_family1', 'unknown_family2']);
+
+        $this->assertSame([], $actual);
+    }
+
+    public function test_it_gets_a_single_family(): void
+    {
+        $query = $this->get(GetFamilies::class);
+
+        $expected = new Family(
+            'accessories',
+            [
+                'en_US' => 'Accessories',
+                'fr_FR' => 'Accessoires'
+            ]
+        );
+        $actual = $query->byCode('accessories');
+
+        $this->assertEqualsCanonicalizing($expected, $actual);
+    }
+
+    public function test_it_returns_nothing_if_the_family_does_not_exist(): void
+    {
+        $query = $this->get(GetFamilies::class);
+
+        $actual = $query->byCode('unknown_family');
+
+        $this->assertNull($actual);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function givenFamilies(array $families): void
+    {
+        $families = array_map(function (array $familyData) {
+            $family = $this->get('pim_catalog.factory.family')->create();
+            $this->get('pim_catalog.updater.family')->update($family, $familyData);
+            $constraintViolations = $this->get('validator')->validate($family);
+
+            Assert::count($constraintViolations, 0);
+
+            return $family;
+        }, $families);
+
+        $this->get('pim_catalog.saver.family')->saveAll($families);
+    }
+}


### PR DESCRIPTION
This PR adds a new public service API in the structure context to get a list of families (or a single one too), that returns basic generic Family read models. We needed this service API for Supplier Portal needs. For now the read model only has what we needed in our side (code and labels), but it should be easy to add new properties if needed.

As discussed with Mathias, there is not LRU cache implementation for now, we thought it would not be needed at this point.