### PR TITLE
RAB-UNIV: Use cache mode in development mode in order to improve build performance

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ createModuleRegistry(Object.keys(aliases), rootDir);
 console.log('Starting webpack from', rootDir, 'in', isProd ? 'prod' : 'dev', 'mode', isStrict ? 'with typechecking' : '');
 
 const webpackConfig = {
+  cache: isProd ? false : {type: 'filesystem'},
   stats: {
     hash: false,
     modules: false,
@@ -61,6 +62,11 @@ const webpackConfig = {
     publicPath: '/dist/',
     filename: '[name].min.js',
     chunkFilename: '[name].bundle.js',
+  },
+  snapshot: {
+    managedPaths: [
+      /^(\/node_modules\/(?!@akeneo))/,
+    ],
   },
   devtool: 'source-map',
   resolve: {
@@ -228,7 +234,13 @@ const webpackConfig = {
   },
 
   watchOptions: {
-    ignored: /node_modules\/(?!@akeneo)|var\/cache|vendor/,
+    ignored: [
+      '/node_modules\/(?!@akeneo)/',
+      path.resolve(rootDir, './config'),
+      path.resolve(rootDir, './tests'),
+      path.resolve(rootDir, './var'),
+      path.resolve(rootDir, './vendor'),
+    ]
   },
 
   plugins: [
@@ -238,18 +250,6 @@ const webpackConfig = {
 
     // Map modules to variables for global use
     new webpack.ProvidePlugin({_: 'underscore', Backbone: 'backbone', $: 'jquery', jQuery: 'jquery'}),
-
-    // Ignore these directories when webpack watches for changes
-    new webpack.WatchIgnorePlugin({
-      paths: [
-        /node_modules\/(?!@akeneo)/,
-        path.resolve(rootDir, './config'),
-        path.resolve(rootDir, './tests'),
-        path.resolve(rootDir, './var'),
-        path.resolve(rootDir, './vendor'),
-      ]
-    }),
-
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': isProd ? JSON.stringify('production') : JSON.stringify('development'),
       'process.env.EDITION': JSON.stringify(process.env.EDITION),


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

Since webpack 5.0, we have the possibility to use cache in order to improve the time used by webpack to build the front cf: [article](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#persistent-caching)

In this PR:
- I activate the cache in dev and deactivate it in production mode (as preconized on official documentation: https://webpack.js.org/configuration/cache/#cache)
- I also removed the usage of `webpack.WatchIgnorePlugin` as it's deprecated now (https://webpack.js.org/plugins/watch-ignore-plugin/) => replaced by `watchOptions.ignored`
- I also configured the `managedPaths` because actually all akeneo workspace are not included into the hash calculation so for webpack if I change `src/Akeneo/Platform/Bundle/UIBundle/Resources/workspaces/system/src/components/SystemIndex.tsx` for example, the generated vendor.js is the same. Default value is `/^(.+?[\\/]node_modules[\\/])` that why we need to redifine it. We already have the problem when we do a webpack-watch => webpack recompile but change are not included, now it's not anymore the case.

Performance analysis:

| project | without cache | with cache |
|-----------|--------------------|----------------|
| EE       | 79.27s            | 18.28s        |
| CE       | 60.56s            | 13.42s        | 

For now, the cache is not stored in the CI, let's see if it work well before doing it

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
