### PR TITLE
[POC] JEL-299: Implement ProductsWereUpdated Event & Message

### DIFF
--- a/config/messages.yml
+++ b/config/messages.yml
@@ -4,3 +4,8 @@ queues:
         consumers:
             - name: dqi_launch_product_and_product_model_evaluations_consumer
               service_handler: 'Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Messenger\LaunchProductAndProductModelEvaluationsHandler'
+    products_were_updated_queue:
+        message_class: Akeneo\Pim\Enrichment\Product\Infrastructure\Messenger\ProductsWereUpdatedMessage
+        consumers:
+            - name: dqi_products_were_updated_consumer
+              service_handler: Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Messenger\ProductsWereUpdatedHandler

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Messenger/ProductsWereUpdatedHandler.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Messenger/ProductsWereUpdatedHandler.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Messenger;
+
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\CreateCriteriaEvaluations;
+use Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuid;
+use Akeneo\Pim\Automation\DataQualityInsights\Domain\ValueObject\ProductUuidCollection;
+use Akeneo\Pim\Enrichment\Product\API\Event\ProductsWereUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Event\ProductWasUpdated;
+use Akeneo\Tool\Component\Messenger\PublicEventMessageInterface;
+use Akeneo\Tool\Component\Messenger\TraceableMessageHandlerInterface;
+use Akeneo\Tool\Component\Messenger\TraceableMessageInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductsWereUpdatedHandler implements TraceableMessageHandlerInterface
+{
+    public function __construct(
+        private readonly CreateCriteriaEvaluations $createProductCriteriaEvaluations,
+        private readonly EvaluateProducts $evaluateProducts,
+    ) {
+    }
+
+    public function __invoke(TraceableMessageInterface $message): void
+    {
+        Assert::isInstanceOf($message, PublicEventMessageInterface::class);
+        $productsWereUpdated = $message->publicEvent();
+        Assert::isInstanceOf($productsWereUpdated, ProductsWereUpdated::class);
+
+        $productUuids = [];
+        /** @var ProductWasUpdated $productWasUpdated */
+        foreach ($productsWereUpdated->events as $productWasUpdated) {
+            $productUuids[] = ProductUuid::fromUuid($productWasUpdated->productUuid());
+        }
+
+        $productUuids = ProductUuidCollection::fromProductUuids($productUuids);
+
+        $this->createProductCriteriaEvaluations->createAll($productUuids);
+        ($this->evaluateProducts)($productUuids);
+    }
+}

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/messenger_handlers.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/messenger_handlers.yml
@@ -10,3 +10,8 @@ services:
             - '@Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetOutdatedProductUuidsByDateAndCriteriaQueryInterface'
             - '@Akeneo\Pim\Automation\DataQualityInsights\Domain\Query\ProductEvaluation\GetOutdatedProductModelIdsByDateAndCriteriaQueryInterface'
             - '@logger'
+
+    Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Messenger\ProductsWereUpdatedHandler:
+        arguments:
+            - '@akeneo.pim.automation.data_quality_insights.create_products_criteria_evaluations'
+            - '@Akeneo\Pim\Automation\DataQualityInsights\Application\ProductEvaluation\EvaluateProducts'

--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Event/ProductsWereUpdated.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Event/ProductsWereUpdated.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\API\Event;
+
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductsWereUpdated
+{
+    /**
+     * @param ProductWasUpdated[] $events
+     */
+    public function __construct(
+        public readonly array $events,
+    ) {
+        Assert::notEmpty($this->events);
+        Assert::allIsInstanceOf($this->events, ProductWasUpdated::class);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Messenger/ProductWasUpdatedSubscriber.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Messenger/ProductWasUpdatedSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Infrastructure\Messenger;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Tool\Component\StorageUtils\StorageEvents;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductWasUpdatedSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $messageBus,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            StorageEvents::POST_SAVE => 'launchProductWasUpdatedMessage',
+            StorageEvents::POST_SAVE_ALL => 'launchProductWereUpdatedMessage',
+        ];
+    }
+
+    public function launchProductWasUpdatedMessage(GenericEvent $event): void
+    {
+        $product = $event->getSubject();
+        $unitary = $event->getArguments()['unitary'] ?? false;
+
+        if (false === $unitary || !$product instanceof ProductInterface) {
+            return;
+        }
+
+        try {
+            // Launch ProductsWereUpdatedMessage with a single event to simplify the messaging stack
+            $this->messageBus->dispatch(ProductsWereUpdatedMessage::fromProducts([$product]));
+        } catch (\Throwable $exception) {
+            $this->logger->error('Failed to launch ProductsWereUpdatedMessage from unitary product update', [
+                'product_uuid' => $product->getUuid()->toString(),
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+
+    public function launchProductWereUpdatedMessage(GenericEvent $event): void
+    {
+        $products = $event->getSubject();
+
+        if (empty($products) || !reset($products) instanceof ProductInterface) {
+            return;
+        }
+
+        try {
+            $this->messageBus->dispatch(ProductsWereUpdatedMessage::fromProducts($products));
+        } catch (\Throwable $exception) {
+            $this->logger->error('Failed to launch ProductsWereUpdatedMessage from batch products update', [
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Messenger/ProductsWereUpdatedMessage.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Messenger/ProductsWereUpdatedMessage.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Infrastructure\Messenger;
+
+use Akeneo\Pim\Enrichment\Component\Product\Model\ProductInterface;
+use Akeneo\Pim\Enrichment\Product\API\Event\ProductWasUpdated;
+use Akeneo\Pim\Enrichment\Product\API\Event\ProductsWereUpdated;
+use Akeneo\Tool\Component\Messenger\NormalizableMessageInterface;
+use Akeneo\Tool\Component\Messenger\PublicEventMessageInterface;
+use Akeneo\Tool\Component\Messenger\TraceableMessageTrait;
+use Ramsey\Uuid\Uuid;
+use Webmozart\Assert\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ProductsWereUpdatedMessage implements PublicEventMessageInterface
+{
+    use TraceableMessageTrait;
+
+    public function __construct(
+        private readonly ProductsWereUpdated $productsWereUpdated
+    ) {
+    }
+
+    public function publicEvent(): object
+    {
+        return $this->productsWereUpdated;
+    }
+
+    public function normalize(): array
+    {
+        return ['events' =>
+            \array_map(
+                fn (ProductWasUpdated $productWasUpdated) => [
+                    'product_uuid' => $productWasUpdated->productUuid()->toString(),
+                ],
+                $this->productsWereUpdated->events
+            )
+        ];
+    }
+
+    public static function denormalize(array $normalized): NormalizableMessageInterface
+    {
+        Assert::keyExists($normalized, 'events', 'Normalized ProductsWereUpdatedMessage must contains a key "events"');
+        Assert::isArray($normalized['events'], 'Normalized ProductsWereUpdatedMessage events property must be an array');
+
+        $events = [];
+        foreach ($normalized['events'] as $normalizedProductWasUpdated) {
+            Assert::isArray($normalizedProductWasUpdated, 'Normalized ProductWasUpdated must be an array');
+            Assert::keyExists($normalizedProductWasUpdated, 'product_uuid', 'Normalized ProductWasUpdated must contains a key "product_uuid"');
+            Assert::string($normalizedProductWasUpdated['product_uuid'], 'Normalized ProductWasUpdated product_uuid property must be a string');
+            $events[] = new ProductWasUpdated(Uuid::fromString($normalizedProductWasUpdated['product_uuid']));
+        }
+
+        return new self(new ProductsWereUpdated($events));
+    }
+
+    /**
+     * @param ProductInterface[] $products
+     */
+    public static function fromProducts(array $products): self
+    {
+        Assert::allIsInstanceOf($products, ProductInterface::class);
+
+        return new self(new ProductsWereUpdated(\array_map(
+            fn (ProductInterface $product) => new ProductWasUpdated($product->getUuid()),
+            $products
+        )));
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/DependencyInjection/AkeneoPimEnrichmentProductExtension.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/DependencyInjection/AkeneoPimEnrichmentProductExtension.php
@@ -28,6 +28,7 @@ final class AkeneoPimEnrichmentProductExtension extends Extension
         $loader->load('factories.yml');
         $loader->load('handlers.yml');
         $loader->load('message_bus.yml');
+        $loader->load('messenger.yml');
         $loader->load('queries.yml');
         $loader->load('query_builders.yml');
         $loader->load('services.yml');

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/messenger.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/messenger.yml
@@ -1,0 +1,7 @@
+services:
+    Akeneo\Pim\Enrichment\Product\Infrastructure\Messenger\ProductWasUpdatedSubscriber:
+        arguments:
+            - '@messenger.bus.default'
+            - '@logger'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/Akeneo/Tool/Component/Messenger/PublicEventMessageInterface.php
+++ b/src/Akeneo/Tool/Component/Messenger/PublicEventMessageInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Tool\Component\Messenger;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+interface PublicEventMessageInterface extends TraceableMessageInterface, NormalizableMessageInterface
+{
+    public function publicEvent(): object;
+}


### PR DESCRIPTION
Goal:
- Launch a public message event when products are updated (single element for unitary update)
- Add a consumer for DQI to evaluate the updated products

Implementation details:
- Use the existing public event `ProductWasUpdated`, but add a new one `ProductsWereCreated` in `API` to batch the events
- Add  a message `ProductsWereCreatedMessage` in `Infrastucture`
- Launch the message from a subscriber on `POST_SAVE` and `POST_SAVE_ALL` events

For the need of DQI evaluations, we don't need to distinct creation and update. For for future needs we could have to implement an event and message `ProductsWereCreated` 