### PR TITLE
PIM-10905: Have a clear error message when SFTP reach timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - PIM-10860: [SLA] Announcements aren't shown
 - PIM-10745: Fix history display for product's quantified association
 - PIM-10874: fix labels api type consistency
+- PIM-10905: Have a clear error message when SFTP reach timeout
 - PIM-10877: Fix sequential edit not working if grid is sorted by quality score
 - PIM-10876: Does not save empty ('') labels and don't show null labels on API REST
 - PIM-10894: Allow research user by email as username.

--- a/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFileSpec.php
+++ b/tests/back/Platform/Specification/Bundle/ImportExportBundle/Infrastructure/StorageClient/TransferFileSpec.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Specification\Akeneo\Platform\Bundle\ImportExportBundle\Infrastructure\StorageClient;
 
 use Akeneo\Platform\Bundle\ImportExportBundle\Domain\StorageClientInterface;
+use League\Flysystem\UnableToWriteFile;
 use PhpSpec\ObjectBehavior;
 
 class TransferFileSpec extends ObjectBehavior


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I added a catch inside TransferFile to catch SFTP network error and have a clearer error message.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
