### PR TITLE
OCT-233: Added email_verified claim to JWT token

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
+++ b/src/Akeneo/Connectivity/Connection/back/Infrastructure/Apps/OAuth/CreateJsonWebToken.php
@@ -39,8 +39,7 @@ class CreateJsonWebToken
          * @var non-empty-string $publicKey
          * @var non-empty-string $privateKey
          */
-        ['public_key' => $publicKey, 'private_key' => $privateKey] = $this->getAsymmetricKeysQuery->execute(
-        )->normalize();
+        ['public_key' => $publicKey, 'private_key' => $privateKey] = $this->getAsymmetricKeysQuery->execute()->normalize();
         $privateKey = InMemory::plainText($privateKey);
         $publicKey = InMemory::plainText($publicKey);
 
@@ -71,6 +70,7 @@ class CreateJsonWebToken
         }
         if ($consentedAuthenticationScopes->hasScope(AuthenticationScope::SCOPE_EMAIL)) {
             $jwtTokenBuilder
+                ->withClaim('email_verified', false)
                 ->withClaim('email', $email);
         }
 

--- a/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/OAuth/CreateJsonWebTokenSpec.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Unit/spec/Infrastructure/Apps/OAuth/CreateJsonWebTokenSpec.php
@@ -149,6 +149,8 @@ class CreateJsonWebTokenSpec extends ObjectBehavior
         if (\in_array(AuthenticationScope::SCOPE_EMAIL, $scopes)) {
             Assert::assertTrue($token->claims()->has('email'));
             Assert::assertEquals($this->email, $token->claims()->get('email'));
+            Assert::assertTrue($token->claims()->has('email_verified'));
+            Assert::assertFalse($token->claims()->get('email_verified'));
         }
     }
 


### PR DESCRIPTION
Added email_verified claim to JWT token when App requests email OpenId scope and set it to false as PIM does not verify its emails and PIM users are free to put anything as email