### PR TITLE
PIM-10980: Fix pagination update when applying filters on product association grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - PIM-10958: Fix attribute option position after clicking on "done"
 - PIM-10976: Fix variant product counter on Product Model Edit Form for variant products without identifier
 - PIM-10983: Error HTTP 500 when adding a custom app
+- PIM-10980: Fix pagination update when applying filters on product association grid
 
 ## Improvements
 

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductDatasource.php
@@ -106,6 +106,7 @@ class AssociatedProductDatasource extends ProductDatasource
             $locale,
             $scope
         );
+        $associatedProductModels = null;
 
         $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
             $associatedProducts,
@@ -134,7 +135,7 @@ class AssociatedProductDatasource extends ProductDatasource
             );
         }
 
-        $rows = ['totalRecords' => count($associatedProductsIds) + count($associatedProductModelsIds)];
+        $rows = ['totalRecords' => $associatedProducts->count() + ($associatedProductModels?->count() ?? 0)];
         $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);
         $rows['meta']['source'] = $this->getNormalizedSource($sourceProduct, $locale, $scope);
 

--- a/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
+++ b/src/Oro/Bundle/PimDataGridBundle/Datasource/AssociatedProductModelDatasource.php
@@ -109,6 +109,7 @@ class AssociatedProductModelDatasource extends ProductDatasource
             $locale,
             $scope
         );
+        $associatedProductModels = null;
 
         $normalizedAssociatedProducts = $this->normalizeProductsAndProductModels(
             $associatedProducts,
@@ -137,7 +138,7 @@ class AssociatedProductModelDatasource extends ProductDatasource
             );
         }
 
-        $rows = ['totalRecords' => count($associatedProductsUuids) + count($associatedProductModelsIdentifiers)];
+        $rows = ['totalRecords' => $associatedProducts->count() + ($associatedProductModels?->count() ?? 0)];
         $rows['data'] = array_merge($normalizedAssociatedProducts, $normalizedAssociatedProductModels);
         $rows['meta']['source'] = $this->getNormalizedSource($sourceProduct, $locale, $scope);
 

--- a/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
+++ b/src/Oro/Bundle/PimDataGridBundle/spec/Datasource/AssociatedProductDatasourceSpec.php
@@ -339,7 +339,6 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         \ArrayIterator $parentAssociationIterator,
         CursorInterface $productCursor,
         CursorInterface $associatedProductCursor,
-        CursorInterface $associatedProductModelCursor,
         Collection $collectionProductModel,
         Collection $parentCollectionProductModel,
         \Iterator $collectionProductModelIterator,
@@ -441,22 +440,6 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $associatedProductCursor->next()->shouldBeCalled();
         $associatedProductCursor->count()->willReturn(2);
 
-        $pqbFactory->create([
-            'repository_parameters' => [],
-            'repository_method'     => 'createQueryBuilder',
-            'limit'                 => 0,
-            'from'                  => 0,
-            'default_locale'        => 'a_locale',
-            'default_scope'         => 'a_channel',
-            'filters'               => null,
-        ])->willReturn($pqbAssoProductModel);
-
-        $pqbAssoProductModel->execute()->willReturn($associatedProductModelCursor);
-
-        $associatedProductModelCursor->valid()->willReturn(true, false);
-        $associatedProductModelCursor->current()->willReturn($associatedProductModel);
-        $associatedProductModelCursor->count()->willReturn(1);
-
         $productNormalizer->normalize($currentProduct, Argument::cetera())->shouldNotBeCalled();
 
         $productNormalizer->normalize($associatedProduct1, 'datagrid', [
@@ -522,7 +505,7 @@ class AssociatedProductDatasourceSpec extends ObjectBehavior
         $results->shouldBeArray();
         $results->shouldHaveCount(3);
         $results->shouldHaveKey('data');
-        $results->shouldHaveKeyWithValue('totalRecords', 3);
+        $results->shouldHaveKeyWithValue('totalRecords', 2);
         $results['data']->shouldBeArray();
         $results['data']->shouldHaveCount(2);
         $results['data']->shouldBeAnArrayOfInstanceOf(ResultRecord::class);


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In the association grid, the pagination was always calculated based on the total number of associated entities, and was not taking filters into account
![1](https://github.com/akeneo/pim-community-dev/assets/5301298/e9525927-a7c4-4d36-aa08-dfe806ba3c19)
![2](https://github.com/akeneo/pim-community-dev/assets/5301298/e38520be-58f8-44a0-b9a5-032e26ab3a43)


**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
