### PR TITLE
GRF: Cleanup user group controller & query

### DIFF
--- a/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UserGroupController.php
+++ b/src/Akeneo/Category/back/Infrastructure/Controller/InternalApi/UserGroupController.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Akeneo\Category\Infrastructure\Controller\InternalApi;
 
-use Akeneo\Category\Infrastructure\Converter\InternalApi\InternalApiToStd;
 use Akeneo\UserManagement\ServiceApi\UserGroup\ListUserGroupInterface;
 use Akeneo\UserManagement\ServiceApi\UserGroup\UserGroup;
 use Akeneo\UserManagement\ServiceApi\UserGroup\UserGroupQuery;
@@ -15,8 +14,6 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @copyright 2022 Akeneo SAS (https://www.akeneo.com)
  * @license   http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
- *
- * @phpstan-import-type StandardInternalApi from InternalApiToStd
  */
 class UserGroupController
 {
@@ -29,7 +26,7 @@ class UserGroupController
     {
         $userGroups = array_map(
             static fn (UserGroup $userGroup) => ['id' => $userGroup->getId(), 'label' => $userGroup->getLabel()],
-            $this->listUserGroup->fromQuery(new UserGroupQuery()),
+            $this->listUserGroup->fromQuery(new UserGroupQuery(limit: 1000)),
         );
 
         return new JsonResponse($userGroups, Response::HTTP_OK);

--- a/src/Akeneo/UserManagement/back/Application/Handler/ListUserGroupHandler.php
+++ b/src/Akeneo/UserManagement/back/Application/Handler/ListUserGroupHandler.php
@@ -25,7 +25,6 @@ class ListUserGroupHandler implements ListUserGroupInterface
      * @return UserGroup[]     */
     public function fromQuery(UserGroupQuery $query): array
     {
-        // @todo implement optional arguments in $query to allow research and pagination
         $result = ($this->findUserGroups)(
             $query->getSearchName(),
             $query->getSearchAfterId(),

--- a/src/Akeneo/UserManagement/back/Infrastructure/Storage/SqlFindUserGroups.php
+++ b/src/Akeneo/UserManagement/back/Infrastructure/Storage/SqlFindUserGroups.php
@@ -61,16 +61,16 @@ class SqlFindUserGroups implements FindUserGroups
         $sqlWherePart = empty($sqlWhereParts) ? '' : 'AND '.implode(' AND ', $sqlWhereParts);
 
         return <<<SQL
-            SELECT 
+            SELECT
                 oag.id,
-                oag.name, 
-                oag.type, 
+                oag.name,
+                oag.type,
                 oag.default_permissions
             FROM oro_access_group oag
             WHERE oag.type = 'default'
-            ${sqlWherePart}
+            $sqlWherePart
             ORDER BY oag.id
-            ${sqlLimitPart} 
+            $sqlLimitPart
         SQL;
     }
 }

--- a/src/Akeneo/UserManagement/back/ServiceApi/UserGroup/UserGroupQuery.php
+++ b/src/Akeneo/UserManagement/back/ServiceApi/UserGroup/UserGroupQuery.php
@@ -4,14 +4,10 @@ namespace Akeneo\UserManagement\ServiceApi\UserGroup;
 
 class UserGroupQuery
 {
-    public const DEFAULT_LIMIT = 1000;
-
-    // @todo add arguments to allow filter on label and pagination
-    // @todo validate the pagination consistency
     public function __construct(
         private ?string $searchName = null,
         private ?int $searchAfterId = null,
-        private int $limit = self::DEFAULT_LIMIT,
+        private ?int $limit = null,
     ) {
     }
 


### PR DESCRIPTION
Linked to this issue https://akeneo.atlassian.net/browse/GRF-752 and this SDS https://akeneo.atlassian.net/browse/SDS-28363

- Removed the default value from the user group query as it's already defined on the SQL query.
- Define the user group limit value of `1000` at the controller level since this is an issue with this route/ui part only and should not impact the bounded context ServiceApi.