### PR TITLE
RAB-1382: Differentiate reset catalog and banner

### DIFF
--- a/front-packages/shared/src/components/page/SandboxHelper.tsx
+++ b/front-packages/shared/src/components/page/SandboxHelper.tsx
@@ -18,7 +18,7 @@ const SandboxHelper = () => {
   const translate = useTranslate();
   const {isEnabled} = useFeatureFlags();
 
-  if (!isEnabled('reset_pim')) {
+  if (!isEnabled('sandbox_banner')) {
     return null;
   }
 

--- a/front-packages/shared/src/components/page/SandboxHelper.unit.tsx
+++ b/front-packages/shared/src/components/page/SandboxHelper.unit.tsx
@@ -3,7 +3,7 @@ import {screen} from '@testing-library/react';
 import {renderWithProviders} from '../../tests/utils';
 import {SandboxHelper} from './SandboxHelper';
 
-let mockedFeatureFlags: string[] = ['reset_pim'];
+let mockedFeatureFlags: string[] = ['sandbox_banner'];
 
 jest.mock('@akeneo-pim-community/shared/src/hooks/useFeatureFlags', () => ({
   useFeatureFlags: () => ({

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/form_extensions/dqi_dashboard/dqi_dashboard.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/form_extensions/dqi_dashboard/dqi_dashboard.yml
@@ -17,7 +17,7 @@ extensions:
         module: pim/sandbox-helper
         parent: akeneo-data-quality-insights-dqi-dashboard-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     akeneo-data-quality-insights-dqi-dashboard-breadcrumb:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/form_extensions/dqi_dashboard/dqi_dashboard.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/form_extensions/dqi_dashboard/dqi_dashboard.yml
@@ -17,7 +17,6 @@ extensions:
         module: pim/sandbox-helper
         parent: akeneo-data-quality-insights-dqi-dashboard-index
         targetZone: helper
-        feature: sandbox_banner
 
     akeneo-data-quality-insights-dqi-dashboard-breadcrumb:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-association-type-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-association-type-edit-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/association_type/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-association-type-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-association-type-edit-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-attribute-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-attribute-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
@@ -33,7 +33,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-attribute-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute/index.yml
@@ -33,7 +33,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-attribute-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-group-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-attribute-group-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/attribute_group/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-attribute-group-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-attribute-group-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-channel-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-channel-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-channel-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-channel-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/index.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-channel-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-channel-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/channel/index.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-channel-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-channel-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/currency/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/currency/index.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-currency-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-currency-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/currency/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/currency/index.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-currency-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-currency-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/export/index-profile.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/export/index-profile.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-export-profile-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-export-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/export/index-profile.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/export/index-profile.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-export-profile-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-export-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-family-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-family-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-family-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-family-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
@@ -33,7 +33,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-family-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-family-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/family/index.yml
@@ -33,7 +33,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-family-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-family-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-group-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-group-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/index.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group/index.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-type-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-group-type-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-type-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-group-type-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/index.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-type-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-group-type-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/group_type/index.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-group-type-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-group-type-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/import/index-profile.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/import/index-profile.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-import-profile-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-import-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/import/index-profile.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/import/index-profile.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-import-profile-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-import-profile-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_base_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-base-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb
@@ -100,7 +100,7 @@ extensions:
             tabCode: pim-job-instance-properties
             jobType: import
             fileExtension: csv
-    
+
     pim-job-instance-csv-product-import-edit-properties-file-upload:
         module: pim/job/common/edit/field/allow-file-upload
         parent: pim-job-instance-csv-product-import-edit-global

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/csv_product_model_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-csv-product-model-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-csv-product-model-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_base_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-base-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/xlsx_product_model_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-xlsx-product-model-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-xlsx-product-model-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-export-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-yml-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-export-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-yml-base-export-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-export-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-yml-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_export_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-export-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-yml-base-export-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-import-edit
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-yml-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_edit.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-import-edit
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-yml-base-import-edit-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -21,7 +21,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-import-show
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-job-instance-yml-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/job_instance/yml_base_import_show.yml
@@ -21,7 +21,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-job-instance-yml-base-import-show
         targetZone: helper
-        feature: sandbox_banner
 
     pim-job-instance-yml-base-import-show-breadcrumbs:
         module: pim/job/common/breadcrumb/breadcrumb

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-product-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-product-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -12,7 +12,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-product-index-grid-container:
         module: pim/common/simple-view

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product/index.yml
@@ -12,7 +12,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-product-index-grid-container:
         module: pim/common/simple-view

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-model-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-product-model-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/product_model/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-product-model-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-product-model-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-group.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-group.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-group-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-user-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-group.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-group.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-group-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-user-group-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-role.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-role.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-role-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-user-role-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-role.yml
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/config/form_extensions/user/index-role.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-role-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-user-role-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -6,7 +6,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-edit-form
         targetZone: helper
-        feature: sandbox_banner
 
     pim-user-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/edit.yml
@@ -6,7 +6,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-edit-form
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-user-edit-form-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/index.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/index.yml
@@ -30,7 +30,6 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-index
         targetZone: helper
-        feature: sandbox_banner
 
     pim-user-index-breadcrumbs:
         module: pim/common/breadcrumbs

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/index.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/form_extensions/index.yml
@@ -30,7 +30,7 @@ extensions:
         module: pim/sandbox-helper
         parent: pim-user-index
         targetZone: helper
-        feature: reset_pim
+        feature: sandbox_banner
 
     pim-user-index-breadcrumbs:
         module: pim/common/breadcrumbs


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, I added a new environment variable for sandbox banner as we don't want to have the rest PIM and the sandbox banner for on the same environment

See: 
https://github.com/akeneo/pim-enterprise-dev/pull/17210
https://github.com/akeneo/pim-onboarder/pull/1097

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
