### PR TITLE
PIM-10925: The search by code is missing on the attribute page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - PIM-10876: Does not save empty ('') labels and don't show null labels on API REST
 - PIM-10894: Allow research user by email as username.
 - PIM-10888: Disable adding an item to an association of its parent already contains the same item.
+- PIM-10925: The search by code is missing on the attribute page
 - PIM-10906: Use user timezone to display dates in history grid
 - PIM-10915: Fix attribute with numeric code throw 500 error on product history
 - PIM-10889: Update Category updated date after setting a labels and show category filtered by updated date on API REST 

--- a/src/Akeneo/Pim/Structure/.php_cd.php
+++ b/src/Akeneo/Pim/Structure/.php_cd.php
@@ -23,6 +23,8 @@ $rules = [
         'Oro\Bundle\FilterBundle\Grid\Extension\Configuration',
         'Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface',
         'Oro\Bundle\FilterBundle\Filter\ChoiceFilter',
+        'Oro\Bundle\FilterBundle\Filter\AbstractFilter',
+        'Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType',
         'Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface',
         'Psr\Log\LoggerInterface',
         'Akeneo\Platform\Bundle\FrameworkBundle\Security\SecurityFacadeInterface',

--- a/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/AttributeFilter.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/AttributeFilter.php
@@ -2,10 +2,10 @@
 
 namespace Akeneo\Pim\Structure\Bundle\Datagrid\Attribute;
 
-use Akeneo\Pim\Enrichment\Component\Product\Query\Filter\Operators;
 use Oro\Bundle\FilterBundle\Datasource\FilterDatasourceAdapterInterface;
 use Oro\Bundle\FilterBundle\Filter\AbstractFilter;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType;
+use Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface as PimFilterDatasourceAdapterInterface;
 
 class AttributeFilter extends AbstractFilter
 {
@@ -14,6 +14,10 @@ class AttributeFilter extends AbstractFilter
      */
     public function apply(FilterDatasourceAdapterInterface $ds, $data)
     {
+        if (!$ds instanceof PimFilterDatasourceAdapterInterface) {
+            return false;
+        }
+
         $data = $this->parseData($data);
         if (0 === count($data)) {
             return false;
@@ -27,13 +31,13 @@ class AttributeFilter extends AbstractFilter
                 $ds->expr()->orX(
                     $ds->expr()->comparison(
                         "$rootAlias.code",
-                        Operators::IS_LIKE,
+                        'LIKE',
                         $parameterName,
                         true
                     ),
                     $ds->expr()->comparison(
                         'translation.label',
-                        Operators::IS_LIKE,
+                        'LIKE',
                         $parameterName,
                         true
                     )

--- a/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/AttributeFilter.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Datagrid/Attribute/AttributeFilter.php
@@ -7,12 +7,12 @@ use Oro\Bundle\FilterBundle\Filter\AbstractFilter;
 use Oro\Bundle\FilterBundle\Form\Type\Filter\TextFilterType;
 use Oro\Bundle\PimFilterBundle\Datasource\FilterDatasourceAdapterInterface as PimFilterDatasourceAdapterInterface;
 
-class AttributeFilter extends AbstractFilter
+final class AttributeFilter extends AbstractFilter
 {
     /**
      * {@inheritDoc}
      */
-    public function apply(FilterDatasourceAdapterInterface $ds, $data)
+    public function apply(FilterDatasourceAdapterInterface $ds, $data): bool
     {
         if (!$ds instanceof PimFilterDatasourceAdapterInterface) {
             return false;
@@ -60,10 +60,8 @@ class AttributeFilter extends AbstractFilter
 
     /**
      * @param mixed $data
-     *
-     * @return array
      */
-    protected function parseData($data)
+    protected function parseData($data): array
     {
         if (!is_array($data) || !array_key_exists('value', $data) || !$data['value']) {
             return [];

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/datagrid/attribute.yml
@@ -68,9 +68,9 @@ datagrid:
         filters:
             columns:
                 label:
-                    type: search
-                    label: label
-                    data_name: translation.label
+                    type: attribute_search
+                    label: code_or_label
+                    data_name: code_or_label
                 type:
                     type:      choice
                     data_name: a.type

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/services.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/services.yml
@@ -91,6 +91,13 @@ services:
         tags:
             - { name: oro_filter.extension.orm_filter.filter, type: datagrid_attribute_family_filter }
 
+    Akeneo\Pim\Structure\Bundle\Datagrid\Attribute\AttributeFilter:
+        arguments:
+            - '@form.factory'
+            - '@oro_filter.filter_utility'
+        tags:
+            - { name: oro_filter.extension.orm_filter.filter, type: attribute_search }
+
     Akeneo\Pim\Structure\Component\Security\CatalogStructureScopeMapper:
         tags:
             - { name: pim_api.security.scope_mapper }

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/translations/jsmessages.en_US.yml
@@ -206,6 +206,7 @@ pim_common:
     label: Label
     label_translations: Label translations
     Label or identifier: label or identifier
+    code_or_label: code or label
     less_than: Less than
     loading: Loading...
     media_upload: Drag and drop to upload or click here

--- a/src/Oro/Bundle/FilterBundle/Datasource/ExpressionBuilderInterface.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/ExpressionBuilderInterface.php
@@ -21,7 +21,7 @@ interface ExpressionBuilderInterface
      * @param mixed $_ Expressions
      * @return mixed
      */
-    public function orX($_);
+    public function orX(...$_);
 
     /**
      * Creates an comparison expression with the given arguments.

--- a/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
+++ b/src/Oro/Bundle/FilterBundle/Datasource/Orm/OrmExpressionBuilder.php
@@ -25,7 +25,7 @@ class OrmExpressionBuilder implements ExpressionBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function orX($_)
+    public function orX(...$_)
     {
         return call_user_func_array([$this->expr, 'orX'], func_get_args());
     }

--- a/src/Oro/Bundle/PimDataGridBundle/Resources/config/requirejs.yml
+++ b/src/Oro/Bundle/PimDataGridBundle/Resources/config/requirejs.yml
@@ -120,6 +120,7 @@ config:
         oro/multiselect-decorator:                  pimdatagrid/js/multiselect-decorator
 
         oro/datafilter/search-filter:               pimdatagrid/js/datafilter/filter/search-filter
+        oro/datafilter/attribute_search-filter:     pimdatagrid/js/datafilter/filter/search-filter
         oro/datafilter/label_or_identifier-filter:  pimdatagrid/js/datafilter/filter/label_or_identifier-filter
         oro/datafilter/price-filter:                pimdatagrid/js/datafilter/filter/price-filter
         oro/datafilter/metric-filter:               pimdatagrid/js/datafilter/filter/metric-filter

--- a/tests/legacy/features/pim/structure/attribute/browse/filter.feature
+++ b/tests/legacy/features/pim/structure/attribute/browse/filter.feature
@@ -13,3 +13,8 @@ Feature: Filter attributes
     When I search "m"
     Then the grid should contain 6 elements
     And I should see entities Comment, Volume, Handmade, Name, Manufacturer and Number in stock
+
+  Scenario: Successfully search on code
+    When I search "side_view"
+    Then the grid should contain 1 elements
+    And I should see entities Side view


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

When attribute mass delete have been release we removed the search by code filter have we believed that we can search by code on attribute group page. 

In this PR, I added the possibility to search by attribute code and attribute label, to do it I added a new oro filter that handle it

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
