### PR TITLE
RAB-1395: Register onTerminate only when an attribute is added to the aggregator

### DIFF
--- a/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/AttributeRemovalSubscriber.php
+++ b/src/Akeneo/Pim/Structure/Bundle/EventSubscriber/AttributeRemovalSubscriber.php
@@ -77,6 +77,11 @@ class AttributeRemovalSubscriber implements EventSubscriberInterface
         $this->attributeCodesToClean = [];
     }
 
+
+    /**
+     * Little hack in order to register on KernelEvents::TERMINATE and ConsoleEvents::TERMINATE only when we are in a context of an attribute deletion
+     * We didn't want to instanciate this class and her service each time a command is executed
+     */
     private function registerCleanAttributeJobOnTerminate()
     {
         if (!$this->terminateEventIsRegistered) {

--- a/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
+++ b/src/Akeneo/Pim/Structure/Bundle/Resources/config/event_subscribers.yml
@@ -30,6 +30,7 @@ services:
             - '@akeneo_batch_queue.launcher.queue_job_launcher'
             - '@akeneo_batch.job.job_instance_repository'
             - '@security.token_storage'
+            - '@event_dispatcher'
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

In this PR, we modified the AttributeRemovalSubscriber in order to listen to the KernelEvents::TERMINATE and ConsoleEvents::TERMINATE only when an attribute is removed.

Why ?
Because actually the service is called each time a console/http request is finished. It's not really a problem in most cases because there is an early return but instantiating the AttributeRemovalSubscriber and her services is costly for the new job stack and it's incompatible with handle multiple job per second. 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
