### PR TITLE
PIM-10976: Fix variant product counter on Product Model Edit Form for variant products without identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - PIM-10967: Fix inconsistency on DQI completeness recommendation
 - PIM-10639: Prevent users to change his password without providing its current password
 - PIM-10958: Fix attribute option position after clicking on "done"
+- PIM-10976: Fix variant product counter on Product Model Edit Form for variant products without identifier
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Storage/Sql/Completeness/VariantProductRatio.php
@@ -83,11 +83,11 @@ SQL;
             SELECT
                 channel.code AS channel_code,
                 locale.code AS locale_code,
-                product.identifier as product_identifier,
+                product.uuid as product_uuid,
                 CASE WHEN (product.product_missing_count = 0) THEN 1 ELSE 0 END as complete
             FROM
               (
-                SELECT DISTINCT product.identifier, completeness.locale_id, completeness.channel_id, completeness.missing_count as product_missing_count
+                SELECT DISTINCT product.uuid, completeness.locale_id, completeness.channel_id, completeness.missing_count as product_missing_count
                 %s
                 INNER JOIN pim_catalog_completeness completeness ON product.uuid = completeness.product_uuid
                 WHERE

--- a/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/CompleteVariantProducts.php
+++ b/src/Akeneo/Pim/Enrichment/Component/Product/ProductModel/Query/CompleteVariantProducts.php
@@ -71,7 +71,7 @@ class CompleteVariantProducts
     {
         return count(
             array_unique(
-                array_column($this->completenesses, 'product_identifier')
+                array_column($this->completenesses, 'product_uuid')
             )
         );
     }

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizerSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/Normalizer/InternalApi/LightEntityWithFamilyVariantNormalizerSpec.php
@@ -163,19 +163,19 @@ class LightEntityWithFamilyVariantNormalizerSpec extends ObjectBehavior
         $variantProductRatioQuery->findComplete($productModel)->willReturn(new CompleteVariantProducts(
             [
                 [
-                    'product_identifier' => 'tshirt_green_s',
+                    'product_uuid' => 'fef4e0bd-63e1-4eba-b89a-8298ab895d78',
                     'channel_code' => 'ecommerce',
                     'locale_code' => 'en_US',
                     'complete' => 0,
                 ],
                 [
-                    'product_identifier' => 'tshirt_green_m',
+                    'product_uuid' => '0285ef68-6d73-4591-bc29-510985834e87',
                     'channel_code' => 'ecommerce',
                     'locale_code' => 'en_US',
                     'complete' => 1,
                 ],
                 [
-                    'product_identifier' => 'tshirt_green_l',
+                    'product_uuid' => '4bda4603-dc11-4754-9934-1105079e5aa6',
                     'channel_code' => 'ecommerce',
                     'locale_code' => 'en_US',
                     'complete' => 1,

--- a/tests/back/Pim/Enrichment/Specification/Component/Product/ProductModel/Query/CompleteVariantProductsSpec.php
+++ b/tests/back/Pim/Enrichment/Specification/Component/Product/ProductModel/Query/CompleteVariantProductsSpec.php
@@ -12,18 +12,18 @@ class CompleteVariantProductsSpec extends ObjectBehavior
     {
         $this->beConstructedWith(
             [
-                ['channel_code' => 'ecommerce', 'locale_code' => 'en_US',  'complete' => 0, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'ecommerce', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'print', 'locale_code' => 'en_US', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'print', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'mobile', 'locale_code' => 'en_US', 'complete' => 0, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'mobile', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-xxs'],
-                ['channel_code' => 'ecommerce', 'locale_code' => 'en_US', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-m'],
-                ['channel_code' => 'ecommerce', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-m'],
-                ['channel_code' => 'print', 'locale_code' => 'en_US', 'complete' => 0, 'product_identifier' => 'biker-jacket-polyester-m'],
-                ['channel_code' => 'print', 'locale_code' => 'fr_FR', 'complete' => 0, 'product_identifier' => 'biker-jacket-polyester-m'],
-                ['channel_code' => 'mobile', 'locale_code' => 'en_US', 'complete' => 1, 'product_identifier' => 'biker-jacket-polyester-m'],
-                ['channel_code' => 'mobile', 'locale_code' => 'fr_FR', 'complete' => 1, 'biker-jacket-polyester-m'],
+                ['channel_code' => 'ecommerce', 'locale_code' => 'en_US',  'complete' => 0, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'ecommerce', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'print', 'locale_code' => 'en_US', 'complete' => 1, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'print', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'mobile', 'locale_code' => 'en_US', 'complete' => 0, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'mobile', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_uuid' => 'ace0d2a2-588c-4aa9-aa7d-9a2b05ce3c45'],
+                ['channel_code' => 'ecommerce', 'locale_code' => 'en_US', 'complete' => 1, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
+                ['channel_code' => 'ecommerce', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
+                ['channel_code' => 'print', 'locale_code' => 'en_US', 'complete' => 0, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
+                ['channel_code' => 'print', 'locale_code' => 'fr_FR', 'complete' => 0, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
+                ['channel_code' => 'mobile', 'locale_code' => 'en_US', 'complete' => 1, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
+                ['channel_code' => 'mobile', 'locale_code' => 'fr_FR', 'complete' => 1, 'product_uuid' => 'e5d46e64-e50e-4c8d-92c2-f12e2cbf92c9'],
             ]
         );
     }


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

The variant counter used to be wrong if several variant products had an empty identifier:

![Screenshot from 2023-05-03 16-12-37](https://github.com/akeneo/pim-community-dev/assets/5301298/e8dc2995-4ac6-4c8c-881a-63262e3d3aac)

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [x] Changelog (maintenance bug fixes)
- [ ] Tech Doc
