### PR TITLE
PIM-10814: Wysiwyg now supports languages that use rtl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - PIM-10829: Fix case-sensitive locale on translatable business objects
 - PIM-10840: Fix attribute update date on attribute options change above 10000 options
 - PIM-10793: Add a command to delete expired tokens
-- PIM-10840: Fix attribute update date on attribute options change above 10000 options 
+- PIM-10840: Fix attribute update date on attribute options change above 10000 options
 - PIM-10868: Fix checkboxes on category trees
 - PIM-10832: Fix compute completeness job after removing an attribute from a family
 - PIM-10820: Partially revert [PIM-10350] to fix case sensitivity on options import
@@ -46,7 +46,7 @@
 - PIM-10925: The search by code is missing on the attribute page
 - PIM-10906: Use user timezone to display dates in history grid
 - PIM-10915: Fix attribute with numeric code throw 500 error on product history
-- PIM-10889: Update Category updated date after setting a labels and show category filtered by updated date on API REST 
+- PIM-10889: Update Category updated date after setting a labels and show category filtered by updated date on API REST
 - PIM-10919: Fix Cleaning Products with removed attributes using identifiers instead of uuids
 - PIM-10911: Add user-agent when sending an event
 - PIM-10885: Use React shared component for locale selector in product form locale switcher
@@ -63,6 +63,7 @@
 - PIM-10916: Fix with_position results on get categories Rest API endpoint
 - PIM-10961: Use React component for product grid locale switcher
 - PIM-10932: Fix data in NumberValueFactory if data contains a white space
+- PIM-10814: Wysiwyg now supports languages that use right-to-left (rtl) scripts
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/pim-wysiwyg.js
@@ -22,6 +22,7 @@ define(['jquery', 'underscore', 'backbone', 'summernote'], function ($, _, Backb
       ['view', ['codeview']],
     ],
     prettifyHtml: false,
+    direction: 'auto',
   };
 
   Backbone.Router.prototype.on('route', function () {

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/product/field/wysiwyg-field.js
@@ -43,6 +43,7 @@ define(['jquery', 'pim/field', 'underscore', 'pim/template/product/field/textare
             ['view', ['codeview']],
           ],
           prettifyHtml: false,
+          direction: 'auto',
         })
         .on('summernote.blur', this.updateModel.bind(this))
         .on('summernote.keyup', this.removeEmptyTags.bind(this));


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Add "dir" option to "auto" for textarea Wysiwyg in order to support rtl and ltr languages.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
