### PR TITLE
PIM-11001: Fix code filter on attributes grid with special character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - PIM-10983: Error HTTP 500 when adding a custom app
 - PIM-10980: Fix pagination update when applying filters on product association grid
 - PIM-10977 : Prevent api users to log in to the PIM via the UI
+- PIM-11001: Fix code filter on attributes grid with special character
 
 ## Improvements
 

--- a/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/StringFilter.php
@@ -80,7 +80,10 @@ class StringFilter extends AbstractFilter
         }
 
         $data['type'] = isset($data['type']) ? $data['type'] : null;
-        $data['value'] = sprintf($this->getFormatByComparisonType($data['type']), $data['value']);
+        $data['value'] = sprintf(
+            $this->getFormatByComparisonType($data['type']),
+            \addcslashes($data['value'], '_%')
+        );
 
         return $data;
     }

--- a/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
+++ b/src/Oro/Bundle/FilterBundle/spec/Filter/StringFilterSpec.php
@@ -52,4 +52,21 @@ class StringFilterSpec extends ObjectBehavior
 
         $this->apply($ds, ['type' => 'empty', 'value' => ''])->shouldReturn(true);
     }
+
+    function it_escapes_special_characters(
+        FilterDatasourceAdapterInterface $ds,
+        ExpressionBuilderInterface $builder)
+    {
+        $this->init('code', ['data_name' => 'a.code']);
+        $ds->generateParameterName('code')->willReturn('code1877008211');
+        $comparisonExpr = new Expr\Comparison('a.code', 'LIKE', ':code1877008211');
+
+        $builder->comparison('a.code', 'LIKE', 'code1877008211', true)->willReturn($comparisonExpr);
+        $ds->expr()->willReturn($builder);
+
+        $ds->addRestriction($comparisonExpr, 'AND', false)->shouldBeCalled();
+        $ds->setParameter('code1877008211', '%fabric\_%')->shouldBeCalled();
+
+        $this->apply($ds, ['type' => 1, 'value' => 'fabric_'])->shouldReturn(true);
+    }
 }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The QB param to add a `LIKE` condition escaped special characters as underscores using sprintf.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
