### PR TITLE
SP-463: add labels in GetAttributes public API

### DIFF
--- a/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
+++ b/src/Akeneo/Pim/Structure/Component/Query/PublicApi/AttributeType/Attribute.php
@@ -20,7 +20,8 @@ final class Attribute
         private ?bool $decimalsAllowed,
         private string $backendType,
         private array $availableLocaleCodes,
-        private ?bool $useableAsGridFilter = null
+        private ?bool $useableAsGridFilter = null,
+        private array $labels = [],
     ) {
     }
 
@@ -87,5 +88,11 @@ final class Attribute
     public function useableAsGridFilter(): ?bool
     {
         return $this->useableAsGridFilter;
+    }
+
+    /** @return array<string, string> */
+    public function labels(): array
+    {
+        return $this->labels;
     }
 }

--- a/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
+++ b/tests/back/Pim/Structure/Integration/Attribute/Query/SqlGetAttributesIntegration.php
@@ -27,28 +27,29 @@ final class SqlGetAttributesIntegration extends TestCase
                 'type' => AttributeTypes::BOOLEAN,
                 'localizable' => false,
                 'scopable' => false,
-                'group' => 'other'
+                'group' => 'other',
+                'labels' => ['en_US' => 'a boolean', 'fr_FR' => 'Un booléen'],
             ],
             [
                 'code' => 'a_textarea',
                 'type' => AttributeTypes::TEXTAREA,
                 'localizable' => false,
                 'scopable' => false,
-                'group' => 'other'
+                'group' => 'other',
             ],
             [
                 'code' => 'a_text',
                 'type' => AttributeTypes::TEXT,
                 'localizable' => false,
                 'scopable' => false,
-                'group' => 'other'
+                'group' => 'other',
             ],
             [
                 'code' => '123',
                 'type' => AttributeTypes::TEXT,
                 'localizable' => false,
                 'scopable' => false,
-                'group' => 'other'
+                'group' => 'other',
             ],
             [
                 'code' => 'a_locale_specific_attribute',
@@ -100,7 +101,7 @@ final class SqlGetAttributesIntegration extends TestCase
         return [
             'a_text' => new Attribute('a_text', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
             'a_textarea' => new Attribute('a_textarea', AttributeTypes::TEXTAREA, [], false, false, null, null, false, 'textarea', []),
-            'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, null, false, 'boolean', []),
+            'a_boolean' => new Attribute('a_boolean', AttributeTypes::BOOLEAN, [], false, false, null, null, false, 'boolean', [], null, ['en_US' => 'a boolean', 'fr_FR' => 'Un booléen']),
             'unknown_attribute_code' => null,
             '123' => new Attribute('123', AttributeTypes::TEXT, [], false, false, null, null, false, 'text', []),
             'a_locale_specific_attribute' => new Attribute('a_locale_specific_attribute', AttributeTypes::BOOLEAN, [], true, false, null, null, false, 'boolean', ['en_US']),


### PR DESCRIPTION
We needed to enrich the GetAttributes public API by adding labels for Supplier Portal needs. It has been decided with @akeneo/squad-chipmunks to only return the available labels (if any) and not the labels of all the locales with a null value if there is no label.