### PR TITLE
GROWTH-76: Update FeatureFlag interface to allow passing the flag being evaluated

### DIFF
--- a/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeFeatureFlag.php
+++ b/src/Akeneo/Connectivity/Connection/back/tests/Integration/Mock/FakeFeatureFlag.php
@@ -26,7 +26,7 @@ class FakeFeatureFlag implements FeatureFlag
         $this->enabled = false;
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->enabled;
     }

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/AllCriteriaFeature.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/AllCriteriaFeature.php
@@ -26,7 +26,7 @@ final class AllCriteriaFeature implements FeatureFlag
     ) {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->featureFlags->isEnabled('data_quality_insights')
             && $this->onlySerenityFeature->isEnabled();

--- a/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/DataQualityInsightsFeature.php
+++ b/src/Akeneo/Pim/Automation/DataQualityInsights/back/Infrastructure/FeatureFlag/DataQualityInsightsFeature.php
@@ -19,7 +19,7 @@ final class DataQualityInsightsFeature implements FeatureFlag
         $this->activationFlag = $activationFlag;
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return (true === $this->activationFlag);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/EnvVarFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/EnvVarFeatureFlag.php
@@ -14,7 +14,7 @@ class EnvVarFeatureFlag implements FeatureFlag
         $this->envVar = boolval($envVar);
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return boolval($this->envVar);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/FakeFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/FakeFeatureFlag.php
@@ -30,7 +30,7 @@ final class FakeFeatureFlag implements FeatureFlag
         $this->enabled = false;
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->enabled;
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyEnterpriseEditionFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyEnterpriseEditionFeatureFlag.php
@@ -23,7 +23,7 @@ final class OnlyEnterpriseEditionFeatureFlag implements FeatureFlag
     ) {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return in_array($this->edition, self::EDITIONS);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFlexibilityOnPremiseFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFlexibilityOnPremiseFeatureFlag.php
@@ -17,7 +17,7 @@ class OnlyFlexibilityOnPremiseFeatureFlag implements FeatureFlag
     ) {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return !in_array($this->edition, self::SAAS_EDITIONS);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFreeTrialFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyFreeTrialFeatureFlag.php
@@ -10,7 +10,7 @@ class OnlyFreeTrialFeatureFlag implements FeatureFlag
     {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->edition === 'pim_trial_instance';
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyGrowthAndSerenityFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyGrowthAndSerenityFeatureFlag.php
@@ -15,7 +15,7 @@ class OnlyGrowthAndSerenityFeatureFlag implements FeatureFlag
     {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return \in_array($this->edition, self::EDITIONS);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyGrowthAndSerenitySandboxFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlyGrowthAndSerenitySandboxFeatureFlag.php
@@ -23,7 +23,7 @@ class OnlyGrowthAndSerenitySandboxFeatureFlag implements FeatureFlag
     ) {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->isSerenitySandbox || $this->isGrowthEditionSandbox;
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlySaasFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlySaasFeatureFlag.php
@@ -22,7 +22,7 @@ final class OnlySaasFeatureFlag implements FeatureFlag
     {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return \in_array($this->edition, self::SAAS_EDITIONS);
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlySerenityFeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Configuration/OnlySerenityFeatureFlag.php
@@ -10,7 +10,7 @@ class OnlySerenityFeatureFlag implements FeatureFlag
     {
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->edition === 'serenity_instance';
     }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/FeatureFlag.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/FeatureFlag.php
@@ -11,5 +11,5 @@ namespace Akeneo\Platform\Bundle\FeatureFlagBundle;
  */
 interface FeatureFlag
 {
-    public function isEnabled(): bool;
+    public function isEnabled(?string $feature = null): bool;
 }

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/ImmutableFeatureFlags.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/ImmutableFeatureFlags.php
@@ -20,7 +20,7 @@ class ImmutableFeatureFlags implements FeatureFlags
     {
         $flag = $this->registry->get($feature);
 
-        return $flag->isEnabled();
+        return $flag->isEnabled($feature);
     }
 
     public function all(): array

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/Registry.php
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/Internal/Registry.php
@@ -38,7 +38,7 @@ class Registry
     {
         $featureFlags = [];
         foreach ($this->flags as $feature => $flag) {
-            $featureFlags[$feature] = $flag->isEnabled();
+            $featureFlags[$feature] = $flag->isEnabled($feature);
         }
 
         return $featureFlags;

--- a/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
+++ b/src/Akeneo/Platform/Bundle/FeatureFlagBundle/README.md
@@ -33,8 +33,8 @@ namespace Akeneo\Platform\Bundle\FeatureFlagBundle;
 
 interface FeatureFlag
 {
-    public function isEnabled(): bool
-}    
+    public function isEnabled(?string $feature = null): bool
+}
 ```
 
 ### Examples
@@ -65,12 +65,12 @@ class EnvVarFeatureFlag implements FeatureFlag
         $this->isEnabled = $isEnabled;
     }
 
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return $this->isEnabled;
     }
 }
-``` 
+```
 
 Another example. Imagine now you want to allow Akeneo people working at Nantes to access a beta `foo` feature. All you have to do is declare in your code a service that implements `Akeneo\Platform\Bundle\FeatureFlagBundle\FeatureFlag`.
 
@@ -80,7 +80,7 @@ services:
         class: 'Akeneo\My\Own\Namespace\FooFeatureFlag'
         arguments:
             - '@request_stack'
-``` 
+```
 
 ```php
 namespace Akeneo\My\Own\Namespace;
@@ -96,10 +96,10 @@ class FooFeatureFlag implements FeatureFlag
     {
         $this->requestStack = $requestStack;
     }
-    
-    public function isEnabled(): bool
+
+    public function isEnabled(?string $feature = null): bool
     {
-        return $this->requestStack->getCurrentRequest()->getClientIp() === $this->$akeneoIpAddress; 
+        return $this->requestStack->getCurrentRequest()->getClientIp() === $this->$akeneoIpAddress;
     }
 }
 ```
@@ -184,7 +184,7 @@ config:
         akeneo_connectivity_connection_settings_index:
           module: pim/controller/connectivity/connection/settings
           feature: myCoolFeature
-``` 
+```
 
 You can easily show or hide a part of HTML code in a Twig template
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/Job/DoctrineJobRepositoryIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/tests/Integration/Job/DoctrineJobRepositoryIntegration.php
@@ -200,8 +200,12 @@ class DoctrineJobRepositoryIntegration extends TestCase
      */
     private function addNewFeatureFlag(string $featureFlag): void
     {
-        $featureFlagService = new class implements FeatureFlag {
-            public function isEnabled(): bool { return false; }
+        $featureFlagService = new class implements FeatureFlag
+        {
+            public function isEnabled(?string $feature = null): bool
+            {
+                return false;
+            }
         };
         $this->get('akeneo.feature_flag.service.registry')->add($featureFlag, $featureFlagService);
     }

--- a/tests/back/Platform/Integration/FeatureFlag/FilePersistedFeatureFlagsIntegration.php
+++ b/tests/back/Platform/Integration/FeatureFlag/FilePersistedFeatureFlagsIntegration.php
@@ -48,7 +48,7 @@ class FilePersistedFeatureFlagsIntegration extends KernelTestCase
 
 class Enabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return true;
     }
@@ -56,7 +56,7 @@ class Enabled implements FeatureFlag
 
 class Disabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return false;
     }

--- a/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/ImmutableFeatureFlagsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/ImmutableFeatureFlagsSpec.php
@@ -32,7 +32,7 @@ class ImmutableFeatureFlagsSpec extends ObjectBehavior
 
 class Enabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return true;
     }
@@ -40,7 +40,7 @@ class Enabled implements FeatureFlag
 
 class Disabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return false;
     }

--- a/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/RegistrySpec.php
+++ b/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/RegistrySpec.php
@@ -47,14 +47,14 @@ class RegistrySpec extends ObjectBehavior
 
 class CustomFlagEnabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return true;
     }
 }
 class CustomFlagDisabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return false;
     }

--- a/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/Test/InMemoryFeatureFlagsSpec.php
+++ b/tests/back/Platform/Specification/Bundle/FeatureFlagBundle/Internal/Test/InMemoryFeatureFlagsSpec.php
@@ -40,7 +40,7 @@ class InMemoryFeatureFlagsSpec extends ObjectBehavior
 
 class Enabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return true;
     }
@@ -48,7 +48,7 @@ class Enabled implements FeatureFlag
 
 class Disabled implements FeatureFlag
 {
-    public function isEnabled(): bool
+    public function isEnabled(?string $feature = null): bool
     {
         return false;
     }


### PR DESCRIPTION
Allows implementation of a service that uses an external solution for resolving the flags.
If the flag is unknown we need to declare a different service for every flag just to pass a parameter, which is very inefficient.