### PR TITLE
RAB-1411: Forward SIGTERM across daemon and watchdog command

### DIFF
--- a/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/PauseJobOnSigtermSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/PauseJobOnSigtermSubscriber.php
@@ -41,7 +41,7 @@ class PauseJobOnSigtermSubscriber implements EventSubscriberInterface
 
         pcntl_signal(\SIGTERM, function () use ($event) {
             $jobExecution = $event->getJobExecution();
-            $this->logger->notice('Received SIGTERM signal.', [
+            $this->logger->notice('Received SIGTERM signal in batch command and pausing the job.', [
                 'job_execution_id' => $jobExecution->getId()
             ]);
 

--- a/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/PauseJobOnSigtermSubscriber.php
+++ b/src/Akeneo/Tool/Bundle/BatchBundle/EventListener/PauseJobOnSigtermSubscriber.php
@@ -41,7 +41,7 @@ class PauseJobOnSigtermSubscriber implements EventSubscriberInterface
 
         pcntl_signal(\SIGTERM, function () use ($event) {
             $jobExecution = $event->getJobExecution();
-            $this->logger->notice('Received SIGTERM signal in batch command and pausing the job.', [
+            $this->logger->notice('Received SIGTERM signal in PauseJobOnSigtermSubscriber and pausing the job.', [
                 'job_execution_id' => $jobExecution->getId()
             ]);
 

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Command/JobExecutionWatchdogCommand.php
@@ -185,6 +185,12 @@ final class JobExecutionWatchdogCommand extends Command
     private function executeProcess(Process $process, int $jobExecutionId): void
     {
         $this->executionManager->updateHealthCheck($jobExecutionId);
+
+        pcntl_signal(\SIGTERM, function () use ($process) {
+            $this->logger->notice('Received SIGTERM signal in watchdog command and forwarding it to subprocess');
+            $process->signal(\SIGTERM);
+        });
+
         $process->start();
 
         $nbIterationBeforeUpdatingHealthCheck = self::HEALTH_CHECK_INTERVAL * 1000000 / self::RUNNING_PROCESS_CHECK_INTERVAL;

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobMessageHandler.php
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/MessageHandler/JobMessageHandler.php
@@ -89,13 +89,13 @@ final class JobMessageHandler implements MessageSubscriberInterface
             $this->logger->debug(sprintf('Command line: "%s"', $process->getCommandLine()));
 
             if ($this->featureFlags->isEnabled('pause_jobs')) {
-                $previousHandler = pcntl_signal_get_handler(\SIGTERM);
+                $previousSigtermHandler = pcntl_signal_get_handler(\SIGTERM);
 
-                pcntl_signal(\SIGTERM, function () use ($process, $previousHandler) {
+                pcntl_signal(\SIGTERM, function () use ($process, $previousSigtermHandler) {
                     $this->logger->notice('Received SIGTERM signal in job message handler and forwarding it to subprocess');
                     $process->signal(\SIGTERM);
-                    if (is_callable($previousHandler)) {
-                        $previousHandler();
+                    if (is_callable($previousSigtermHandler)) {
+                        $previousSigtermHandler();
                     }
                 });
             }

--- a/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
+++ b/src/Akeneo/Tool/Bundle/BatchQueueBundle/Resources/config/services.yml
@@ -122,6 +122,7 @@ services:
         arguments:
             - '@logger'
             - '%kernel.project_dir%'
+            - '@feature_flags'
         tags:
             - { name: messenger.message_handler }
             - { name: monolog.logger, channel: job_queue }


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

I added SIGTERM signal handler to forward the signal across consumer, watchdog and batch command processes.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
