### PR TITLE
PIM-10967: Fix inconsistency on DQI completeness recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - PIM-10814: Wysiwyg now supports languages that use right-to-left (rtl) scripts
 - PIM-10956: Fix deletion of category with enriched category template
 - PIM-10914: Add title and ellipsis for long labels on attribute select
+- PIM-10967: Fix inconsistency on DQI completeness recommendation
 - PIM-10639 : Prevent users to change his password without providing its current password
 
 ## Improvements

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Application/ProductEvaluation/CompleteEvaluationWithImprovableAttributes.php
@@ -61,8 +61,13 @@ class CompleteEvaluationWithImprovableAttributes
         $evaluationResultData = $criterionEvaluation->getResult()->getData();
         $evaluationResultData['attributes_with_rates'] = $this->getAttributesWithRates($completenessResult);
 
+        /**
+         * In some cases the rates of the persisted result are different from the one just calculated (See PIM-10967)
+         * It can happen when the required attributes list of a family has been changed, but the impacted products have not been re-evaluated yet
+         * So we also need to replace the rates to be always accurate with the list of improvable attributes
+         */
         $completedCriterionEvaluationResult = new Read\CriterionEvaluationResult(
-            $criterionEvaluation->getResult()->getRates(),
+            $completenessResult->getRates(),
             $criterionEvaluation->getResult()->getStatus(),
             $evaluationResultData
         );


### PR DESCRIPTION
In some cases the rates of the persisted result are different from the one just calculated. It can happen when the required attributes list of a family has been changed, but the impacted products have not been re-evaluated yet (by the cron job)

The simplest solution is to replace the rates to be always accurate with the list of improvable attributes