### PR TITLE
PIM-10932: Fix data in NumberValueFactory if data contains a white space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - PIM-10951: Fix grid search with special characters
 - PIM-10916: Fix with_position results on get categories Rest API endpoint
 - PIM-10961: Use React component for product grid locale switcher
+- PIM-10932: Fix data in NumberValueFactory if data contains a white space
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/NumberValueFactory.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/Factory/Value/NumberValueFactory.php
@@ -33,6 +33,10 @@ final class NumberValueFactory extends ScalarValueFactory implements ValueFactor
     {
         $attributeCode = $attribute->code();
 
+        if (\is_string($data)) {
+            $data = \trim($data);
+        }
+
         if ($attribute->isLocalizableAndScopable()) {
             return NumberValue::scopableLocalizableValue($attributeCode, $data, $channelCode, $localeCode);
         }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/NumberValueFactorySpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Factory/Value/NumberValueFactorySpec.php
@@ -103,6 +103,13 @@ final class NumberValueFactorySpec extends ObjectBehavior
         $value->shouldBeLike(NumberValue::value('an_attribute', 1234567890));
     }
 
+    public function it_creates_a_non_localizable_and_non_scopable_value_without_checking_the_data_with_space()
+    {
+        $attribute = $this->getAttribute(false, false);
+        $value = $this->createWithoutCheckingData($attribute, null, null, ' 1234567890');
+        $value->shouldBeLike(NumberValue::value('an_attribute', 1234567890));
+    }
+
     public function it_throws_an_exception_if_it_is_not_a_scalar()
     {
         $this->shouldThrow(InvalidPropertyTypeException::class)->during('createByCheckingData', [


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

If data has been corrupted and contains a white space, the user cannot save the product anymore.
So we make sure to trim the number data if it's a string

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
