### PR TITLE
PIM-11005: Skip invalid entities during compute_family_variant_structure_changes job

### DIFF
--- a/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
+++ b/tests/back/Pim/Enrichment/Integration/Product/Job/ComputeFamilyVariantStructureChangesTaskletIntegration.php
@@ -47,7 +47,7 @@ final class ComputeFamilyVariantStructureChangesTaskletIntegration extends TestC
     /**
      * @test
      */
-    public function it_compute_product_values_when_family_variant_structure_changes()
+    public function it_computes_product_values_when_family_variant_structure_changes(): void
     {
         $rootProductModel = $this->createRootProductModel('familyVariantA1');
         $subProductModel = $this->createSubProductModel();


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The `compute_family_variant_structure_changes` job used to stop as soon as it encountered an invalid product or model, thus leaving other entities of the family variant in an invalid state.
We now simply skip the invalid entities and keep on with the job execution so that the other entities are properly updated 

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [ ] Changelog (maintenance bug fixes)
- [ ] Tech Doc
