### PR TITLE
PIM-10887 :  Prevent channel creation on validation error during import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - PIM-10919: Fix Cleaning Products with removed attributes using identifiers instead of uuids
 - PIM-10911: Add user-agent when sending an event
 - PIM-10885: Use React shared component for locale selector in product form locale switcher
+- PIM-10887: Prevent channel creation on validation error during import
 
 ## Improvements
 

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Model/Channel.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Model/Channel.php
@@ -315,8 +315,9 @@ class Channel implements ChannelInterface
      */
     public function removeLocale(LocaleInterface $locale)
     {
-        $this->locales->removeElement($locale);
-        $locale->removeChannel($this);
+        if ($this->locales->removeElement($locale)) {
+            $locale->removeChannel($this);
+        }
 
         return $this;
     }

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Model/Locale.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Model/Locale.php
@@ -99,7 +99,7 @@ class Locale implements LocaleInterface, VersionableInterface
     /**
      * {@inheritdoc}
      */
-    public function isActivated()
+    public function isActivated(): bool
     {
         return $this->activated;
     }
@@ -123,25 +123,10 @@ class Locale implements LocaleInterface, VersionableInterface
     /**
      * {@inheritdoc}
      */
-    public function setChannels($channels)
-    {
-        $this->channels = new ArrayCollection();
-        $this->activated = false;
-
-        foreach ($channels as $channel) {
-            $this->addChannel($channel);
-        }
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function addChannel(ChannelInterface $channel)
     {
-        $this->channels[] = $channel;
-        if ($this->channels->count() > 0) {
+        if (!$this->channels->contains($channel)) {
+            $this->channels->add($channel);
             $this->activated = true;
         }
 

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Model/LocaleInterface.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Model/LocaleInterface.php
@@ -66,13 +66,6 @@ interface LocaleInterface extends ReferableInterface
     public function hasChannel(ChannelInterface $channel);
 
     /**
-     * @param ArrayCollection $channels
-     *
-     * @return LocaleInterface
-     */
-    public function setChannels($channels);
-
-    /**
      * @param ChannelInterface $channel
      *
      * @return LocaleInterface

--- a/src/Akeneo/Channel/back/Infrastructure/Component/Updater/ChannelUpdater.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Component/Updater/ChannelUpdater.php
@@ -21,19 +21,12 @@ use Doctrine\Common\Util\ClassUtils;
  */
 class ChannelUpdater implements ObjectUpdaterInterface
 {
-    /**
-     * @param IdentifiableObjectRepositoryInterface $categoryRepository
-     * @param IdentifiableObjectRepositoryInterface $localeRepository
-     * @param IdentifiableObjectRepositoryInterface $currencyRepository
-     * @param IdentifiableObjectRepositoryInterface $attributeRepository
-     * @param TranslatableUpdater                   $translatableUpdater
-     */
     public function __construct(
-        protected IdentifiableObjectRepositoryInterface $categoryRepository,
-        protected IdentifiableObjectRepositoryInterface $localeRepository,
-        protected IdentifiableObjectRepositoryInterface $currencyRepository,
-        protected IdentifiableObjectRepositoryInterface $attributeRepository,
-        protected TranslatableUpdater $translatableUpdater
+        protected readonly IdentifiableObjectRepositoryInterface $categoryRepository,
+        protected readonly IdentifiableObjectRepositoryInterface $localeRepository,
+        protected readonly IdentifiableObjectRepositoryInterface $currencyRepository,
+        protected readonly IdentifiableObjectRepositoryInterface $attributeRepository,
+        protected readonly TranslatableUpdater $translatableUpdater
     ) {
     }
 
@@ -53,7 +46,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *     'category_tree' => 'master'
      * ]
      */
-    public function update($channel, array $data, array $options = [])
+    public function update($channel, array $data, array $options = []): self
     {
         if (!$channel instanceof ChannelInterface) {
             throw InvalidObjectException::objectExpected(
@@ -79,7 +72,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @throws InvalidPropertyTypeException
      * @throws UnknownPropertyException
      */
-    protected function validateDataType($field, $data)
+    protected function validateDataType($field, $data): void
     {
         if (in_array($field, ['labels', 'locales', 'currencies', 'conversion_units'])) {
             if (!is_array($data)) {
@@ -112,7 +105,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *
      * @throws InvalidPropertyException
      */
-    protected function setData(ChannelInterface $channel, $field, $data)
+    protected function setData(ChannelInterface $channel, $field, $data): void
     {
         switch ($field) {
             case 'code':
@@ -141,7 +134,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      * @param ChannelInterface $channel
      * @param array            $localizedLabels
      */
-    private function setLabels($channel, $localizedLabels)
+    private function setLabels($channel, $localizedLabels): void
     {
         // using known locale code when found (modulo case-insensitive comparison)
         // leaving unknown locale code as is for the moment (Jira PIM-10372)
@@ -150,7 +143,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
             $knownLocale = $this->localeRepository->findOneByIdentifier($localeCode);
             $normalizedLocalCode = null === $knownLocale ? $localeCode : $knownLocale->getCode();
             $normalizedLocalizedLabels[$normalizedLocalCode] = $label;
-        };
+        }
 
         $this->translatableUpdater->update($channel, $normalizedLocalizedLabels);
     }
@@ -161,7 +154,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *
      * @throws InvalidPropertyException
      */
-    protected function setCategoryTree(ChannelInterface $channel, $treeCode)
+    protected function setCategoryTree(ChannelInterface $channel, $treeCode): void
     {
         $category = $this->categoryRepository->findOneByIdentifier($treeCode);
         if (null === $category) {
@@ -182,7 +175,7 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *
      * @throws InvalidPropertyException
      */
-    protected function setCurrencies(ChannelInterface $channel, array $currencyCodes)
+    protected function setCurrencies(ChannelInterface $channel, array $currencyCodes): void
     {
         $currencies = [];
         foreach ($currencyCodes as $currencyCode) {
@@ -209,9 +202,8 @@ class ChannelUpdater implements ObjectUpdaterInterface
      *
      * @throws InvalidPropertyException
      */
-    protected function setLocales(ChannelInterface $channel, array $localeCodes)
+    protected function setLocales(ChannelInterface $channel, array $localeCodes): void
     {
-        $locales = [];
         foreach ($localeCodes as $localeCode) {
             $locale = $this->localeRepository->findOneByIdentifier($localeCode);
             if (null === $locale) {
@@ -224,8 +216,13 @@ class ChannelUpdater implements ObjectUpdaterInterface
                 );
             }
 
-            $locales[] = $locale;
+            $channel->addLocale($locale);
         }
-        $channel->setLocales($locales);
+
+        foreach ($channel->getLocales() as $locale) {
+            if (!in_array($locale->getCode(), $localeCodes)) {
+                $channel->removeLocale($locale);
+            }
+        }
     }
 }

--- a/src/Akeneo/Channel/back/Infrastructure/EventListener/ChannelLocaleSubscriber.php
+++ b/src/Akeneo/Channel/back/Infrastructure/EventListener/ChannelLocaleSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Channel\Infrastructure\EventListener;
 
 use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
-use Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface;
 use Akeneo\Channel\Infrastructure\Component\Repository\LocaleRepositoryInterface;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
@@ -16,7 +15,7 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
- * Storage event subscriber that update channel locales
+ * Storage event subscriber that updates channel locales
  *
  * @author    Clement Gautier <clement.gautier@akeneo.com>
  * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
@@ -24,32 +23,16 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
  */
 class ChannelLocaleSubscriber implements EventSubscriberInterface
 {
-    protected LocaleRepositoryInterface $repository;
-
-    protected BulkSaverInterface $saver;
-
-    protected TokenStorageInterface $tokenStorage;
-
-    private JobLauncherInterface $jobLauncher;
-
-    private string $jobName;
-
-    private IdentifiableObjectRepositoryInterface $jobInstanceRepository;
-
     public function __construct(
-        LocaleRepositoryInterface $repository,
-        BulkSaverInterface $saver,
-        TokenStorageInterface $tokenStorage,
-        JobLauncherInterface $jobLauncher,
-        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
-        string $jobName
+        private readonly LocaleRepositoryInterface $repository,
+        private readonly BulkSaverInterface $saver,
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly JobLauncherInterface $jobLauncher,
+        private readonly IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        private readonly string $jobName,
+        private array $updatedLocales = [],
+        private array $localesRemovedFromChannel = [],
     ) {
-        $this->repository = $repository;
-        $this->saver = $saver;
-        $this->tokenStorage = $tokenStorage;
-        $this->jobLauncher = $jobLauncher;
-        $this->jobInstanceRepository = $jobInstanceRepository;
-        $this->jobName = $jobName;
     }
 
     /**
@@ -58,89 +41,59 @@ class ChannelLocaleSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            StorageEvents::PRE_REMOVE => 'removeChannel',
-            StorageEvents::PRE_SAVE   => 'updateChannel',
+            StorageEvents::PRE_SAVE => 'storeUpdatedLocales',
+            StorageEvents::POST_SAVE => 'saveLocales',
         ];
     }
 
-    public function removeChannel(GenericEvent $event)
+    public function storeUpdatedLocales(GenericEvent $event): void
     {
         $channel = $event->getSubject();
-
         if (!$channel instanceof ChannelInterface) {
             return;
         }
-
-        $locales = $channel->getLocales();
-        $updatedLocales = [];
-
-        foreach ($locales as $locale) {
-            $locale->removeChannel($channel);
-            $updatedLocales[] = $locale;
-        }
-
-        if (!empty($updatedLocales)) {
-            $this->saver->saveAll($updatedLocales);
-        }
-    }
-
-    public function updateChannel(GenericEvent $event)
-    {
-        $channel = $event->getSubject();
-
-        if (!$channel instanceof ChannelInterface) {
-            return;
-        }
-
-        $this->updateChannelInBackend($channel);
-    }
-
-    /**
-     * Update the channel and if at least a locale is removed, it launches the completeness cleaning with a command.
-     * @see https://akeneo.atlassian.net/browse/PIM-7155
-     */
-    private function updateChannelInBackend(ChannelInterface $channel): void
-    {
-        $oldLocales = $this->repository->getDeletedLocalesForChannel($channel);
-        $oldLocalesCodes = array_map(
-            function (LocaleInterface $locale) {
-                return $locale->getCode();
-            },
-            $oldLocales
-        );
-        $updatedLocales = [];
 
         foreach ($channel->getLocales() as $locale) {
             if (!$locale->hasChannel($channel)) {
                 $locale->addChannel($channel);
             }
-            $updatedLocales[] = $locale;
+            $this->updatedLocales[$channel->getCode()][$locale->getCode()] = $locale;
         }
 
+        $oldLocales = $this->repository->getDeletedLocalesForChannel($channel);
         foreach ($oldLocales as $locale) {
-            $locale->removeChannel($channel);
-            $updatedLocales[] = $locale;
-        }
-
-        if (!empty($updatedLocales)) {
-            $this->saver->saveAll($updatedLocales);
-        }
-
-        if (!empty($oldLocalesCodes)) {
-            $this->removeCompletenessForChannelAndLocales($oldLocalesCodes, $channel->getCode());
+            if ($locale->hasChannel($channel)) {
+                $locale->removeChannel($channel);
+            }
+            $this->updatedLocales[$channel->getCode()][$locale->getCode()] = $locale;
+            $this->localesRemovedFromChannel[$channel->getCode()][$locale->getCode()] = $locale->getCode();
         }
     }
 
-    private function removeCompletenessForChannelAndLocales(array $localesCodes, string $channelCode): void
+    public function saveLocales(GenericEvent $event): void
     {
-        $user = $this->tokenStorage->getToken()->getUser();
+        $channel = $event->getSubject();
+        if (!$channel instanceof ChannelInterface || !isset($this->updatedLocales[$channel->getCode()])) {
+            return;
+        }
+        $this->saver->saveAll(array_values($this->updatedLocales[$channel->getCode()]));
+        $this->removeCompletenessForChannelAndLocales($channel->getCode());
+    }
+
+    private function removeCompletenessForChannelAndLocales(string $channelCode): void
+    {
+        if (!isset($this->localesRemovedFromChannel[$channelCode])) {
+            return;
+        }
+
+        $user = $this->tokenStorage->getToken()?->getUser();
         $jobInstance = $this->jobInstanceRepository->findOneByIdentifier($this->jobName);
 
         $this->jobLauncher->launch(
             $jobInstance,
             $user,
             [
-                'locales_identifier' => $localesCodes,
+                'locales_identifier' => array_values($this->localesRemovedFromChannel[$channelCode]),
                 'channel_code' => $channelCode,
                 'username' => $user->getUserIdentifier(),
             ]

--- a/src/Akeneo/Channel/back/Infrastructure/EventListener/RemoveLocalesFromChannelSubscriber.php
+++ b/src/Akeneo/Channel/back/Infrastructure/EventListener/RemoveLocalesFromChannelSubscriber.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Infrastructure\EventListener;
+
+use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class RemoveLocalesFromChannelSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly BulkSaverInterface $localeSaver,
+        private array $localesToSave = []
+    ) {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::PRE_REMOVE => 'removeLocalesFromChannel',
+            StorageEvents::POST_REMOVE => 'saveLocales',
+        ];
+    }
+
+    public function removeLocalesFromChannel(GenericEvent $event): void
+    {
+        $channel = $event->getSubject();
+        if (!$channel instanceof ChannelInterface) {
+            return;
+        }
+
+        foreach ($channel->getLocales() as $locale) {
+            $channel->removeLocale($locale);
+            $this->localesToSave[$channel->getCode()][] = $locale;
+        }
+    }
+
+    public function saveLocales(GenericEvent $event): void
+    {
+        $channel = $event->getSubject();
+        if (!$channel instanceof ChannelInterface || !isset($this->localesToSave[$channel->getCode()])) {
+            return;
+        }
+
+        $this->localeSaver->saveAll($this->localesToSave[$channel->getCode()]);
+    }
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Processor/Denormalization/ChannelProcessor.php
+++ b/src/Akeneo/Channel/back/Infrastructure/Processor/Denormalization/ChannelProcessor.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Channel\Infrastructure\Processor\Denormalization;
+
+use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Tool\Component\Connector\Processor\Denormalization\AbstractProcessor;
+use Akeneo\Tool\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\PropertyException;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ChannelProcessor extends AbstractProcessor implements ItemProcessorInterface, StepExecutionAwareInterface
+{
+    public function __construct(
+        IdentifiableObjectRepositoryInterface $repository,
+        private readonly SimpleFactoryInterface $channelFactory,
+        private readonly ObjectUpdaterInterface $channelUpdater,
+        private readonly ValidatorInterface $validator,
+        private readonly ObjectDetacherInterface $objectDetacher
+    ) {
+        parent::__construct($repository);
+    }
+
+    public function process($item)
+    {
+        $itemIdentifier = $this->getItemIdentifier($this->repository, $item);
+        $channel = $this->findOrCreateObject($itemIdentifier);
+
+        try {
+            $this->channelUpdater->update($channel, $item);
+        } catch (PropertyException $exception) {
+            $this->skipItemWithMessage($item, $exception->getMessage(), $exception);
+        }
+
+        $violations = $this->validator->validate($channel);
+        if ($violations->count() > 0) {
+            if (null === $channel->getId()) {
+                foreach ($channel->getLocales() as $locale) {
+                    $channel->removeLocale($locale);
+                }
+            }
+
+            $this->objectDetacher->detach($channel);
+            $this->skipItemWithConstraintViolations($item, $violations);
+        }
+
+        if (null !== $this->stepExecution) {
+            $this->saveProcessedItemInStepExecutionContext($itemIdentifier, $channel);
+        }
+
+        return $channel;
+    }
+
+    private function saveProcessedItemInStepExecutionContext(string $itemIdentifier, mixed $processedItem)
+    {
+        $executionContext = $this->stepExecution->getExecutionContext();
+        $processedItemsBatch = $executionContext->get('processed_items_batch') ?? [];
+        $processedItemsBatch[$itemIdentifier] = $processedItem;
+
+        $executionContext->put('processed_items_batch', $processedItemsBatch);
+    }
+
+    private function findOrCreateObject(string $itemIdentifier)
+    {
+        $entity = $this->repository->findOneByIdentifier($itemIdentifier);
+        if (null === $entity) {
+            if ('' === $itemIdentifier || null === $this->stepExecution) {
+                return $this->channelFactory->create();
+            }
+
+            $executionContext = $this->stepExecution->getExecutionContext();
+            $processedItemsBatch = $executionContext->get('processed_items_batch') ?? [];
+
+            return $processedItemsBatch[$itemIdentifier] ?? $this->channelFactory->create();
+        }
+
+        return $entity;
+    }
+}

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/doctrine/model/Locale.orm.yml
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/doctrine/model/Locale.orm.yml
@@ -21,5 +21,4 @@ Akeneo\Channel\Infrastructure\Component\Model\Locale:
             targetEntity: Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface
             mappedBy: locales
             cascade:
-                - persist
                 - detach

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/processors.yml
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/processors.yml
@@ -20,7 +20,7 @@ services:
     ### Channel
     #TODO: fix the dependency to the processor class
     pim_connector.processor.denormalization.channel:
-        class: 'Akeneo\Tool\Component\Connector\Processor\Denormalization\Processor'
+        class: 'Akeneo\Channel\Infrastructure\Processor\Denormalization\ChannelProcessor'
         arguments:
             - '@pim_catalog.repository.channel'
             - '@pim_catalog.factory.channel'

--- a/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/services.yml
+++ b/src/Akeneo/Channel/back/Infrastructure/Symfony/Resources/config/services.yml
@@ -77,6 +77,15 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    pim_enrich.event_subscriber.storage.remove_locales_from_channel:
+        class: 'Akeneo\Channel\Infrastructure\EventListener\RemoveLocalesFromChannelSubscriber'
+        arguments:
+            - '@pim_catalog.saver.locale'
+            - []
+        tags:
+            - { name: kernel.event_subscriber }
+
+
     ### Channel
     pim_catalog.factory.channel:
         class: '%akeneo_storage_utils.factory.simple.class%'

--- a/src/Akeneo/Channel/back/tests/Integration/ChannelTestCase.php
+++ b/src/Akeneo/Channel/back/tests/Integration/ChannelTestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Akeneo\Test\Channel\Integration;
 
 use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
-use Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface;
 use Akeneo\Test\Integration\Configuration;
 use Akeneo\Test\Integration\TestCase;
 use Akeneo\Test\Pim\Enrichment\Product\Helper\FeatureHelper;
@@ -78,22 +77,6 @@ class ChannelTestCase extends TestCase
         $this->get('pim_user.saver.user')->save($user);
 
         return $user;
-    }
-
-    /**
-     * @param ChannelInterface[] $channels
-     */
-    protected function createLocale(string $localeCode, array $channels = []): LocaleInterface
-    {
-        $locale = $this->get('pim_catalog.factory.locale')->create();
-        $locale->setCode($localeCode);
-        $locale->setChannels($channels);
-
-        $violations = $this->get('validator')->validate($locale);
-        Assert::assertSame(0, $violations->count(), (string) $violations);
-        $this->get('pim_catalog.saver.locale')->save($locale);
-
-        return $locale;
     }
 
     /**

--- a/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Processor/Denormalization/ChannelProcessorSpec.php
+++ b/src/Akeneo/Channel/back/tests/Specification/Infrastructure/Processor/Denormalization/ChannelProcessorSpec.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Specification\Akeneo\Channel\Infrastructure\Processor\Denormalization;
+
+use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
+use Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface;
+use Akeneo\Channel\Infrastructure\Component\Updater\ChannelUpdater;
+use Akeneo\Channel\Infrastructure\Processor\Denormalization\ChannelProcessor;
+use Akeneo\Tool\Component\Batch\Item\ExecutionContext;
+use Akeneo\Tool\Component\Batch\Item\InvalidItemException;
+use Akeneo\Tool\Component\Batch\Item\ItemProcessorInterface;
+use Akeneo\Tool\Component\Batch\Model\StepExecution;
+use Akeneo\Tool\Component\Batch\Step\StepExecutionAwareInterface;
+use Akeneo\Tool\Component\Connector\Exception\InvalidItemFromViolationsException;
+use Akeneo\Tool\Component\StorageUtils\Detacher\ObjectDetacherInterface;
+use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyException;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactory;
+use Akeneo\Tool\Component\StorageUtils\Factory\SimpleFactoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
+use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+class ChannelProcessorSpec extends ObjectBehavior
+{
+    public function let(
+        IdentifiableObjectRepositoryInterface $repository,
+        SimpleFactory $factory,
+        ObjectUpdaterInterface $updater,
+        ValidatorInterface $validator,
+        ObjectDetacherInterface $objectDetacher
+    ): void {
+        $this->beConstructedWith($repository, $factory, $updater, $validator, $objectDetacher);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(ChannelProcessor::class);
+    }
+
+    public function it_is_a_processor(): void
+    {
+        $this->shouldImplement(ItemProcessorInterface::class);
+        $this->shouldImplement(StepExecutionAwareInterface::class);
+    }
+
+    public function it_updates_an_existing_channel(
+        IdentifiableObjectRepositoryInterface $repository,
+        ChannelUpdater $updater,
+        ValidatorInterface $validator,
+        ChannelInterface $channel,
+    ): void {
+        $repository->getIdentifierProperties()->willReturn(['code']);
+        $repository->findOneByIdentifier('mycode')->willReturn($channel);
+
+        $channel->getId()->willReturn(42);
+
+        $values = $this->getValues();
+
+        $updater
+            ->update($channel, $values)
+            ->shouldBeCalled();
+
+        $validator
+            ->validate($channel)
+            ->willReturn(new ConstraintViolationList());
+
+        $this
+            ->process($values)
+            ->shouldReturn($channel);
+    }
+
+    public function it_skips_a_channel_when_update_fails(
+        IdentifiableObjectRepositoryInterface $repository,
+        ChannelUpdater $updater,
+        ValidatorInterface $validator,
+        ChannelInterface $channel,
+    ): void {
+        $repository->getIdentifierProperties()->willReturn(['code']);
+        $repository->findOneByIdentifier(Argument::any())->willReturn($channel);
+
+        $channel->getId()->willReturn(42);
+
+        $values = $this->getValues();
+
+        $updater
+            ->update($channel, $values)
+            ->shouldBeCalled();
+
+        $validator
+            ->validate($channel)
+            ->willReturn(new ConstraintViolationList());
+
+        $this
+            ->process($values)
+            ->shouldReturn($channel);
+
+        $updater
+            ->update($channel, $values)
+            ->willThrow(new InvalidPropertyException('code', 'value', 'className', 'The code could not be blank.'));
+
+        $this
+            ->shouldThrow(InvalidItemException::class)
+            ->during(
+                'process',
+                [$values]
+            );
+    }
+
+    public function it_skips_a_channel_when_object_is_invalid(
+        IdentifiableObjectRepositoryInterface $repository,
+        ChannelUpdater $updater,
+        ValidatorInterface $validator,
+        ObjectDetacherInterface $objectDetacher,
+        ChannelInterface $channel
+    ): void {
+        $repository->getIdentifierProperties()->willReturn(['code']);
+        $repository->findOneByIdentifier(Argument::any())->willReturn($channel);
+
+        $channel->getId()->willReturn(42);
+
+        $values = $this->getValues();
+
+        $updater
+            ->update($channel, $values)
+            ->shouldBeCalled();
+
+        $violation = new ConstraintViolation('Error', 'foo', [], 'bar', 'code', 'mycode');
+        $violations = new ConstraintViolationList([$violation]);
+        $validator->validate($channel)
+            ->willReturn($violations);
+
+        $objectDetacher->detach($channel)->shouldBeCalled();
+        $this
+            ->shouldThrow(InvalidItemException::class)
+            ->during(
+                'process',
+                [$values]
+            );
+    }
+
+    public function it_does_not_create_the_same_channel_twice_in_the_same_batch(
+        IdentifiableObjectRepositoryInterface $repository,
+        ChannelUpdater $updater,
+        ValidatorInterface $validator,
+        SimpleFactoryInterface $factory,
+        StepExecution $stepExecution,
+        ExecutionContext $executionContext,
+        ChannelInterface $channel
+    ): void {
+        $this->setStepExecution($stepExecution);
+        $repository->getIdentifierProperties()->willReturn(['code']);
+        $stepExecution->getExecutionContext()->willReturn($executionContext);
+        $executionContext->get('processed_items_batch')->willReturn(null);
+
+        $repository->findOneByIdentifier('mycode')->willReturn(null);
+        $factory->create()->shouldBeCalledTimes(1)->willReturn($channel);
+
+        $executionContext
+            ->put('processed_items_batch', ['mycode' => $channel])
+            ->shouldBeCalled()
+            ->will(function() use ($executionContext, $channel) {
+                $executionContext->get('processed_items_batch')->willReturn(['mycode' => $channel]);
+            });
+
+        $firstChannelValues = $this->getValues();
+
+        $updater
+            ->update($channel, $firstChannelValues)
+            ->shouldBeCalled();
+
+        $validator
+            ->validate($channel)
+            ->willReturn(new ConstraintViolationList());
+
+        $this
+            ->process($firstChannelValues)
+            ->shouldReturn($channel);
+
+        $secondChannelValues = $this->getValues();
+        $secondChannelValues['label'] = 'Another label';
+
+        $updater
+            ->update($channel, $secondChannelValues)
+            ->shouldBeCalled();
+
+        $validator
+            ->validate($channel)
+            ->willReturn(new ConstraintViolationList());
+
+        $this
+            ->process($secondChannelValues)
+            ->shouldReturn($channel);
+    }
+
+    public function it_remove_relationship_between_locale_and_channel_on_validation_error_for_new_channel(
+        SimpleFactoryInterface $factory,
+        IdentifiableObjectRepositoryInterface $repository,
+        ChannelUpdater $updater,
+        ValidatorInterface $validator,
+        ObjectDetacherInterface $objectDetacher,
+        ChannelInterface $channel,
+        LocaleInterface $locale
+    ): void {
+        $factory->create()
+            ->shouldBeCalledTimes(1)
+            ->willReturn($channel);
+        $channel
+            ->getId()
+            ->shouldBeCalled()
+            ->willReturn(null);
+        $channel
+            ->getLocales()
+            ->shouldBeCalled()
+            ->willReturn([$locale]);
+        $channel
+            ->removeLocale(Argument::any())
+            ->shouldBeCalledOnce();
+
+        $repository->getIdentifierProperties()->willReturn(['code']);
+        $repository->findOneByIdentifier(Argument::any())->willReturn(null);
+
+        $values = $this->getValues();
+
+        $updater
+            ->update($channel, $values)
+            ->shouldBeCalled();
+
+        $violation = new ConstraintViolation('Error', 'foo', [], 'bar', 'code', 'mycode');
+        $violations = new ConstraintViolationList([$violation]);
+        $validator->validate($channel)
+            ->shouldBeCalled()
+            ->willReturn($violations);
+
+        $objectDetacher->detach($channel)->shouldBeCalled();
+
+        $this
+            ->shouldThrow(InvalidItemFromViolationsException::class)
+            ->during(
+                'process',
+                [$values]
+            );
+    }
+
+    private function getValues(): array
+    {
+        return [
+            'code'       => 'mycode',
+            'label'      => 'Ecommerce',
+            'locales'    => ['en_US', 'fr_FR'],
+            'currencies' => ['EUR', 'USD'],
+            'tree'       => 'master_catalog',
+            'color'      => 'orange'
+        ];
+    }
+}

--- a/tests/back/Acceptance/Channel/ChannelContext.php
+++ b/tests/back/Acceptance/Channel/ChannelContext.php
@@ -77,7 +77,7 @@ final class ChannelContext implements Context
     }
 
     /**
-     * @when the locale :localeCode is removed from the :channelCode channel
+     * @When the locale :localeCode is removed from the :channelCode channel
      */
     public function iRemoveTheLocaleFromTheChannel(string $localeCode, string $channelCode)
     {

--- a/tests/back/Acceptance/Locale/LocaleContext.php
+++ b/tests/back/Acceptance/Locale/LocaleContext.php
@@ -11,18 +11,10 @@ use PHPUnit\Framework\Assert;
 
 final class LocaleContext implements Context
 {
-    /** @var InMemoryLocaleRepository */
-    private $localeRepository;
-
-    /** @var EntityBuilder */
-    private $localeBuilder;
-
     public function __construct(
-        InMemoryLocaleRepository $localeRepository,
-        EntityBuilder $localeBuilder
+        private readonly InMemoryLocaleRepository $localeRepository,
+        private readonly EntityBuilder $localeBuilder
     ) {
-        $this->localeRepository = $localeRepository;
-        $this->localeBuilder = $localeBuilder;
     }
 
     /**
@@ -40,15 +32,19 @@ final class LocaleContext implements Context
     }
 
     /**
-     * @Then the locales :localeCodes is activated
+     * @Then /^the locale(?:s|) "(?P<localeCodes>.*)" should be (?P<activation>activated|deactivated)$/
      */
-    public function iShouldHaveActivatedLocales(string $localeCodes)
+    public function iShouldHaveLocales(string $localeCodes, string $activation)
     {
         $localeCodes = new ListOfCodes($localeCodes);
 
         foreach ($localeCodes->explode() as $localeCode) {
             $locale = $this->localeRepository->findOneByIdentifier($localeCode);
-            Assert::assertTrue($locale->isActivated());
+            if ('activated' === $activation) {
+                Assert::assertTrue($locale->isActivated());
+            } else {
+                Assert::assertFalse($locale->isActivated());
+            }
         }
     }
 }

--- a/tests/back/Channel/Specification/Infrastructure/Component/Updater/ChannelUpdaterSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/Component/Updater/ChannelUpdaterSpec.php
@@ -15,6 +15,7 @@ use Akeneo\Tool\Component\StorageUtils\Exception\InvalidPropertyTypeException;
 use Akeneo\Tool\Component\StorageUtils\Exception\UnknownPropertyException;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Updater\ObjectUpdaterInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use PhpSpec\ObjectBehavior;
 use Akeneo\Category\Infrastructure\Component\Model\CategoryInterface;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
@@ -28,7 +29,6 @@ function makeLocale(string $code): Locale
 }
 class ChannelUpdaterSpec extends ObjectBehavior
 {
-
     private static Locale $enUS;
     private static Locale $frFR;
 
@@ -108,11 +108,18 @@ class ChannelUpdaterSpec extends ObjectBehavior
 
         $localeRepository->findOneByIdentifier('en_US')->willReturn($this::$enUS);
         $localeRepository->findOneByIdentifier('fr_FR')->willReturn($this::$frFR);
-        $channel->setLocales([$this::$enUS, $this::$frFR])->shouldBeCalled();
+        $channel->addLocale($this::$enUS)
+            ->shouldBeCalledOnce();
+        $channel->addLocale($this::$frFR)
+            ->shouldBeCalledOnce();
+        $channel->getLocales()
+            ->shouldBeCalledOnce()
+            ->willReturn(new ArrayCollection([$this::$enUS, $this::$frFR]));
 
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
         $currencyRepository->findOneByIdentifier('USD')->willReturn($usd);
-        $channel->setCurrencies([$eur, $usd])->shouldBeCalled();
+        $channel->setCurrencies([$eur, $usd])
+            ->shouldBeCalledOnce();
 
         $maximumDiagonalAttribute->getMetricFamily()->willReturn('Length');
         $weightAttribute->getMetricFamily()->willReturn('Weight');
@@ -129,7 +136,6 @@ class ChannelUpdaterSpec extends ObjectBehavior
 
         $this->update($channel, $values, []);
     }
-
 
     function it_updates_a_channel_with_conversion_units_empty(
         $categoryRepository,
@@ -163,7 +169,13 @@ class ChannelUpdaterSpec extends ObjectBehavior
 
         $localeRepository->findOneByIdentifier('en_US')->willReturn($this::$enUS);
         $localeRepository->findOneByIdentifier('fr_FR')->willReturn($this::$frFR);
-        $channel->setLocales([$this::$enUS, $this::$frFR])->shouldBeCalled();
+        $channel->addLocale($this::$enUS)
+            ->shouldBeCalledOnce();
+        $channel->addLocale($this::$frFR)
+            ->shouldBeCalledOnce();
+        $channel->getLocales()
+            ->shouldBeCalledOnce()
+            ->willReturn(new ArrayCollection([$this::$enUS, $this::$frFR]));
 
         $currencyRepository->findOneByIdentifier('EUR')->willReturn($eur);
         $currencyRepository->findOneByIdentifier('USD')->willReturn($usd);

--- a/tests/back/Channel/Specification/Infrastructure/EventListener/ChannelLocaleSubscriberSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/EventListener/ChannelLocaleSubscriberSpec.php
@@ -2,17 +2,17 @@
 
 namespace Specification\Akeneo\Channel\Infrastructure\EventListener;
 
-use Akeneo\Tool\Bundle\BatchBundle\Job\JobInstanceRepository;
+use Akeneo\Channel\Infrastructure\Component\Model\Channel;
+use Akeneo\Channel\Infrastructure\Component\Model\Locale;
+use Akeneo\Channel\Infrastructure\Component\Repository\LocaleRepositoryInterface;
+use Akeneo\Channel\Infrastructure\EventListener\ChannelLocaleSubscriber;
 use Akeneo\Tool\Bundle\BatchBundle\Launcher\JobLauncherInterface;
+use Akeneo\Tool\Component\Batch\Model\JobExecution;
 use Akeneo\Tool\Component\Batch\Model\JobInstance;
 use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryInterface;
 use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
 use Akeneo\Tool\Component\StorageUtils\StorageEvents;
 use PhpSpec\ObjectBehavior;
-use Akeneo\Channel\Infrastructure\EventListener\ChannelLocaleSubscriber;
-use Akeneo\Channel\Infrastructure\Component\Model\ChannelInterface;
-use Akeneo\Channel\Infrastructure\Component\Model\LocaleInterface;
-use Akeneo\Channel\Infrastructure\Component\Repository\LocaleRepositoryInterface;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -21,13 +21,19 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class ChannelLocaleSubscriberSpec extends ObjectBehavior
 {
-    function let(
+    public function let(
         LocaleRepositoryInterface $repository,
         BulkSaverInterface $saver,
         TokenStorageInterface $tokenStorage,
         JobLauncherInterface $jobLauncher,
-        IdentifiableObjectRepositoryInterface $jobInstanceRepository
-    ) {
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        TokenInterface $token,
+        UserInterface $user
+    ): void {
+        $user->getUserIdentifier()->willReturn('julia');
+        $token->getUser()->willReturn($user);
+        $tokenStorage->getToken()->willReturn($token);
+
         $this->beConstructedWith(
             $repository,
             $saver,
@@ -38,123 +44,85 @@ class ChannelLocaleSubscriberSpec extends ObjectBehavior
         );
     }
 
-    function it_is_initializable()
+    public function it_is_initializable(): void
     {
         $this->shouldHaveType(ChannelLocaleSubscriber::class);
     }
 
-    function it_subscribes_to_storage_events()
+    public function it_subscribes_to_save_events(): void
     {
-        $this->getSubscribedEvents()->shouldReturn([
-            StorageEvents::PRE_REMOVE => 'removeChannel',
-            StorageEvents::PRE_SAVE => 'updateChannel',
-        ]);
+        $this->getSubscribedEvents()->shouldHaveKey(StorageEvents::PRE_SAVE);
+        $this->getSubscribedEvents()->shouldHaveKey(StorageEvents::POST_SAVE);
     }
 
-    function it_does_not_remove_channel_on_non_channels($saver, GenericEvent $event, \stdClass $channel)
+    public function it_only_handles_channels(BulkSaverInterface $saver): void
     {
-        $event->getSubject()->willReturn($channel);
+        $subject = new \stdClass();
         $saver->saveAll(Argument::any())->shouldNotBeCalled();
 
-        $this->removeChannel($event);
+        $this->storeUpdatedLocales(new GenericEvent($subject));
+        $this->saveLocales(new GenericEvent($subject));
     }
 
-    function it_removes_channel($saver, GenericEvent $event, ChannelInterface $channel, LocaleInterface $locale)
-    {
-        $event->getSubject()->willReturn($channel);
-        $saver->saveAll([$locale])->shouldBeCalled();
-        $channel->getLocales()->willReturn([$locale]);
-        $locale->removeChannel($channel)->shouldBeCalled();
-
-        $this->removeChannel($event);
-    }
-
-    function it_does_not_upadte_channel_on_non_channels($saver, GenericEvent $event, \stdClass $channel)
-    {
-        $event->getSubject()->willReturn($channel);
-        $saver->saveAll(Argument::any())->shouldNotBeCalled();
-
-        $this->updateChannel($event);
-    }
-
-    function it_updates_channel_when_a_locale_has_been_removed(
-        $repository,
-        $saver,
-        $tokenStorage,
-        UserInterface $user,
-        JobInstanceRepository $jobInstanceRepository,
-        JobInstance $jobInstance,
+    public function it_saves_locales_related_to_updated_channels(
+        LocaleRepositoryInterface $repository,
+        BulkSaverInterface $saver,
         JobLauncherInterface $jobLauncher,
-        GenericEvent $event,
-        ChannelInterface $channel,
-        LocaleInterface $localeEn,
-        LocaleInterface $localeFr,
-        LocaleInterface $localeEs,
-        TokenInterface $token
-    ) {
-        $event->getSubject()->willReturn($channel);
-        $repository->getDeletedLocalesForChannel($channel)->willReturn([$localeEn]);
+    ): void {
+        $enUS = new Locale();
+        $enUS->setCode('en_US');
+        $frFR = new Locale();
+        $frFR->setCode('fr_FR');
+        $channel = new Channel();
+        $channel->setCode('ecommerce');
+        $channel->addLocale($enUS);
+        $channel->addLocale($frFR);
 
-        $localeEn->getCode()->willReturn('en_US');
-        $localeFr->hasChannel($channel)->willReturn(true);
-        $localeEs->hasChannel($channel)->willReturn(false);
+        $repository->getDeletedLocalesForChannel($channel)->shouldBeCalled()->willReturn([]);
+        $saver->saveAll([$enUS, $frFR])->shouldBeCalled();
+        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
 
-        $channel->getLocales()->willReturn([$localeFr, $localeEs]);
-        $channel->getCode()->willReturn('print');
-        $channel->hasLocale($localeEn)->willReturn(false);
-        $channel->hasLocale($localeFr)->willReturn(true);
+        $this->storeUpdatedLocales(new GenericEvent($channel));
+        $this->saveLocales(new GenericEvent($channel));
+    }
 
-        $localeEn->removeChannel($channel)->shouldBeCalled();
-        $localeEs->addChannel($channel)->shouldBeCalled();
+    public function it_saves_locales_removed_from_channels_and_launches_the_clean_completeness_job(
+        LocaleRepositoryInterface $repository,
+        BulkSaverInterface $saver,
+        JobLauncherInterface $jobLauncher,
+        IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        JobInstance $jobInstance,
+        JobExecution $jobExecution,
+        UserInterface $user,
+    ): void {
+        $enUS = new Locale();
+        $enUS->setCode('en_US');
+        $channel = new Channel();
+        $channel->setCode('ecommerce');
+        $channel->addLocale($enUS);
+        $frFR = new Locale();
+        $frFR->setCode('fr_FR');
+        $deDE = new Locale();
+        $deDE->setCode('de_DE');
 
-        $saver->saveAll([$localeFr, $localeEs, $localeEn])->shouldBeCalled();
+        $repository->getDeletedLocalesForChannel($channel)->shouldBeCalled()->willReturn([$frFR, $deDE]);
+        $saver->saveAll([$enUS, $frFR, $deDE])->shouldBeCalled();
 
-        $tokenStorage->getToken()->willReturn($token);
-        $token->getUser()->willReturn($user);
-        $user->getUserIdentifier()->willReturn('julia');
-
-        $jobInstanceRepository
-            ->findOneByIdentifier('remove_completeness_for_channel_and_locale')
-            ->willReturn($jobInstance);
-
+        $jobInstanceRepository->findOneByIdentifier('remove_completeness_for_channel_and_locale')
+            ->shouldBeCalled()->willReturn($jobInstance);
         $jobLauncher->launch(
             $jobInstance,
             $user,
             [
-                'locales_identifier' => ['en_US'],
-                'channel_code' => 'print',
+                'locales_identifier' => ['fr_FR', 'de_DE'],
+                'channel_code' => 'ecommerce',
                 'username' => 'julia',
             ]
-        )->shouldBeCalled();
+        )
+            ->shouldBeCalledOnce()
+            ->willReturn($jobExecution);
 
-        $this->updateChannel($event);
-    }
-
-    function it_updates_channel_without_removed_locale(
-        $repository,
-        $saver,
-        GenericEvent $event,
-        ChannelInterface $channel,
-        LocaleInterface $localeFr,
-        LocaleInterface $localeEs,
-        JobLauncherInterface $jobLauncher
-    ) {
-        $event->getSubject()->willReturn($channel);
-        $repository->getDeletedLocalesForChannel($channel)->willReturn([]);
-
-        $localeFr->hasChannel($channel)->willReturn(true);
-        $localeEs->hasChannel($channel)->willReturn(false);
-
-        $channel->getLocales()->willReturn([$localeFr, $localeEs]);
-        $channel->getCode()->willReturn('print');
-        $channel->hasLocale($localeFr)->willReturn(true);
-
-        $localeEs->addChannel($channel)->shouldBeCalled();
-
-        $saver->saveAll([$localeFr, $localeEs])->shouldBeCalled();
-
-        $jobLauncher->launch(Argument::cetera())->shouldNotBeCalled();
-
-        $this->updateChannel($event);
+        $this->storeUpdatedLocales(new GenericEvent($channel));
+        $this->saveLocales(new GenericEvent($channel));
     }
 }

--- a/tests/back/Channel/Specification/Infrastructure/EventListener/RemoveLocalesFromChannelSubscriberSpec.php
+++ b/tests/back/Channel/Specification/Infrastructure/EventListener/RemoveLocalesFromChannelSubscriberSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Specification\Akeneo\Channel\Infrastructure\EventListener;
+
+use Akeneo\Channel\Infrastructure\Component\Model\Channel;
+use Akeneo\Channel\Infrastructure\Component\Model\Locale;
+use Akeneo\Channel\Infrastructure\EventListener\RemoveLocalesFromChannelSubscriber;
+use Akeneo\Pim\Enrichment\Component\Product\Model\Product;
+use Akeneo\Tool\Component\StorageUtils\Saver\BulkSaverInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class RemoveLocalesFromChannelSubscriberSpec extends ObjectBehavior
+{
+    public function let(BulkSaverInterface $localeSaver): void
+    {
+        $this->beConstructedWith($localeSaver);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldImplement(EventSubscriberInterface::class);
+        $this->shouldHaveType(RemoveLocalesFromChannelSubscriber::class);
+    }
+
+    public function it_subscribes_to_remove_events(): void
+    {
+        $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::PRE_REMOVE);
+        $this::getSubscribedEvents()->shouldHaveKey(StorageEvents::POST_REMOVE);
+    }
+
+    public function it_only_handles_channels(BulkSaverInterface $localeSaver): void
+    {
+        $product = new Product();
+
+        $localeSaver->saveAll(Argument::any())->shouldNotBeCalled();
+
+        $this->removeLocalesFromChannel(new GenericEvent($product));
+        $this->saveLocales(new GenericEvent($product));
+    }
+
+    public function it_removes_locales_from_deleted_channel_and_saves_them(BulkSaverInterface $localeSaver): void
+    {
+        $enUS = new Locale();
+        $frFR = new Locale();
+        $channel = new Channel();
+        $channel->setCode('ecommerce');
+        $channel->addLocale($enUS);
+        $channel->addLocale($frFR);
+
+        $localeSaver->saveAll([$enUS, $frFR])->shouldBeCalled();
+
+        $this->removeLocalesFromChannel(new GenericEvent($channel));
+        $this->saveLocales(new GenericEvent($channel));
+    }
+}

--- a/tests/features/channel/locale/locale_status.feature
+++ b/tests/features/channel/locale/locale_status.feature
@@ -7,12 +7,15 @@ Feature: Manage the locale status
   Scenario: By default a locale is disabled by when it is added to a channel it becomes enabled
     Given the following locales "fr_FR, en_US"
     And the following "ecommerce" channel with locales "fr_FR"
+    Then the locale "fr_FR" should be activated
+    And the locale "en_US" should be deactivated
     When the locale "en_US" is added to the "ecommerce" channel
-    Then the locales "fr_FR,en_US" is activated
+    Then the locales "fr_FR,en_US" should be activated
 
   @acceptance-back
   Scenario: When a locale is removed from a channel it becomes disabled
     Given the following locales "fr_FR, en_US"
     And the following "ecommerce" channel with locales "fr_FR, en_US"
     When the locale "fr_FR" is removed from the "ecommerce" channel
-    Then the locales "en_US" is activated
+    Then the locale "en_US" should be activated
+    And the locale "fr_FR" should be deactivated


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Prevent channel creation on validation error during import

- Create channel processor from generic to remove association between channels and locales on new channels
- Update `ChannelLocaleSubscriber` in order to save locale updates only on **POST** events 
- Remove cascade persist between from Locale To channels
- Update acceptance test to check activation/deactivation of locale

**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
