### PR TITLE
PIM-11003: Fix scrolling on Product edit form attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - PIM-11001: Fix code filter on attributes grid with special character
 - PIM-11002: Fix bad context locale used in DQI dashboard families widget
 - PIM-10997: Update error message when trying to delete role with linked users or connections
+- PIM-11003: Fix scrolling on Product edit form attributes
 
 ## Improvements
 

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/router.js
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/js/router.js
@@ -95,7 +95,7 @@ define([
           }
 
           $('#container').empty();
-          var $view = $('<div class="view"></div>').appendTo($('#container'));
+          var $view = $('<div class="view-global"></div>').appendTo($('#container'));
 
           if (controller.feature && !FeatureFlags.isEnabled(controller.feature)) {
             this.hideLoadingMask();

--- a/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/Default.less
+++ b/src/Akeneo/Platform/Bundle/UIBundle/Resources/public/less/pages/Default.less
@@ -156,6 +156,9 @@
 /* Temporary block */
 .view {
   height: 100%;
+}
+.view-global {
+  height: 100%;
   overflow: auto;
 }
 .app {


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The classname used as root for React pages was the same as the classname used as a container for attributes.
From now on, the class used as root for React pages will be `view-global`

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
