### PR TITLE
PIM-10928: pim:update:check-requirements can create indexes which are unreachable from the PIM

### DIFF
--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -1,5 +1,9 @@
 # 6.0.x
 
+## Bug fixes
+
+- PIM-10928: Fix pim:update:check-requirements can create indexes which are unreachable from the PIM
+
 # 6.0.82 (2023-04-24)
 
 ## Bug fixes

--- a/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
+++ b/src/Akeneo/Platform/Bundle/FrameworkBundle/Command/CheckUpdateRequirementsCommand.php
@@ -50,7 +50,7 @@ class CheckUpdateRequirementsCommand extends Command
     private function validateThatElasticsearchIndexesAreCompliant(RequirementCollection $requirements): void
     {
         $firstElasticsearchHost = current($this->elasticsearchHosts);
-        $registeredIndexes = $this->getIndexesUsedByThePIM();
+        $registeredAlias = $this->getAliasUsedByThePIM();
 
         $indexConfigurations = $this->client->indices()->get(['index' => '*']);
         foreach ($indexConfigurations as $indexName => $indexConfiguration) {
@@ -64,7 +64,7 @@ class CheckUpdateRequirementsCommand extends Command
                 new Requirement(
                     str_starts_with($versionCreated, '7') || str_starts_with($versionCreated, '8'),
                     "Index $indexName creation version",
-                    !in_array($indexName, $registeredIndexes) ?
+                    !in_array($aliasName, $registeredAlias) ?
                         "The index $indexName seems to not be used by the PIM, please check if you use it. If you didn't use it delete it: curl --location --request DELETE 'http://$firstElasticsearchHost/$indexName'. If you want to keep it, reindex it with ElasticSearch 7: bin/console akeneo:elasticsearch:update-index-version $aliasName"
                         : "The index $indexName should be re-indexed in order to be created with Elasticsearch 7, run: bin/console akeneo:elasticsearch:update-index-version $aliasName"
                 )
@@ -72,7 +72,7 @@ class CheckUpdateRequirementsCommand extends Command
         }
     }
 
-    private function getIndexesUsedByThePIM(): array
+    private function getAliasUsedByThePIM(): array
     {
         $registeredIndexNames = [];
         $clients = $this->clientRegistry->getClients();

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Command/UpdateIndexVersionCommand.php
@@ -92,7 +92,7 @@ class UpdateIndexVersionCommand extends Command
         $sourceIndexConfiguration = $this->indexUpdaterClient->getIndexConfiguration($sourceAliasName);
         $sourceIsAnAlias = $this->indexUpdaterClient->isAnAlias($sourceAliasName);
         if (!$sourceIsAnAlias && $this->indexUpdaterClient->haveAlias($sourceAliasName)) {
-            throw new \Exception('Index with alias is not allowed, you should give the alias instead');
+            throw new \Exception('Cannot find index with this alias, Please provide the correct index alias.');
         }
 
         if (!$sourceIsAnAlias) {

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/Infrastructure/Client/IndexUpdaterClient.php
@@ -201,9 +201,16 @@ final class IndexUpdaterClient
         $this->assertResponseIsAcknowledged($this->client->indices()->delete(['index' => $indexName]));
     }
 
-    public function indexHaveAlias(string $indexName): bool
+    public function isAnAlias(string $indexName): bool
     {
         return $this->client->indices()->existsAlias(['name' => $indexName]);
+    }
+
+    public function haveAlias(string $indexName): bool
+    {
+        $aliasConfiguration = $this->client->indices()->get(['index' => $indexName]);
+
+        return array_keys($aliasConfiguration)[0] === $indexName;
     }
 
     public function renameAlias(string $sourceAliasName, string $sourceIndexName, string $destinationIndexName): void

--- a/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
+++ b/src/Akeneo/Tool/Bundle/ElasticsearchBundle/tests/integration/UpdateIndexVersionIntegration.php
@@ -51,7 +51,7 @@ class UpdateIndexVersionIntegration extends TestCase
     {
         $this->assertCommandFailedWithMessage(
             $this->runUpdateIndexVersionCommand($this->getProductAndProductModelIndexName()),
-            "Index with alias is not allowed, you should give the alias instead"
+            "Cannot find index with this alias, Please provide the correct index alias."
         );
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR:
- We fixed the `pim:update:check-requirements` command: this command check the index version and check if the index is used by the PIM, problem is that it compare an alias name with an index name. We fixed it, now it compare the alias names.
- We fixed the `akeneo:elasticsearch:update-index-version`: this command reindex into another index the alias given. Problem it can lead to the deletion of the alias used by the PIM if the user send the index name instead of the alias. We now return an error when the parameter is an index with an alias (we continue to accept index without alias because some client does not have an index `akeneo_pim_product_and_product_model` without alias

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
