### PR TITLE
PIM-10908: Add zdd migration to add an index on akeneo_file_storage_file_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - PIM-10856: Prevent the creation of a useless PHP session when a new token is created in the API
 - PIM-10870: Fix display of permissions when empty
 - PIM-10860: [SLA] Announcements aren't shown
+- PIM-10908: Add zdd migration to add an index on akeneo_file_storage_file_info
 - PIM-10745: Fix history display for product's quantified association
 - PIM-10874: fix labels api type consistency
 - PIM-10877: Fix sequential edit not working if grid is sorted by quality score

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Command/V20230324153137AddIndexOnFileInfoZddMigration.php
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Command/V20230324153137AddIndexOnFileInfoZddMigration.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Akeneo\Tool\Bundle\FileStorageBundle\Command;
+
+use Akeneo\Platform\Bundle\InstallerBundle\Command\ZddMigration;
+use Doctrine\DBAL\Connection;
+
+class V20230324153137AddIndexOnFileInfoZddMigration implements ZddMigration
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    public function migrate(): void
+    {
+        if ($this->indexExists()) {
+            return;
+        }
+
+        $sql = <<<SQL
+CREATE INDEX original_filename_hash_storage_idx ON akeneo_file_storage_file_info (original_filename, hash, storage) LOCK = NONE;
+SQL;
+
+        $this->connection->executeQuery($sql);
+    }
+
+    /**
+     * TODO: Call this method in a classic doctrine migration for Saas.
+     * It should be done when we're sure this migration has been executed in a Zdd way on production.
+     */
+    public function migrateNotZdd(): void
+    {
+        $this->migrate();
+    }
+
+    public function getName(): string
+    {
+        return 'V20230324153137AddIndexOnFileInfoZddMigration';
+    }
+
+    private function indexExists(): bool
+    {
+        $sql = <<<SQL
+SHOW INDEX FROM akeneo_file_storage_file_info WHERE Key_name = 'original_filename_hash_storage_idx';
+SQL;
+
+        return 0 < $this->connection->executeQuery($sql)->rowCount();
+    }
+}

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/cli_commands.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/cli_commands.yml
@@ -6,3 +6,11 @@ services:
         tags:
             - { name: console.command }
             - { name: 'akeneo.command.authenticated_as_admin_user' }
+
+    Akeneo\Tool\Bundle\FileStorageBundle\Command\V20230324153137AddIndexOnFileInfoZddMigration:
+        arguments:
+            - '@database_connection'
+        tags:
+            - { name: 'akeneo.pim.zdd_migration' }
+            - { name: 'akeneo.command.authenticated_as_admin_user' }
+        public: true

--- a/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/model/doctrine/FileInfo.orm.yml
+++ b/src/Akeneo/Tool/Bundle/FileStorageBundle/Resources/config/model/doctrine/FileInfo.orm.yml
@@ -2,6 +2,12 @@ Akeneo\Tool\Component\FileStorage\Model\FileInfo:
     type: entity
     repositoryClass: Akeneo\Tool\Bundle\FileStorageBundle\Doctrine\ORM\Repository\FileInfoRepository
     table: akeneo_file_storage_file_info
+    indexes:
+        original_filename_hash_storage_idx:
+            columns:
+                - original_filename
+                - hash
+                - storage
     fields:
         id:
             type: integer

--- a/tests/back/Tool/Integration/FileStorage/Command/V20230324153137AddIndexOnFileInfoZddMigrationIntegration.php
+++ b/tests/back/Tool/Integration/FileStorage/Command/V20230324153137AddIndexOnFileInfoZddMigrationIntegration.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Akeneo\Test\Tool\Integration\FileStorage\Command;
+
+use Akeneo\Test\Integration\Configuration;
+use Akeneo\Test\Integration\TestCase;
+use Akeneo\Tool\Bundle\FileStorageBundle\Command\V20230324153137AddIndexOnFileInfoZddMigration;
+use Doctrine\DBAL\Connection;
+
+class V20230324153137AddIndexOnFileInfoZddMigrationIntegration extends TestCase
+{
+    private V20230324153137AddIndexOnFileInfoZddMigration $migration;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->migration = $this->get('Akeneo\Tool\Bundle\FileStorageBundle\Command\V20230324153137AddIndexOnFileInfoZddMigration');
+        $this->connection = $this->get('database_connection');
+    }
+
+    public function test_it_creates_index(): void
+    {
+        $this->removeIndex();
+
+        $this->assertFalse($this->indexExists());
+
+        $this->migration->migrate();
+
+        $this->assertTrue($this->indexExists());
+    }
+
+    public function test_it_does_not_fail_if_index_already_exists(): void
+    {
+        $this->assertTrue($this->indexExists());
+
+        $this->migration->migrate();
+
+        $this->assertTrue($this->indexExists());
+    }
+
+    private function indexExists(): bool
+    {
+        $sql = <<<SQL
+SHOW INDEX FROM akeneo_file_storage_file_info WHERE Key_name = 'original_filename_hash_storage_idx';
+SQL;
+
+        return 0 < $this->connection->executeQuery($sql)->rowCount();
+    }
+
+    private function removeIndex(): void
+    {
+        $sql = <<<SQL
+DROP INDEX original_filename_hash_storage_idx ON akeneo_file_storage_file_info;
+SQL;
+
+        $this->connection->executeQuery($sql);
+    }
+
+    protected function getConfiguration(): Configuration
+    {
+        return $this->catalog->useTechnicalCatalog();
+    }
+}


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Some instance could have a lot of files (several millions). That leads to performance issues when we want to query the file info table to retrieve if a file is already stored. To resolve this issue, I added a ZDD migration which add an index on `original_name`, `hash` and `storage` columns of `akeneo_file_storage_file_info` table.
On the impacted instance, the query pass from more of 1m to less than 1s.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
