### PR TITLE
OCT-232: add tests and refacto

### DIFF
--- a/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/ProductMappingRespectsSchemaTest.php
+++ b/components/catalogs/back/tests/Integration/Infrastructure/Validation/ProductMapping/ProductMappingRespectsSchemaTest.php
@@ -87,7 +87,7 @@ class ProductMappingRespectsSchemaTest extends IntegrationTestCase
         $this->assertEquals(0, $violations->count());
     }
 
-    private function validCasesProvider(): array
+    public function validCasesProvider(): array
     {
         return [
             'Basic use case' => [
@@ -186,7 +186,7 @@ class ProductMappingRespectsSchemaTest extends IntegrationTestCase
         $this->assertEquals($errorCount, $violations->count());
     }
 
-    private function invalidCasesProvider(): array
+    public function invalidCasesProvider(): array
     {
         return [
             'Targets are missing' => [


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**
The first goal was to add :
- One case where the source does not match the target type + format
- One case where a required target has no source
- One required field in the valid schema test case.

I took advantage of this development to refactor. Now we have :
- Only one place to run `createAttribute` method. 
- Only one schema (versus three)
- A assert on the number of violations to consolidate the tests
- Data providers to simplify the adding of new tests

We can imagine in the future to make optional the check the number of violations.
<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
