### PR TITLE
PIM-10983: Error HTTP 500 when adding a custom app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - PIM-10639: Prevent users to change his password without providing its current password
 - PIM-10958: Fix attribute option position after clicking on "done"
 - PIM-10976: Fix variant product counter on Product Model Edit Form for variant products without identifier
+- PIM-10983: Error HTTP 500 when adding a custom app
 
 ## Improvements
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/Resources/config/model/doctrine/JobInstance.orm.yml
@@ -28,7 +28,6 @@ Akeneo\Tool\Component\Batch\Model\JobInstance:
             column: job_name
         status:
             type: integer
-            lenght: 11
             column: status
         connector:
             type: string

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Group.orm.yml
@@ -13,7 +13,7 @@ Akeneo\UserManagement\Component\Model\Group:
             type: string
             unique: true
             nullable: false
-            lenght: 30
+            length: 255
         defaultPermissions:
             column: default_permissions
             type: json

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
@@ -16,7 +16,7 @@ Akeneo\UserManagement\Component\Model\Role:
             lenght: 30
         label:
             type: string
-            lenght: 30
+            length: 255
         type:
             type: string
             nullable: false

--- a/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
+++ b/src/Akeneo/UserManagement/Bundle/Resources/config/model/doctrine/Role.orm.yml
@@ -13,7 +13,7 @@ Akeneo\UserManagement\Component\Model\Role:
             type: string
             unique: true
             nullable: false
-            lenght: 30
+            length: 255
         label:
             type: string
             length: 255

--- a/upgrades/schema/Version_8_0_20230511113912_fix_oro_access_tables_columns_length.php
+++ b/upgrades/schema/Version_8_0_20230511113912_fix_oro_access_tables_columns_length.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @copyright 2023 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ *
+ * Fix label and role column length to 255 in oro_access_role table and name column length to 255 in oro_access_group table
+ */
+final class Version_8_0_20230511113912_fix_oro_access_tables_columns_length extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix label and role column length to 255 in oro_access_role table and name column length to 255 in oro_access_group table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<SQL
+            ALTER TABLE oro_access_role 
+                MODIFY label VARCHAR(255) NOT NULL, 
+                MODIFY role VARCHAR(255) NOT NULL
+            ;
+            SQL
+        );
+
+        $this->addSql(<<<SQL
+            ALTER TABLE akeneo_connectivity_connected_app 
+                DROP CONSTRAINT FK_CONNECTIVITY_CONNECTED_APP_user_group_name
+            ;
+            SQL
+        );
+        $this->addSql(<<<SQL
+            ALTER TABLE oro_access_group 
+                MODIFY name VARCHAR(255) NOT NULL
+            ;
+            SQL
+        );
+        $this->addSql(<<<SQL
+            ALTER TABLE akeneo_connectivity_connected_app 
+                ADD CONSTRAINT FK_CONNECTIVITY_CONNECTED_APP_user_group_name FOREIGN KEY (user_group_name) REFERENCES oro_access_group (name);
+            SQL
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigrationException();
+    }
+}

--- a/upgrades/test_schema/Version_8_0_20230511113912_fix_oro_access_tables_columns_length_Integration.php
+++ b/upgrades/test_schema/Version_8_0_20230511113912_fix_oro_access_tables_columns_length_Integration.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pim\Upgrade\Schema\Tests;
+
+use Akeneo\Test\Integration\TestCase;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   https://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class Version_8_0_20230511113912_fix_oro_access_tables_columns_length_Integration extends TestCase
+{
+    use ExecuteMigrationTrait;
+
+    private const MIGRATION_LABEL = '_8_0_20230511113912_fix_oro_access_tables_columns_length';
+
+    private Connection $connection;
+
+    /** @test */
+    public function it_does_not_change_column_length_if_already_correct(): void
+    {
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'label'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'role'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_group', 'name'));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'label'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'role'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_group', 'name'));
+    }
+
+    /** @test */
+    public function it_updates_column_length(): void
+    {
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'label'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'role'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_group', 'name'));
+
+        $this->connection->executeStatement(<<<SQL
+            ALTER TABLE oro_access_role 
+                MODIFY label VARCHAR(30) NOT NULL,
+                MODIFY role VARCHAR(30) NOT NULL
+            ;
+        SQL);
+        $this->connection->executeStatement(<<<SQL
+            ALTER TABLE akeneo_connectivity_connected_app 
+                DROP CONSTRAINT FK_CONNECTIVITY_CONNECTED_APP_user_group_name
+            ;
+            SQL
+        );
+        $this->connection->executeStatement(<<<SQL
+            ALTER TABLE oro_access_group MODIFY name VARCHAR(30) NOT NULL;
+        SQL);
+        $this->connection->executeStatement(<<<SQL
+            ALTER TABLE akeneo_connectivity_connected_app 
+                ADD CONSTRAINT FK_CONNECTIVITY_CONNECTED_APP_user_group_name FOREIGN KEY (user_group_name) REFERENCES oro_access_group (name);
+            SQL
+        );
+        Assert::assertEquals(30, $this->countColumnLength('oro_access_role', 'label'));
+        Assert::assertEquals(30, $this->countColumnLength('oro_access_role', 'role'));
+        Assert::assertEquals(30, $this->countColumnLength('oro_access_group', 'name'));
+
+        $this->reExecuteMigration(self::MIGRATION_LABEL);
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'label'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_role', 'role'));
+        Assert::assertEquals(255, $this->countColumnLength('oro_access_group', 'name'));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->get('database_connection');
+    }
+
+    protected function getConfiguration()
+    {
+        return $this->catalog->useMinimalCatalog();
+    }
+
+    private function countColumnLength(string $tableName, string $columnName): int
+    {
+        $maxLength = $this->connection->executeQuery(
+            <<<SQL
+                SELECT CHARACTER_MAXIMUM_LENGTH 
+                FROM INFORMATION_SCHEMA.COLUMNS 
+                WHERE TABLE_SCHEMA ='akeneo_pim_test' 
+                AND TABLE_NAME = :tableName
+                AND COLUMN_NAME = :columnName
+                LIMIT 1;
+            SQL,
+            [
+                'tableName' => $tableName,
+                'columnName' => $columnName,
+            ]
+            )->fetchOne();
+
+        return (int) $maxLength;
+    }
+}


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In some old PIMs, the `label` column of `oro_access_role` table was set to `varchar(30)` and during the migration from PaaS to SaaS was not updated to `varchar(255)` due to some typo in configuration.

This PR fixes the typo and add a simple migration to fix the column size.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
