### PR TITLE
PIM-10915: fix dynamic typing to cast to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - PIM-10894: Allow research user by email as username.
 - PIM-10888: Disable adding an item to an association of its parent already contains the same item.
 - PIM-10906: Use user timezone to display dates in history grid
+- PIM-10915: Fix attribute with numeric code throw 500 error on product history
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Normalizer/InternalApi/VersionNormalizer.php
@@ -134,7 +134,7 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
     {
         $attributeCodes = [];
         foreach (array_keys($changeset) as $valueHeader) {
-            $attributeCode = $this->extractAttributeCode($valueHeader);
+            $attributeCode = $this->extractAttributeCode((string) $valueHeader);
 
             $attributeCodes[$attributeCode] = true;
         }
@@ -143,7 +143,7 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
 
         foreach ($changeset as $valueHeader => $valueChanges) {
             $context['versioned_attribute'] = $valueHeader;
-            $attributeCode = $this->extractAttributeCode($valueHeader);
+            $attributeCode = $this->extractAttributeCode((string) $valueHeader);
             $context['attribute'] = $attributeCode;
 
             if (isset($attributeTypes[$attributeCode])) {
@@ -168,10 +168,10 @@ class VersionNormalizer implements NormalizerInterface, CacheableSupportsMethodI
      * For example, in "price-EUR", the attribute code is "price".
      * For "desc-ecom-en_US", this is "desc".
      */
-    protected function extractAttributeCode($valueHeader)
+    protected function extractAttributeCode(string $valueHeader): string
     {
-        if (($separatorPos = strpos($valueHeader, self::ATTRIBUTE_HEADER_SEPARATOR)) !== false) {
-            return substr($valueHeader, 0, $separatorPos);
+        if (($separatorPos = \strpos($valueHeader, self::ATTRIBUTE_HEADER_SEPARATOR)) !== false) {
+            return \substr($valueHeader, 0, $separatorPos);
         }
 
         return $valueHeader;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

PHP convert type to int when key is numeric.
`strpos` and `substr` use only string

So we need to cast before calling this functions

**Definition Of Done (for Core Developer only)**

- [X] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
