### PR TITLE
OCT-249: add a quick fix to avoid flacky CI

### DIFF
--- a/components/catalogs/back/tests/Integration/IntegrationTestCase.php
+++ b/components/catalogs/back/tests/Integration/IntegrationTestCase.php
@@ -87,6 +87,7 @@ abstract class IntegrationTestCase extends WebTestCase
         self::getContainer()->get(ExperimentalTransactionHelper::class)->beginTransactions();
 
         self::getContainer()->get(FeatureFlags::class)->enable('catalogs');
+        self::getContainer()->get(FeatureFlags::class)->enable('asset_manager');
     }
 
     protected function overrideServices(): void


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**
This fix allows to unlock the CI and will be removed when the migration of catalogs from CE to EE will be completed (ASAP)

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
