### PR TITLE
Fix database akeneo_pim does not exist when launching make database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ check-requirements:
 
 .PHONY: database
 database:
-	$(PHP_RUN) bin/console doctrine:database:drop --force
+	$(PHP_RUN) bin/console doctrine:database:drop --force --if-exists
 	$(PHP_RUN) bin/console doctrine:database:create --if-not-exists
 	$(PHP_RUN) bin/console pim:installer:db ${O}
 


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In some case the `akeneo_pim` database does not exist when we launch `make database` command. 

When it's the case we have the following error 
```
Can't drop database 'akeneo_pim'; database doesn't exist
```

In order to not have to create manually the database and relaunch the command I added to the drop database an if exist check.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
