### PR TITLE
PIM-11016: Improve the clean-removed-attributes command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 - PIM-11013 : Fix edit user profile without password changes
 - PIM-11012 : Add helper if selected UI language is not sufficiently supported
 - PIM-11023 : Fix product search containing underscores
+- PIM-11016 : Improve the clean-removed-attributes command
 
 ## Improvements
 

--- a/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
+++ b/src/Akeneo/Pim/Enrichment/Bundle/Command/CleanRemovedAttributesFromProductAndProductModelCommand.php
@@ -100,7 +100,7 @@ class CleanRemovedAttributesFromProductAndProductModelCommand extends Command
     {
         $this
             ->setDescription('Removes all values of deleted attributes on all products and product models')
-            ->addOption('all-blacklisted-attributes', null, InputOption::VALUE_OPTIONAL)
+            ->addOption('all-blacklisted-attributes')
             ->addArgument('attributes', InputArgument::OPTIONAL | InputArgument::IS_ARRAY);
     }
 


### PR DESCRIPTION
**Description (for Contributor and Core Developer)**

The option `all-blacklisted-attributes` is set to null by default.

So we have to remove `InputOption::VALUE_OPTIONAL` to ignore this parameter if it is not set.

**Definition Of Done (for Core Developer only)**

- [ ] Tests
- [ ] Migration & Installer
- [ ] PM Validation (Story)
- [X] Changelog (maintenance bug fixes)
- [ ] Tech Doc
