### PR TITLE
CXP-1442: Refactored source object from components props

### DIFF
--- a/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/DefaultValue.integration.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/DefaultValue.integration.tsx
@@ -9,12 +9,7 @@ test('it displays a Text input when the target type is string', () => {
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'string'}
-                    source={{source: null, scope: null, locale: null}}
-                    onChange={jest.fn()}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'string'} value={undefined} onChange={jest.fn()} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -22,7 +17,7 @@ test('it displays a Text input when the target type is string', () => {
     expect(screen.getByTestId('string-default-value')).toBeInTheDocument();
 });
 
-test('it updates the source for type string when a default value changes', () => {
+test('it updates the default value for type string when a default value changes', () => {
     const onChange = jest.fn();
 
     render(
@@ -30,10 +25,10 @@ test('it updates the source for type string when a default value changes', () =>
             <QueryClientProvider client={new QueryClient()}>
                 <DefaultValue
                     targetTypeKey={'string'}
-                    source={{source: null, scope: null, locale: null, default: 'Default string value'}}
+                    value={'Default string value'}
                     onChange={onChange}
                     error={undefined}
-                ></DefaultValue>
+                />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -44,15 +39,10 @@ test('it updates the source for type string when a default value changes', () =>
     const input = screen.getByTestId('string-default-value');
     fireEvent.change(input, {target: {value: 'Updated default string value'}});
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-        default: 'Updated default string value',
-    });
+    expect(onChange).toHaveBeenCalledWith('Updated default string value');
 });
 
-test('it removes the source default value for type string when the text input is empty', () => {
+test('it returns undefined value for type string when the text input is empty', () => {
     const onChange = jest.fn();
 
     render(
@@ -60,10 +50,10 @@ test('it removes the source default value for type string when the text input is
             <QueryClientProvider client={new QueryClient()}>
                 <DefaultValue
                     targetTypeKey={'string'}
-                    source={{source: null, scope: null, locale: null, default: 'Default string value'}}
+                    value={'Default string value'}
                     onChange={onChange}
                     error={undefined}
-                ></DefaultValue>
+                />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -74,23 +64,14 @@ test('it removes the source default value for type string when the text input is
     const input = screen.getByTestId('string-default-value');
     fireEvent.change(input, {target: {value: ''}});
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-    });
+    expect(onChange).toHaveBeenCalledWith(undefined);
 });
 
 test('it displays a Boolean input when the target type is boolean', () => {
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'boolean'}
-                    source={{source: null, scope: null, locale: null}}
-                    onChange={jest.fn()}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'boolean'} value={undefined} onChange={jest.fn()} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -98,18 +79,13 @@ test('it displays a Boolean input when the target type is boolean', () => {
     expect(screen.getByTestId('boolean-default-value')).toBeInTheDocument();
 });
 
-test('it updates the source for type boolean when a default value changes', () => {
+test('it updates the default value for type boolean when a default value changes', () => {
     const onChange = jest.fn();
 
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'boolean'}
-                    source={{source: null, scope: null, locale: null, default: false}}
-                    onChange={onChange}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'boolean'} value={false} onChange={onChange} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -122,26 +98,16 @@ test('it updates the source for type boolean when a default value changes', () =
 
     fireEvent.click(booleanInputTrue);
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-        default: true,
-    });
+    expect(onChange).toHaveBeenCalledWith(true);
 });
 
-test('it removes the source default value for type boolean when clear button is clicked', () => {
+test('it returns undefined value for type boolean when clear button is clicked', () => {
     const onChange = jest.fn();
 
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'boolean'}
-                    source={{source: null, scope: null, locale: null, default: false}}
-                    onChange={onChange}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'boolean'} value={false} onChange={onChange} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -152,23 +118,14 @@ test('it removes the source default value for type boolean when clear button is 
     const booleanInputTrue = screen.getByText('Clear value');
     fireEvent.click(booleanInputTrue);
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-    });
+    expect(onChange).toHaveBeenCalledWith(undefined);
 });
 
 test('it displays a number input when the target type is number', () => {
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'number'}
-                    source={{source: null, scope: null, locale: null}}
-                    onChange={jest.fn()}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'number'} value={undefined} onChange={jest.fn()} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -176,18 +133,13 @@ test('it displays a number input when the target type is number', () => {
     expect(screen.getByTestId('number-default-value')).toBeInTheDocument();
 });
 
-test('it updates the source for type number when a default value changes', () => {
+test('it updates the default value for type number when a default value changes', () => {
     const onChange = jest.fn();
 
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'number'}
-                    source={{source: null, scope: null, locale: null, default: 250}}
-                    onChange={onChange}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'number'} value={250} onChange={onChange} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -198,26 +150,16 @@ test('it updates the source for type number when a default value changes', () =>
     const input = screen.getByTestId('number-default-value');
     fireEvent.change(input, {target: {value: '42'}});
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-        default: 42,
-    });
+    expect(onChange).toHaveBeenCalledWith(42);
 });
 
-test('it removes the source default value for type number when the number input is empty', () => {
+test('it returns undefined value for type number when the number input is empty', () => {
     const onChange = jest.fn();
 
     render(
         <ThemeProvider theme={pimTheme}>
             <QueryClientProvider client={new QueryClient()}>
-                <DefaultValue
-                    targetTypeKey={'number'}
-                    source={{source: null, scope: null, locale: null, default: 42}}
-                    onChange={onChange}
-                    error={undefined}
-                ></DefaultValue>
+                <DefaultValue targetTypeKey={'number'} value={42} onChange={onChange} error={undefined} />
             </QueryClientProvider>
         </ThemeProvider>
     );
@@ -228,9 +170,5 @@ test('it removes the source default value for type number when the number input 
     const input = screen.getByTestId('number-default-value');
     fireEvent.change(input, {target: {value: ''}});
 
-    expect(onChange).toHaveBeenCalledWith({
-        source: null,
-        scope: null,
-        locale: null,
-    });
+    expect(onChange).toHaveBeenCalledWith(undefined);
 });

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectChannelCurrenciesDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectChannelCurrenciesDropdown.tsx
@@ -2,7 +2,6 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {Field, Helper, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
-import {Source} from '../../models/Source';
 import {useChannelCurrencies} from '../../hooks/useChannelCurrencies';
 
 const DropdownField = styled(Field)`
@@ -10,23 +9,22 @@ const DropdownField = styled(Field)`
 `;
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    currency: string | null;
+    channel: string | null;
+    onChange: (newCurrency: string) => void;
     error: string | undefined;
     disabled: boolean;
 };
 
-export const SelectChannelCurrencyDropdown: FC<Props> = ({source, onChange, error, disabled}) => {
+export const SelectChannelCurrencyDropdown: FC<Props> = ({currency, channel, onChange, error, disabled}) => {
     const translate = useTranslate();
-    const {data: currencies} = useChannelCurrencies(source.scope);
+    const {data: currencies} = useChannelCurrencies(channel);
 
     return (
         <DropdownField label={translate('akeneo_catalogs.product_mapping.source.parameters.currency.label')}>
             <SelectInput
-                value={source.parameters?.currency ?? null}
-                onChange={newCurrency =>
-                    onChange({...source, parameters: {...source.parameters, currency: newCurrency}})
-                }
+                value={currency}
+                onChange={onChange}
                 clearable={false}
                 invalid={error !== undefined}
                 emptyResultLabel={translate('akeneo_catalogs.common.select.no_matches')}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectCurrencyDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectCurrencyDropdown.tsx
@@ -2,7 +2,6 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {Field, Helper, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
-import {Source} from '../../models/Source';
 import {useCurrencies} from '../../../../hooks/useCurrencies';
 
 const DropdownField = styled(Field)`
@@ -10,21 +9,19 @@ const DropdownField = styled(Field)`
 `;
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    currency: string | null;
+    onChange: (newCurrency: string) => void;
     error: string | undefined;
 };
-export const SelectCurrencyDropdown: FC<Props> = ({source, onChange, error}) => {
+export const SelectCurrencyDropdown: FC<Props> = ({currency, onChange, error}) => {
     const translate = useTranslate();
     const {data: currencies} = useCurrencies();
 
     return (
         <DropdownField label={translate('akeneo_catalogs.product_mapping.source.parameters.currency.label')}>
             <SelectInput
-                value={source.parameters?.currency ?? null}
-                onChange={newCurrency =>
-                    onChange({...source, parameters: {...source.parameters, currency: newCurrency}})
-                }
+                value={currency}
+                onChange={onChange}
                 clearable={false}
                 invalid={error !== undefined}
                 emptyResultLabel={translate('akeneo_catalogs.common.select.no_matches')}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectLabelLocaleDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectLabelLocaleDropdown.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 import {Field, Helper, Locale as LocaleLabel, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
 import {useUniqueEntitiesByCode} from '../../../../hooks/useUniqueEntitiesByCode';
-import {Source} from '../../models/Source';
 import {useInfiniteLocales} from '../../../../hooks/useInfiniteLocales';
 import {useLocalesByCodes} from '../../../../hooks/useLocalesByCodes';
 import {Locale} from '../../../../models/Locale';
@@ -13,25 +12,23 @@ const DropdownField = styled(Field)`
 `;
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    locale: string | null;
+    onChange: (newLocale: string) => void;
     error: string | undefined;
     disabled: boolean;
 };
 
-export const SelectLabelLocaleDropdown: FC<Props> = ({source, onChange, error, disabled}) => {
+export const SelectLabelLocaleDropdown: FC<Props> = ({locale, onChange, error, disabled}) => {
     const translate = useTranslate();
-    const {data: selected} = useLocalesByCodes([source.parameters?.label_locale ?? '']);
+    const {data: selected} = useLocalesByCodes([locale ?? '']);
     const {data: results, fetchNextPage} = useInfiniteLocales();
     const locales = useUniqueEntitiesByCode<Locale>(selected, results);
 
     return (
         <DropdownField label={translate('akeneo_catalogs.product_mapping.source.parameters.label_locale.label')}>
             <SelectInput
-                value={source.parameters?.label_locale ?? null}
-                onChange={newLocale =>
-                    onChange({...source, parameters: {...source.parameters, label_locale: newLocale}})
-                }
+                value={locale}
+                onChange={onChange}
                 onNextPage={fetchNextPage}
                 clearable={false}
                 invalid={error !== undefined}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectMeasurementUnitDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceParameters/SelectMeasurementUnitDropdown.tsx
@@ -2,7 +2,6 @@ import React, {FC} from 'react';
 import styled from 'styled-components';
 import {Field, Helper, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
-import {Source} from '../../models/Source';
 import {useMeasurements} from '../../../../hooks/useMeasurements';
 
 const DropdownField = styled(Field)`
@@ -10,21 +9,21 @@ const DropdownField = styled(Field)`
 `;
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    unit: string | null;
+    onChange: (newUnit: string) => void;
     error: string | undefined;
-    measurementFamily: string | null;
+    measurementFamily: string;
 };
 
-export const SelectMeasurementUnitDropdown: FC<Props> = ({source, onChange, error, measurementFamily}) => {
+export const SelectMeasurementUnitDropdown: FC<Props> = ({unit, onChange, error, measurementFamily}) => {
     const translate = useTranslate();
-    const {data: measurementUnits} = useMeasurements(measurementFamily ?? '');
+    const {data: measurementUnits} = useMeasurements(measurementFamily);
     return (
         <>
             <DropdownField label={translate('akeneo_catalogs.product_mapping.source.parameters.unit.label')}>
                 <SelectInput
-                    value={source.parameters?.unit ?? null}
-                    onChange={newUnit => onChange({...source, parameters: {...source.parameters, unit: newUnit}})}
+                    value={unit}
+                    onChange={onChange}
                     clearable={false}
                     invalid={error !== undefined}
                     emptyResultLabel={translate('akeneo_catalogs.common.select.no_matches')}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectChannelDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectChannelDropdown.tsx
@@ -5,25 +5,24 @@ import {useInfiniteChannels} from '../../../../hooks/useInfiniteChannels';
 import {useUniqueEntitiesByCode} from '../../../../hooks/useUniqueEntitiesByCode';
 import {Channel} from '../../../../models/Channel';
 import {useChannel} from '../../../../hooks/useChannel';
-import {Source} from '../../models/Source';
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    channel: string | null;
+    onChange: (channel: string) => void;
     error: string | undefined;
 };
 
-export const SelectChannelDropdown: FC<Props> = ({source, onChange, error}) => {
+export const SelectChannelDropdown: FC<Props> = ({channel, onChange, error}) => {
     const translate = useTranslate();
-    const {data: selected} = useChannel(source.scope);
+    const {data: selected} = useChannel(channel);
     const {data: results, fetchNextPage} = useInfiniteChannels();
     const channels = useUniqueEntitiesByCode<Channel>(selected ? [selected] : [], results);
 
     return (
         <>
             <SelectInput
-                value={source.scope}
-                onChange={newChannel => onChange({...source, scope: newChannel, locale: null})}
+                value={channel}
+                onChange={onChange}
                 onNextPage={fetchNextPage}
                 clearable={false}
                 invalid={error !== undefined}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectChannelLocaleDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectChannelLocaleDropdown.tsx
@@ -1,25 +1,25 @@
 import React, {FC} from 'react';
 import {Helper, Locale, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
-import {Source} from '../../models/Source';
 import {useChannelLocales} from '../../../../hooks/useChannelLocales';
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    channel: string | null;
+    locale: string | null;
+    onChange: (locale: string) => void;
     error: string | undefined;
     disabled: boolean;
 };
 
-export const SelectChannelLocaleDropdown: FC<Props> = ({source, onChange, error, disabled}) => {
+export const SelectChannelLocaleDropdown: FC<Props> = ({channel, locale, onChange, error, disabled}) => {
     const translate = useTranslate();
-    const {data: locales} = useChannelLocales(source.scope);
+    const {data: locales} = useChannelLocales(channel);
 
     return (
         <>
             <SelectInput
-                value={source.locale}
-                onChange={newLocale => onChange({...source, locale: newLocale})}
+                value={locale}
+                onChange={onChange}
                 clearable={false}
                 invalid={error !== undefined}
                 emptyResultLabel={translate('akeneo_catalogs.common.select.no_matches')}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectLocaleDropdown.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SelectLocaleDropdown.tsx
@@ -2,28 +2,27 @@ import React, {FC} from 'react';
 import {Helper, Locale as LocaleLabel, SelectInput} from 'akeneo-design-system';
 import {useTranslate} from '@akeneo-pim-community/shared';
 import {useUniqueEntitiesByCode} from '../../../../hooks/useUniqueEntitiesByCode';
-import {Source} from '../../models/Source';
 import {useInfiniteLocales} from '../../../../hooks/useInfiniteLocales';
 import {useLocalesByCodes} from '../../../../hooks/useLocalesByCodes';
 import {Locale} from '../../../../models/Locale';
 
 type Props = {
-    source: Source;
-    onChange: (source: Source) => void;
+    locale: string | null;
+    onChange: (locale: string) => void;
     error: string | undefined;
 };
 
-export const SelectLocaleDropdown: FC<Props> = ({source, onChange, error}) => {
+export const SelectLocaleDropdown: FC<Props> = ({locale, onChange, error}) => {
     const translate = useTranslate();
-    const {data: selected} = useLocalesByCodes([source.locale ?? '']);
+    const {data: selected} = useLocalesByCodes([locale ?? '']);
     const {data: results, fetchNextPage} = useInfiniteLocales();
     const locales = useUniqueEntitiesByCode<Locale>(selected, results);
 
     return (
         <>
             <SelectInput
-                value={source.locale}
-                onChange={newLocale => onChange({...source, locale: newLocale})}
+                value={locale}
+                onChange={onChange}
                 onNextPage={fetchNextPage}
                 clearable={false}
                 invalid={error !== undefined}

--- a/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SourceSettings.tsx
+++ b/components/catalogs/front/src/components/ProductMapping/components/SourceSelection/SourceSettings.tsx
@@ -1,4 +1,4 @@
-import React, {FC, useCallback} from 'react';
+import React, {FC} from 'react';
 import {SelectChannelDropdown} from './SelectChannelDropdown';
 import {SelectLocaleDropdown} from './SelectLocaleDropdown';
 import {SelectChannelLocaleDropdown} from './SelectChannelLocaleDropdown';
@@ -23,6 +23,28 @@ const BulletLine = styled.div`
     align-items: center;
 `;
 
+const prefillEmptySourceValue = (source: Source, attributeType: string) => {
+    if (
+        (attributeType === 'pim_catalog_simpleselect' || attributeType === 'pim_catalog_multiselect') &&
+        (undefined === source.parameters?.label_locale || null === source.parameters?.label_locale)
+    ) {
+        return {...source, parameters: {...source.parameters, label_locale: source.locale ?? null}};
+    }
+
+    if (
+        ['categories', 'family', 'status'].includes(source.source ?? '') &&
+        (undefined === source.parameters?.label_locale || null === source.parameters?.label_locale)
+    ) {
+        return {...source, parameters: {...source.parameters, label_locale: null}};
+    }
+
+    if (attributeType === 'pim_catalog_price_collection' && !(source.parameters?.currency ?? false)) {
+        return {...source, parameters: {...source.parameters, currency: null}};
+    }
+
+    return source;
+};
+
 type Props = {
     source: Source;
     attribute: Attribute;
@@ -31,54 +53,44 @@ type Props = {
 };
 
 export const SourceSettings: FC<Props> = ({source, attribute, errors, onChange}) => {
-    const onChangeMiddleware = useCallback(
-        source => {
-            if (
-                (attribute.type === 'pim_catalog_simpleselect' || attribute.type === 'pim_catalog_multiselect') &&
-                (undefined === source.parameters?.label_locale || null === source.parameters?.label_locale)
-            ) {
-                source = {...source, parameters: {...source.parameters, label_locale: source.locale ?? null}};
-            }
+    const onChangeMiddleware = (newSource: Source) => {
+        onChange(prefillEmptySourceValue(newSource, attribute.type));
+    };
 
-            if (
-                ['categories', 'family', 'status'].includes(source.source) &&
-                (undefined === source.parameters?.label_locale || null === source.parameters?.label_locale)
-            ) {
-                source = {...source, parameters: {...source.parameters, label_locale: null}};
-            }
+    const handleChannelChange = (newChannel: string) =>
+        onChangeMiddleware({
+            ...source,
+            scope: newChannel,
+            locale: null,
+        });
 
-            if (attribute?.type === 'pim_catalog_price_collection' && !(source.parameters.currency ?? false)) {
-                source = {...source, parameters: {...source.parameters, currency: null}};
-            }
+    const handleLocaleChange = (newLocale: string) => onChangeMiddleware({...source, locale: newLocale});
 
-            if (attribute?.type === 'pim_catalog_metric') {
-                source = {...source, parameters: {...source.parameters, unit: attribute.default_measurement_unit}};
-            }
-            onChange(source);
-        },
-
-        [onChange, attribute]
-    );
     return (
         <>
             {attribute.scopable && (
                 <BulletLine>
                     <Bullet />
-                    <SelectChannelDropdown source={source} onChange={onChangeMiddleware} error={errors?.scope} />
+                    <SelectChannelDropdown
+                        channel={source.scope}
+                        onChange={handleChannelChange}
+                        error={errors?.scope}
+                    />
                 </BulletLine>
             )}
             {attribute.localizable && !attribute.scopable && (
                 <BulletLine>
                     <Bullet />
-                    <SelectLocaleDropdown source={source} onChange={onChangeMiddleware} error={errors?.locale} />
+                    <SelectLocaleDropdown locale={source.locale} onChange={handleLocaleChange} error={errors?.locale} />
                 </BulletLine>
             )}
             {attribute.localizable && attribute.scopable && (
                 <BulletLine>
                     <Bullet />
                     <SelectChannelLocaleDropdown
-                        source={source}
-                        onChange={onChangeMiddleware}
+                        channel={source.scope}
+                        locale={source.locale}
+                        onChange={handleLocaleChange}
                         error={errors?.locale}
                         disabled={source.scope === null}
                     />


### PR DESCRIPTION
Field components for source settings and source parameters accept source data structure as a prop and obfuscate small details within (such as resetting some parameter on channel change or resetting locale on channel change) instead of handling only data they are responsible for.
The point of this PR is to simplify the API of these components and lift up side effects to the parent components