### PR TITLE
PIM-10877: Fix sequential edit when grid is sorted by quality score

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- [Backport PIM-10877] PIM-10954: Fix sequential edit when grid is sorted by quality score
+
 # 6.0.81 (2023-04-18)
 
 ## Bug fixes

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/Symfony/Resources/config/productgrid.yml
@@ -29,7 +29,7 @@ services:
 
     Akeneo\Pim\Automation\DataQualityInsights\Infrastructure\Elasticsearch\Sorter\QualityScoreSorter:
         arguments:
-            - ['quality_score']
+            - ['quality_score', 'data_quality_insights_score']
         tags:
             - { name: pim_catalog.elasticsearch.query.sorter, priority: 30 }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Backport #19379 into 6.0

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
