### PR TITLE
PIM-10955: rollback PIM-10916 to fix perf issue on categories API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - PIM-10936: Fix an issue where completeness could not be saved after migrating to UUIDs
 - PIM-10938: Fix getNextObject when use clicks on variant during sequential edit
 - PIM-10948: Fix number value comparison
+- PIM-10955: Temporary rollback of PIM-10916 causing performance issue on categories API
 
 ## Improvements
 

--- a/src/Akeneo/Category/back/Infrastructure/Storage/Sql/GetCategoriesSql.php
+++ b/src/Akeneo/Category/back/Infrastructure/Storage/Sql/GetCategoriesSql.php
@@ -36,7 +36,7 @@ final class GetCategoriesSql implements GetCategoriesInterface
                 FROM pim_catalog_category category
                 JOIN pim_catalog_category_translation translation ON translation.foreign_key = category.id
                 WHERE $sqlWhere
-                AND translation.label IS NOT NULL 
+                AND translation.label IS NOT NULL
                 AND translation.label != ''
                 GROUP BY category.code
             ),
@@ -45,21 +45,22 @@ final class GetCategoriesSql implements GetCategoriesInterface
                 FROM pim_catalog_category category
                 LEFT JOIN pim_catalog_category_tree_template ctt ON ctt.category_tree_id = category.id
                 LEFT JOIN pim_catalog_category_template template ON template.uuid = ctt.category_template_uuid
-                WHERE $sqlWhere 
-                AND template.is_deactivated IS NULL 
+                WHERE $sqlWhere
+                AND template.is_deactivated IS NULL
                     OR template.is_deactivated = 0
             ),
             position as (
-                SELECT code, position 
+                SELECT code, position
                 FROM (
                     SELECT
                         category.code,
                         category.id as category_id,
                         sibling.id as sibling_id,
-                        ROW_NUMBER() over (PARTITION BY category.parent_id, category.id ORDER BY sibling.lft) as position
+                        ROW_NUMBER() over (PARTITION BY category.parent_id ORDER BY sibling.lft) as position
                     FROM pim_catalog_category category
-                        JOIN pim_catalog_category sibling on category.parent_id = sibling.parent_id
+                        JOIN pim_catalog_category sibling on category.id = sibling.id
                     WHERE $sqlWhere
+                    AND category.parent_id IS NOT NULL
                 ) r
                 WHERE sibling_id = category_id
             )
@@ -76,7 +77,7 @@ final class GetCategoriesSql implements GetCategoriesInterface
                 translation.translations,
                 IF(:with_position, COALESCE(position.position, 1), '') as position,
                 IF(:with_enriched_attributes, enriched_values.value_collection, '') as value_collection
-            FROM 
+            FROM
                 pim_catalog_category category
                 LEFT JOIN translation ON translation.code = category.code
                 LEFT JOIN position on position.code = category.code


### PR DESCRIPTION
Temporary rollback of a fix that cause performance issue on the categories Rest API.