### PR TITLE
Add dryRun on UpsertProductCommand

### DIFF
--- a/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UpsertProductCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/API/Command/UpsertProductCommand.php
@@ -31,22 +31,24 @@ final class UpsertProductCommand
      * The product can now be created or updated by :
      * - a ProductIdentifier: the value of the identifier attribute
      * - a ProductUuid: the uuid of the existing product or the one you want to assign to the future product
-     * - null: the product will have a random uuid and no identifier
+     * - null: the product will have a random uuid and no identifier.
+     *
      * @param ValueUserIntent[] $valueUserIntents
      */
     private function __construct(
-        private int $userId,
-        private ProductUuid | ProductIdentifier | null $productIdentifierOrUuid,
-        private ?FamilyUserIntent $familyUserIntent = null,
-        private ?CategoryUserIntent $categoryUserIntent = null,
-        private ?ParentUserIntent $parentUserIntent = null,
-        private ?GroupUserIntent $groupUserIntent = null,
-        private ?SetEnabled $enabledUserIntent = null,
-        private ?AssociationUserIntentCollection $associationUserIntents = null,
-        private ?QuantifiedAssociationUserIntentCollection $quantifiedAssociationUserIntents = null,
-        private array $valueUserIntents = []
+        private readonly int $userId,
+        private readonly ProductUuid|ProductIdentifier|null $productIdentifierOrUuid,
+        private readonly ?FamilyUserIntent $familyUserIntent = null,
+        private readonly ?CategoryUserIntent $categoryUserIntent = null,
+        private readonly ?ParentUserIntent $parentUserIntent = null,
+        private readonly ?GroupUserIntent $groupUserIntent = null,
+        private readonly ?SetEnabled $enabledUserIntent = null,
+        private readonly ?AssociationUserIntentCollection $associationUserIntents = null,
+        private readonly ?QuantifiedAssociationUserIntentCollection $quantifiedAssociationUserIntents = null,
+        private readonly array $valueUserIntents = [],
+        private readonly bool $dryRun = false,
     ) {
-        /**
+        /*
          * TODO to remove when false negative will be fixed
          * Call to static method Webmozart\Assert\Assert::allImplementsInterface() with array<Akeneo\Pim\Enrichment\Product\API\Command\UserIntent\ValueUserIntent> and
         'Akeneo\\Pim\\Enrichment\\Product\\API\\Command\\UserIntent\\ValueUserIntent' will always evaluate to false.
@@ -81,6 +83,15 @@ final class UpsertProductCommand
 
     /**
      * @param UserIntent[] $userIntents
+     */
+    public static function createWithIdentifierDryRun(int $userId, ProductIdentifier $productIdentifier, array $userIntents): self
+    {
+        return self::create($userIntents, $userId, $productIdentifier, true);
+    }
+
+    /**
+     * @param UserIntent[] $userIntents
+     *
      * @deprecated
      */
     public static function createFromCollection(int $userId, string $productIdentifier, array $userIntents): self
@@ -149,11 +160,20 @@ final class UpsertProductCommand
         return $this->quantifiedAssociationUserIntents;
     }
 
+    public function dryRun(): bool
+    {
+        return $this->dryRun;
+    }
+
     /**
      * @param UserIntent[] $userIntents
      */
-    private static function create(array $userIntents, int $userId, ProductIdentifier | ProductUuid | null $productIdentifierOrUuid = null): self
-    {
+    private static function create(
+        array $userIntents,
+        int $userId,
+        ProductIdentifier|ProductUuid|null $productIdentifierOrUuid = null,
+        bool $dryRun = false
+    ): self {
         $valueUserIntents = [];
         $categoryUserIntent = null;
         $groupUserIntent = null;
@@ -170,10 +190,10 @@ final class UpsertProductCommand
             if ($userIntent instanceof ValueUserIntent) {
                 $valueUserIntents[] = $userIntent;
             } elseif ($userIntent instanceof GroupUserIntent) {
-                Assert::null($groupUserIntent, "Only one group intent can be passed to the command.");
+                Assert::null($groupUserIntent, 'Only one group intent can be passed to the command.');
                 $groupUserIntent = $userIntent;
             } elseif ($userIntent instanceof SetEnabled) {
-                Assert::null($enabledUserIntent, "Only one enabled intent can be passed to the command.");
+                Assert::null($enabledUserIntent, 'Only one enabled intent can be passed to the command.');
                 $enabledUserIntent = $userIntent;
             } elseif ($userIntent instanceof FamilyUserIntent) {
                 Assert::null($familyUserIntent, 'Only one family intent can be passed to the command.');
@@ -201,7 +221,8 @@ final class UpsertProductCommand
             quantifiedAssociationUserIntents: [] === $quantifiedAssociationUserIntents
                 ? null
                 : new QuantifiedAssociationUserIntentCollection($quantifiedAssociationUserIntents),
-            valueUserIntents: $valueUserIntents
+            valueUserIntents: $valueUserIntents,
+            dryRun: $dryRun
         );
     }
 }

--- a/src/Akeneo/Pim/Enrichment/Product/back/Application/UpsertProductHandler.php
+++ b/src/Akeneo/Pim/Enrichment/Product/back/Application/UpsertProductHandler.php
@@ -39,7 +39,7 @@ final class UpsertProductHandler
         private ValidatorInterface $productValidator,
         private EventDispatcherInterface $eventDispatcher,
         private UserIntentApplierRegistry $applierRegistry,
-        private TokenStorageInterface $tokenStorage
+        private TokenStorageInterface $tokenStorage,
     ) {
     }
 
@@ -72,6 +72,10 @@ final class UpsertProductHandler
         $violations = $this->productValidator->validate($product);
         if (0 < $violations->count()) {
             throw new LegacyViolationsException($violations);
+        }
+
+        if ($command->dryRun()) {
+            return;
         }
 
         $isUpdate = $product->isDirty();


### PR DESCRIPTION
<!-- <3 Thanks for taking the time to contribute! You're awesome! <3 -->

<!-- If you've never contributed to this repository before, please read https://github.com/akeneo/pim-community-dev/blob/master/.github/CONTRIBUTING.md -->

**Description (for Contributor and Core Developer)**

In some cases, we want to validate a product and don't save it.
This is why we are adding a `dryRun` version of the UpsertProductCommand so that the product is not saved at the end.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
