### PR TITLE
RAB-1395: Fix the AttributeRemovalSubscriber that is instanciating a lot of services

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/AttributeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Akeneo\Pim\Structure\Bundle\Controller\InternalApi;
 
 use Akeneo\Pim\Enrichment\Bundle\Filter\ObjectFilterInterface;
+use Akeneo\Pim\Structure\Bundle\EventSubscriber\AttributeRemovalSubscriber;
 use Akeneo\Pim\Structure\Bundle\Query\PublicApi\Attribute\Sql\AttributeIsAFamilyVariantAxis;
 use Akeneo\Pim\Structure\Component\Exception\CannotRemoveAttributeException;
 use Akeneo\Pim\Structure\Component\Factory\AttributeFactory;
@@ -104,7 +105,8 @@ class AttributeController
         NormalizerInterface $lightAttributeNormalizer,
         TranslatorInterface $translator,
         AttributeIsAFamilyVariantAxis $attributeIsAFamilyVariantAxisQuery,
-        ObjectRepository $channelRepository
+        ObjectRepository $channelRepository,
+        private readonly AttributeRemovalSubscriber $attributeRemovalSubscriber,
     ) {
         $this->attributeRepository = $attributeRepository;
         $this->normalizer = $normalizer;
@@ -346,6 +348,8 @@ class AttributeController
 
             return new JsonResponse(['message' => $message], Response::HTTP_BAD_REQUEST);
         }
+
+        $this->attributeRemovalSubscriber->flushEvents();
 
         return new JsonResponse(null, Response::HTTP_NO_CONTENT);
     }

--- a/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/MassDeleteAttributeController.php
+++ b/src/Akeneo/Pim/Structure/Bundle/Controller/InternalApi/MassDeleteAttributeController.php
@@ -15,7 +15,6 @@ use Akeneo\Tool\Component\StorageUtils\Repository\IdentifiableObjectRepositoryIn
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 

--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/AttributeRemovalSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/AttributeRemovalSubscriber.php
@@ -27,10 +27,10 @@ class AttributeRemovalSubscriber implements EventSubscriberInterface
     private array $attributeCodesToClean = [];
 
     public function __construct(
-        private AttributeCodeBlacklister $attributeCodeBlacklister,
-        private JobLauncherInterface $jobLauncher,
-        private IdentifiableObjectRepositoryInterface $jobInstanceRepository,
-        private TokenStorageInterface $tokenStorage,
+        private readonly AttributeCodeBlacklister $attributeCodeBlacklister,
+        private readonly JobLauncherInterface $jobLauncher,
+        private readonly IdentifiableObjectRepositoryInterface $jobInstanceRepository,
+        private readonly TokenStorageInterface $tokenStorage,
     ) {
     }
 
@@ -38,8 +38,6 @@ class AttributeRemovalSubscriber implements EventSubscriberInterface
     {
         return [
             StorageEvents::POST_REMOVE => 'blacklistAttributeCodeAndLaunchJob',
-            TerminateEvent::class => 'flushEvents',
-            ConsoleTerminateEvent::class => 'flushEvents',
         ];
     }
 

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/controllers.yml
@@ -124,6 +124,7 @@ services:
             - '@translator'
             - '@akeneo.pim.structure.query.attribute_is_an_family_variant_axis'
             - '@pim_catalog.repository.channel'
+            - '@pim_catalog.event_subscriber.attribute_removal'
 
     pim_enrich.controller.rest.attribute_group:
         public: true

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/steps.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/steps.yml
@@ -465,6 +465,7 @@ services:
             - '@pim_enrich.repository.attribute.search'
             - '@pim_catalog.remover.attribute'
             - '@translator'
+            - '@pim_catalog.event_subscriber.attribute_removal'
 
     pim_connector.step.delete_attributes:
         class: 'Akeneo\Tool\Component\Connector\Step\TaskletStep'

--- a/src/Akeneo/Pim/Structure/Component/Attribute/Job/DeleteAttributesTasklet.php
+++ b/src/Akeneo/Pim/Structure/Component/Attribute/Job/DeleteAttributesTasklet.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Akeneo\Pim\Structure\Component\Attribute\Job;
 
+use Akeneo\Pim\Structure\Bundle\EventSubscriber\AttributeRemovalSubscriber;
 use Akeneo\Pim\Structure\Component\Exception\CannotRemoveAttributeException;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
 use Akeneo\Tool\Component\Batch\Item\DataInvalidItem;
@@ -26,6 +27,7 @@ class DeleteAttributesTasklet implements TaskletInterface, TrackableTaskletInter
         private readonly SearchableRepositoryInterface $attributeRepository,
         private readonly RemoverInterface $remover,
         private readonly TranslatorInterface $translator,
+        private readonly AttributeRemovalSubscriber $attributeRemovalSubscriber,
     ) {
     }
 
@@ -51,6 +53,8 @@ class DeleteAttributesTasklet implements TaskletInterface, TrackableTaskletInter
         foreach ($attributes as $attribute) {
             $this->delete($attribute);
         }
+
+        $this->attributeRemovalSubscriber->flushEvents();
     }
 
     /**

--- a/tests/back/Pim/Structure/Specification/Component/Attribute/Job/DeleteAttributesTaskletSpec.php
+++ b/tests/back/Pim/Structure/Specification/Component/Attribute/Job/DeleteAttributesTaskletSpec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Specification\Akeneo\Pim\Structure\Component\Attribute\Job;
 
+use Akeneo\Pim\Structure\Bundle\EventSubscriber\AttributeRemovalSubscriber;
 use Akeneo\Pim\Structure\Component\Attribute\Job\DeleteAttributesTasklet;
 use Akeneo\Pim\Structure\Component\Exception\CannotRemoveAttributeException;
 use Akeneo\Pim\Structure\Component\Model\Attribute;
@@ -24,11 +25,13 @@ class DeleteAttributesTaskletSpec extends ObjectBehavior
         SearchableRepositoryInterface $attributeRepository,
         RemoverInterface $attributeRemover,
         TranslatorInterface $translator,
+        AttributeRemovalSubscriber $attributeRemovalSubscriber,
     ): void {
         $this->beConstructedWith(
             $attributeRepository,
             $attributeRemover,
             $translator,
+            $attributeRemovalSubscriber,
         );
     }
 
@@ -63,6 +66,7 @@ class DeleteAttributesTaskletSpec extends ObjectBehavior
         RemoverInterface $attributeRemover,
         StepExecution $stepExecution,
         JobParameters $jobParameters,
+        AttributeRemovalSubscriber $attributeRemovalSubscriber,
     ): void {
         $this->setStepExecution($stepExecution);
         $filters = [
@@ -95,6 +99,8 @@ class DeleteAttributesTaskletSpec extends ObjectBehavior
         $attributeRemover->remove($attribute3)->shouldBeCalled();
         $stepExecution->incrementSummaryInfo('deleted_attributes')->shouldBeCalled();
         $stepExecution->incrementProcessedItems()->shouldBeCalled();
+
+        $attributeRemovalSubscriber->flushEvents()->shouldBeCalledOnce();
 
         $this->execute();
     }


### PR DESCRIPTION
Call subscriber explicitly instead of relying on symfony events to improve performances