### PR TITLE
CPM-1050: Add fallback in helpCenter url in case of endpoint error

### DIFF
--- a/front-packages/shared/src/components/Navigation/PimNavigation.tsx
+++ b/front-packages/shared/src/components/Navigation/PimNavigation.tsx
@@ -86,6 +86,7 @@ const PimNavigation: FC<Props> = ({entries, activeEntryCode, activeSubEntryCode,
   }, [activeNavigationEntry, activeSubEntryCode]);
 
   const helpCenterUrl = useMemo(() => {
+    if (!pimVersion) return 'https://help.akeneo.com';
     const isSerenity = pimVersion?.pim_version.split('.').length === 1;
     const version = isSerenity ? 'serenity' : `v${pimVersion?.pim_version.split('.')[0]}`;
     const campaign = isSerenity ? 'serenity' : `${pimVersion?.pim_edition}${pimVersion?.pim_version}`;


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If endpoint `pim_analytics_data_collect` is in error, there is a js error bellow.
We prevent this error from happening by adding a fallback in case there is no `pimVersion` set

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
