### PR TITLE
PIM-10978 Make sure to change updated date on edited category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PIM-10983: Error HTTP 500 when adding a custom app
 - PIM-10980: Fix pagination update when applying filters on product association grid
 - PIM-10977 : Prevent api users to log in to the PIM via the UI
+- PIM-10978: Make sure to change updated date on edited category 
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/.php_cd.php
@@ -280,6 +280,7 @@ $rules = [
         'Akeneo\Category\Infrastructure\Component\Classification\CategoryAwareInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\Repository\CategoryFilterableRepositoryInterface',
         'Akeneo\Category\Infrastructure\Component\Classification\Repository\CategoryRepositoryInterface',
+        'Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLUpdateCategoryUpdatedDate',
     ])->in('Akeneo\Pim\Enrichment\Component'),
 ];
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Resources/config/updaters.yml
@@ -115,6 +115,7 @@ services:
         arguments:
             - '@pim_catalog.updater.category.base'
             - '@pim_enrichment.updater.translatable'
+            - '@Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLUpdateCategoryUpdatedDate'
 
     pim_catalog.updater.group:
         class: '%pim_catalog.updater.group.class%'

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/AntiCorruptionLayer/ACLUpdateCategoryUpdatedDate.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/AntiCorruptionLayer/ACLUpdateCategoryUpdatedDate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer;
+
+use Akeneo\Category\Domain\Query\UpdateCategoryUpdatedDate;
+
+/**
+ * @copyright 2023 Akeneo SAS (https://www.akeneo.com)
+ * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+final class ACLUpdateCategoryUpdatedDate implements UpdateCategoryUpdatedDate
+{
+    public function __construct(private UpdateCategoryUpdatedDate $updateCategoryUpdatedDate)
+    {
+    }
+
+    public function execute(string $categoryCode): void
+    {
+        $this->updateCategoryUpdatedDate->execute($categoryCode);
+    }
+}

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/anti_corruption_layer.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/anti_corruption_layer.yml
@@ -3,4 +3,9 @@ services:
         class: Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLGetAttributeTypes
         arguments:
             - '@pim_catalog.repository.attribute'
-    
+
+    Akeneo\Category\Domain\Query\ACLUpdateCategoryUpdatedDate:
+        class: Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLUpdateCategoryUpdatedDate
+        arguments:
+            - '@Akeneo\Category\Domain\Query\UpdateCategoryUpdatedDate'
+

--- a/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/anti_corruption_layer.yml
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Infrastructure/Symfony/Resources/config/anti_corruption_layer.yml
@@ -4,8 +4,8 @@ services:
         arguments:
             - '@pim_catalog.repository.attribute'
 
-    Akeneo\Category\Domain\Query\ACLUpdateCategoryUpdatedDate:
-        class: Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLUpdateCategoryUpdatedDate
+    Akeneo\Pim\Enrichment\Product\Infrastructure\AntiCorruptionLayer\ACLUpdateCategoryUpdatedDate:
+        class: ~
         arguments:
             - '@Akeneo\Category\Domain\Query\UpdateCategoryUpdatedDate'
 

--- a/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Test/.php_cd.php
@@ -84,6 +84,7 @@ $rules = [
         'Akeneo\Pim\Structure\Component\Repository\AttributeRepositoryInterface',
         'Akeneo\Tool\Component\StorageUtils\Cache\CachedQueryInterface',
         'Akeneo\Tool\Component\StorageUtils\Cache\LRUCache',
+        'Akeneo\Category\Domain\Query\UpdateCategoryUpdatedDate',
 
         // Symfony, Doctrine DBAL and other libs
         'Webmozart\Assert\Assert',


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

An anticorruption layer has been introduced in the Pim\Enrichment part of the code to be able to use the service to update the category "updated" column during categories import.
We implemented an ACL because the code for the import of categories will be reworked in the future (i.e. it will be part of the new Bounded Context Category, hence no ACL needed anymore) and because a service api is not a desired solution: this updating service is very specific to Category BC and should not be callable outside of the BC. 

<!-- Please write a description, add some context, and feel free to add screenshots if relevant. -->

**Definition Of Done (for Core Developer only)**

- [x] Changelog (maintenance bug fixes)
