### PR TITLE
SP-489: Add attribute codes in `SqlGetFamilies` query of `Structure` context public Api

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetFamilies.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Query/PublicApi/Family/Sql/SqlGetFamilies.php
@@ -21,16 +21,31 @@ class SqlGetFamilies implements GetFamilies
         }
 
         $sql = <<<SQL
-SELECT
-   family.code AS code,
-   COALESCE(JSON_OBJECTAGG(trans.locale, trans.label), JSON_ARRAY()) AS labels,
-   JSON_ARRAYAGG(attribute.code) AS attributeCodes
+WITH family_label as (
+    SELECT family.code AS family_code, JSON_OBJECTAGG(translation.locale, translation.label) AS labels
+    FROM pim_catalog_family family
+        LEFT JOIN pim_catalog_family_translation translation ON family.id = translation.foreign_key
+    WHERE family.code IN (:familyCodes)
+    AND translation.label IS NOT NULL
+    AND translation.label != ''
+    GROUP BY family.code
+),
+family_attribute as (
+    SELECT family.code AS family_code, attribute.code AS attribute_code
+    FROM pim_catalog_family family
+        INNER JOIN pim_catalog_family_attribute family_attribute ON family_attribute.family_id = family.id
+        INNER JOIN pim_catalog_attribute attribute ON attribute.id = family_attribute.attribute_id
+    WHERE family.code IN (:familyCodes)
+)
+SELECT 
+    family.code, 
+    family_label.labels, 
+    JSON_ARRAYAGG(family_attribute.attribute_code) AS attributeCodes
 FROM pim_catalog_family family
-INNER JOIN pim_catalog_family_translation trans ON family.id = trans.foreign_key
-INNER JOIN pim_catalog_family_attribute family_attribute ON family_attribute.family_id = family.id
-INNER JOIN pim_catalog_attribute attribute ON attribute.id = family_attribute.attribute_id
+    LEFT JOIN family_label ON family.code = family_label.family_code
+    INNER JOIN family_attribute ON family_attribute.family_code = family.code
 WHERE family.code IN (:familyCodes)
-GROUP BY family.code, attribute.code
+GROUP BY family.code
 SQL;
         $rows = $this->connection->executeQuery(
             $sql,
@@ -44,7 +59,7 @@ SQL;
         foreach ($rows as $row) {
             $families[$row['code']] = new Family(
                 $row['code'],
-                json_decode($row['labels'], true),
+                $row['labels'] !== null ? json_decode($row['labels'], true) : [],
                 json_decode($row['attributeCodes'], true)
             );
         }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
@@ -9,6 +9,7 @@ final class Family
     public function __construct(
         public readonly string $code,
         public readonly array $labels,
+        public readonly array $attributeCodes,
     ) {
     }
 }

--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/Family/Family.php
@@ -6,6 +6,10 @@ namespace Akeneo\Pim\Structure\Component\Query\PublicApi\Family;
 
 final class Family
 {
+    /**
+     * @param array<string, string> $labels
+     * @params list<string> $attributeCodes
+     */
     public function __construct(
         public readonly string $code,
         public readonly array $labels,

--- a/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
@@ -33,6 +33,7 @@ final class SqlGetFamilyIntegration extends TestCase
             [
                 'code' => 'accessories',
                 'labels' => [
+                    'de_DE' => 'Zubehör',
                     'en_US' => 'Accessories',
                     'fr_FR' => 'Accessoires',
                 ],
@@ -44,10 +45,6 @@ final class SqlGetFamilyIntegration extends TestCase
             ],
             [
                 'code' => 'hats',
-                'labels' => [
-                    'en_US' => 'Hats',
-                    'fr_FR' => 'Chapeaux',
-                ],
                 'attributes' => [
                     'sku',
                     'description',
@@ -55,6 +52,7 @@ final class SqlGetFamilyIntegration extends TestCase
                 ],
             ],
         ]);
+        $this->givenActiveLocales(['en_US', 'fr_FR', 'de_DE']);
     }
 
     public function test_it_gets_families_by_codes(): void
@@ -65,6 +63,7 @@ final class SqlGetFamilyIntegration extends TestCase
             'accessories' => new Family(
                 'accessories',
                 [
+                    'de_DE' => 'Zubehör',
                     'en_US' => 'Accessories',
                     'fr_FR' => 'Accessoires',
                 ],
@@ -78,8 +77,13 @@ final class SqlGetFamilyIntegration extends TestCase
                 ],
                 ['sku', 'description', 'price'],
             ),
+            'hats' => new Family(
+                'hats',
+                [],
+                ['sku', 'description', 'name'],
+            ),
         ];
-        $actual = $query->byCodes(['shoes', 'accessories']);
+        $actual = $query->byCodes(['shoes', 'accessories', 'hats']);
 
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
@@ -100,6 +104,7 @@ final class SqlGetFamilyIntegration extends TestCase
         $expected = new Family(
             'accessories',
             [
+                'de_DE' => 'Zubehör',
                 'en_US' => 'Accessories',
                 'fr_FR' => 'Accessoires',
             ],
@@ -159,5 +164,16 @@ final class SqlGetFamilyIntegration extends TestCase
         }, $attributeCodes);
 
         $this->get('pim_catalog.saver.attribute')->saveAll($attributes);
+    }
+
+    private function givenActiveLocales(array $localeCodes): void
+    {
+        $ecommerce = $this->get('pim_catalog.repository.channel')->findOneByIdentifier('ecommerce');
+        foreach ($localeCodes as $localeCode) {
+
+            $locale = $this->get('pim_catalog.repository.locale')->findOneByIdentifier($localeCode);
+            $ecommerce->addLocale($locale);
+        }
+        $this->get('pim_catalog.saver.channel')->save($ecommerce);
     }
 }

--- a/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Family/SqlGetFamilyIntegration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AkeneoTest\Pim\Structure\Integration\Family;
 
+use Akeneo\Pim\Structure\Component\AttributeTypes;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\Family;
 use Akeneo\Pim\Structure\Component\Query\PublicApi\Family\GetFamilies;
 use Akeneo\Test\Integration\Configuration;
@@ -15,27 +16,43 @@ final class SqlGetFamilyIntegration extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        $this->givenAttributes(['description', 'price', 'color', 'name']);
         $this->givenFamilies([
             [
                 'code' => 'shoes',
                 'labels' => [
                     'en_US' => 'Shoes',
-                    'fr_FR' => 'Chaussures'
-                ]
+                    'fr_FR' => 'Chaussures',
+                ],
+                'attributes' => [
+                    'sku',
+                    'description',
+                    'price',
+                ],
             ],
             [
                 'code' => 'accessories',
                 'labels' => [
                     'en_US' => 'Accessories',
-                    'fr_FR' => 'Accessoires'
-                ]
+                    'fr_FR' => 'Accessoires',
+                ],
+                'attributes' => [
+                    'sku',
+                    'color',
+                    'name',
+                ],
             ],
             [
                 'code' => 'hats',
                 'labels' => [
                     'en_US' => 'Hats',
-                    'fr_FR' => 'Chapeaux'
-                ]
+                    'fr_FR' => 'Chapeaux',
+                ],
+                'attributes' => [
+                    'sku',
+                    'description',
+                    'name',
+                ],
             ],
         ]);
     }
@@ -49,15 +66,17 @@ final class SqlGetFamilyIntegration extends TestCase
                 'accessories',
                 [
                     'en_US' => 'Accessories',
-                    'fr_FR' => 'Accessoires'
-                ]
+                    'fr_FR' => 'Accessoires',
+                ],
+                ['sku', 'color', 'name'],
             ),
-            'shoes' =>new Family(
+            'shoes' => new Family(
                 'shoes',
                 [
                     'en_US' => 'Shoes',
-                    'fr_FR' => 'Chaussures'
+                    'fr_FR' => 'Chaussures',
                 ],
+                ['sku', 'description', 'price'],
             ),
         ];
         $actual = $query->byCodes(['shoes', 'accessories']);
@@ -82,8 +101,9 @@ final class SqlGetFamilyIntegration extends TestCase
             'accessories',
             [
                 'en_US' => 'Accessories',
-                'fr_FR' => 'Accessoires'
-            ]
+                'fr_FR' => 'Accessoires',
+            ],
+            ['sku', 'color', 'name'],
         );
         $actual = $query->byCode('accessories');
 
@@ -117,5 +137,27 @@ final class SqlGetFamilyIntegration extends TestCase
         }, $families);
 
         $this->get('pim_catalog.saver.family')->saveAll($families);
+    }
+
+    private function givenAttributes(array $attributeCodes): void
+    {
+        $attributes = array_map(function ($attributeCode) {
+            $attribute = $this->get('pim_catalog.factory.attribute')->create();
+            $this->get('pim_catalog.updater.attribute')->update(
+                $attribute,
+                [
+                    'code' => $attributeCode,
+                    'type' => 'pim_catalog_text',
+                    'group' => 'other'
+                ]
+            );
+
+            $errors = $this->get('validator')->validate($attribute);
+            Assert::count($errors, 0);
+
+            return $attribute;
+        }, $attributeCodes);
+
+        $this->get('pim_catalog.saver.attribute')->saveAll($attributes);
     }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Update existing public service API introduce by https://github.com/akeneo/pim-community-dev/pull/19438
Add a flat array of family attribute codes

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
