### PR TITLE
PH-1028: :bug: Handle custom job config in watchdog

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -147,7 +147,7 @@ final class JobExecutionWatchdogCommand extends Command
     private function buildBatchCommand(
         string $console,
         string $phpPath,
-        string $jobCode,
+        ?string $jobCode,
         int $jobExecutionId,
         array $batchCommandOptions
     ): array {

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -63,9 +63,9 @@ final class JobExecutionWatchdogCommand extends Command
                 'Job code to launch when no execution id provided'
             )
             ->addOption(
-                'job_config',
+                'config',
                 null,
-                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+                InputOption::VALUE_REQUIRED,
                 'Job configuration overriding default config'
             )
             ->addOption(
@@ -97,7 +97,7 @@ final class JobExecutionWatchdogCommand extends Command
             throw new \InvalidArgumentException('You must specify job_execution_id or job_code');
         }
         if (null === $jobExecutionId) {
-            $jobConfiguration = $input->getOption('job_config') ?? [];
+            $jobConfiguration = $input->getOption('config') ? \json_decode($input->getOption('config'), true) : [];
             $jobExecution = $this->createJobExecutionHandler->createFromBatchCode($jobCode, $jobConfiguration, null);
             $jobExecutionId = $jobExecution->getId();
         }
@@ -161,7 +161,7 @@ final class JobExecutionWatchdogCommand extends Command
         ];
 
         foreach ($batchCommandOptions as $optionName => $optionValue) {
-            if (in_array($optionName, ['job_execution_id', 'job_code', 'job_config'])) {
+            if (in_array($optionName, ['job_execution_id', 'job_code', 'config'])) {
                 continue;
             }
             switch (true) {

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -65,7 +65,7 @@ final class JobExecutionWatchdogCommand extends Command
             ->addOption(
                 'job_config',
                 null,
-                InputOption::VALUE_REQUIRED,
+                InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Job configuration overriding default config'
             )
             ->addOption(
@@ -90,8 +90,8 @@ final class JobExecutionWatchdogCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $jobExecutionId = $input->getOption('job_execution_id') ? (int)$input->getOption('job_execution_id') : null;
-        $jobCode = $input->getOption('job_code') ? (string)$input->getOption('job_code') : null;
+        $jobExecutionId = $input->getOption('job_execution_id') ? (int) $input->getOption('job_execution_id') : null;
+        $jobCode = $input->getOption('job_code') ? (string) $input->getOption('job_code') : null;
 
         if (null === $jobExecutionId && null === $jobCode) {
             throw new \InvalidArgumentException('You must specify job_execution_id or job_code');
@@ -129,10 +129,10 @@ final class JobExecutionWatchdogCommand extends Command
             );
         } finally {
             // update status if the job execution failed due to an uncatchable error as a fatal error
-            if ($this->executionManager->getExitStatus((int)$jobExecutionId)?->isRunning()) {
+            if ($this->executionManager->getExitStatus((int) $jobExecutionId)?->isRunning()) {
                 $this->executionManager->markAsFailed($jobExecutionId);
             }
-            $this->releaseJobLock((int)$jobExecutionId);
+            $this->releaseJobLock((int) $jobExecutionId);
         }
 
         $executionTimeInSec = time() - $startTime;

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/PurgeVersioningWatchdogIntegration.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/tests/integration/Command/PurgeVersioningWatchdogIntegration.php
@@ -57,7 +57,7 @@ class PurgeVersioningWatchdogIntegration extends TestCase
     public function it_purges_versions_with_custom_config(): void
     {
         $output = $this->runWatchdog([
-            '--job_config' => ['less-than-days' => 5, 'more-than-days' => 15],
+            '--config' => ['less-than-days' => 5, 'more-than-days' => 15],
         ]);
         $result = $output->fetch();
 
@@ -90,7 +90,7 @@ class PurgeVersioningWatchdogIntegration extends TestCase
     public function it_cannot_purges_versions_with_wrong_config(): void
     {
         $output = $this->runWatchdog([
-            '--job_config' => ['unknow-option' => 'foo'],
+            '--config' => ['unknow-option' => 'foo'],
         ]);
         $result = $output->fetch();
 
@@ -136,7 +136,7 @@ class PurgeVersioningWatchdogIntegration extends TestCase
 
         $arrayInput = array_merge($defaultArrayInput, $arrayInput);
         if (isset($arrayInput['--config'])) {
-            $arrayInput['--config'] = json_encode($arrayInput['--config']);
+            $arrayInput['--config'] = \json_encode($arrayInput['--config']);
         }
 
         $input = new ArrayInput($arrayInput);


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The watchdog command was not able to transfer custom options to the `akeneo:batch:job` command.

We fix this by creating the job execution with the provided configuration, so the right parameters will be stored in the database job_execution.

**Workflow:**

- Launch watchdog command with custom config

```bash
bin/console akeneo:batch:watchdog --job_code=versioning_purge --config='{"more-than-days": 15, "less-than-days": 5}'
```

- The watchdog creates a job_execution with the custom parameters
- The batch command is launched by the watchdog with the created job execution ID

**Definition Of Done (for Core Developer only)**

- [x] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
