### PR TITLE
PIM-10972: change the way incomplete row are filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug fixes
 
+- PIM-10972: Fix shifting data during import
 - PIM-10950: Fix wrongly removed code filter on attribute page
 - PIM-10789: Fix password is displayed in SFTP and Amazon S3 form and encrypted password is displayed on history
 - PIM-10779: Fix lowercase on get attribute group code for dqi activation

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -95,12 +95,16 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface
         $this->checkColumnNumber($countHeaders, $countData, $data, $filePath);
 
         if ($countHeaders > $countData) {
-            $missingValuesCount = $countHeaders - $countData;
-            $missingValues = array_fill(0, $missingValuesCount, '');
-            $data = array_merge($data, $missingValues);
+            $keys = array_keys($data);
+            $missingIndexes = array_diff(range(0, max(array_keys($headers))), $keys);
+
+            foreach ($missingIndexes as $missingIndex) {
+                $data[$missingIndex] = '';
+            }
+            ksort($data);
         }
 
-        $item = array_combine($this->fileIterator->getHeaders(), $data);
+        $item = array_combine($headers, $data);
 
         try {
             $item = $this->converter->convert($item, $this->getArrayConverterOptions());

--- a/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
+++ b/src/Akeneo/Tool/Component/Connector/Reader/File/Xlsx/Reader.php
@@ -95,13 +95,8 @@ class Reader implements FileReaderInterface, TrackableItemReaderInterface
         $this->checkColumnNumber($countHeaders, $countData, $data, $filePath);
 
         if ($countHeaders > $countData) {
-            $keys = array_keys($data);
-            $missingIndexes = array_diff(range(0, max(array_keys($headers))), $keys);
-
-            foreach ($missingIndexes as $missingIndex) {
-                $data[$missingIndex] = '';
-            }
-            ksort($data);
+            $dataMask = array_fill(0, $countHeaders, '');
+            $data = array_replace($dataMask, $data);
         }
 
         $item = array_combine($headers, $data);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

see https://akeneo.atlassian.net/browse/PIM-10972

![Screenshot from 2023-05-15 15-46-39](https://github.com/akeneo/pim-community-dev/assets/35272857/06d2f44e-59a4-49ac-822e-c8bd1737920b)

In the case of an imported file with a large amount of columns, the file iterator removes empty values which leads to have data shifted. The fix is to rebuilt the row with empty values.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
