### PR TITLE
fix stateful UcsMiddleware injecting wrong tenant id in messages

### DIFF
--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -6,6 +6,7 @@ namespace Akeneo\Tool\Bundle\MessengerBundle\Middleware;
 
 use Akeneo\Tool\Bundle\MessengerBundle\Stamp\TenantIdStamp;
 use Akeneo\Tool\Component\Messenger\Tenant\TenantAwareInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Middleware\MiddlewareInterface;
 use Symfony\Component\Messenger\Middleware\StackInterface;
@@ -16,8 +17,10 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  */
 class UcsMiddleware implements MiddlewareInterface
 {
-    public function __construct(private readonly ?string $pimTenantId)
-    {
+    public function __construct(
+        private readonly ?string $pimTenantId,
+        private readonly LoggerInterface $logger,
+    ) {
     }
 
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
@@ -25,6 +28,13 @@ class UcsMiddleware implements MiddlewareInterface
         // We always try to use the tenantid from the stamp, if there is any, in case of long-running process.
         // If there is none, we fallback on the tenantid coming from the env variables.
         $tenantId = $envelope->last(TenantIdStamp::class)?->pimTenantId() ?: $this->pimTenantId;
+
+        if (empty($tenantId)) {
+            $this->logger->warning(sprintf(
+                'A message of type "%s" is consumed without a tenant id available',
+                get_class($envelope->getMessage()),
+            ));
+        }
 
         if ($tenantId && null === $envelope->last(TenantIdStamp::class)) {
             $envelope = $envelope->with(new TenantIdStamp($tenantId));

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Middleware/UcsMiddleware.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\Middleware\StackInterface;
  */
 class UcsMiddleware implements MiddlewareInterface
 {
-    public function __construct(private ?string $pimTenantId)
+    public function __construct(private readonly ?string $pimTenantId)
     {
     }
 

--- a/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
+++ b/src/Akeneo/Tool/Bundle/MessengerBundle/Resources/config/transport.yml
@@ -16,3 +16,4 @@ services:
     Akeneo\Tool\Bundle\MessengerBundle\Middleware\UcsMiddleware:
         arguments:
             - '%env(default::string:APP_TENANT_ID)%'
+            - '@logger'

--- a/tests/back/Tool/Integration/Batch/Command/BatchCommandIntegration.php
+++ b/tests/back/Tool/Integration/Batch/Command/BatchCommandIntegration.php
@@ -97,7 +97,7 @@ class BatchCommandIntegration extends TestCase
     public function testLaunchJobWithValidEmail()
     {
         $output = $this->launchJob(['--email' => ['ziggy@akeneo.com']]);
-        $this->assertEquals('Export csv_product_export has been successfully executed.' . PHP_EOL, $output->fetch());
+        $this->assertStringContainsString('Export csv_product_export has been successfully executed.', $output->fetch());
     }
 
     public function testLaunchJobWithInvalidJobInstance()


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In the previous version of `UcsMiddleware`, the property `$this->pimTenantId`, from `APP_TENANT_ID` env var, was used for adding the tenant id into messages.
In long running processes, this variable was supposed to stay null after each envelope.
That was not the case because after the first message is consumed, it becomes stateful because of the line
```
$this->pimTenantId = $stamp->pimTenantId();
```

With the new version, the middleware never become stateful in long-running processes and always use the stamp as a source of truth.

Since the webhook feature has no visible impact on the PIM (it's a background process that does not change PIM data), it took a lot of time to be noticed.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
