### PR TITLE
OCT-code-improvements: use interface instead of method_exists, split services.yml

### DIFF
--- a/components/catalogs/back/src/Application/Handler/GetMappedProductsHandler.php
+++ b/components/catalogs/back/src/Application/Handler/GetMappedProductsHandler.php
@@ -13,7 +13,7 @@ use Akeneo\Catalogs\Application\Persistence\Catalog\Product\GetRawProductQueryIn
 use Akeneo\Catalogs\Application\Persistence\Catalog\Product\GetRawProductsQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Category\GetProductCategoriesLabelsQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\ProductMappingSchema\GetProductMappingSchemaQueryInterface;
-use Akeneo\Catalogs\Application\Persistence\WarmupableQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\WarmupAwareQueryInterface;
 use Akeneo\Catalogs\Application\Service\DispatchInvalidCatalogDisabledEventInterface;
 use Akeneo\Catalogs\Application\Validation\IsCatalogValidInterface;
 use Akeneo\Catalogs\Domain\Catalog;
@@ -100,7 +100,7 @@ final class GetMappedProductsHandler
      */
     private function warmupProductCategoryCache(array $productMapping, array $productUuids): void
     {
-        if (!$this->getProductCategoriesLabelsQuery instanceof WarmupableQueryInterface
+        if (!$this->getProductCategoriesLabelsQuery instanceof WarmupAwareQueryInterface
             || [] === $productUuids
         ) {
             return;

--- a/components/catalogs/back/src/Application/Persistence/WarmupAwareQueryInterface.php
+++ b/components/catalogs/back/src/Application/Persistence/WarmupAwareQueryInterface.php
@@ -8,7 +8,7 @@ namespace Akeneo\Catalogs\Application\Persistence;
  * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-interface WarmupableQueryInterface
+interface WarmupAwareQueryInterface
 {
     /**
      * @param array<string, mixed> $options

--- a/components/catalogs/back/src/Application/Persistence/WarmupableQueryInterface.php
+++ b/components/catalogs/back/src/Application/Persistence/WarmupableQueryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Catalogs\Application\Persistence;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface WarmupableQueryInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function warmup(array $options = []): void;
+}

--- a/components/catalogs/back/src/Infrastructure/Persistence/Category/GetProductCategoriesLabelsQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Category/GetProductCategoriesLabelsQuery.php
@@ -6,7 +6,7 @@ namespace Akeneo\Catalogs\Infrastructure\Persistence\Category;
 
 use Akeneo\Catalogs\Application\Persistence\Category\GetCategoriesByCodeQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Category\GetProductCategoriesLabelsQueryInterface;
-use Akeneo\Catalogs\Application\Persistence\WarmupableQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\WarmupAwareQueryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Query\GetProductCategoryCodesQuery;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
@@ -17,7 +17,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
  * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQueryInterface, WarmupableQueryInterface
+class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQueryInterface, WarmupAwareQueryInterface
 {
     /** @var array<string, string[]> $categoryCodesByProduct */
     private array $categoryCodesByProduct = [];

--- a/components/catalogs/back/src/Infrastructure/Persistence/Category/GetProductCategoriesLabelsQuery.php
+++ b/components/catalogs/back/src/Infrastructure/Persistence/Category/GetProductCategoriesLabelsQuery.php
@@ -6,6 +6,7 @@ namespace Akeneo\Catalogs\Infrastructure\Persistence\Category;
 
 use Akeneo\Catalogs\Application\Persistence\Category\GetCategoriesByCodeQueryInterface;
 use Akeneo\Catalogs\Application\Persistence\Category\GetProductCategoriesLabelsQueryInterface;
+use Akeneo\Catalogs\Application\Persistence\WarmupableQueryInterface;
 use Akeneo\Pim\Enrichment\Product\API\Query\GetProductCategoryCodesQuery;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
@@ -16,7 +17,7 @@ use Symfony\Component\Messenger\Stamp\HandledStamp;
  * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
-class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQueryInterface
+class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQueryInterface, WarmupableQueryInterface
 {
     /** @var array<string, string[]> $categoryCodesByProduct */
     private array $categoryCodesByProduct = [];
@@ -36,7 +37,10 @@ class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQuery
      */
     public function execute(string $productUuid, string $locale): array
     {
-        $this->warmup([$productUuid], [$locale]);
+        $this->warmup([
+            'productUuids' => [$productUuid],
+            'locales' => [$locale],
+        ]);
 
         return \array_map(
             fn (string $categoryCode): string => $this->categoryLabelsByLocale[$locale][$categoryCode] ?? \sprintf('[%s]', $categoryCode),
@@ -45,14 +49,22 @@ class GetProductCategoriesLabelsQuery implements GetProductCategoriesLabelsQuery
     }
 
     /**
-     * @param string[] $productUuids
-     * @param string[] $locales
+     * @psalm-suppress MoreSpecificImplementedParamType
+     *
+     * @param array{
+     *     productUuids?: array<string>,
+     *     locales?: array<string>,
+     * } $options
      */
-    public function warmup(array $productUuids, array $locales): void
+    public function warmup(array $options = []): void
     {
-        $this->warmupProductCategories($productUuids);
+        if (isset($options['productUuids'])) {
+            $this->warmupProductCategories($options['productUuids']);
 
-        $this->warmupCategoryLabels($productUuids, $locales);
+            if (isset($options['locales'])) {
+                $this->warmupCategoryLabels($options['productUuids'], $options['locales']);
+            }
+        }
     }
 
     /**

--- a/components/catalogs/back/src/Infrastructure/Symfony/DependencyInjection/AkeneoCatalogsExtension.php
+++ b/components/catalogs/back/src/Infrastructure/Symfony/DependencyInjection/AkeneoCatalogsExtension.php
@@ -23,7 +23,11 @@ class AkeneoCatalogsExtension extends Extension
     public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-        $loader->load('services.yml');
+        $loader->load('buses.yml');
+        $loader->load('event_subscribers.yml');
         $loader->load('jobs.yml');
+        $loader->load('queries.yml');
+        $loader->load('services.yml');
+        $loader->load('validation.yml');
     }
 }

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/buses.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/buses.yml
@@ -1,0 +1,12 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Akeneo\Catalogs\ServiceAPI\Messenger\CommandBus:
+        arguments:
+            $messageBus: '@catalogs.command.bus'
+
+    Akeneo\Catalogs\ServiceAPI\Messenger\QueryBus:
+        arguments:
+            $messageBus: '@catalogs.query.bus'

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/event_subscribers.yml
@@ -1,0 +1,24 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Akeneo\Catalogs\Infrastructure\EventSubscriber\CurrencyDeactivationSubscriber:
+        arguments:
+            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
+            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
+
+    Akeneo\Catalogs\Infrastructure\EventSubscriber\ChannelRemovalSubscriber:
+        arguments:
+            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
+            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
+
+    Akeneo\Catalogs\Infrastructure\EventSubscriber\LocaleDeactivationSubscriber:
+        arguments:
+            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
+            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
+
+    Akeneo\Catalogs\Infrastructure\EventSubscriber\AttributeRemovalSubscriber:
+        arguments:
+            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
+            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/queries.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/queries.yml
@@ -1,0 +1,109 @@
+parameters:
+    akeneo_catalog.max_number_of_catalogs_per_user: 15
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Akeneo\Catalogs\Application\Persistence\:
+        resource: '../../../../Application/Persistence/**/*QueryInterface.php'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\:
+        resource: '../../../../Infrastructure/Persistence/**/*Query.php'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\IsCatalogsNumberLimitReachedQuery:
+        arguments:
+            $limit: '%akeneo_catalog.max_number_of_catalogs_per_user%'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Family\SearchFamilyQuery:
+        arguments:
+            - '@pim_enrich.repository.family.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Family\GetFamiliesByCodeQuery:
+        arguments:
+            - '@pim_enrich.repository.family.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Family\GetFamilyLabelByCodeAndLocaleQuery:
+        arguments:
+            - '@pim_enrich.repository.family.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\SearchAttributesQuery:
+        arguments:
+            - '@pim_enrich.repository.attribute.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\SearchAttributeOptionsQuery:
+        arguments:
+            - '@pim_enrich.repository.attribute_option.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\GetAttributeOptionsByCodeQuery:
+        arguments:
+            - '@pim_enrich.repository.attribute_option.search'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\FindOneAttributeByCodeQuery:
+        arguments:
+            $repository: '@pim_catalog.repository.attribute'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetChannelLocalesQuery:
+        arguments:
+            - '@pim_catalog.repository.channel'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelQuery:
+        arguments:
+            - '@pim_catalog.repository.channel'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelsQuery:
+        arguments:
+            - '@pim_catalog.repository.channel'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelsByCodeQuery:
+        arguments:
+            - '@pim_catalog.repository.channel'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetLocalesQuery:
+        arguments:
+            - '@pim_catalog.repository.locale'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetLocalesByCodeQuery:
+        arguments:
+            - '@pim_catalog.repository.locale'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoriesByCodeQuery:
+        arguments:
+            - '@pim_catalog.repository.category'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoryTreeRootsQuery:
+        arguments:
+            - '@akeneo.enrichment.public_api.find_category_trees'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoryChildrenQuery:
+        arguments:
+            - '@pim_catalog.repository.category'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetProductCategoriesLabelsQuery:
+        arguments:
+            $enrichmentQueryBus: '@pim_enrich.product.query_message_bus'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\Product\GetProductsWithFilteredValuesQuery:
+        arguments:
+            $getConnectorProducts: '@akeneo.pim.enrichment.product.connector.get_product_from_uuids'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\Product\GetProductQuery:
+        arguments:
+            $getConnectorProducts: '@akeneo.pim.enrichment.product.connector.get_product_from_uuids'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Measurement\GetMeasurementsFamilyQuery:
+        arguments:
+            - '@akeneo_measurement.service_api.find_measurement_families'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Currency\IsCurrencyActivatedQuery:
+        arguments:
+            - '@pim_catalog.repository.currency'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Currency\GetCurrenciesQuery:
+        arguments:
+            - '@pim_catalog.repository.currency'
+
+    Akeneo\Catalogs\Infrastructure\Persistence\Currency\GetChannelCurrenciesQuery:
+        arguments:
+            - '@pim_catalog.repository.channel'

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/services.yml
@@ -1,7 +1,3 @@
-parameters:
-    akeneo_catalog.max_number_of_catalogs_per_user: 15
-    akeneo_catalog.max_criteria_per_catalog: 25
-
 services:
     _defaults:
         autowire: true
@@ -14,11 +10,12 @@ services:
     Akeneo\Catalogs\:
         resource: '../../../../'
         exclude:
-            - '../../../Symfony/'
             - '../../../../Domain/'
             - '../../../../ServiceAPI/'
-            - '../../../../Application/Exception'
-            - '../../../../Application/Mapping/Measurement/Exception'
+            - '../../../../Application/Persistence'
+            - '../../../../Infrastructure/EventSubscriber'
+            - '../../../../Infrastructure/Job'
+            - '../../../../Infrastructure/Persistence'
             - '../../../../Infrastructure/Validation'
 
     Akeneo\Catalogs\Application\Handler\:
@@ -29,14 +26,6 @@ services:
         resource: '../../../../Infrastructure/Controller/'
         tags: [ 'controller.service_arguments' ]
         public: true
-
-    Akeneo\Catalogs\ServiceAPI\Messenger\CommandBus:
-        arguments:
-            $messageBus: '@catalogs.command.bus'
-
-    Akeneo\Catalogs\ServiceAPI\Messenger\QueryBus:
-        arguments:
-            $messageBus: '@catalogs.query.bus'
 
     Akeneo\Platform\Bundle\FrameworkBundle\Security\SecurityFacadeInterface:
         alias: 'oro_security.security_facade'
@@ -70,140 +59,9 @@ services:
             - '@Akeneo\Catalogs\Infrastructure\TemporaryEnrichmentBridge\SearchAfterSizeUuidResultCursorFactory'
             - '@pim_catalog.elasticsearch.product_query_builder_search_after_resolver'
 
-    # Validation
-    Akeneo\Catalogs\Infrastructure\Validation\IsCatalogValid: ~
-
-    Akeneo\Catalogs\Application\Validation\IsCatalogValidInterface: '@Akeneo\Catalogs\Infrastructure\Validation\IsCatalogValid'
-
-    Akeneo\Catalogs\Infrastructure\Validation\:
-        resource: '../../../Validation/**/*Validator.php'
-
-    Akeneo\Catalogs\Infrastructure\Validation\CatalogProductSelectionCriteriaValidator:
-        arguments:
-            $maxCriteriaPerCatalog: '%akeneo_catalog.max_criteria_per_catalog%'
-
-    # Persistence
-    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\IsCatalogsNumberLimitReachedQuery:
-        arguments:
-            $limit: '%akeneo_catalog.max_number_of_catalogs_per_user%'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Family\SearchFamilyQuery:
-        arguments:
-            - '@pim_enrich.repository.family.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Family\GetFamiliesByCodeQuery:
-        arguments:
-            - '@pim_enrich.repository.family.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Family\GetFamilyLabelByCodeAndLocaleQuery:
-        arguments:
-            - '@pim_enrich.repository.family.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\SearchAttributesQuery:
-        arguments:
-            - '@pim_enrich.repository.attribute.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\SearchAttributeOptionsQuery:
-        arguments:
-            - '@pim_enrich.repository.attribute_option.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\GetAttributeOptionsByCodeQuery:
-        arguments:
-            - '@pim_enrich.repository.attribute_option.search'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Attribute\FindOneAttributeByCodeQuery:
-        arguments:
-            $repository: '@pim_catalog.repository.attribute'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetChannelLocalesQuery:
-        arguments:
-            - '@pim_catalog.repository.channel'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelQuery:
-        arguments:
-            - '@pim_catalog.repository.channel'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelsQuery:
-        arguments:
-            - '@pim_catalog.repository.channel'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Channel\GetChannelsByCodeQuery:
-        arguments:
-            - '@pim_catalog.repository.channel'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetLocalesQuery:
-        arguments:
-            - '@pim_catalog.repository.locale'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Locale\GetLocalesByCodeQuery:
-        arguments:
-            - '@pim_catalog.repository.locale'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoriesByCodeQuery:
-        arguments:
-            - '@pim_catalog.repository.category'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoryTreeRootsQuery:
-        arguments:
-            - '@akeneo.enrichment.public_api.find_category_trees'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetCategoryChildrenQuery:
-        arguments:
-            - '@pim_catalog.repository.category'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Category\GetProductCategoriesLabelsQuery:
-        arguments:
-            $enrichmentQueryBus: '@pim_enrich.product.query_message_bus'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\Product\GetProductsWithFilteredValuesQuery:
-        arguments:
-            $getConnectorProducts: '@akeneo.pim.enrichment.product.connector.get_product_from_uuids'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Catalog\Product\GetProductQuery:
-        arguments:
-            $getConnectorProducts: '@akeneo.pim.enrichment.product.connector.get_product_from_uuids'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Measurement\GetMeasurementsFamilyQuery:
-        arguments:
-            - '@akeneo_measurement.service_api.find_measurement_families'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Currency\IsCurrencyActivatedQuery:
-        arguments:
-            - '@pim_catalog.repository.currency'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Currency\GetCurrenciesQuery:
-        arguments:
-            - '@pim_catalog.repository.currency'
-
-    Akeneo\Catalogs\Infrastructure\Persistence\Currency\GetChannelCurrenciesQuery:
-        arguments:
-            - '@pim_catalog.repository.channel'
-
-    # Storage
     Akeneo\Catalogs\Infrastructure\Storage\CatalogsMappingStorage:
         arguments:
             $filesystem: '@oneup_flysystem.catalogs_mapping_filesystem'
-
-    # EventSubscriber
-    Akeneo\Catalogs\Infrastructure\EventSubscriber\CurrencyDeactivationSubscriber:
-        arguments:
-            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
-            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
-
-    Akeneo\Catalogs\Infrastructure\EventSubscriber\ChannelRemovalSubscriber:
-        arguments:
-            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
-            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
-
-    Akeneo\Catalogs\Infrastructure\EventSubscriber\LocaleDeactivationSubscriber:
-        arguments:
-            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
-            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
-
-    Akeneo\Catalogs\Infrastructure\EventSubscriber\AttributeRemovalSubscriber:
-        arguments:
-            $jobInstanceRepository: '@akeneo_batch.job.job_instance_repository'
-            $jobLauncher: '@akeneo_batch_queue.launcher.queue_job_launcher'
 
     Akeneo\Catalogs\Application\Mapping\ValueExtractor\Registry\ValueExtractorRegistry:
         arguments:

--- a/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/validation.yml
+++ b/components/catalogs/back/src/Infrastructure/Symfony/Resources/config/validation.yml
@@ -1,0 +1,18 @@
+parameters:
+    akeneo_catalog.max_criteria_per_catalog: 25
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    Akeneo\Catalogs\Infrastructure\Validation\IsCatalogValid: ~
+
+    Akeneo\Catalogs\Application\Validation\IsCatalogValidInterface: '@Akeneo\Catalogs\Infrastructure\Validation\IsCatalogValid'
+
+    Akeneo\Catalogs\Infrastructure\Validation\:
+        resource: '../../../Validation/**/*Validator.php'
+
+    Akeneo\Catalogs\Infrastructure\Validation\CatalogProductSelectionCriteriaValidator:
+        arguments:
+            $maxCriteriaPerCatalog: '%akeneo_catalog.max_criteria_per_catalog%'


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In this PR, I introduce 2 improvements:
- split services.yml in multiple files to add clarity
- remove the use of `method_exists()` by adding an interface

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
